### PR TITLE
Added docs on write-only backups

### DIFF
--- a/v22.1/backup.md
+++ b/v22.1/backup.md
@@ -42,11 +42,8 @@ To view the contents of an Enterprise backup created with the `BACKUP` statement
 
 - [Full cluster backups](take-full-and-incremental-backups.html#full-backups) can only be run by members of the [`admin` role](security-reference/authorization.html#admin-role). By default, the `root` user belongs to the `admin` role.
 - For all other backups, the user must have [read access](security-reference/authorization.html#managing-privileges) on all objects being backed up. Database backups require `CONNECT` privileges, and table backups require `SELECT` privileges. Backups of user-defined schemas, or backups containing user-defined types, require `USAGE` privileges.
-- **New in v22.1:** `BACKUP` requires full read and write permissions to its target destination. `BACKUP` does **not** require delete or overwrite permissions to its target destination.
-
-{{site.data.alerts.callout_success}}
-As of v22.1, it is possible to write backups to a cloud storage bucket that you have configured with [object locking](use-cloud-storage-for-bulk-operations.html#object-locking).
-{{site.data.alerts.end}}
+- `BACKUP` requires full read and write permissions to its target destination.
+- **New in v22.1:** `BACKUP` does **not** require delete or overwrite permissions to its target destination. This allows `BACKUP` to write to cloud storage buckets that have [object locking](use-cloud-storage-for-bulk-operations.html#object-locking) configured.
 
 ### Destination privileges
 

--- a/v22.1/backup.md
+++ b/v22.1/backup.md
@@ -42,7 +42,11 @@ To view the contents of an Enterprise backup created with the `BACKUP` statement
 
 - [Full cluster backups](take-full-and-incremental-backups.html#full-backups) can only be run by members of the [`admin` role](security-reference/authorization.html#admin-role). By default, the `root` user belongs to the `admin` role.
 - For all other backups, the user must have [read access](security-reference/authorization.html#managing-privileges) on all objects being backed up. Database backups require `CONNECT` privileges, and table backups require `SELECT` privileges. Backups of user-defined schemas, or backups containing user-defined types, require `USAGE` privileges.
-- `BACKUP` requires full read and write (including delete and overwrite) permissions to its target destination.
+- **New in v22.1:** `BACKUP` requires full read and write permissions to its target destination. `BACKUP` does **not** require delete or overwrite permissions to its target destination.
+
+{{site.data.alerts.callout_success}}
+As of v22.1, it is possible to write backups to a cloud storage bucket that you have configured with [object locking](use-cloud-storage-for-bulk-operations.html#object-locking).
+{{site.data.alerts.end}}
 
 ### Destination privileges
 

--- a/v22.1/use-cloud-storage-for-bulk-operations.md
+++ b/v22.1/use-cloud-storage-for-bulk-operations.md
@@ -225,6 +225,18 @@ A custom root CA can be appended to the system's default CAs by setting the `clo
 
 </section>
 
+## Additional cloud storage feature support
+
+### Object locking
+
+<span class="version-tag">New in v22.1:</span> To complete a backup successfully, `BACKUP` requires [read and write permissions](backup.html#required-privileges) to cloud storage buckets. Delete and overwrite permissions are **not** required. As a result, you can write backups to cloud storage buckets with object locking enabled. This allows you to store backup data using a _write-once-read-many (WORM)_ model, which refers to storage that prevents any kind of deletion or modification to the objects once written.
+
+For specific cloud-storage provider documentation, see the following:
+
+- [AWS S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html)
+- [Retention policies and Bucket Lock in Google Cloud Storage](https://cloud.google.com/storage/docs/bucket-lock)
+- [Immutable storage in Azure Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/immutable-storage-overview)
+
 ## See also
 
 - [`BACKUP`](backup.html)

--- a/v22.1/use-cloud-storage-for-bulk-operations.md
+++ b/v22.1/use-cloud-storage-for-bulk-operations.md
@@ -229,7 +229,7 @@ A custom root CA can be appended to the system's default CAs by setting the `clo
 
 ### Object locking
 
-<span class="version-tag">New in v22.1:</span> To complete a backup successfully, `BACKUP` requires [read and write permissions](backup.html#required-privileges) to cloud storage buckets. Delete and overwrite permissions are **not** required. As a result, you can write backups to cloud storage buckets with object locking enabled. This allows you to store backup data using a _write-once-read-many (WORM)_ model, which refers to storage that prevents any kind of deletion or modification to the objects once written.
+<span class="version-tag">New in v22.1:</span> Delete and overwrite permissions are **not** required. To complete a backup successfully, `BACKUP` requires [read and write permissions](backup.html#required-privileges) to cloud storage buckets. As a result, you can write backups to cloud storage buckets with object locking enabled. This allows you to store backup data using a _write-once-read-many (WORM)_ model, which refers to storage that prevents any kind of deletion or modification to the objects once written.
 
 For specific cloud-storage provider documentation, see the following:
 


### PR DESCRIPTION
Fixes [DOC-3197](https://cockroachlabs.atlassian.net/browse/DOC-3197) [DOC-2761](https://cockroachlabs.atlassian.net/browse/DOC-2761) [DOC-3096](https://cockroachlabs.atlassian.net/browse/DOC-3096) 

This adjusts the privileges listed on the backup page for the updated write-only backups that are the standard behavior with v22.1. 

PR also adds additional section to the Cloud Storage page, so that we can describe upcoming features that we're supporting for cloud storage. Before the 22.1 GA release, intelligent tiering can also be added to this section.

Note: per previous conversations in past PRs, this PR doesn't include how the write-only backups are implemented. This is to avoid going into detail on the file structure of the backup, which changes frequently. Can adjust this as we feel necessary, could also be something that we describe in conceptual docs for 22.1 (https://cockroachlabs.atlassian.net/browse/DOC-1604 that was put on hold due to backup planning shifting)