### PR TITLE
add stuck ranges snippet and tweak decommission nodes troubleshooting

### DIFF
--- a/v21.2/cluster-setup-troubleshooting.md
+++ b/v21.2/cluster-setup-troubleshooting.md
@@ -467,15 +467,6 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 **Solution:** Confirm that there are enough nodes with sufficient storage space to take over the replicas from the node you want to remove.
 
-### Decommissioned nodes displayed in UI forever
-
-By design, decommissioned nodes are displayed in the DB Console forever. We retain the list of decommissioned nodes for the following reasons:
-
--   Decommissioning is not entirely free, so showing those decommissioned nodes in the UI reminds you of the baggage your cluster will have to carry around forever.
--   It also explains to future administrations why your node IDs have gaps (e.g., why the nodes are numbered n1, n2, and n8).
-
-You can follow the discussion here: [https://github.com/cockroachdb/cockroach/issues/24636](https://github.com/cockroachdb/cockroach/issues/24636)
-
 ## Replication issues
 
 ### DB Console shows under-replicated/unavailable ranges

--- a/v21.2/node-shutdown.md
+++ b/v21.2/node-shutdown.md
@@ -786,3 +786,4 @@ On the **Cluster Overview** page of the DB Console, the [node status](ui-cluster
 - [`cockroach start`](cockroach-start.html)
 - [Node status](ui-cluster-overview-page.html#node-status)
 - [Replication Layer](architecture/replication-layer.html)
+- [Decommissioning issues](cluster-setup-troubleshooting.html#decommissioning-issues)

--- a/v22.1/cluster-setup-troubleshooting.md
+++ b/v22.1/cluster-setup-troubleshooting.md
@@ -463,6 +463,8 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 ### Decommissioning process hangs indefinitely
 
+If the [decommissioning process](node-shutdown.html?filters=decommission#remove-nodes) appears to be hung on a node, a message like the following will print to `stderr`:
+
 ~~~
 possible decommission stall detected
 n3 still has replica id 2 for range r1

--- a/v22.1/cluster-setup-troubleshooting.md
+++ b/v22.1/cluster-setup-troubleshooting.md
@@ -463,18 +463,18 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 ### Decommissioning process hangs indefinitely
 
-**Explanation:** Before decommissioning a node, you need to make sure other nodes are available to take over the range replicas from the node. If no other nodes are available, the decommission process will hang indefinitely.
+~~~
+possible decommission stall detected
+n3 still has replica id 2 for range r1
+n3 still has replica id 3 for range r2
+n3 still has replica id 2 for range r3
+n3 still has replica id 3 for range r4
+n3 still has replica id 2 for range r5
+~~~
+
+**Explanation:** Before decommissioning a node, you need to make sure other nodes are available to take over the range replicas from the node. If no other nodes are available, the decommission process will hang indefinitely. For more information, see [Node Shutdown](node-shutdown.html?filters=decommission#size-and-replication-factor).
 
 **Solution:** Confirm that there are enough nodes with sufficient storage space to take over the replicas from the node you want to remove.
-
-### Decommissioned nodes displayed in UI forever
-
-By design, decommissioned nodes are displayed in the DB Console forever. We retain the list of decommissioned nodes for the following reasons:
-
--   Decommissioning is not entirely free, so showing those decommissioned nodes in the UI reminds you of the baggage your cluster will have to carry around forever.
--   It also explains to future administrations why your node IDs have gaps (e.g., why the nodes are numbered n1, n2, and n8).
-
-You can follow the discussion here: [https://github.com/cockroachdb/cockroach/issues/24636](https://github.com/cockroachdb/cockroach/issues/24636)
 
 ## Replication issues
 

--- a/v22.1/node-shutdown.md
+++ b/v22.1/node-shutdown.md
@@ -808,3 +808,4 @@ On the **Cluster Overview** page of the DB Console, the [node status](ui-cluster
 - [`cockroach start`](cockroach-start.html)
 - [Node status](ui-cluster-overview-page.html#node-status)
 - [Replication Layer](architecture/replication-layer.html)
+- [Decommissioning issues](cluster-setup-troubleshooting.html#decommissioning-issues)


### PR DESCRIPTION
Fixes DOC-2874.

- Documented an example "stuck ranges" snippet
- Also removed outdated troubleshooting topic on decommissioned nodes being displayed forever in UI.