### PR TITLE
update K8s Operator cert rotation to avoid downtime

### DIFF
--- a/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
@@ -19,7 +19,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ shell
-        $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+        $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
         ~~~
 
     1. To use a custom namespace, edit all instances of `namespace: cockroach-operator-system` with your desired namespace.
@@ -85,7 +85,7 @@
     {{site.data.alerts.end}}
 
     {{site.data.alerts.callout_info}}
-    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. To authenticate using your own CA, see [Secure the Cluster](secure-cockroachdb-kubernetes.html).
+    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. To authenticate using your own CA, see [Certificate Management](secure-cockroachdb-kubernetes.html).
     {{site.data.alerts.end}}
 
 1. Apply `example.yaml`:

--- a/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
@@ -85,7 +85,7 @@
     {{site.data.alerts.end}}
 
     {{site.data.alerts.callout_info}}
-    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. To authenticate using your own CA, see [Certificate Management](secure-cockroachdb-kubernetes.html).
+    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. If you want to authenticate using your own CA, [specify the generated secrets in the custom resource](secure-cockroachdb-kubernetes.html#use-a-custom-ca) **before** proceeding to the next step.
     {{site.data.alerts.end}}
 
 1. Apply `example.yaml`:

--- a/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
@@ -19,7 +19,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ shell
-        $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+        $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
         ~~~
 
     1. To use a custom namespace, edit all instances of `namespace: cockroach-operator-system` with your desired namespace.
@@ -85,7 +85,7 @@
     {{site.data.alerts.end}}
 
     {{site.data.alerts.callout_info}}
-    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. To authenticate using your own CA, see [Secure the Cluster](secure-cockroachdb-kubernetes.html).
+    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. To authenticate using your own CA, see [Certificate Management](secure-cockroachdb-kubernetes.html).
     {{site.data.alerts.end}}
 
 1. Apply `example.yaml`:

--- a/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
@@ -85,7 +85,7 @@
     {{site.data.alerts.end}}
 
     {{site.data.alerts.callout_info}}
-    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. To authenticate using your own CA, see [Certificate Management](secure-cockroachdb-kubernetes.html).
+    By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. This means that if you do not provide a CA, a `cockroach`-generated CA is used. If you want to authenticate using your own CA, [specify the generated secrets in the custom resource](secure-cockroachdb-kubernetes.html#use-a-custom-ca) **before** proceeding to the next step.
     {{site.data.alerts.end}}
 
 1. Apply `example.yaml`:

--- a/v21.2/secure-cockroachdb-kubernetes.md
+++ b/v21.2/secure-cockroachdb-kubernetes.md
@@ -135,7 +135,7 @@ Complete the following steps **before** [initializing the cluster](deploy-cockro
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
+1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -341,7 +341,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
+1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell

--- a/v21.2/secure-cockroachdb-kubernetes.md
+++ b/v21.2/secure-cockroachdb-kubernetes.md
@@ -35,7 +35,7 @@ If you are running a secure Helm deployment on Kubernetes 1.22 and later, you mu
 <section class="filter-content" markdown="1" data-scope="operator">
 By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster.
 
-To use your own certificate authority instead, add the following to the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+To use your own certificate authority instead, add the following to the Operator's custom resource **before** [initializing the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
 
 ~~~ yaml
 spec:
@@ -85,6 +85,10 @@ The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly 
 {{site.data.alerts.end}}
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{{site.data.alerts.callout_info}}
+Complete the following steps **before** [initializing the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster).
+{{site.data.alerts.end}}
+
 1. Create two directories:
 
     {% include_cached copy-clipboard.html %}
@@ -183,13 +187,6 @@ The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly 
       clientTLSSecret: cockroachdb.client.root
       nodeTLSSecret: cockroachdb.node
     ~~~
-
-1. Apply the new settings to the cluster:
-
-	{% include_cached copy-clipboard.html %}
-	~~~ shell
-	$ kubectl apply -f example.yaml
-	~~~
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">

--- a/v21.2/secure-cockroachdb-kubernetes.md
+++ b/v21.2/secure-cockroachdb-kubernetes.md
@@ -33,7 +33,7 @@ If you are running a secure Helm deployment on Kubernetes 1.22 and later, you mu
 ## Use a custom CA
 
 <section class="filter-content" markdown="1" data-scope="operator">
-By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. 
+By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster.
 
 To use your own certificate authority instead, add the following to the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
 
@@ -131,18 +131,18 @@ The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly 
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create the certificate and key pair for your CockroachDB nodes:
+1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     cockroach cert create-node \
     localhost 127.0.0.1 \
     cockroachdb-public \
-    cockroachdb-public.default \
-    cockroachdb-public.default.svc.cluster.local \
+    cockroachdb-public.cockroach-operator-system \
+    cockroachdb-public.cockroach-operator-system.svc.cluster.local \
     *.cockroachdb \
-    *.cockroachdb.default \
-    *.cockroachdb.default.svc.cluster.local \
+    *.cockroachdb.cockroach-operator-system \
+    *.cockroachdb.cockroach-operator-system.svc.cluster.local \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
@@ -329,23 +329,12 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     --overwrite
     ~~~
 
-1. Delete the existing client secret:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl delete secret cockroachdb.client.root
-    ~~~
-
-    ~~~
-    secret "cockroachdb.client.root" deleted
-    ~~~
-
-1. Upload the new client certificate and key to the Kubernetes cluster as a secret, renaming them to the filenames required by the Operator:
+1. Upload the new client certificate and key to the Kubernetes cluster as a **new** secret, renaming them to the filenames required by the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl create secret \
-    generic cockroachdb.client.root \
+    generic cockroachdb.client.root.2 \
     --from-file=tls.key=certs/client.root.key \
     --from-file=tls.crt=certs/client.root.crt \
     --from-file=ca.crt=certs/ca.crt
@@ -355,40 +344,29 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key:
+1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     cockroach cert create-node \
     localhost 127.0.0.1 \
     cockroachdb-public \
-    cockroachdb-public.default \
-    cockroachdb-public.default.svc.cluster.local \
+    cockroachdb-public.cockroach-operator-system \
+    cockroachdb-public.cockroach-operator-system.svc.cluster.local \
     *.cockroachdb \
-    *.cockroachdb.default \
-    *.cockroachdb.default.svc.cluster.local \
+    *.cockroachdb.cockroach-operator-system \
+    *.cockroachdb.cockroach-operator-system.svc.cluster.local \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key \
     --overwrite
     ~~~
 
-1. Delete the existing node secret:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl delete secret cockroachdb.node
-    ~~~
-
-    ~~~
-    secret "cockroachdb.node" deleted
-    ~~~
-
-1. Upload the new node certificate and key to the Kubernetes cluster as a secret, renaming them to the filenames required by the Operator:
+1. Upload the new node certificate and key to the Kubernetes cluster as a **new** secret, renaming them to the filenames required by the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl create secret \
-    generic cockroachdb.node \
+    generic cockroachdb.node.2 \
     --from-file=tls.key=certs/node.key \
     --from-file=tls.crt=certs/node.crt \
     --from-file=ca.crt=certs/ca.crt
@@ -396,6 +374,14 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
     ~~~
     secret/cockroachdb.node created
+    ~~~
+
+1. Add `nodeTLSSecret` and `clientTLSSecret` to the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster), specifying the new secret names:
+
+    ~~~ yaml
+    spec:
+      clientTLSSecret: cockroachdb.client.root.2
+      nodeTLSSecret: cockroachdb.node.2
     ~~~
 
 1. Check that the secrets were created on the cluster:
@@ -406,31 +392,21 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     ~~~
 
     ~~~
-    NAME                      TYPE                                  DATA   AGE
-    cockroachdb.client.root   Opaque                                3      4s
-    cockroachdb.node          Opaque                                3      1s
-    default-token-6js7b       kubernetes.io/service-account-token   3      9h
+    NAME                        TYPE                                  DATA   AGE
+    cockroachdb.client.root.2   Opaque                                3      4s
+    cockroachdb.node.2          Opaque                                3      1s
+    default-token-6js7b         kubernetes.io/service-account-token   3      9h
     ~~~
 
     {{site.data.alerts.callout_info}}
     Remember that `nodeTLSSecret` and `clientTLSSecret` in the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster) must specify these secret names. For details, see [Use a custom CA](#use-a-custom-ca).
     {{site.data.alerts.end}}
 
-1. Trigger a rolling restart of the pods by annotating the cluster (named `cockroachdb` in our [deployment example](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster)):
+1. Apply the new settings to the cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    kubectl annotate {cluster-name} cockroachdb crdb.io/restarttype='rolling'
-    ~~~
-
-    {{site.data.alerts.callout_success}}
-    If you used a different CA to sign the new certificates, trigger a full restart of the cluster instead: `kubectl annotate {cluster-name} cockroachdb crdb.io/restarttype='fullcluster'`.
-
-    **Note:** A full restart will cause a temporary database outage.
-    {{site.data.alerts.end}}
-
-    ~~~
-    crdbcluster.crdb.cockroachlabs.com/cockroachdb annotated
+    $ kubectl apply -f example.yaml
     ~~~
 
     The pods will terminate and restart one at a time, using the new certificates.
@@ -448,6 +424,28 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     cockroachdb-0                         1/1     Running       0          4h16m
     cockroachdb-1                         1/1     Terminating   0          4h16m
     cockroachdb-2                         1/1     Running       0          43s
+    ~~~
+
+1. Delete the existing client secret that is no longer in use:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secret cockroachdb.client.root
+    ~~~
+
+    ~~~
+    secret "cockroachdb.client.root" deleted
+    ~~~
+
+1. Delete the existing node secret that is no longer in use:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secret cockroachdb.node
+    ~~~
+
+    ~~~
+    secret "cockroachdb.node" deleted
     ~~~
 </section>
 

--- a/v22.1/secure-cockroachdb-kubernetes.md
+++ b/v22.1/secure-cockroachdb-kubernetes.md
@@ -135,7 +135,7 @@ Complete the following steps **before** [initializing the cluster](deploy-cockro
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
+1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -341,7 +341,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
+1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell

--- a/v22.1/secure-cockroachdb-kubernetes.md
+++ b/v22.1/secure-cockroachdb-kubernetes.md
@@ -35,7 +35,7 @@ If you are running a secure Helm deployment on Kubernetes 1.22 and later, you mu
 <section class="filter-content" markdown="1" data-scope="operator">
 By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster.
 
-To use your own certificate authority instead, add the following to the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+To use your own certificate authority instead, add the following to the Operator's custom resource **before** [initializing the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
 
 ~~~ yaml
 spec:
@@ -85,6 +85,10 @@ The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly 
 {{site.data.alerts.end}}
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{{site.data.alerts.callout_info}}
+Complete the following steps **before** [initializing the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster).
+{{site.data.alerts.end}}
+
 1. Create two directories:
 
     {% include_cached copy-clipboard.html %}
@@ -183,13 +187,6 @@ The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly 
       clientTLSSecret: cockroachdb.client.root
       nodeTLSSecret: cockroachdb.node
     ~~~
-
-1. Apply the new settings to the cluster:
-
-	{% include_cached copy-clipboard.html %}
-	~~~ shell
-	$ kubectl apply -f example.yaml
-	~~~
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">

--- a/v22.1/secure-cockroachdb-kubernetes.md
+++ b/v22.1/secure-cockroachdb-kubernetes.md
@@ -33,7 +33,7 @@ If you are running a secure Helm deployment on Kubernetes 1.22 and later, you mu
 ## Use a custom CA
 
 <section class="filter-content" markdown="1" data-scope="operator">
-By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. 
+By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster.
 
 To use your own certificate authority instead, add the following to the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
 
@@ -131,18 +131,18 @@ The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly 
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create the certificate and key pair for your CockroachDB nodes:
+1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     cockroach cert create-node \
     localhost 127.0.0.1 \
     cockroachdb-public \
-    cockroachdb-public.default \
-    cockroachdb-public.default.svc.cluster.local \
+    cockroachdb-public.cockroach-operator-system \
+    cockroachdb-public.cockroach-operator-system.svc.cluster.local \
     *.cockroachdb \
-    *.cockroachdb.default \
-    *.cockroachdb.default.svc.cluster.local \
+    *.cockroachdb.cockroach-operator-system \
+    *.cockroachdb.cockroach-operator-system.svc.cluster.local \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
@@ -329,23 +329,12 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     --overwrite
     ~~~
 
-1. Delete the existing client secret:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl delete secret cockroachdb.client.root
-    ~~~
-
-    ~~~
-    secret "cockroachdb.client.root" deleted
-    ~~~
-
-1. Upload the new client certificate and key to the Kubernetes cluster as a secret, renaming them to the filenames required by the Operator:
+1. Upload the new client certificate and key to the Kubernetes cluster as a **new** secret, renaming them to the filenames required by the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl create secret \
-    generic cockroachdb.client.root \
+    generic cockroachdb.client.root.2 \
     --from-file=tls.key=certs/client.root.key \
     --from-file=tls.crt=certs/client.root.crt \
     --from-file=ca.crt=certs/ca.crt
@@ -355,40 +344,29 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key:
+1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     cockroach cert create-node \
     localhost 127.0.0.1 \
     cockroachdb-public \
-    cockroachdb-public.default \
-    cockroachdb-public.default.svc.cluster.local \
+    cockroachdb-public.cockroach-operator-system \
+    cockroachdb-public.cockroach-operator-system.svc.cluster.local \
     *.cockroachdb \
-    *.cockroachdb.default \
-    *.cockroachdb.default.svc.cluster.local \
+    *.cockroachdb.cockroach-operator-system \
+    *.cockroachdb.cockroach-operator-system.svc.cluster.local \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key \
     --overwrite
     ~~~
 
-1. Delete the existing node secret:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl delete secret cockroachdb.node
-    ~~~
-
-    ~~~
-    secret "cockroachdb.node" deleted
-    ~~~
-
-1. Upload the new node certificate and key to the Kubernetes cluster as a secret, renaming them to the filenames required by the Operator:
+1. Upload the new node certificate and key to the Kubernetes cluster as a **new** secret, renaming them to the filenames required by the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl create secret \
-    generic cockroachdb.node \
+    generic cockroachdb.node.2 \
     --from-file=tls.key=certs/node.key \
     --from-file=tls.crt=certs/node.crt \
     --from-file=ca.crt=certs/ca.crt
@@ -396,6 +374,14 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
     ~~~
     secret/cockroachdb.node created
+    ~~~
+
+1. Add `nodeTLSSecret` and `clientTLSSecret` to the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster), specifying the new secret names:
+
+    ~~~ yaml
+    spec:
+      clientTLSSecret: cockroachdb.client.root.2
+      nodeTLSSecret: cockroachdb.node.2
     ~~~
 
 1. Check that the secrets were created on the cluster:
@@ -406,31 +392,21 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     ~~~
 
     ~~~
-    NAME                      TYPE                                  DATA   AGE
-    cockroachdb.client.root   Opaque                                3      4s
-    cockroachdb.node          Opaque                                3      1s
-    default-token-6js7b       kubernetes.io/service-account-token   3      9h
+    NAME                        TYPE                                  DATA   AGE
+    cockroachdb.client.root.2   Opaque                                3      4s
+    cockroachdb.node.2          Opaque                                3      1s
+    default-token-6js7b         kubernetes.io/service-account-token   3      9h
     ~~~
 
     {{site.data.alerts.callout_info}}
     Remember that `nodeTLSSecret` and `clientTLSSecret` in the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster) must specify these secret names. For details, see [Use a custom CA](#use-a-custom-ca).
     {{site.data.alerts.end}}
 
-1. Trigger a rolling restart of the pods by annotating the cluster (named `cockroachdb` in our [deployment example](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster)):
+1. Apply the new settings to the cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    kubectl annotate {cluster-name} cockroachdb crdb.io/restarttype='rolling'
-    ~~~
-
-    {{site.data.alerts.callout_success}}
-    If you used a different CA to sign the new certificates, trigger a full restart of the cluster instead: `kubectl annotate {cluster-name} cockroachdb crdb.io/restarttype='fullcluster'`.
-
-    **Note:** A full restart will cause a temporary database outage.
-    {{site.data.alerts.end}}
-
-    ~~~
-    crdbcluster.crdb.cockroachlabs.com/cockroachdb annotated
+    $ kubectl apply -f example.yaml
     ~~~
 
     The pods will terminate and restart one at a time, using the new certificates.
@@ -448,6 +424,28 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     cockroachdb-0                         1/1     Running       0          4h16m
     cockroachdb-1                         1/1     Terminating   0          4h16m
     cockroachdb-2                         1/1     Running       0          43s
+    ~~~
+
+1. Delete the existing client secret that is no longer in use:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secret cockroachdb.client.root
+    ~~~
+
+    ~~~
+    secret "cockroachdb.client.root" deleted
+    ~~~
+
+1. Delete the existing node secret that is no longer in use:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secret cockroachdb.node
+    ~~~
+
+    ~~~
+    secret "cockroachdb.node" deleted
     ~~~
 </section>
 


### PR DESCRIPTION
Fixes DOC-2467.

- Updated the K8s Operator cert rotation steps to avoid downtime.
- Updated the cert generation snippet to use the Operator's default namespace.