### PR TITLE
Bump operator version to v2.5.3

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -26,7 +26,7 @@ include:
 keep_files:
 - _internal
 markdown: Redcarpet
-operator_version: v2.5.1
+operator_version: v2.5.3
 plugins:
 - jekyll-include-cache
 release_info:


### PR DESCRIPTION
We recently released a new version of the public operator containing a
bugfix that has been coming up in support tickets and Slack (issues with
`cockroachDBVersion` is set and `image` is not).