### PR TITLE
Add docs on super regions

### DIFF
--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -163,6 +163,12 @@
                 ]
               },
               {
+                "title": "<code>ADD SUPER REGION</code> (Enterprise)",
+                "urls": [
+                  "/${VERSION}/add-super-region.html"
+                ]
+              },
+              {
                 "title": "<code>ALTER CHANGEFEED</code> (Enterprise)",
                 "urls": [
                   "/${VERSION}/alter-changefeed.html"
@@ -226,6 +232,12 @@
                 "title": "<code>ALTER SEQUENCE</code>",
                 "urls": [
                   "/${VERSION}/alter-sequence.html"
+                ]
+              },
+              {
+                "title": "<code>ALTER SUPER REGION</code> (Enterprise)",
+                "urls": [
+                  "/${VERSION}/alter-super-region.html"
                 ]
               },
               {
@@ -418,6 +430,12 @@
                 "title": "<code>DROP REGION (Enterprise)</code>",
                 "urls": [
                   "/${VERSION}/drop-region.html"
+                ]
+              },
+              {
+                "title": "<code>DROP SUPER REGION</code> (Enterprise)",
+                "urls": [
+                  "/${VERSION}/drop-super-region.html"
                 ]
               },
               {
@@ -832,6 +850,12 @@
                 "title": "<code>SHOW REGIONS</code>",
                 "urls": [
                   "/${VERSION}/show-regions.html"
+                ]
+              },
+              {
+                "title": "<code>SHOW SUPER REGIONS</code>",
+                "urls": [
+                  "/${VERSION}/show-super-regions.html"
                 ]
               },
               {

--- a/_includes/v22.1/sql/enable-super-region-primary-region-changes.md
+++ b/_includes/v22.1/sql/enable-super-region-primary-region-changes.md
@@ -1,0 +1,23 @@
+By default, you may not change the [primary region](set-primary-region.html) of a [multi-region database](multiregion-overview.html) when that region is part of a super region. This is a safety setting designed to prevent you from accidentally moving the data for a [regional table](regional-tables.html) that is meant to be stored in the super region out of that super region, which could break your data domiciling setup.
+
+If you are sure about what you are doing, you can allow modifying the primary region by setting the `override_multi_region_zone_config` [session setting](set-vars.html) to `'on'`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET override_multi_region_zone_config = 'on';
+~~~
+
+~~~
+SET
+~~~
+
+You can also accomplish this by setting the `sql.defaults.alter_primary_region_super_region_override.enable` [cluster setting](cluster-settings.html) to `true`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET CLUSTER SETTING  sql.defaults.alter_primary_region_super_region_override.enable = true;
+~~~
+
+~~~
+SET CLUSTER SETTING
+~~~

--- a/_includes/v22.1/sql/enable-super-regions.md
+++ b/_includes/v22.1/sql/enable-super-regions.md
@@ -1,0 +1,21 @@
+To enable super regions, set the `enable_super_regions` [session setting](set-vars.html) to `'on'`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET enable_super_regions = 'on';
+~~~
+
+~~~
+SET
+~~~
+
+You can also set the `sql.defaults.super_regions.enabled` [cluster setting](cluster-settings.html) to `true`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET CLUSTER SETTING  sql.defaults.super_regions.enabled = true;
+~~~
+
+~~~
+SET CLUSTER SETTING
+~~~

--- a/_includes/v22.1/sql/multiregion-example-setup.md
+++ b/_includes/v22.1/sql/multiregion-example-setup.md
@@ -6,7 +6,7 @@ To follow along with the examples below, start a [demo cluster](cockroach-demo.h
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach demo --global --nodes 9 --no-example-database
+$ cockroach demo --global --nodes 9
 ~~~
 
 To see the regions available to the databases in the cluster, use a `SHOW REGIONS FROM CLUSTER` statement:

--- a/_includes/v22.1/sql/multiregion-movr-add-regions.md
+++ b/_includes/v22.1/sql/multiregion-movr-add-regions.md
@@ -1,0 +1,8 @@
+Execute the following statements. They will tell CockroachDB about the database's regions. This information is necessary so that CockroachDB can later move data around to optimize access to particular data from particular regions. For more information about how this works at a high level, see [Database Regions](multiregion-overview.html#database-regions).
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE movr PRIMARY REGION "us-east1";
+ALTER DATABASE movr ADD REGION "europe-west1";
+ALTER DATABASE movr ADD REGION "us-west1";
+~~~

--- a/_includes/v22.1/sql/super-region-considerations.md
+++ b/_includes/v22.1/sql/super-region-considerations.md
@@ -1,0 +1,7 @@
+To use super regions, you must keep the following considerations in mind:
+
+- Your cluster must be a [multi-region cluster](multiregion-overview.html).
+- Super regions [must be enabled](#enable-super-regions).
+- Super regions can only contain [database regions](multiregion-overview.html#database-regions) that have already been added with [`ADD REGION`](add-region.html).
+- Each database region can only belong to one super region. In other words, given two super regions _A_ and _B_, the set of database regions in _A_ must be [disjoint](https://en.wikipedia.org/wiki/Disjoint_sets) from the set of database regions in _B_.
+- You cannot [drop a region](drop-region.html) that is part of a super region until you either [alter the super region](alter-super-region.html) to remove it, or [drop the super region](drop-super-region.html) altogether.

--- a/v22.1/add-region.md
+++ b/v22.1/add-region.md
@@ -132,5 +132,8 @@ SHOW REGIONS FROM DATABASE foo;
 - [`SET PRIMARY REGION`](set-primary-region.html)
 - [`DROP REGION`](drop-region.html)
 - [`SHOW REGIONS`](show-regions.html)
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
 - [`ALTER TABLE`](alter-table.html)
 - [SQL Statements](sql-statements.html)

--- a/v22.1/add-super-region.md
+++ b/v22.1/add-super-region.md
@@ -1,0 +1,94 @@
+---
+title: ADD SUPER REGION
+summary: The ADD SUPER REGION statement creates a set of regions where data from regional tables with home rows in the super region is stored in the super region.
+toc: true
+docs_area: reference.sql
+---
+
+ The `ALTER DATABASE .. ADD SUPER REGION` [statement](sql-statements.html) adds a [super region](multiregion-overview.html#super-regions) to a [multi-region database](multiregion-overview.html).
+
+{% include enterprise-feature.md %}
+
+{{site.data.alerts.callout_info}}
+`ADD SUPER REGION` is a subcommand of [`ALTER DATABASE`](alter-database.html).
+{{site.data.alerts.end}}
+
+{% include common/experimental-warning.md %}
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/alter_database_add_super_region.html %}
+</div>
+
+## Parameters
+
+| Parameter       | Description                                                                                              |
+|-----------------+----------------------------------------------------------------------------------------------------------|
+| `database_name` | The database to which you are adding a [super region](multiregion-overview.html#super-regions).          |
+| `name`          | The name of the [super region](multiregion-overview.html#super-regions) being added to this database.    |
+| `name_list`     | The super region consists of this set of [database regions](multiregion-overview.html#database-regions). |
+
+## Required privileges
+
+To add a super region to a database, the user must have one of the following:
+
+- Membership to the [`admin`](security-reference/authorization.html#admin-role) role for the cluster.
+- Either [ownership](security-reference/authorization.html#object-ownership) or the [`CREATE` privilege](security-reference/authorization.html#supported-privileges) for the database.
+
+## Considerations
+
+{% include {{page.version.version}}/sql/super-region-considerations.md %}
+
+## Examples
+
+The examples in this section use the following setup.
+
+{% include {{page.version.version}}/sql/multiregion-example-setup.md %}
+
+#### Set up movr database regions
+
+{% include {{page.version.version}}/sql/multiregion-movr-add-regions.md %}
+
+#### Set up movr global tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-global.md %}
+
+#### Set up movr regional tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-regional-by-row.md %}
+
+### Enable super regions
+
+{% include {{page.version.version}}/sql/enable-super-regions.md %}
+
+### Add a super region to a database
+
+To add a super region to a multi-region database, use the `ALTER DATABASE ... ADD SUPER REGION` statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE movr ADD SUPER REGION "usa" VALUES "us-east1", "us-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD SUPER REGION
+~~~
+
+### Allow user to modify a primary region that is part of a super region
+
+{% include {{page.version.version}}/sql/enable-super-region-primary-region-changes.md %}
+
+## See also
+
+- [Multi-Region Capabilities Overview](multiregion-overview.html)
+- [Super regions](multiregion-overview.html#super-regions)
+- [`SET PRIMARY REGION`](set-primary-region.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`ALTER SUPER REGION`](alter-super-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
+- [`DROP REGION`](drop-region.html)
+- [`SHOW REGIONS`](show-regions.html)
+- [`ALTER TABLE`](alter-table.html)
+- [`ALTER DATABASE`](alter-database.html)
+- [SQL Statements](sql-statements.html)

--- a/v22.1/alter-database.md
+++ b/v22.1/alter-database.md
@@ -19,6 +19,9 @@ Subcommand | Description
 [`ADD REGION`](add-region.html) |  Add a region to a [multi-region database](multiregion-overview.html).
 [`DROP REGION`](drop-region.html) |  Drop a region from a [multi-region database](multiregion-overview.html).
 [`SET PRIMARY REGION`](set-primary-region.html) |  Set the primary region of a [multi-region database](multiregion-overview.html).
+[`ADD SUPER REGION`](add-super-region.html) | <span class="version-tag">New in v22.1:</span> Add a super region made up of a set of [database regions](multiregion-overview.html#super-regions) such that data from [regional tables](regional-tables.html) will be stored in only those regions.
+[`DROP SUPER REGION`](drop-super-region.html) | <span class="version-tag">New in v22.1:</span> Drop a super region made up of a set of [database regions](multiregion-overview.html#super-regions).
+[`ALTER SUPER REGION`](alter-super-region.html) | <span class="version-tag">New in v22.1:</span> Alter an existing [super region](multiregion-overview.html#super-regions) to include a different set of regions. A super region is made up of a set of regions added with [`ADD REGION`](add-region.html) such that data from [regional tables](regional-tables.html) will be stored in only those regions.
 [`SET <sessionvar>`](alter-role.html#set-default-session-variable-values-for-a-specific-database) |  Set the default session variable values for the database. This syntax is identical to [`ALTER ROLE ALL IN DATABASE SET <sessionvar>`](alter-role.html).
 `RESET <sessionvar>` |  Reset the default session variable values for the database to the system defaults. This syntax is identical to [`ALTER ROLE ALL IN DATABASE RESET <sessionvar>`](alter-role.html).
 [`SURVIVE {ZONE,REGION} FAILURE`](survive-failure.html) |  Add a survival goal to a [multi-region database](multiregion-overview.html).

--- a/v22.1/alter-super-region.md
+++ b/v22.1/alter-super-region.md
@@ -1,0 +1,98 @@
+---
+title: ALTER SUPER REGION
+summary: The ALTER SUPER REGION statement alters an existing super region to include a different set of regions.
+toc: true
+docs_area: reference.sql
+---
+
+The `ALTER DATABASE .. ALTER SUPER REGION` [statement](sql-statements.html) alters an existing [super region](multiregion-overview.html#super-regions) of a [multi-region database](multiregion-overview.html).
+
+{% include enterprise-feature.md %}
+
+{{site.data.alerts.callout_info}}
+`ALTER SUPER REGION` is a subcommand of [`ALTER DATABASE`](alter-database.html).
+{{site.data.alerts.end}}
+
+{% include common/experimental-warning.md %}
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/alter_database_alter_super_region.html %}
+</div>
+
+## Parameters
+
+| Parameter       | Description                                                                                                          |
+|-----------------+----------------------------------------------------------------------------------------------------------------------|
+| `database_name` | The database with the [super region](multiregion-overview.html#super-regions) you are altering.                      |
+| `name`          | The name of the [super region](multiregion-overview.html#super-regions) being altered.                               |
+| `name_list`     | The altered super region will consist of this set of [database regions](multiregion-overview.html#database-regions). |
+
+## Required privileges
+
+To alter a database's super region, the user must have one of the following:
+
+- Membership to the [`admin`](security-reference/authorization.html#admin-role) role for the cluster.
+- Either [ownership](security-reference/authorization.html#object-ownership) or the [`CREATE` privilege](security-reference/authorization.html#supported-privileges) for the database.
+
+## Considerations
+
+{% include {{page.version.version}}/sql/super-region-considerations.md %}
+
+## Examples
+
+The examples in this section use the following setup.
+
+{% include {{page.version.version}}/sql/multiregion-example-setup.md %}
+
+#### Set up movr database regions
+
+{% include {{page.version.version}}/sql/multiregion-movr-add-regions.md %}
+
+#### Set up movr global tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-global.md %}
+
+#### Set up movr regional tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-regional-by-row.md %}
+
+### Enable super regions
+
+{% include {{page.version.version}}/sql/enable-super-regions.md %}
+
+### Alter a super region
+
+This example assumes you have already added a `"usa"` super region as shown in the example [Add a super region to a database](add-super-region.html#add-a-super-region-to-a-database). If you wanted to [drop the region](drop-region.html) `us-west1`, you would first need to remove it from the super region.
+
+To remove a region from a super region, use the `ALTER DATABASE ... ALTER SUPER REGION` statement and list only the regions that should remain in the super region:
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE movr ALTER SUPER REGION "usa" VALUES "us-east1";
+~~~
+
+~~~
+ALTER DATABASE ALTER SUPER REGION
+~~~
+
+To add a region to a super region, alter the super region as shown above to be a list of regions that includes the existing and the new regions.
+
+### Allow user to modify a primary region that is part of a super region
+
+{% include {{page.version.version}}/sql/enable-super-region-primary-region-changes.md %}
+
+## See also
+
+- [Multi-Region Capabilities Overview](multiregion-overview.html)
+- [Super regions](multiregion-overview.html#super-regions)
+- [`SET PRIMARY REGION`](set-primary-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`DROP REGION`](drop-region.html)
+- [`SHOW REGIONS`](show-regions.html)
+- [`ALTER TABLE`](alter-table.html)
+- [`ALTER DATABASE`](alter-database.html)
+- [SQL Statements](sql-statements.html)

--- a/v22.1/demo-low-latency-multi-region-deployment.md
+++ b/v22.1/demo-low-latency-multi-region-deployment.md
@@ -288,14 +288,7 @@ Back in the SQL shell, switch to the `movr` database:
 USE movr;
 ~~~
 
-Execute the following statements. They will tell CockroachDB about the database's regions. This information is necessary so that CockroachDB can later move data around to optimize access to particular data from particular regions. For more information about how this works at a high level, see [Database Regions](multiregion-overview.html#database-regions).
-
-{% include copy-clipboard.html %}
-~~~ sql
-ALTER DATABASE movr PRIMARY REGION "us-east1";
-ALTER DATABASE movr ADD REGION "europe-west1";
-ALTER DATABASE movr ADD REGION "us-west1";
-~~~
+{% include {{page.version.version}}/sql/multiregion-movr-add-regions.md %}
 
 ### Configure table localities
 

--- a/v22.1/drop-region.md
+++ b/v22.1/drop-region.md
@@ -220,5 +220,8 @@ HINT: you must add additional regions to the database or change the survivabilit
 - [`SET PRIMARY REGION`](set-primary-region.html)
 - [`ADD REGION`](add-region.html)
 - [`SHOW REGIONS`](show-regions.html)
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
 - [`ALTER TABLE`](alter-table.html)
 - [SQL Statements](sql-statements.html)

--- a/v22.1/drop-super-region.md
+++ b/v22.1/drop-super-region.md
@@ -1,0 +1,104 @@
+---
+title: DROP SUPER REGION
+summary: The DROP SUPER REGION statement drops a super region from a multi-region database.
+toc: true
+docs_area: reference.sql
+---
+
+ The `ALTER DATABASE .. DROP SUPER REGION` [statement](sql-statements.html) drops a [super region](multiregion-overview.html#super-regions) from a [multi-region database](multiregion-overview.html).
+ 
+{% include enterprise-feature.md %}
+
+{{site.data.alerts.callout_info}}
+`DROP SUPER REGION` is a subcommand of [`ALTER DATABASE`](alter-database.html).
+{{site.data.alerts.end}}
+
+{% include common/experimental-warning.md %}
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/alter_database_drop_super_region.html %}
+</div>
+
+## Parameters
+
+| Parameter       | Description                                                                                               |
+|-----------------+-----------------------------------------------------------------------------------------------------------|
+| `database_name` | The database from which you are dropping a [super region](multiregion-overview.html#super-regions).       |
+| `name`          | The name of the [super region](multiregion-overview.html#super-regions) being dropped from this database. |
+
+## Required privileges
+
+To drop a super region from a database, the user must have one of the following:
+
+- Membership to the [`admin`](security-reference/authorization.html#roles) role for the cluster.
+- Either [ownership](security-reference/authorization.html#object-ownership) or the [`CREATE` privilege](security-reference/authorization.html#supported-privileges) for the database.
+
+## Considerations
+
+{% include {{page.version.version}}/sql/super-region-considerations.md %}
+
+## Examples
+
+The examples in this section use the following setup.
+
+{% include {{page.version.version}}/sql/multiregion-example-setup.md %}
+
+#### Set up movr database regions
+
+{% include {{page.version.version}}/sql/multiregion-movr-add-regions.md %}
+
+#### Set up movr global tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-global.md %}
+
+#### Set up movr regional tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-regional-by-row.md %}
+
+### Enable super regions
+
+{% include {{page.version.version}}/sql/enable-super-regions.md %}
+
+### Drop a super region from a database
+
+To drop a super region from a multi-region database, use a [`DROP SUPER REGION`](drop-super-region.html) statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE movr DROP SUPER REGION "usa";
+~~~
+
+~~~
+ALTER DATABASE DROP SUPER REGION
+~~~
+
+Note that you cannot [drop a region](drop-region.html) that is part of a super region until you either [alter the super region](alter-super-region.html) to remove it, or [drop the super region](drop-super-region.html) altogether.
+
+For example, using the super region that was added in [`ADD SUPER REGION`](add-super-region.html#add-a-super-region-to-a-database):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE movr DROP REGION "us-west1";
+~~~
+
+~~~
+ERROR: region us-west1 is part of super region usa
+SQLSTATE: 2BP01
+HINT: you must first drop super region usa before you can drop the region us-west1
+~~~
+
+## See also
+
+- [Multi-Region Capabilities Overview](multiregion-overview.html)
+- [Super regions](multiregion-overview.html#super-regions)
+- [`SET PRIMARY REGION`](set-primary-region.html)
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`ALTER SUPER REGION`](alter-super-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
+- [`ADD REGION`](add-region.html)
+- [`SHOW REGIONS`](show-regions.html)
+- [`ALTER TABLE`](alter-table.html)
+- [`ALTER DATABASE`](alter-database.html)
+- [SQL Statements](sql-statements.html)

--- a/v22.1/multiregion-overview.md
+++ b/v22.1/multiregion-overview.md
@@ -66,6 +66,36 @@ To show all of a database's regions, execute the [`SHOW REGIONS FROM DATABASE` s
 If the default survival goals and table localities meet your needs, there is nothing else you need to do once you have set a database's primary region.
 {{site.data.alerts.end}}
 
+## Super regions
+
+{% include common/experimental-warning.md %}
+
+<span class="version-tag">New in v22.1:</span> Super regions allow you to define a set of [database regions](#database-regions) such that the following [schema objects](schema-design-overview.html#database-schema-objects) will have all of their replicas stored _only_ in regions that are members of the super region:
+
+- [Regional tables](#regional-tables) whose home region is a member of the super region.
+- Any row of a [regional by row table](#regional-by-row-tables) whose [home region](set-locality.html#crdb_region) is a member of the super region.
+
+The primary use case for super regions is data domiciling. As mentioned above, data from [regional](#regional-tables) and [regional by row](#regional-by-row-tables) tables will be stored only in regions that are members of the super region. Further, if the super region contains 3 or more regions and if you use [`REGION` survival goals](#survive-region-failures), the data domiciled in the super region will remain available if you lose a region.
+
+{% include {{page.version.version}}/sql/super-region-considerations.md %}
+
+<a name="enable-super-regions"></a>
+
+For more information about how to enable and use super regions, see:
+
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`ALTER SUPER REGION`](alter-super-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
+
+Note that super regions take a different approach to data domiciling than [`ALTER DATABASE ... PLACEMENT RESTRICTED`](placement-restricted.html). Specifically, super regions make it so that all [replicas](architecture/overview.html#architecture-replica) (both voting and [non-voting](architecture/replication-layer.html#non-voting-replicas)) are placed within the super region, whereas `PLACEMENT RESTRICTED` makes it so that there are no non-voting replicas.
+
+For more information about data domiciling using `PLACEMENT RESTRICTED`, see [Data Domiciling with CockroachDB](data-domiciling.html).
+
+{{site.data.alerts.callout_info}}
+Super regions rely on the underlying [replication zone system](configure-replication-zones.html), which was historically built for performance, not for domiciling. The replication system's top priority is to prevent the loss of data and it may override the zone configurations if necessary to ensure data durability. For more information, see [Configure Replication Zones](https://www.cockroachlabs.com/docs/v21.2/configure-replication-zones#types-of-constraints).
+{{site.data.alerts.end}}
+
 ## Survival goals
 
 A _survival goal_ dictates how many simultaneous failure(s) a database can survive. All tables within the same database operate with the **same survival goal**. Each database can have its own survival goal setting.

--- a/v22.1/show-regions.md
+++ b/v22.1/show-regions.md
@@ -194,4 +194,8 @@ SHOW REGIONS FROM ALL DATABASES;
 
 - [Multi-Region Capabilities Overview](multiregion-overview.html)
 - [`ADD REGION`](add-region.html)
+- [`DROP REGION`](drop-region.html)
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`SHOW SUPER REGIONS`](show-super-regions.html)
 - [SQL Statements](sql-statements.html)

--- a/v22.1/show-super-regions.md
+++ b/v22.1/show-super-regions.md
@@ -1,0 +1,94 @@
+---
+title: SHOW SUPER REGIONS
+summary: The SHOW SUPER REGIONS statement shows the super regions in a multi-region cluster.
+toc: true
+docs_area: reference.sql
+---
+
+ The `SHOW SUPER REGIONS` [statement](sql-statements.html) lists the [super regions](multiregion-overview.html#super-regions) for a multi-region cluster.
+
+{% include common/experimental-warning.md %}
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/show_regions.html %}
+</div>
+
+## Required privileges
+
+To view the super regions in a database, the user must have one of the following:
+
+- Membership to the [`admin`](security-reference/authorization.html#admin-role) role for the cluster.
+- Either [ownership](security-reference/authorization.html#object-ownership) or the [`CREATE` privilege](security-reference/authorization.html#supported-privileges) for the database.
+
+## Parameters
+
+| Parameter                     | Description                                                                                   |
+|-------------------------------+-----------------------------------------------------------------------------------------------|
+| `FROM DATABASE database_name` | Show all [super regions](multiregion-overview.html#super-regions) for the specified database. |
+
+## Response
+
+`SHOW SUPER REGIONS FROM DATABASE` returns the following fields for each super region:
+
+| Field               | Description                                                 |
+|---------------------+-------------------------------------------------------------|
+| `database_name`     | The database name this super region is associated with.     |
+| `super_region_name` | The name of a super region associated with the database.    |
+| `regions`           | The list of database regions that make up the super region. |
+
+## Considerations
+
+{% include {{page.version.version}}/sql/super-region-considerations.md %}
+
+## Examples
+
+The examples in this section use the following setup.
+
+{% include {{page.version.version}}/sql/multiregion-example-setup.md %}
+
+#### Set up movr database regions
+
+{% include {{page.version.version}}/sql/multiregion-movr-add-regions.md %}
+
+#### Set up movr global tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-global.md %}
+
+#### Set up movr regional tables
+
+{% include {{page.version.version}}/sql/multiregion-movr-regional-by-row.md %}
+
+### Enable super regions
+
+{% include {{page.version.version}}/sql/enable-super-regions.md %}
+
+### View the super regions from a database
+
+`SHOW SUPER REGIONS FROM DATABASE` returns the [super regions](multiregion-overview.html#super-regions) for the specified database.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW SUPER REGIONS FROM DATABASE movr;
+~~~
+
+~~~
+  database_name | super_region_name |       regions
+----------------+-------------------+----------------------
+  movr          | usa               | {us-east1,us-west1}
+(1 row)
+~~~
+
+{{site.data.alerts.callout_info}}
+The preceding example shows the super region that was added in [`ADD SUPER REGION`](add-super-region.html#add-a-super-region-to-a-database).
+{{site.data.alerts.end}}
+
+## See also
+
+- [Multi-Region Capabilities Overview](multiregion-overview.html)
+- [Super regions](multiregion-overview.html#super-regions)
+- [`ADD SUPER REGION`](add-super-region.html)
+- [`DROP SUPER REGION`](drop-super-region.html)
+- [`ALTER SUPER REGION`](alter-super-region.html)
+- [SQL Statements](sql-statements.html)

--- a/v22.1/sql-statements.md
+++ b/v22.1/sql-statements.md
@@ -36,6 +36,7 @@ Statement | Usage
 ----------|------------
 [`ADD COLUMN`](add-column.html) | Add columns to a table.
 [`ADD REGION`](add-region.html) |  Add a [region](multiregion-overview.html#database-regions) to a database. Note that [multi-region features](multiregion-overview.html) require an [Enterprise license](enterprise-licensing.html).
+[`ADD SUPER REGION`](add-super-region.html) | <span class="version-tag">New in v22.1:</span> Add a super region made up of a set of regions added with [`ADD REGION`](add-region.html) such that data from [regional tables](regional-tables.html) will be stored in only those regions.
 [`ADD CONSTRAINT`](add-constraint.html) | Add a constraint to a column.
 [`ALTER COLUMN`](alter-column.html) | Change a column's [Default constraint](default-value.html), [`NOT NULL` constraint](not-null.html), or [data type](data-types.html).
 [`ALTER DATABASE`](alter-database.html) | Apply a schema change to a database.
@@ -46,6 +47,7 @@ Statement | Usage
 [`ALTER RANGE`](alter-range.html) | Configure the replication zone for a system range.
 [`ALTER SCHEMA`](alter-schema.html) |  Alter a user-defined schema.
 [`ALTER SEQUENCE`](alter-sequence.html) | Apply a schema change to a sequence.
+[`ALTER SUPER REGION`](alter-super-region.html) | <span class="version-tag">New in v22.1:</span> Alter an existing [super region](multiregion-overview.html#super-regions) to include a different set of regions. A super region is made up of a set of regions added with [`ADD REGION`](add-region.html) such that data from [regional tables](regional-tables.html) will be stored in only those regions.
 [`ALTER TABLE`](alter-table.html) | Apply a schema change to a table.
 [`ALTER TYPE`](alter-type.html) |  Modify a user-defined, [enumerated data type](enum.html).
 [`ALTER USER`](alter-user.html) | add, change, or remove a user's password and to change the login privileges for a role.
@@ -66,6 +68,7 @@ Statement | Usage
 [`DROP DATABASE`](drop-database.html) | Remove a database and all its objects.
 [`DROP INDEX`](drop-index.html) | Remove an index for a table.
 [`DROP REGION`](drop-region.html) |  Drop a [region](multiregion-overview.html#database-regions) from a database. Note that [multi-region features](multiregion-overview.html) require an [Enterprise license](enterprise-licensing.html).
+[`DROP SUPER REGION`](drop-super-region.html) | <span class="version-tag">New in v22.1:</span> Drop a super region made up of a set of [database regions](multiregion-overview.html#super-regions).
 [`DROP SCHEMA`](drop-schema.html) |  Drop a user-defined schema.
 [`DROP SEQUENCE`](drop-sequence.html) | Remove a sequence.
 [`DROP TABLE`](drop-table.html) | Remove a table.
@@ -91,6 +94,7 @@ Statement | Usage
 [`SHOW LOCALITY`](show-locality.html) | View the locality of the current node.
 [`SHOW PARTITIONS`](show-partitions.html) | List partitions in a database. Note that [partitioning](partitioning.html) requires an [Enterprise license](enterprise-licensing.html).
 [`SHOW REGIONS`](show-regions.html) |  List the [cluster regions](multiregion-overview.html#cluster-regions) or [database regions](multiregion-overview.html#database-regions) in a [multi-region cluster](multiregion-overview.html).
+[`SHOW SUPER REGIONS`](show-super-regions.html) | <span class="version-tag">New in v22.1:</span> List the [super regions](multiregion-overview.html#super-regions) associated with a database in a [multi-region cluster](multiregion-overview.html).
 [`SHOW SCHEMAS`](show-schemas.html) | List the schemas in a database.
 [`SHOW SEQUENCES`](show-sequences.html) | List the sequences in a database.
 [`SHOW TABLES`](show-tables.html) | List tables or views in a database or virtual schema.


### PR DESCRIPTION
Fixes DOC-2581
Fixes DOC-2899
Fixes DOC-3099
Fixes DOC-3110

Summary of changes:

- Add section on super regions to 'Multiregion Overview' page

- Add SQL reference pages with examples:

  - 'ADD SUPER REGION'

  - 'DROP SUPER REGION'

  - 'ALTER SUPER REGION'

  - 'SHOW SUPER REGIONS'

- Add links to the above statements as needed from the 'ALTER DATABASE'
  and 'SQL Statements' pages