### PR TITLE
Docs on exclude_data_from_backup parameter

### DIFF
--- a/_includes/v22.1/backups/advanced-examples-list.md
+++ b/_includes/v22.1/backups/advanced-examples-list.md
@@ -8,3 +8,4 @@ For examples of advanced `BACKUP` and `RESTORE` use cases, see:
 - [Remove the foreign key before restore](restore.html#remove-the-foreign-key-before-restore)
 - [Restoring users from `system.users` backup](restore.html#restoring-users-from-system-users-backup)
 - [Show an incremental backup at a different location](show-backup.html#show-a-backup-taken-with-the-incremental-location-option)
+- [Exclude a table's data from backups](#exclude-a-tables-data-from-backups)

--- a/_includes/v22.1/backups/advanced-examples-list.md
+++ b/_includes/v22.1/backups/advanced-examples-list.md
@@ -8,4 +8,4 @@ For examples of advanced `BACKUP` and `RESTORE` use cases, see:
 - [Remove the foreign key before restore](restore.html#remove-the-foreign-key-before-restore)
 - [Restoring users from `system.users` backup](restore.html#restoring-users-from-system-users-backup)
 - [Show an incremental backup at a different location](show-backup.html#show-a-backup-taken-with-the-incremental-location-option)
-- [Exclude a table's data from backups](#exclude-a-tables-data-from-backups)
+- [Exclude a table's data from backups](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups)

--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -697,6 +697,12 @@
                 ]
               },
               {
+                "title": "<code>SET</code> &lt;storage parameter&gt;",
+                "urls": [
+                  "/${VERSION}/set-storage-parameter.html"
+                ]
+              },
+              {
                 "title": "<code>SET CLUSTER SETTING</code>",
                 "urls": [
                   "/${VERSION}/set-cluster-setting.html"

--- a/v22.1/alter-table.md
+++ b/v22.1/alter-table.md
@@ -2,7 +2,7 @@
 title: ALTER TABLE
 summary: Use the ALTER TABLE statement to change the schema of a table.
 toc: true
-docs_area: reference.sql 
+docs_area: reference.sql
 ---
 
 The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table. For information on using `ALTER TABLE`, see the pages for its relevant [subcommands](#subcommands).
@@ -34,6 +34,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`UNSPLIT AT`](unsplit-at.html) | Remove a range split enforcement at a specified row in the table. | No
 [`VALIDATE CONSTRAINT`](validate-constraint.html) | Check whether values in a column match a [constraint](constraints.html) on the column. | Yes
 [`SET LOCALITY {REGIONAL BY TABLE, REGIONAL BY ROW, GLOBAL}`](set-locality.html) |  Set the table locality for a table in a [multi-region database](multiregion-overview.html). | No
+[`SET (storage parameter)`](set-storage-parameter.html) | Set a storage parameter on a table. | Yes
 
 ## Viewing schema changes
 

--- a/v22.1/backup.md
+++ b/v22.1/backup.md
@@ -33,6 +33,7 @@ Because CockroachDB is designed with high fault tolerance, these backups are des
 - Backups will export [Enterprise license keys](enterprise-licensing.html) during a [full cluster backup](#backup-a-cluster). When you [restore](restore.html) a full cluster with an Enterprise license, it will restore the Enterprise license of the cluster you are restoring from.
 - [Zone configurations](configure-zone.html) present on the destination cluster prior to a restore will be **overwritten** during a [cluster restore](restore.html#full-cluster) with the zone configurations from the [backed up cluster](#backup-a-cluster). If there were no customized zone configurations on the cluster when the backup was taken, then after the restore the destination cluster will use the zone configuration from the [`RANGE DEFAULT` configuration](configure-replication-zones.html#view-the-default-replication-zone).
 - You cannot restore a backup of a multi-region database into a single-region database.
+- Exclude a table's row data from a backup using the [`exclude_data_from_backup`](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups) parameter.
 
 {{site.data.alerts.callout_success}}
 To view the contents of an Enterprise backup created with the `BACKUP` statement, use [`SHOW BACKUP`](show-backup.html).
@@ -104,6 +105,12 @@ Object | Depends On
 Table with [foreign key](foreign-key.html) constraints | The table it `REFERENCES`; however, this dependency can be [removed during the restore](restore.html#skip_missing_foreign_keys).
 Table with a [sequence](create-sequence.html) | The sequence it uses; however, this dependency can be [removed during the restore](restore.html#skip_missing_sequences).
 [Views](views.html) | The tables used in the view's `SELECT` statement.
+
+{{site.data.alerts.callout_info}}
+To exclude a table's row data from a backup, use the `exclude_data_from_backup` parameter with [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups).
+
+For more detail, see the [Exclude a table's data from backups](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups) example.
+{{site.data.alerts.end}}
 
 ### Users and privileges
 

--- a/v22.1/create-table.md
+++ b/v22.1/create-table.md
@@ -947,6 +947,25 @@ Inserting explicit values does not affect the next value of the sequence:
 If the `numerical` column were to follow the `ALWAYS` rule instead, then the sequence values in the column could not be overwritten.
 {{site.data.alerts.end}}
 
+### Create a table with data excluded from backup
+
+<span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, a table could contain high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](take-full-and-incremental-backups.html#incremental-backups) schedule for the database or cluster that will hold the table. You can use the `exclude_data_from_backup = true` parameter with `CREATE TABLE` to mark a table's row data for exclusion from a backup:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE promo_codes (
+    code VARCHAR NOT NULL,
+    description VARCHAR NULL,
+    creation_time TIMESTAMP NULL,
+    expiration_time TIMESTAMP NULL,
+    rules JSONB NULL,
+    CONSTRAINT promo_codes_pkey PRIMARY KEY (code ASC)
+  )
+WITH (exclude_data_from_backup = true);
+~~~
+
+To set `exclude_data_from_backup` on an existing table, see the [Exclude a table's data from backups](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups) example.
+
 ## See also
 
 - [`INSERT`](insert.html)

--- a/v22.1/restore.md
+++ b/v22.1/restore.md
@@ -24,6 +24,7 @@ You can restore:
 - `RESTORE` no longer requires an Enterprise license, regardless of the options passed to it or to the backup it is restoring.
 - [Zone configurations](configure-zone.html) present on the destination cluster prior to a restore will be **overwritten** during a [cluster restore](restore.html#full-cluster) with the zone configurations from the [backed up cluster](backup.html#backup-a-cluster). If there were no customized zone configurations on the cluster when the backup was taken, then after the restore the destination cluster will use the zone configuration from the [`RANGE DEFAULT` configuration](configure-replication-zones.html#view-the-default-replication-zone).
 - You cannot restore a backup of a multi-region database into a single-region database.
+- When the [`exclude_data_from_backup`](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups) parameter is set on a table, the table will not contain row data when restored.
 
 ## Required privileges
 
@@ -91,6 +92,10 @@ You can restore:
 - [Databases](#databases)
 - [Tables](#tables)
 
+{{site.data.alerts.callout_info}}
+You can exclude a table's row data from a backup using the [`exclude_data_from_backup`](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups) parameter. With this parameter set, a table will be empty when restored.
+{{site.data.alerts.end}}
+
 #### Full cluster
 
  A full cluster restore can only be run on a target cluster with no user-created databases or tables. Restoring a full cluster includes:
@@ -102,7 +107,7 @@ You can restore:
 - All [views](views.html)
 
 {{site.data.alerts.callout_info}}
-When you restore a full cluster with an Enterprise license, it will restore the [Enterprise license](enterprise-licensing.html) of the cluster you are restoring from. If you want to use a different license in the new cluster, make sure to [update the license](licensing-faqs.html#set-a-license) _after_ the restore is complete.
+When you restore a full cluster with an Enterprise license, it will restore the [Enterprise license](enterprise-licensing.html) of the cluster you are restoring from. If you want to use a different license in the new cluster, make sure to [update the license](licensing-faqs.html#set-a-license) **after** the restore is complete.
 {{site.data.alerts.end}}
 
 #### Databases

--- a/v22.1/set-storage-parameter.md
+++ b/v22.1/set-storage-parameter.md
@@ -51,17 +51,17 @@ SHOW CREATE user_promo_codes;
 ~~~
 
 ~~~
-table_name    |                                                create_statement
+table_name         |                                                create_statement
 -------------------+------------------------------------------------------------------------------------------------------------------
-user_promo_codes | CREATE TABLE public.user_promo_codes (
-              |     city VARCHAR NOT NULL,
-              |     user_id UUID NOT NULL,
-              |     code VARCHAR NOT NULL,
-              |     "timestamp" TIMESTAMP NULL,
-              |     usage_count INT8 NULL,
-              |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
-              |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
-              | ) WITH (exclude_data_from_backup = true)
+user_promo_codes   | CREATE TABLE public.user_promo_codes (
+                   |     city VARCHAR NOT NULL,
+                   |     user_id UUID NOT NULL,
+                   |     code VARCHAR NOT NULL,
+                   |     "timestamp" TIMESTAMP NULL,
+                   |     usage_count INT8 NULL,
+                   |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
+                   |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
+                   | ) WITH (exclude_data_from_backup = true)
 (1 row)
 ~~~
 

--- a/v22.1/set-storage-parameter.md
+++ b/v22.1/set-storage-parameter.md
@@ -1,0 +1,84 @@
+---
+title: SET (storage parameter)
+summary: SET (storage parameter) applies a storage parameter to a table.
+toc: true
+docs_area: reference.sql
+---
+
+The `SET (storage parameter)` [statement](sql-statements.html) sets a storage parameter on a table.
+
+{{site.data.alerts.callout_info}}
+The `SET (storage parameter)` is a subcommand of [`ALTER TABLE`](alter-table.html).
+{{site.data.alerts.end}}
+
+## Syntax
+
+~~~
+ALTER TABLE {table} SET (storage_parameter);
+~~~
+
+## Parameters
+
+| Parameter    | Description                                                                                                                                                                                  |
+|--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `table` | The table to which you are setting the parameter.                                                                                                    |
+| `storage_parameter`   | The `storage_parameter` to apply to the table. See [Examples](#examples) for the available parameters. |
+
+## Required privileges
+
+The user must be a member of the [`admin`](security-reference/authorization.html#roles) or [owner](security-reference/authorization.html#object-ownership) roles, or have the [`CREATE` privilege](security-reference/authorization.html#supported-privileges) on the table.
+
+## Examples
+
+### Exclude a table's data from backups
+
+<span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](take-full-and-incremental-backups.html#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or `ALTER TABLE` statement to mark a table's row data for exclusion from a backup.
+
+For more detail and an example through the backup and [restore](restore.html) process using this parameter, see [Take Full and Incremental Backups](take-full-and-incremental-backups.html#exclude-a-tables-data-from-backups).
+
+To set the `exclude_data_from_backup` parameter for a table, run the following:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE movr.user_promo_codes SET (exclude_data_from_backup = true);
+~~~
+
+The `CREATE` statement for this table will now show the parameter set:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW CREATE user_promo_codes;
+~~~
+
+~~~
+table_name    |                                                create_statement
+-------------------+------------------------------------------------------------------------------------------------------------------
+user_promo_codes | CREATE TABLE public.user_promo_codes (
+              |     city VARCHAR NOT NULL,
+              |     user_id UUID NOT NULL,
+              |     code VARCHAR NOT NULL,
+              |     "timestamp" TIMESTAMP NULL,
+              |     usage_count INT8 NULL,
+              |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
+              |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
+              | ) WITH (exclude_data_from_backup = true)
+(1 row)
+~~~
+
+Backups will no longer include the data within the `user_promo_codes` table. The table will still be present in the backup, but it will be empty.
+
+To remove this parameter from a table, run:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE movr.user_promo_codes SET (exclude_data_from_backup = false);
+~~~
+
+This will ensure that the table's data is stored in subsequent backups that you take.
+
+## See also
+
+- [`CREATE TABLE`](create-table.html)
+- [Take Full and Incremental Backups](take-full-and-incremental-backups.html)
+- [`BACKUP`](backup.html)
+- [`RESTORE`](restore.html)

--- a/v22.1/take-full-and-incremental-backups.md
+++ b/v22.1/take-full-and-incremental-backups.md
@@ -500,14 +500,14 @@ Using the `movr` database as an example:
 SHOW TABLES;
 ~~~
 ~~~
-schema_name |         table_name         | type  | owner | estimated_row_count | locality
+schema_name   |         table_name         | type  | owner | estimated_row_count | locality
 --------------+----------------------------+-------+-------+---------------------+-----------
-public      | promo_codes                | table | root  |                1021 | NULL
-public      | rides                      | table | root  |                 730 | NULL
-public      | user_promo_codes           | table | root  |                  58 | NULL
-public      | users                      | table | root  |                 211 | NULL
-public      | vehicle_location_histories | table | root  |               10722 | NULL
-public      | vehicles                   | table | root  |                  69 | NULL
+public        | promo_codes                | table | root  |                1021 | NULL
+public        | rides                      | table | root  |                 730 | NULL
+public        | user_promo_codes           | table | root  |                  58 | NULL
+public        | users                      | table | root  |                 211 | NULL
+public        | vehicle_location_histories | table | root  |               10722 | NULL
+public        | vehicles                   | table | root  |                  69 | NULL
 ~~~
 
 If the `user_promo_codes` table's data does not need to be included in future backups, you can run the following to exclude the table's row data:
@@ -545,17 +545,17 @@ You'll find that the table schema is restored:
 SHOW CREATE user_promo_codes;
 ~~~
 ~~~
-table_name    |                                                create_statement
+table_name         |                                                create_statement
 -------------------+------------------------------------------------------------------------------------------------------------------
-user_promo_codes | CREATE TABLE public.user_promo_codes (
-              |     city VARCHAR NOT NULL,
-              |     user_id UUID NOT NULL,
-              |     code VARCHAR NOT NULL,
-              |     "timestamp" TIMESTAMP NULL,
-              |     usage_count INT8 NULL,
-              |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
-              |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
-              | ) WITH (exclude_data_from_backup = true)
+user_promo_codes   | CREATE TABLE public.user_promo_codes (
+                   |     city VARCHAR NOT NULL,
+                   |     user_id UUID NOT NULL,
+                   |     code VARCHAR NOT NULL,
+                   |     "timestamp" TIMESTAMP NULL,
+                   |     usage_count INT8 NULL,
+                   |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
+                   |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
+                   | ) WITH (exclude_data_from_backup = true)
 ~~~
 
 However, the `user_promo_codes` table has no row data:

--- a/v22.1/take-full-and-incremental-backups.md
+++ b/v22.1/take-full-and-incremental-backups.md
@@ -271,7 +271,7 @@ For more examples on how to schedule backups that take full and incremental back
 
 <span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups) statement to mark a table's row data for exclusion from a backup.
 
-It is important to note that the backup will still contain the table, but it will be empty. Also, setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
+It is important to note that the backup will still contain the table, but it will be empty. Setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table, and it also respects the configured GC TTL. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
 
 Using the `movr` database as an example:
 
@@ -381,7 +381,7 @@ For more examples on how to schedule backups that take full and incremental back
 
 <span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups) statement to mark a table's row data for exclusion from a backup.
 
-It is important to note that the backup will still contain the table, but it will be empty. Also, setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
+It is important to note that the backup will still contain the table, but it will be empty. Setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table, and it also respects the configured GC TTL. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
 
 Using the `movr` database as an example:
 
@@ -491,7 +491,7 @@ For more examples on how to schedule backups that take full and incremental back
 
 <span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups) statement to mark a table's row data for exclusion from a backup.
 
-It is important to note that the backup will still contain the table, but it will be empty. Also, setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
+It is important to note that the backup will still contain the table, but it will be empty. Setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table, and it also respects the configured GC TTL. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
 
 Using the `movr` database as an example:
 

--- a/v22.1/take-full-and-incremental-backups.md
+++ b/v22.1/take-full-and-incremental-backups.md
@@ -265,6 +265,93 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
 (1 row)
 ~~~
 
+For more examples on how to schedule backups that take full and incremental backups, see [`CREATE SCHEDULE FOR BACKUP`](create-schedule-for-backup.html).
+
+### Exclude a table's data from backups
+
+<span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups) statement to mark a table's row data for exclusion from a backup.
+
+It is important to note that the backup will still contain the table, but it will be empty. Also, setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
+
+Using the `movr` database as an example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TABLES;
+~~~
+~~~
+schema_name |         table_name         | type  | owner | estimated_row_count | locality
+--------------+----------------------------+-------+-------+---------------------+-----------
+public      | promo_codes                | table | root  |                1021 | NULL
+public      | rides                      | table | root  |                 730 | NULL
+public      | user_promo_codes           | table | root  |                  58 | NULL
+public      | users                      | table | root  |                 211 | NULL
+public      | vehicle_location_histories | table | root  |               10722 | NULL
+public      | vehicles                   | table | root  |                  69 | NULL
+~~~
+
+If the `user_promo_codes` table's data does not need to be included in future backups, you can run the following to exclude the table's row data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE movr.user_promo_codes SET (exclude_data_from_backup = true);
+~~~
+
+Then back up the `movr` database:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+BACKUP DATABASE movr INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' AS OF SYSTEM TIME '-10s';
+~~~
+
+Restore the database with a [new name](restore.html#new-db-name):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+RESTORE DATABASE movr FROM LATEST IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH new_db_name = new_movr;
+~~~
+
+Move to the new database:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+USE new_movr;
+~~~
+
+You'll find that the table schema is restored:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW CREATE user_promo_codes;
+~~~
+~~~
+table_name    |                                                create_statement
+-------------------+------------------------------------------------------------------------------------------------------------------
+user_promo_codes | CREATE TABLE public.user_promo_codes (
+              |     city VARCHAR NOT NULL,
+              |     user_id UUID NOT NULL,
+              |     code VARCHAR NOT NULL,
+              |     "timestamp" TIMESTAMP NULL,
+              |     usage_count INT8 NULL,
+              |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
+              |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
+              | ) WITH (exclude_data_from_backup = true)
+~~~
+
+However, the `user_promo_codes` table has no row data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT * FROM user_promo_codes;
+~~~
+~~~
+city | user_id | code | timestamp | usage_count
+-----+---------+------+-----------+--------------
+(0 rows)
+~~~
+
+To create a table with `exclude_data_from_backup`, see [Create a table with data excluded from backup](create-table.html#create-a-table-with-data-excluded-from-backup).
+
 </section>
 
 <section class="filter-content" markdown="1" data-scope="azure">
@@ -287,6 +374,93 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
   588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 'azure://{CONTAINER NAME}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH detached
 (1 row)
 ~~~
+
+For more examples on how to schedule backups that take full and incremental backups, see [`CREATE SCHEDULE FOR BACKUP`](create-schedule-for-backup.html).
+
+### Exclude a table's data from backups
+
+<span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups) statement to mark a table's row data for exclusion from a backup.
+
+It is important to note that the backup will still contain the table, but it will be empty. Also, setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
+
+Using the `movr` database as an example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TABLES;
+~~~
+~~~
+schema_name |         table_name         | type  | owner | estimated_row_count | locality
+--------------+----------------------------+-------+-------+---------------------+-----------
+public      | promo_codes                | table | root  |                1021 | NULL
+public      | rides                      | table | root  |                 730 | NULL
+public      | user_promo_codes           | table | root  |                  58 | NULL
+public      | users                      | table | root  |                 211 | NULL
+public      | vehicle_location_histories | table | root  |               10722 | NULL
+public      | vehicles                   | table | root  |                  69 | NULL
+~~~
+
+If the `user_promo_codes` table's data does not need to be included in future backups, you can run the following to exclude the table's row data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE movr.user_promo_codes SET (exclude_data_from_backup = true);
+~~~
+
+Then back up the `movr` database:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+BACKUP DATABASE movr INTO 'azure://{CONTAINER NAME}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' AS OF SYSTEM TIME '-10s';
+~~~
+
+Restore the database with a [new name](restore.html#new-db-name):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+RESTORE DATABASE movr FROM LATEST IN 'azure://{CONTAINER NAME}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH new_db_name = new_movr;
+~~~
+
+Move to the new database:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+USE new_movr;
+~~~
+
+You'll find that the table schema is restored:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW CREATE user_promo_codes;
+~~~
+~~~
+table_name    |                                                create_statement
+-------------------+------------------------------------------------------------------------------------------------------------------
+user_promo_codes | CREATE TABLE public.user_promo_codes (
+              |     city VARCHAR NOT NULL,
+              |     user_id UUID NOT NULL,
+              |     code VARCHAR NOT NULL,
+              |     "timestamp" TIMESTAMP NULL,
+              |     usage_count INT8 NULL,
+              |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
+              |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
+              | ) WITH (exclude_data_from_backup = true)
+~~~
+
+However, the `user_promo_codes` table has no row data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT * FROM user_promo_codes;
+~~~
+~~~
+city | user_id | code | timestamp | usage_count
+-----+---------+------+-----------+--------------
+(0 rows)
+~~~
+
+To create a table with `exclude_data_from_backup`, see [Create a table with data excluded from backup](create-table.html#create-a-table-with-data-excluded-from-backup).
 
 </section>
 
@@ -311,9 +485,94 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
 (1 row)
 ~~~
 
-</section>
-
 For more examples on how to schedule backups that take full and incremental backups, see [`CREATE SCHEDULE FOR BACKUP`](create-schedule-for-backup.html).
+
+### Exclude a table's data from backups
+
+<span class="version-tag">New in v22.1:</span> In some situations, you may want to exclude a table's row data from a [backup](backup.html). For example, you have a table that contains high-churn data that you would like to [garbage collect](architecture/storage-layer.html#garbage-collection) more quickly than the [incremental backup](#incremental-backups) schedule for the database or cluster holding the table. You can use the `exclude_data_from_backup = true` parameter with a [`CREATE TABLE`](create-table.html#create-a-table-with-data-excluded-from-backup) or [`ALTER TABLE`](set-storage-parameter.html#exclude-a-tables-data-from-backups) statement to mark a table's row data for exclusion from a backup.
+
+It is important to note that the backup will still contain the table, but it will be empty. Also, setting this parameter prevents the cluster or database backup from delaying [GC TTL](configure-replication-zones.html#gc-ttlseconds) on the key span for this table. This is useful when you want to set a shorter garbage collection window for tables containing high-churn data to avoid an accumulation of unnecessary data.
+
+Using the `movr` database as an example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TABLES;
+~~~
+~~~
+schema_name |         table_name         | type  | owner | estimated_row_count | locality
+--------------+----------------------------+-------+-------+---------------------+-----------
+public      | promo_codes                | table | root  |                1021 | NULL
+public      | rides                      | table | root  |                 730 | NULL
+public      | user_promo_codes           | table | root  |                  58 | NULL
+public      | users                      | table | root  |                 211 | NULL
+public      | vehicle_location_histories | table | root  |               10722 | NULL
+public      | vehicles                   | table | root  |                  69 | NULL
+~~~
+
+If the `user_promo_codes` table's data does not need to be included in future backups, you can run the following to exclude the table's row data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE movr.user_promo_codes SET (exclude_data_from_backup = true);
+~~~
+
+Then back up the `movr` database:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+BACKUP DATABASE movr INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' AS OF SYSTEM TIME '-10s';
+~~~
+
+Restore the database with a [new name](restore.html#new-db-name):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+RESTORE DATABASE movr FROM LATEST IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH new_db_name = new_movr;
+~~~
+
+Move to the new database:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+USE new_movr;
+~~~
+
+You'll find that the table schema is restored:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW CREATE user_promo_codes;
+~~~
+~~~
+table_name    |                                                create_statement
+-------------------+------------------------------------------------------------------------------------------------------------------
+user_promo_codes | CREATE TABLE public.user_promo_codes (
+              |     city VARCHAR NOT NULL,
+              |     user_id UUID NOT NULL,
+              |     code VARCHAR NOT NULL,
+              |     "timestamp" TIMESTAMP NULL,
+              |     usage_count INT8 NULL,
+              |     CONSTRAINT user_promo_codes_pkey PRIMARY KEY (city ASC, user_id ASC, code ASC),
+              |     CONSTRAINT user_promo_codes_city_user_id_fkey FOREIGN KEY (city, user_id) REFERENCES public.users(city, id)
+              | ) WITH (exclude_data_from_backup = true)
+~~~
+
+However, the `user_promo_codes` table has no row data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT * FROM user_promo_codes;
+~~~
+~~~
+city | user_id | code | timestamp | usage_count
+-----+---------+------+-----------+--------------
+(0 rows)
+~~~
+
+To create a table with `exclude_data_from_backup`, see [Create a table with data excluded from backup](create-table.html#create-a-table-with-data-excluded-from-backup).
+
+</section>
 
 ### Advanced examples
 


### PR DESCRIPTION
Fixes [DOC-3286](https://cockroachlabs.atlassian.net/browse/DOC-3286)

Added docs on new `exclude_data_from_backup` parameter. Included:

- Longer examples on Take Full and Incremental Backups page
- New page for the `SET (storage parameter)` subcommand of `ALTER TABLE`
- Short-form example on `CREATE TABLE`
- Notes/considerations to `BACKUP` & `RESTORE` pages