### PR TITLE
Quick fix to diagram URL

### DIFF
--- a/v21.2/set-vars.md
+++ b/v21.2/set-vars.md
@@ -30,7 +30,7 @@ The `SET` statement can set a session variable for the duration of the current s
 ### SET SESSION
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-21.2/grammar_svg/set_var.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/set_session.html %}
 </div>
 
 {{site.data.alerts.callout_info}}

--- a/v22.1/set-vars.md
+++ b/v22.1/set-vars.md
@@ -30,7 +30,7 @@ The `SET` statement can set a session variable for the duration of the current s
 ### SET SESSION
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/set_var.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/set_session.html %}
 </div>
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
The sql diagram on the 22.1 session vars page is not showing for the `SET SESSION` sql: https://www.cockroachlabs.com/docs/dev/set-vars.html#set-session 

Corrected the URL.