### PR TITLE
Document non-experimental DateStyle and IntervalStyle session parameters

### DIFF
--- a/_includes/v22.1/misc/session-vars.html
+++ b/_includes/v22.1/misc/session-vars.html
@@ -74,19 +74,8 @@
     <code>datestyle</code>
    </td>
    <td> The input string format for <a href="date.html"><code>DATE</code></a> and <a href="timestamp.html"><code>TIMESTAMP</code></a> values.
-     <br>Accepted values include <code>ISO,MDY</code>, <code>ISO,DMY</code>, and <code>ISO,YMD</code>.
-     <br>To set <code>datestyle</code> to a value other than the default (<code>ISO,MDY</code>), you must first set the <code>datestyle_enabled</code> session variable to <code>true</code>.</td>
+     <br>Accepted values include <code>ISO,MDY</code>, <code>ISO,DMY</code>, and <code>ISO,YMD</code>.</td>
    <td>The value set by the <code>sql.defaults.datestyle</code> <a href="cluster-settings.html">cluster setting</a> (<code>ISO,MDY</code>, by default).</td>
-   <td>Yes</td>
-   <td>Yes</td>
-  </tr>
-
-  <tr>
-   <td>
-    <code>datestyle_enabled</code>
-   </td>
-   <td> Enables setting the <code>datestyle</code> session variable to a supported format.</td>
-   <td>The value set by the <code>sql.defaults.datestyle.enabled</code> <a href="cluster-settings.html">cluster setting</a> (<code>false</code>, by default).</td>
    <td>Yes</td>
    <td>Yes</td>
   </tr>
@@ -298,19 +287,8 @@
     <code>intervalstyle</code>
    </td>
    <td> The input string format for <a href="interval.html"><code>INTERVAL</code></a> values.
-     <br>Accepted values include <code>postgres</code>, <code>iso_8601</code>, and <code>sql_standard</code>.
-     <br>To set <code>intervalstyle</code> to a value other than the default (<code>postgres</code>), you must first set the <code>intervalstyle_enabled</code> session variable to <code>true</code>.</td>
+     <br>Accepted values include <code>postgres</code>, <code>iso_8601</code>, and <code>sql_standard</code>.</td>
    <td>The value set by the <code>sql.defaults.intervalstyle</code> <a href="cluster-settings.html">cluster setting</a> (<code>postgres</code>, by default).</td>
-   <td>Yes</td>
-   <td>Yes</td>
-  </tr>
-
-  <tr>
-   <td>
-    <code>intervalstyle_enabled</code>
-   </td>
-   <td> Enables setting the <code>intervalstyle</code> session variable to a supported format.</td>
-   <td>The value set by the <code>sql.defaults.intervalstyle.enabled</code> <a href="cluster-settings.html">cluster setting</a> (<code>false</code>, by default).</td>
    <td>Yes</td>
    <td>Yes</td>
   </tr>

--- a/v22.1/date.md
+++ b/v22.1/date.md
@@ -17,7 +17,7 @@ CockroachDB also supports using uninterpreted [string literals](sql-constants.ht
 - `MM-DD-YYYY`
 - `MM-DD-YY` (default)/`YY-MM-DD`/`DD-MM-YY`
 
-To change the input format of truncated dates (e.g., `12-16-06`) from `MM-DD-YY` to `YY-MM-DD` or `DD-MM-YY`, set the `datestyle` [session variable](set-vars.html) or the `sql.defaults.datestyle ` [cluster setting](cluster-settings.html). To set the `datestyle` session variable, the `datestyle_enabled` session variable must be set to `true`.
+To change the input format of truncated dates (e.g., `12-16-06`) from `MM-DD-YY` to `YY-MM-DD` or `DD-MM-YY`, set the `datestyle` [session variable](set-vars.html) or the `sql.defaults.datestyle ` [cluster setting](cluster-settings.html).
 
 ## PostgreSQL compatibility
 

--- a/v22.1/interval.md
+++ b/v22.1/interval.md
@@ -24,12 +24,6 @@ Abbreviated PostgreSQL | `INTERVAL '1 yr 2 mons 3 d 4 hrs 5 mins 6 secs'`
 
 The value of `intervalstyle` affects how CockroachDB parses certain `INTERVAL` values. Specifically, when `intervalstyle = 'sql_standard'`, and when the `INTERVAL` value begins with a negative symbol, CockroachDB parses all fields as negative values (e.g., `-3 years 1 day` is parsed as `-(3 years 1 day)`, or `-3 years, -1 day`). When `intervalstyle = 'postgres'` (the default format), and when the `INTERVAL` value begins with a negative symbol, CockroachDB only applies the negative symbol to the field that it directly precedes (e.g., `-3 years 1 day` is parsed as `-3 years, +1 day`).
 
-To set the `intervalstyle` session variable, the `intervalstyle_enabled` session variable must be set to `true`. At the beginning of each session, the `intervalstyle_enabled` variable is set to the value of the `sql.defaults.intervalstyle.enabled` cluster setting (`false`, by default).
-
-{{site.data.alerts.callout_info}}
-When the `intervalstyle_enabled` [session variable](set-vars.html) is set to `true`, you cannot [cast values](#supported-casting-and-conversion) from `INTERVAL` to `STRING` or from `STRING` to `INTERVAL` if the value belongs to a [computed column](computed-columns.html), a [partially-indexed column](partial-indexes.html), or a [geo-partitioned column](partitioning.html). To work around this limitation, use the `to_char_with_style(interval, style)` or `parse_interval(interval, intervalstyle)` [built-in functions](functions-and-operators.html).
-{{site.data.alerts.end}}
-
 ### Details on SQL Standard input
 
 Without a [precision](#precision) or [duration field](#duration-fields) specified, expect the following behavior from SQL Standard input (`Y-M D H:M:S`):

--- a/v22.1/timestamp.md
+++ b/v22.1/timestamp.md
@@ -52,7 +52,7 @@ ISO 8601 | `TIMESTAMP '2016-01-25T10:10:10.555555'`
 
 To express a `TIMESTAMPTZ` value with time zone offset from UTC, use the following format: `TIMESTAMPTZ '2016-01-25 10:10:10.555555-05:00'`. The fractional portion is optional and is rounded to microseconds (6 digits after decimal) for compatibility with the PostgreSQL wire protocol.
 
-By default, CockroachDB interprets truncated dates (e.g., `12-16-06`) as `MM-DD-YY`. To change the input string format of truncated dates, set the `datestyle` [session variable](set-vars.html) or the `sql.defaults.datestyle ` [cluster setting](cluster-settings.html). To set the `datestyle` session variable, the `datestyle_enabled` session variable must be set to `true`.
+By default, CockroachDB interprets truncated dates (e.g., `12-16-06`) as `MM-DD-YY`. To change the input string format of truncated dates, set the `datestyle` [session variable](set-vars.html) or the `sql.defaults.datestyle ` [cluster setting](cluster-settings.html).
 
 ## Size
 


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-2593

`datestyle_enabled` and `intervalstyle_enabled` now have no effect because they are always true.
(I just deleted references to those variables, but let me know if there should be a more direct note to say that they are no longer necessary)
There is also no longer any issue with those variables and casting between INTERVALs and STRINGs.