### PR TITLE
DOC-2123 add alerting rules endpoint, events

### DIFF
--- a/v21.2/monitoring-and-alerting.md
+++ b/v21.2/monitoring-and-alerting.md
@@ -140,7 +140,9 @@ replicas_quiescent{store="1"} 20
 ...
 ~~~
 
-{{site.data.alerts.callout_info}}In addition to using the exported time series data to monitor a cluster via an external system, you can write alerting rules against them to make sure you are promptly notified of critical events or issues that may require intervention or investigation. See [Events to Alert On](#events-to-alert-on) for more details.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+In addition to using the exported time-series data to monitor a cluster via an external system, you can write alerting rules against them to make sure you are promptly notified of critical events or issues that may require intervention or investigation. See [Events to Alert On](#events-to-alert-on) for more details.
+{{site.data.alerts.end}}
 
 ## Events to alert on
 

--- a/v22.1/common-issues-to-monitor.md
+++ b/v22.1/common-issues-to-monitor.md
@@ -110,7 +110,7 @@ If [issues at the storage layer](#lsm-health) remain unresolved, affected nodes 
 
 - The `/health` endpoint of the [Cluster API](cluster-api.html) returns a `500` error when a node is unhealthy.
 
-- A [Prometheus alert](monitoring-and-alerting.html#node-is-down) can notify when a node has been down for 5 minutes or more.
+- A [Prometheus alert](monitoring-and-alerting.html#node-is-down) can notify when a node has been down for 15 minutes or more.
 
 If nodes have shut down, this can also be caused by [insufficient storage capacity](#storage-capacity).
 
@@ -148,7 +148,7 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 - The `OPS` [logging channel](logging-overview.html#logging-channels) will record a [`node_restart` event](eventlog.html#node_restart) whenever a node rejoins the cluster after being offline.
 
-- A [Prometheus alert](monitoring-and-alerting.html#node-is-restarting-too-frequently) can notify when a node has restarted more than 5 times in 10 minutes.
+- A [Prometheus alert](monitoring-and-alerting.html#node-is-restarting-too-frequently) can notify when a node has restarted more than once in the last 10 minutes.
 
 ##### Verify OOM errors
 

--- a/v22.1/monitor-cockroachdb-with-prometheus.md
+++ b/v22.1/monitor-cockroachdb-with-prometheus.md
@@ -17,7 +17,7 @@ CockroachDB generates detailed time series metrics for each node in a cluster. T
 
 1. Download the [2.x Prometheus tarball](https://prometheus.io/download/) for your OS.
 
-2. Extract the binary and add it to your `PATH`. This makes it easy to start Prometheus from any shell.
+2. Extract the binary and add it to your system `PATH`. This makes it easy to start Prometheus from any shell.
 
 3. Make sure Prometheus installed successfully:
 
@@ -27,10 +27,10 @@ CockroachDB generates detailed time series metrics for each node in a cluster. T
     ~~~
 
     ~~~
-    prometheus, version 2.2.1 (branch: HEAD, revision: bc6058c81272a8d938c05e75607371284236aadc)
-      build user:       root@149e5b3f0829
-      build date:       20180314-14:21:40
-      go version:       go1.10
+    prometheus, version 2.34.0 (branch: HEAD, revision: 881111fec4332c33094a6fb2680c71fffc427275)
+      build user:       root@d80b449ae319
+      build date:       20220315-15:04:36
+      go version:       go1.17.8
     ~~~
 
 ## Step 2. Configure Prometheus
@@ -89,13 +89,14 @@ CockroachDB generates detailed time series metrics for each node in a cluster. T
     ~~~
 
     ~~~
-    INFO[0000] Starting prometheus (version=1.4.1, branch=master, revision=2a89e8733f240d3cd57a6520b52c36ac4744ce12)  source=main.go:77
-    INFO[0000] Build context (go=go1.7.3, user=root@e685d23d8809, date=20161128-10:02:41)  source=main.go:78
-    INFO[0000] Loading configuration file prometheus.yml     source=main.go:250
-    INFO[0000] Loading series map and head chunks...         source=storage.go:354
-    INFO[0000] 0 series loaded.                              source=storage.go:359
-    INFO[0000] Listening on :9090                            source=web.go:248
-    INFO[0000] Starting target manager...                    source=targetmanager.go:63
+    ts=2022-04-20T18:57:45.857Z caller=main.go:516 level=info msg="Starting Prometheus" version="(version=2.34.0, branch=HEAD, revision=881111fec4332c33094a6fb2680c71fffc427275)"
+    ts=2022-04-20T18:57:45.857Z caller=main.go:521 level=info build_context="(go=go1.17.8, user=root@d80b449ae319, date=20220315-15:04:36)"
+    ...
+    ts=2022-04-20T18:57:45.859Z caller=web.go:540 level=info component=web msg="Start listening for connections" address=localhost:9090
+    ...
+    ts=2022-04-20T18:57:46.811Z caller=main.go:1142 level=info msg="Loading configuration file" filename=prometheus.yml
+    ts=2022-04-20T18:57:46.973Z caller=main.go:1179 level=info msg="Completed loading of configuration file" filename=prometheus.yml totalDuration=162.470967ms db_storage=1.057µs remote_storage=5.151µs web_handler=457ns query_engine=889ns scrape=150.34215ms scrape_sd=74.253µs notify=94.531µs notify_sd=26.921µs rules=11.488407ms tracing=19.58µs
+    ts=2022-04-20T18:57:46.973Z caller=main.go:910 level=info msg="Server is ready to receive web requests."
     ~~~
 
 2. Point your browser to `http://<hostname of machine running prometheus>:9090`, where you can use the Prometheus UI to query, aggregate, and graph CockroachDB time series metrics.
@@ -108,7 +109,7 @@ Active monitoring helps you spot problems early, but it is also essential to sen
 
 1. Download the [latest Alertmanager tarball](https://prometheus.io/download/#alertmanager) for your OS.
 
-2. Extract the binary and add it to your `PATH`. This makes it easy to start Alertmanager from any shell.
+2. Extract the binary and add it to your system `PATH`. This makes it easy to start Alertmanager from any shell.
 
 3. Make sure Alertmanager installed successfully:
 
@@ -118,19 +119,19 @@ Active monitoring helps you spot problems early, but it is also essential to sen
     ~~~
 
     ~~~
-    alertmanager, version 0.15.0-rc.1 (branch: HEAD, revision: acb111e812530bec1ac6d908bc14725793e07cf3)
-      build user:       root@f278953f13ef
-      build date:       20180323-13:07:06
-      go version:       go1.10
+    alertmanager, version 0.24.0 (branch: HEAD, revision: f484b17fa3c583ed1b2c8bbcec20ba1db2aa5f11)
+      build user:       root@8fd670bfea94
+      build date:       20220325-09:24:35
+      go version:       go1.17.8
     ~~~
 
-4. [Edit the Alertmanager configuration file](https://prometheus.io/docs/alerting/configuration/) that came with the binary, `simple.yml`, to specify the desired receivers for notifications.
+4. [Edit the Alertmanager configuration file](https://prometheus.io/docs/alerting/configuration/) that came with the binary, `alertmanager.yml`, to specify the desired receivers for notifications.
 
 5. Start the Alertmanager server, with the `--config.file` flag pointing to the configuration file:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ alertmanager --config.file=simple.yml
+    $ alertmanager --config.file=alertmanager.yml
     ~~~
 
 6. Point your browser to `http://<hostname of machine running alertmanager>:9093`, where you can use the Alertmanager UI to define rules for [silencing alerts](https://prometheus.io/docs/alerting/alertmanager/#silences).

--- a/v22.1/monitoring-and-alerting.md
+++ b/v22.1/monitoring-and-alerting.md
@@ -45,7 +45,7 @@ These endpoints are also available through the [Cluster API](cluster-api.html) u
 
 If a node is down, the `http://<host>:<http-port>/health` endpoint returns a `Connection refused` error:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ shell
 $ curl http://localhost:8080/health
 ~~~
@@ -76,7 +76,7 @@ The `http://<node-host>:<http-port>/health?ready=1` endpoint returns an HTTP `50
 
 - The node is unable to communicate with a majority of the other nodes in the cluster, likely because the cluster is unavailable due to too many nodes being down.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ shell
 $ curl http://localhost:8080/health?ready=1
 ~~~
@@ -119,7 +119,7 @@ The [`cockroach node status`](cockroach-node.html) command gives you metrics abo
 
 Every node of a CockroachDB cluster exports granular time series metrics at `http://<host>:<http-port>/_status/vars`. The metrics are formatted for easy integration with [Prometheus](monitor-cockroachdb-with-prometheus.html), an open source tool for storing, aggregating, and querying time series data, but the format is **easy-to-parse** and can be processed to work with other third-party monitoring systems (e.g., [Sysdig](https://sysdig.atlassian.net/wiki/plugins/servlet/mobile?contentId=64946336#content/view/64946336) and [Stackdriver](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd)).
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ shell
 $ curl http://localhost:8080/_status/vars
 ~~~
@@ -140,55 +140,190 @@ replicas_quiescent{store="1"} 20
 ...
 ~~~
 
-{{site.data.alerts.callout_info}}In addition to using the exported time series data to monitor a cluster via an external system, you can write alerting rules against them to make sure you are promptly notified of critical events or issues that may require intervention or investigation. See [Events to Alert On](#events-to-alert-on) for more details.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+In addition to using the exported time-series data to monitor a cluster via an external system, you can write alerting rules against them to make sure you are promptly notified of critical events or issues that may require intervention or investigation. See [Events to alert on](#events-to-alert-on) for more details.
+{{site.data.alerts.end}}
 
-## Events to alert on
+## Alerting tools
 
-Active monitoring helps you spot problems early, but it is also essential to create alerting rules that promptly send notifications when there are events that require investigation or intervention. This section identifies the most important events to create alerting rules for, with the [Prometheus endpoint](#prometheus-endpoint) metrics to use for detecting the events.
+In addition to actively monitoring the overall health and performance of a cluster, it is also essential to configure alerting rules that promptly send notifications when CockroachDB experiences events that require investigation or intervention.
 
-{{site.data.alerts.callout_success}}If you use Prometheus for monitoring, you can also use our pre-defined <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">alerting rules</a> with Alertmanager. See <a href="monitor-cockroachdb-with-prometheus.html">Monitor CockroachDB with Prometheus</a> for guidance.{{site.data.alerts.end}}
+This section identifies the most important events that you might want to create alerting rules for, and provides pre-defined rules definitions for these events appropriate for use with Prometheus' Alertmanager.
 
-### Node is down
+### Alertmanager
 
-- **Rule:** Send an alert when a node has been down for 5 minutes or more.
+If you have configured [Prometheus](monitor-cockroachdb-with-prometheus.html) to monitor your CockroachDB instance, you can also configure alerting rule definitions to have Prometheus' Alertmanager detect [important events](#events-to-alert-on) and alert you when they occur.
+
+#### Prometheus alerting rules endpoint
+
+<span class="version-tag">New in v22.1:</span> Every CockroachDB node exports an alerting rules template at `http://<host>:<http-port>/api/v2/rules/`. These rule definitions are formatted for easy integration with Prometheus' Alertmanager.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ curl http://localhost:8080/api/v2/rules/
+~~~
+
+~~~
+rules/alerts:
+    rules:
+        - alert: UnavailableRanges
+          expr: (sum by(instance, cluster) (ranges_unavailable)) > 0
+          for: 10m0s
+          annotations:
+            {% raw %}summary: Instance {{ $labels.instance }} has {{ $value }} unavailable ranges{% endraw %}
+        - alert: TrippedReplicaCircuitBreakers
+          expr: (sum by(instance, cluster) (kv_replica_circuit_breaker_num_tripped_replicas)) > 0
+          for: 10m0s
+          annotations:
+            {% raw %}summary: Instance {{ $labels.instance }} has {{ $value }} tripped per-Replica circuit breakers{% endraw %}
+...
+~~~
+
+#### Working with Alertmanager rules
+
+To add a rule from the `api/v2/rules/` rules endpoint, create or edit your `alerts.rules.yml` file and copy the rule definition for the event you want to alert on. For example, to add a rule to alert you when unavailable ranges are detected, copy the following from the rules endpoint into your `alerts.rules.yml` file:
+
+{% include_cached copy-clipboard.html %}
+~~~
+- alert: UnavailableRanges
+  expr: (sum by(instance, cluster) (ranges_unavailable)) > 0
+  for: 10m0s
+  annotations:
+    {% raw %}summary: Instance {{ $labels.instance }} has {{ $value }} unavailable ranges{% endraw %}
+~~~
+
+If you already followed the steps from [Monitor CockroachDB with Prometheus](monitor-cockroachdb-with-prometheus.html), you should already have a `alerts.rules.yml` file. If you are creating a new `alerts.rules.yml` file, be sure that it begins with the following three lines:
+
+{% include_cached copy-clipboard.html %}
+~~~
+groups:
+- name: rules/alerts.rules
+  rules:
+~~~
+
+Place your desired rule(s) underneath the `rules:` header. For example, the following shows an `alerts.rules.yml` file with the unavailable ranges rule defined:
+
+{% include_cached copy-clipboard.html %}
+~~~
+groups:
+- name: rules/alerts.rules
+  rules:
+  - alert: UnavailableRanges
+    expr: (sum by(instance, cluster) (ranges_unavailable)) > 0
+    for: 10m0s
+    annotations:
+      {% raw %}summary: Instance {{ $labels.instance }} has {{ $value }} unavailable ranges{% endraw %}
+~~~
+
+Once you have created or edited your `alerts.rules.yml` file, reference it in your `prometheus.yml` configuration file with the following:
+
+{% include_cached copy-clipboard.html %}
+~~~
+rule_files:
+- "rules/alerts.rules.yml"
+~~~
+
+If you already followed the steps from [Monitor CockroachDB with Prometheus](monitor-cockroachdb-with-prometheus.html), this reference is already present in your `prometheus.yml` file.
+
+Start Prometheus and Alertmanager to begin watching for events to alert on. You can view imported rules on your Prometheus server's web interface at `http://<host>:<http-port>/rules`. Use the "State" column to verify that the rules were imported correctly.
+
+### Events to alert on
+
+{{site.data.alerts.callout_info}}
+Currently, not all events listed have corresponding alert rule definitions available from the `api/v2/rules/` endpoint. Many events not yet available in this manner are defined in the <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">pre-defined alerting rules</a>. For more details, see [Monitor CockroachDB with Prometheus](monitor-cockroachdb-with-prometheus.html).
+{{site.data.alerts.end}}
+
+#### Node is down
+
+- **Rule:** Send an alert when a node has been down for 15 minutes or more.
 
 - **How to detect:** If a node is down, its `_status/vars` endpoint will return a `Connection refused` error. Otherwise, the `liveness_livenodes` metric will be the total number of live nodes in the cluster.
 
-### Node is restarting too frequently
+- **Rule definition:** Use the `InstanceDead` alert from our <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">pre-defined alerting rules</a>.
 
-- **Rule:** Send an alert if a node has restarted more than 5 times in 10 minutes.
+#### Node is restarting too frequently
+
+- **Rule:** Send an alert if a node has restarted more than once in the last 10 minutes.
 
 - **How to detect:** Calculate this using the number of times the `sys_uptime` metric in the node's `_status/vars` output was reset back to zero. The `sys_uptime` metric gives you the length of time, in seconds, that the `cockroach` process has been running.
 
-### Node is running low on disk space
+- **Rule definition:** Use the `InstanceFlapping` alert from our <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">pre-defined alerting rules</a>.
+
+#### Node is running low on disk space
 
 - **Rule:** Send an alert when a node has less than 15% of free space remaining.
 
 - **How to detect:** Divide the `capacity` metric by the `capacity_available` metric in the node's `_status/vars` output.
 
-### Node is not executing SQL
+- **Rule definition:** Use the `StoreDiskLow` alert from our <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">pre-defined alerting rules</a>.
+
+#### Node is not executing SQL
 
 - **Rule:** Send an alert when a node is not executing SQL despite having connections.
 
 - **How to detect:** The `sql_conns` metric in the node's `_status/vars` output will be greater than `0` while the `sql_query_count` metric will be `0`. You can also break this down by statement type using `sql_select_count`, `sql_insert_count`, `sql_update_count`, and `sql_delete_count`.
 
-### CA certificate expires soon
+#### CA certificate expires soon
 
 - **Rule:** Send an alert when the CA certificate on a node will expire in less than a year.
 
 - **How to detect:** Calculate this using the `security_certificate_expiration_ca` metric in the node's `_status/vars` output.
 
-### Node certificate expires soon
+- **Rule definition:** Use the `CACertificateExpiresSoon` alert from our <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">pre-defined alerting rules</a>.
+
+#### Node certificate expires soon
 
 - **Rule:** Send an alert when a node's certificate will expire in less than a year.
 
 - **How to detect:** Calculate this using the `security_certificate_expiration_node` metric in the node's `_status/vars` output.
 
-### Changefeed is experiencing high latency
+- **Rule definition:** Use the `NodeCertificateExpiresSoon` alert from our <a href="https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml">pre-defined alerting rules</a>.
+
+#### Changefeed is experiencing high latency
 
 - **Rule:** Send an alert when the latency of any changefeed running on any node is higher than the set threshold, which depends on the [`gc.ttlseconds`](configure-replication-zones.html#replication-zone-variables) variable set in the cluster.
 
 - **How to detect:** Calculate this using a threshold, where the threshold is less than the value of the [`gc.ttlseconds`](configure-replication-zones.html#replication-zone-variables) variable. For example, `changefeed.max_behind_nanos > [some threshold]`.
+
+#### Unavailable ranges
+
+- **Rule:** Send an alert when the number of ranges with fewer live replicas than needed for quorum is non-zero for too long.
+
+- **How to detect:** Calculate this using the `ranges_unavailable` metric in the node's `_status/vars` output.
+
+- **Rule definition:** Use the `UnavailableRanges` alerting rule from your cluster's [`api/v2/rules/` metrics endpoint](#alertmanager).
+
+#### Tripped replica circuit breakers
+
+- **Rule:** Send an alert when a replica stops serving traffic due to other replicas being offline for too long.
+
+- **How to detect:** Calculate this using the `kv_replica_circuit_breaker_num_tripped_replicas` metric in the node's `_status/vars` output.
+
+- **Rule definition:** Use the `TrippedReplicaCircuitBreakers` alerting rule from your cluster's [`api/v2/rules/` metrics endpoint](#alertmanager).
+
+#### Under-replicated ranges
+
+- **Rule:** Send an alert when the number of ranges with replication below the [replication factor](configure-replication-zones.html#num_replicas) is non-zero for too long.
+
+- **How to detect:** Calculate this using the `ranges_underreplicated` metric in the node's `_status/vars` output.
+
+- **Rule definition:** Use the `UnderreplicatedRanges` alerting rule from your cluster's [`api/v2/rules/` metrics endpoint](#alertmanager).
+
+#### Requests stuck in Raft
+
+- **Rule:** Send an alert when requests are taking a very long time in replication.
+
+- **How to detect:** Calculate this using the `requests_slow_raft` metric in the node's `_status/vars` output.
+
+- **Rule definition:** Use the `RequestsStuckInRaft` alerting rule from your cluster's [`api/v2/rules/` metrics endpoint](#alertmanager).
+
+#### High open file descriptor count
+
+- **Rule:** Send an alert when a cluster is getting close to the [open file descriptor limit](recommended-production-settings.html#file-descriptors-limit).
+
+- **How to detect:** Calculate this using the `sys_fd_softlimit` metric in the node's `_status/vars` output.
+
+- **Rule definition:** Use the `HighOpenFDCount` alerting rule from your cluster's [`api/v2/rules/` metrics endpoint](#alertmanager).
 
 ## See also
 


### PR DESCRIPTION
Addresses: DOC-2123
CRDB: (couldn't find in Jira)

- Added new `Alerting tools` section to `v22.1/monitoring-and-alerting.md`, showcasing new metrics endpoint, including: 
  - Accessing the new endpoint, configuring Alertmanager, configuring Prometheus
  - Expanded `Events to alert on` to include location of corresponding rules definition, some from old pre-defined `yaml` file, some from this PR.
- Updated code examples to use latest Prometheus | Alertmanager values on `v22.1/monitor-cockroachdb-with-prometheus.md`
- Fixed broken link on `v21.2/monitoring-and-alerting.md`

Please see my comments below in this review -- I had some relevant notes / questions for you. Thank you so much!

[v22.1/monitoring-and-alerting.md](https://deploy-preview-13692--cockroachdb-docs.netlify.app/docs/dev/monitoring-and-alerting.html) | [ v22.1/monitor-cockroachdb-with-prometheus.md](https://deploy-preview-13692--cockroachdb-docs.netlify.app/docs/dev/monitor-cockroachdb-with-prometheus.html) | [v21.2/monitoring-and-alerting.md](https://deploy-preview-13692--cockroachdb-docs.netlify.app/docs/stable/monitoring-and-alerting.html)