### PR TITLE
DOC-3061 link to sha256sum for supported releases

### DIFF
--- a/releases/index.md
+++ b/releases/index.md
@@ -25,6 +25,8 @@ After downloading your desired release, learn how to [install CockroachDB](../{{
   {% assign old_release_format = "True" %}
 {% endif %} {% comment %} For all releases prior to and including 20.1, we use different logic to generate the page (vXX.Y.Z.html vs vXX.Y.html#vXX-Y-Z). {% endcomment %}
 
+{% assign shareleases = "v21.1,v21.2,v22.1" | split: "," %} {% comment %} For all Production releases 21.1 and later, we provide shasum files as well. {% endcomment %}
+
 ## {{ v.major_version }}
 
 <div id="os-tabs" class="filters filters-big clearfix">
@@ -72,15 +74,30 @@ After downloading your desired release, learn how to [install CockroachDB](../{{
             <td class="os-release-cell">
                 <section class="filter-content" data-scope="linux">
                     <a class="os-release-link" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.linux-amd64.tgz">Precompiled 64-bit Binary</a>
+                    {% if shareleases contains v.major_version %}
+                        {% if s == "Production" %}
+                            <a class="os-release-link" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.linux-amd64.tgz.sha256sum">SHA256</a>
+                        {% endif %}
+                    {% endif %}
                 </section>
                 <section class="filter-content" data-scope="mac">
                     <a class="os-release-link" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.darwin-10.9-amd64.tgz">Precompiled 64-bit Binary</a>
+                    {% if shareleases contains v.major_version %}
+                        {% if s == "Production" %}
+                        <a class="os-release-link" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.darwin-10.9-amd64.tgz.sha256sum">SHA256</a>
+                        {% endif %}
+                    {% endif %}
                 </section>
                 <section class="filter-content" data-scope="windows">
                 {% if r.no_windows == "true" %}
                     N/A
                 {% else %}
                     <a class="os-release-link" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.windows-6.2-amd64.zip">Precompiled 64-bit Binary</a>
+                    {% if shareleases contains v.major_version %}
+                        {% if s == "Production" %}
+                        <a class="os-release-link" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.windows-6.2-amd64.zip.sha256sum">SHA256</a>
+                        {% endif %}
+                    {% endif %}
                 {% endif %}
                 </section>
                 <section class="filter-content" data-scope="docker">


### PR DESCRIPTION
Addresses: DOC-3061
Upstream: RE-190

- Adds links to `sha256sum` files alongside the binary downloads we include them for:
  - `linux` | `macOS` | `windows`
  - `v21.1` or later
  - `Production` only

Re: "`Production` only": Technically, it looks like:
  - we do have a `sha256sum` file for one Testing release: [v22.1 beta4](https://binaries.cockroachdb.com/cockroach-v22.1.0-beta.4.darwin-10.9-amd64.tgz.sha256sum) (as this was generated by the build toolchain, not by hand), but
  - we don't include them for past Testing releases, even for v21.1 and v21.2.
So I've opted not to include Testing releases at all in this PR.

Some considerations:
- I got this working by putting the logic directly in the `<tbody>`. If you know of a smarter way to do this above, I'm all ears!
- IMPORTANT: Current approach then requires editing `shareleases` for each major version. This might be cumbersome, or missed in a, say, prep-v22.2 step. Any ideas at how to make this more future-proof?
- As always, I am no designer. Any better way of laying out the two links (Download SHA256) side by side? Is link title `SHA256` useful enough? Wanted to avoid drawing too much attention away from the download link, which is all ~95% of users care about.