### PR TITLE
Added cockroach convert-url to cockroach commands overview page

### DIFF
--- a/v21.2/cockroach-commands.md
+++ b/v21.2/cockroach-commands.md
@@ -29,6 +29,7 @@ Command | Usage
 [`cockroach debug job-trace`](cockroach-debug-job-trace.html) | Generate trace payloads for an executing job from a particular node.
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge multiple log files from different machines into a single stream.
+[`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers) | <span class="version-tag">New in v21.2:</span> Convert a connection URL to a format recognized by a [supported client driver](third-party-database-tools.html#drivers).
 [`cockroach workload`](cockroach-workload.html) | Run a built-in load generator against a cluster.
 [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) |  Upload a file to the `externalIODir` on a node's local file system.
 [`cockroach userfile upload`](cockroach-userfile-upload.html)   |  The cockroach userfile upload command uploads a file to user-scoped file storage.

--- a/v22.1/cockroach-commands.md
+++ b/v22.1/cockroach-commands.md
@@ -28,6 +28,7 @@ Command | Usage
 [`cockroach debug list-files`](cockroach-debug-list-files.html) | Show the files that will be collected by using `cockroach debug zip`.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node.
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
+[`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers) | Convert a connection URL to a format recognized by a [supported client driver](third-party-database-tools.html#drivers).
 [`cockroach gen`](cockroach-gen.html) | Generate man pages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.
 [`cockroach statement-diag`](cockroach-statement-diag.html)  | Manage and download statement diagnostics bundles.
 [`cockroach userfile upload`](cockroach-userfile-upload.html) | Upload a file to user-scoped file storage.


### PR DESCRIPTION
Follow-up on https://github.com/cockroachdb/docs/pull/12260.
Fixes https://cockroachlabs.atlassian.net/browse/DOC-1413.

I don't think the `cockroach convert-url` command merits its own page or an entry in the navbar. I do think users might find it helpful to have it listed in the `cockroach` commands overview page.