### PR TITLE
Removed instances of http storage in local file bulk doc

### DIFF
--- a/v21.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.1/use-a-local-file-server-for-bulk-operations.md
@@ -4,7 +4,7 @@ summary: Learn how to create a simple file server for use with bulk operations w
 toc: true
 ---
 
-If you need a location to store files for the [`IMPORT`](import.html) process or [CockroachDB backups](backup.html), but do not have access to (or cannot use) [cloud storage providers](use-cloud-storage-for-bulk-operations.html), you can run a local file server. You can then use this file server by leveraging support for our [HTTP Export Storage API](#http-export-storage-api).
+If you need a location to store files for the [`IMPORT`](import.html) process, but do not have access to (or cannot use) [cloud storage providers](use-cloud-storage-for-bulk-operations.html), you can run a local file server. You can then use this file server by leveraging support for our [HTTP Export Storage API](#http-export-storage-api).
 
 This is especially useful for:
 
@@ -13,7 +13,7 @@ This is especially useful for:
 
 ## HTTP export storage API
 
-CockroachDB tasks that require reading or writing external files (such as [`IMPORT`](import.html) and [`BACKUP`](backup.html)) can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
+CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
 
 This API uses the `GET`, `PUT` and `DELETE` methods. This behaves like you would expect typical HTTP requests to work. After a `PUT` request to some path, a subsequent `GET` request should return the content sent in the `PUT` request body, at least until a `DELETE` request is received for that path.
 
@@ -93,8 +93,7 @@ $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/d
 ## See also
 
 - [`IMPORT`][import]
-- [`BACKUP`](backup.html) (*Enterprise only*)
-- [`RESTORE`](restore.html) (*Enterprise only*)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
 
 <!-- Reference Links -->
 

--- a/v21.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.1/use-a-local-file-server-for-bulk-operations.md
@@ -11,6 +11,10 @@ This is especially useful for:
 - Implementing a compatibility layer in front of custom or proprietary storage providers for which CockroachDB does not yet have built-in support
 - Using on-premises storage
 
+{{site.data.alerts.callout_info}}
+HTTP file servers are not supported as storage for [backups](take-full-and-incremental-backups.html).
+{{site.data.alerts.end}}
+
 ## HTTP export storage API
 
 CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.

--- a/v21.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.1/use-a-local-file-server-for-bulk-operations.md
@@ -17,7 +17,7 @@ HTTP file servers are not supported as storage for [backups](take-full-and-incre
 
 ## HTTP export storage API
 
-CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
+A CockroachDB [`IMPORT`](import.html) process that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
 
 This API uses the `GET`, `PUT` and `DELETE` methods. This behaves like you would expect typical HTTP requests to work. After a `PUT` request to some path, a subsequent `GET` request should return the content sent in the `PUT` request body, at least until a `DELETE` request is received for that path.
 

--- a/v21.2/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.2/use-a-local-file-server-for-bulk-operations.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: manage
 ---
 
-If you need a location to store files for the [`IMPORT`](import.html) process or [CockroachDB backups](backup.html), but do not have access to (or cannot use) [cloud storage providers](use-cloud-storage-for-bulk-operations.html), you can run a local file server. You can then use this file server by leveraging support for our [HTTP Export Storage API](#http-export-storage-api).
+If you need a location to store files for the [`IMPORT`](import.html) process, but do not have access to (or cannot use) [cloud storage providers](use-cloud-storage-for-bulk-operations.html), you can run a local file server. You can then use this file server by leveraging support for our [HTTP Export Storage API](#http-export-storage-api).
 
 This is especially useful for:
 
@@ -14,7 +14,7 @@ This is especially useful for:
 
 ## HTTP export storage API
 
-CockroachDB tasks that require reading or writing external files (such as [`IMPORT`](import.html) and [`BACKUP`](backup.html)) can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
+CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
 
 This API uses the `GET`, `PUT` and `DELETE` methods. This behaves like you would expect typical HTTP requests to work. After a `PUT` request to some path, a subsequent `GET` request should return the content sent in the `PUT` request body, at least until a `DELETE` request is received for that path.
 
@@ -94,8 +94,7 @@ $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/d
 ## See also
 
 - [`IMPORT`][import]
-- [`BACKUP`](backup.html) (*Enterprise only*)
-- [`RESTORE`](restore.html) (*Enterprise only*)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.2/use-a-local-file-server-for-bulk-operations.md
@@ -12,6 +12,10 @@ This is especially useful for:
 - Implementing a compatibility layer in front of custom or proprietary storage providers for which CockroachDB does not yet have built-in support
 - Using on-premises storage
 
+{{site.data.alerts.callout_info}}
+HTTP file servers are not supported as storage for [backups](take-full-and-incremental-backups.html).
+{{site.data.alerts.end}}
+
 ## HTTP export storage API
 
 CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.

--- a/v21.2/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.2/use-a-local-file-server-for-bulk-operations.md
@@ -18,7 +18,7 @@ HTTP file servers are not supported as storage for [backups](take-full-and-incre
 
 ## HTTP export storage API
 
-CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
+A CockroachDB [`IMPORT`](import.html) process that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
 
 This API uses the `GET`, `PUT` and `DELETE` methods. This behaves like you would expect typical HTTP requests to work. After a `PUT` request to some path, a subsequent `GET` request should return the content sent in the `PUT` request body, at least until a `DELETE` request is received for that path.
 

--- a/v22.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v22.1/use-a-local-file-server-for-bulk-operations.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: manage
 ---
 
-If you need a location to store files for the [`IMPORT`](import.html) process or [CockroachDB backups](backup.html), but do not have access to (or cannot use) [cloud storage providers](use-cloud-storage-for-bulk-operations.html), you can run a local file server. You can then use this file server by leveraging support for our [HTTP Export Storage API](#http-export-storage-api).
+If you need a location to store files for the [`IMPORT`](import.html) process, but do not have access to (or cannot use) [cloud storage providers](use-cloud-storage-for-bulk-operations.html), you can run a local file server. You can then use this file server by leveraging support for our [HTTP Export Storage API](#http-export-storage-api).
 
 This is especially useful for:
 
@@ -14,7 +14,7 @@ This is especially useful for:
 
 ## HTTP export storage API
 
-CockroachDB tasks that require reading or writing external files (such as [`IMPORT`](import.html) and [`BACKUP`](backup.html)) can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
+CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
 
 This API uses the `GET`, `PUT` and `DELETE` methods. This behaves like you would expect typical HTTP requests to work. After a `PUT` request to some path, a subsequent `GET` request should return the content sent in the `PUT` request body, at least until a `DELETE` request is received for that path.
 
@@ -94,8 +94,7 @@ $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/d
 ## See also
 
 - [`IMPORT`][import]
-- [`BACKUP`](backup.html) (*Enterprise only*)
-- [`RESTORE`](restore.html) (*Enterprise only*)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
 
 <!-- Reference Links -->
 

--- a/v22.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v22.1/use-a-local-file-server-for-bulk-operations.md
@@ -12,6 +12,10 @@ This is especially useful for:
 - Implementing a compatibility layer in front of custom or proprietary storage providers for which CockroachDB does not yet have built-in support
 - Using on-premises storage
 
+{{site.data.alerts.callout_info}}
+HTTP file servers are not supported as storage for [backups](take-full-and-incremental-backups.html).
+{{site.data.alerts.end}}
+
 ## HTTP export storage API
 
 CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.

--- a/v22.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v22.1/use-a-local-file-server-for-bulk-operations.md
@@ -18,7 +18,7 @@ HTTP file servers are not supported as storage for [backups](take-full-and-incre
 
 ## HTTP export storage API
 
-CockroachDB [`IMPORT`](import.html) that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
+A CockroachDB [`IMPORT`](import.html) process that requires reading or writing external files can use the HTTP Export Storage API by prefacing the address with `http`, e.g., `http://fileserver/mnt/cockroach-exports`.
 
 This API uses the `GET`, `PUT` and `DELETE` methods. This behaves like you would expect typical HTTP requests to work. After a `PUT` request to some path, a subsequent `GET` request should return the content sent in the `PUT` request body, at least until a `DELETE` request is received for that path.
 


### PR DESCRIPTION
Follow-up to #13403 that I missed! Local File Server page also has instances mentioning backup with `http` storage. Updated through to v21.1 per typical docs updated policy.