### PR TITLE
DOC-2514 ZONECONFIG for SHOW RANGES

### DIFF
--- a/v22.1/show-ranges.md
+++ b/v22.1/show-ranges.md
@@ -19,7 +19,7 @@ To show range information for a specific row in a table or index, use the [`SHOW
 
 ## Required privileges
 
-Only members of the [`admin` role](security-reference/authorization.html#admin-role) can run `SHOW RANGES`. By default, the `root` user belongs to the `admin` role.
+To use the `SHOW RANGES` statement, a user must either be a member of the [`admin`](security-reference/authorization.html#admin-role) role (the `root` user belongs to the `admin` role by default) or have the `ZONECONFIG` [privilege](security-reference/authorization.html#managing-privileges) defined.
 
 ## Parameters
 


### PR DESCRIPTION
Addresses: DOC-2514
CRDB Commit: [#75551](https://github.com/cockroachdb/cockroach/pull/75551)

- Updated *Required privileges* section on `SHOW RANGES` reference page to include mention of `ZONECONFIG` priv.

Staging: [show-ranges](https://deploy-preview-13656--cockroachdb-docs.netlify.app/docs/v22.1/show-ranges#required-privileges)