### PR TITLE
Add additional troubleshooting entry for certificate signed by unknown authority errors

### DIFF
--- a/cockroachcloud/troubleshooting-page.md
+++ b/cockroachcloud/troubleshooting-page.md
@@ -38,11 +38,11 @@ Error: x509: certificate signed by unknown authority
 Failed running "sql"
 ~~~
 
-There are two possible causes of this error: incorrect cluster names in the connection string, and CA certificate conflicts in the `cockroach` certificate search path.
+There are two possible causes of this error: incorrect [routing ID](../{{site.versions["stable"]}}/connect-to-the-database.html#connection-parameters) in the connection string, and CA certificate conflicts in the `cockroach` certificate search path.
 
-<h4>Solution: incorrect cluster name in the connection string</h4>
+<h4>Solution: incorrect routing ID in the connection string</h4>
 
-Check if you are using the right cluster name in the [connection method](connect-to-your-cluster.html#step-3-connect-to-your-cluster). You can find your cluster name in the {{ site.data.products.db }} Console by navigating to **Cluster Overview** > **Connect** > **Step 2. Connect** and locating the parameter `cluster={cluster-name}` in your connection string.
+Check if you are using the right routing ID in the [connection method](connect-to-your-cluster.html#step-3-connect-to-your-cluster). You can find your routing ID in the {{ site.data.products.db }} Console by navigating to **Cluster Overview** > **Connect** > **Select option/language** and select **General connection string**, and then locating the parameter `cluster={routing-id}` in your connection string.
 
 <h4>Solution: CA certificate conflicts</h4>
 

--- a/cockroachcloud/troubleshooting-page.md
+++ b/cockroachcloud/troubleshooting-page.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshoot CockroachDB Cloud
-summary: The SQL Users page displays a list of SQL users who can access the cluster.
+summary: CockroachDB Cloud errors and solutions.
 toc: true
 docs_area: manage
 ---
@@ -15,7 +15,7 @@ We have updated the CA certificate used by {{ site.data.products.serverless }} c
 
 ### Cannot load certificates
 
-You see the following error when you are using the `cockroach sql` command to connect to your {{ site.data.products.serverless }} cluster:
+You see the following error when you are using the [`cockroach sql`](../{{site.versions["stable"]}}/cockroach-sql.html) command to connect to your {{ site.data.products.serverless }} cluster:
 
 ~~~
 ERROR: cannot load certificates.
@@ -29,18 +29,31 @@ Failed running "sql"
 
 Update to the latest [CockroachDB client](../releases/index.html#production-releases). You need to use v21.2.5 or later of the CockroachDB client to connect to your cluster without specifying the CA certificate path in the connection string.
 
-### Wrong cluster name in the connection string
+### Certificate signed by unknown authority
 
-The following error is displayed on the terminal if you use a wrong cluster name in the connection string while trying to connect to a cluster:
+The following error is displayed when trying to connect to a cluster:
 
 ~~~
 Error: x509: certificate signed by unknown authority
 Failed running "sql"
 ~~~
 
-<h4>Solution</h4>
+There are two possible causes of this error: incorrect cluster names in the connection string, and CA certificate conflicts in the `cockroach` certificate search path.
 
-Check if you are using the right cluster name in the [connection method](connect-to-your-cluster.html#step-3-connect-to-your-cluster). You can find your cluster name in the {{ site.data.products.db }} Console by navigating to **Cluster Overview** > **Connect** > **Step 2. Connect** > **Connection string** and locating the parameter `cluster={cluster-name}` in your connection string.
+<h4>Solution: incorrect cluster name in the connection string</h4>
+
+Check if you are using the right cluster name in the [connection method](connect-to-your-cluster.html#step-3-connect-to-your-cluster). You can find your cluster name in the {{ site.data.products.db }} Console by navigating to **Cluster Overview** > **Connect** > **Step 2. Connect** and locating the parameter `cluster={cluster-name}` in your connection string.
+
+<h4>Solution: CA certificate conflicts</h4>
+
+If you have existing certificates in `~/.cockroach-certs` used to connect to {{ site.data.products.core }} or {{ site.data.products.dedicated }} clusters and are trying to connect to a {{ site.data.products.serverless }} cluster using [`cockroach sql`](../{{site.versions["stable"]}}/cockroach-sql.html), you need download the CA cert by running the command from the **Cluster Overview** > **Connect** dialog if you have not already done so, and then set the `sslrootcert` parameter in the connection string you use when running `cockroach sql`.
+
+For example, on Linux and Mac, set the `sslrootcert` parameter to `$HOME/.postgresql/root.crt` in the connection string:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+cockroach sql --url "postgresql://maxroach@free-tier4.aws-us-west-2.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full&sslrootcert=$HOME/.postgresql/root.crt&options=--cluster%3Ddim-dog-2114"
+~~~
 
 ### Invalid cluster name in a third-party tool
 


### PR DESCRIPTION
Users may encounter errors when connecting to Serverless clusters when they have existing certificates in `~/.cockroach-certs`.

Fixes DOC-3377.