### PR TITLE
configure K8s logging

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -26,7 +26,7 @@ include:
 keep_files:
 - _internal
 markdown: Redcarpet
-operator_version: v2.5.3
+operator_version: v2.6.0
 plugins:
 - jekyll-include-cache
 release_info:

--- a/v21.2/monitor-cockroachdb-kubernetes.md
+++ b/v21.2/monitor-cockroachdb-kubernetes.md
@@ -274,3 +274,146 @@ Active monitoring helps you spot problems early, but it is also essential to sen
           - alert: TestAlertManager
             expr: vector(1)
         ~~~
+
+<section class="filter-content" markdown="1" data-scope="operator">
+## Configure logging
+
+When running CockroachDB v21.1 and later, you can use the Operator to configure the CockroachDB logging system. This allows you to output logs to specified [file or network log sinks](configure-logs.html#configure-log-sinks). For more information about the logging system, see [Configure log sinks](configure-logs.html#configure-log-sinks).
+
+{{site.data.alerts.callout_info}}
+By default, Kubernetes deployments running CockroachDB v20.2 or earlier output all logs to `stderr`.
+{{site.data.alerts.end}}
+
+The logging configuration is defined in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) object, using the key `logging.yaml`. For example:
+
+~~~ yaml
+apiVersion: v1
+data:
+  logging.yaml: |
+    sinks:
+      file-groups:
+        dev:
+          channels: DEV
+          filter: WARNING
+      fluent-servers:
+        ops:
+          channels: [OPS, HEALTH, SQL_SCHEMA]
+          address: 127.0.0.1:5170
+          net: tcp
+          redact: true
+        security:
+          channels: [SESSIONS, USER_ADMIN, PRIVILEGES, SENSITIVE_ACCESS]
+          address: 127.0.0.1:5170
+          net: tcp
+          auditable: true
+kind: ConfigMap
+metadata:
+  name: logconfig
+  namespace: cockroach-operator-system
+~~~
+
+The above configuration overrides the [default logging configuration](#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
+
+- Save [`DEV`](logging.html#dev) channel logs to disk for troubleshooting.
+- Send operational- and security-related logs to a [network collector](logging-use-cases.html#network-logging).
+
+The ConfigMap `name` is specified in the `logConfigMap` object of the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+
+~~~ yaml
+spec:
+  logConfigMap: logconfig
+~~~
+
+By default, the Operator also modifies the [default logging configuration](#default-logging-configuration) with the following:
+
+~~~ yaml
+sinks:
+  stderr:
+    channels: OPS
+      redact: true
+~~~
+
+This outputs logging events in the [`OPS`](logging.html#ops) channel to a `cockroach-stderr.log` file.
+
+### Example: Creating a troubleshooting log file on pods
+
+In this example, CockroachDB has already been deployed on a Kubernetes cluster. We override the [default logging configuration](#default-logging-configuration) to output [`DEV`](logging.html#dev) logs to a `cockroach-dev.log` file.
+
+1. Create a ConfigMap named `logconfig`. Note that `namespace` is set to the Operator's default namespace (`cockroach-operator-system`):
+
+    ~~~ yaml
+    apiVersion: v1
+    data:
+      logging.yaml: |
+        sinks:
+          file-groups:
+            dev:
+              channels: DEV
+              filter: WARNING
+    kind: ConfigMap
+    metadata:
+      name: logconfig
+      namespace: cockroach-operator-system
+    ~~~
+
+    For simplicity, also name the YAML file `logconfig.yaml`.
+
+    This configuration outputs `DEV` logs with severity [`WARNING`](logging.html#logging-levels-severities) to a `cockroach-dev.log` file on each pod.
+
+1. Apply the ConfigMap to the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    kubectl apply -f log.yaml
+    ~~~
+
+    ~~~
+    configmap/logconfig created
+    ~~~
+
+1. Add the `name` of the ConfigMap in `logConfigMap` to the [Operator's custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+
+    ~~~ yaml
+    spec:
+      logConfigMap: logconfig
+    ~~~
+
+1. Apply the new settings to the cluster:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl apply -f example.yaml
+    ~~~
+
+    The changes will be rolled out to each pod.
+
+1. See the log files on a pod:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec cockroachdb-2 -- ls cockroach-data/logs
+    ~~~
+
+    ~~~
+    cockroach-dev.cockroachdb-2.unknownuser.2022-05-02T19_03_03Z.000001.log
+    cockroach-dev.log
+    cockroach-health.cockroachdb-2.unknownuser.2022-05-02T18_53_01Z.000001.log
+    cockroach-health.log
+    cockroach-pebble.cockroachdb-2.unknownuser.2022-05-02T18_52_48Z.000001.log
+    cockroach-pebble.log
+    cockroach-stderr.cockroachdb-2.unknownuser.2022-05-02T18_52_48Z.000001.log
+    cockroach-stderr.cockroachdb-2.unknownuser.2022-05-02T19_03_03Z.000001.log
+    cockroach-stderr.cockroachdb-2.unknownuser.2022-05-02T20_04_03Z.000001.log
+    cockroach-stderr.log
+    cockroach.cockroachdb-2.unknownuser.2022-05-02T18_52_48Z.000001.log
+    cockroach.log
+    ...
+    ~~~
+
+1. View a log file:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec cockroachdb-2 -- cat cockroach-data/logs/cockroach-dev.log
+    ~~~  
+</section>

--- a/v21.2/monitor-cockroachdb-kubernetes.md
+++ b/v21.2/monitor-cockroachdb-kubernetes.md
@@ -312,7 +312,7 @@ metadata:
   namespace: cockroach-operator-system
 ~~~
 
-The above configuration overrides the [default logging configuration](#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
+The above configuration overrides the [default logging configuration](configure-logs.html#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
 
 - Save [`DEV`](logging.html#dev) channel logs to disk for troubleshooting.
 - Send operational- and security-related logs to a [network collector](logging-use-cases.html#network-logging).
@@ -324,7 +324,7 @@ spec:
   logConfigMap: logconfig
 ~~~
 
-By default, the Operator also modifies the [default logging configuration](#default-logging-configuration) with the following:
+By default, the Operator also modifies the [default logging configuration](configure-logs.html#default-logging-configuration) with the following:
 
 ~~~ yaml
 sinks:
@@ -337,7 +337,7 @@ This outputs logging events in the [`OPS`](logging.html#ops) channel to a `cockr
 
 ### Example: Creating a troubleshooting log file on pods
 
-In this example, CockroachDB has already been deployed on a Kubernetes cluster. We override the [default logging configuration](#default-logging-configuration) to output [`DEV`](logging.html#dev) logs to a `cockroach-dev.log` file.
+In this example, CockroachDB has already been deployed on a Kubernetes cluster. We override the [default logging configuration](configure-logs.html#default-logging-configuration) to output [`DEV`](logging.html#dev) logs to a `cockroach-dev.log` file.
 
 1. Create a ConfigMap named `logconfig`. Note that `namespace` is set to the Operator's default namespace (`cockroach-operator-system`):
 

--- a/v22.1/monitor-cockroachdb-kubernetes.md
+++ b/v22.1/monitor-cockroachdb-kubernetes.md
@@ -274,3 +274,146 @@ Active monitoring helps you spot problems early, but it is also essential to sen
           - alert: TestAlertManager
             expr: vector(1)
         ~~~
+
+<section class="filter-content" markdown="1" data-scope="operator">
+## Configure logging
+
+When running CockroachDB v21.1 and later, you can use the Operator to configure the CockroachDB logging system. This allows you to output logs to specified [file or network log sinks](configure-logs.html#configure-log-sinks). For more information about the logging system, see [Configure log sinks](configure-logs.html#configure-log-sinks).
+
+{{site.data.alerts.callout_info}}
+By default, Kubernetes deployments running CockroachDB v20.2 or earlier output all logs to `stderr`.
+{{site.data.alerts.end}}
+
+The logging configuration is defined in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) object, using the key `logging.yaml`. For example:
+
+~~~ yaml
+apiVersion: v1
+data:
+  logging.yaml: |
+    sinks:
+      file-groups:
+        dev:
+          channels: DEV
+          filter: WARNING
+      fluent-servers:
+        ops:
+          channels: [OPS, HEALTH, SQL_SCHEMA]
+          address: 127.0.0.1:5170
+          net: tcp
+          redact: true
+        security:
+          channels: [SESSIONS, USER_ADMIN, PRIVILEGES, SENSITIVE_ACCESS]
+          address: 127.0.0.1:5170
+          net: tcp
+          auditable: true
+kind: ConfigMap
+metadata:
+  name: logconfig
+  namespace: cockroach-operator-system
+~~~
+
+The above configuration overrides the [default logging configuration](#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
+
+- Save [`DEV`](logging.html#dev) channel logs to disk for troubleshooting.
+- Send operational- and security-related logs to a [network collector](logging-use-cases.html#network-logging).
+
+The ConfigMap `name` is specified in the `logConfigMap` object of the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+
+~~~ yaml
+spec:
+  logConfigMap: logconfig
+~~~
+
+By default, the Operator also modifies the [default logging configuration](#default-logging-configuration) with the following:
+
+~~~ yaml
+sinks:
+  stderr:
+    channels: OPS
+      redact: true
+~~~
+
+This outputs logging events in the [`OPS`](logging.html#ops) channel to a `cockroach-stderr.log` file.
+
+### Example: Creating a troubleshooting log file on pods
+
+In this example, CockroachDB has already been deployed on a Kubernetes cluster. We override the [default logging configuration](#default-logging-configuration) to output [`DEV`](logging.html#dev) logs to a `cockroach-dev.log` file.
+
+1. Create a ConfigMap named `logconfig`. Note that `namespace` is set to the Operator's default namespace (`cockroach-operator-system`):
+
+    ~~~ yaml
+    apiVersion: v1
+    data:
+      logging.yaml: |
+        sinks:
+          file-groups:
+            dev:
+              channels: DEV
+              filter: WARNING
+    kind: ConfigMap
+    metadata:
+      name: logconfig
+      namespace: cockroach-operator-system
+    ~~~
+
+    For simplicity, also name the YAML file `logconfig.yaml`.
+
+    This configuration outputs `DEV` logs with severity [`WARNING`](logging.html#logging-levels-severities) to a `cockroach-dev.log` file on each pod.
+
+1. Apply the ConfigMap to the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    kubectl apply -f log.yaml
+    ~~~
+
+    ~~~
+    configmap/logconfig created
+    ~~~
+
+1. Add the `name` of the ConfigMap in `logConfigMap` to the [Operator's custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+
+    ~~~ yaml
+    spec:
+      logConfigMap: logconfig
+    ~~~
+
+1. Apply the new settings to the cluster:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl apply -f example.yaml
+    ~~~
+
+    The changes will be rolled out to each pod.
+
+1. See the log files on a pod:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec cockroachdb-2 -- ls cockroach-data/logs
+    ~~~
+
+    ~~~
+    cockroach-dev.cockroachdb-2.unknownuser.2022-05-02T19_03_03Z.000001.log
+    cockroach-dev.log
+    cockroach-health.cockroachdb-2.unknownuser.2022-05-02T18_53_01Z.000001.log
+    cockroach-health.log
+    cockroach-pebble.cockroachdb-2.unknownuser.2022-05-02T18_52_48Z.000001.log
+    cockroach-pebble.log
+    cockroach-stderr.cockroachdb-2.unknownuser.2022-05-02T18_52_48Z.000001.log
+    cockroach-stderr.cockroachdb-2.unknownuser.2022-05-02T19_03_03Z.000001.log
+    cockroach-stderr.cockroachdb-2.unknownuser.2022-05-02T20_04_03Z.000001.log
+    cockroach-stderr.log
+    cockroach.cockroachdb-2.unknownuser.2022-05-02T18_52_48Z.000001.log
+    cockroach.log
+    ...
+    ~~~
+
+1. View a log file:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec cockroachdb-2 -- cat cockroach-data/logs/cockroach-dev.log
+    ~~~  
+</section>

--- a/v22.1/monitor-cockroachdb-kubernetes.md
+++ b/v22.1/monitor-cockroachdb-kubernetes.md
@@ -312,7 +312,7 @@ metadata:
   namespace: cockroach-operator-system
 ~~~
 
-The above configuration overrides the [default logging configuration](#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
+The above configuration overrides the [default logging configuration](configure-logs.html#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
 
 - Save [`DEV`](logging.html#dev) channel logs to disk for troubleshooting.
 - Send operational- and security-related logs to a [network collector](logging-use-cases.html#network-logging).
@@ -324,7 +324,7 @@ spec:
   logConfigMap: logconfig
 ~~~
 
-By default, the Operator also modifies the [default logging configuration](#default-logging-configuration) with the following:
+By default, the Operator also modifies the [default logging configuration](configure-logs.html#default-logging-configuration) with the following:
 
 ~~~ yaml
 sinks:
@@ -337,7 +337,7 @@ This outputs logging events in the [`OPS`](logging.html#ops) channel to a `cockr
 
 ### Example: Creating a troubleshooting log file on pods
 
-In this example, CockroachDB has already been deployed on a Kubernetes cluster. We override the [default logging configuration](#default-logging-configuration) to output [`DEV`](logging.html#dev) logs to a `cockroach-dev.log` file.
+In this example, CockroachDB has already been deployed on a Kubernetes cluster. We override the [default logging configuration](configure-logs.html#default-logging-configuration) to output [`DEV`](logging.html#dev) logs to a `cockroach-dev.log` file.
 
 1. Create a ConfigMap named `logconfig`. Note that `namespace` is set to the Operator's default namespace (`cockroach-operator-system`):
 

--- a/v22.1/monitor-cockroachdb-kubernetes.md
+++ b/v22.1/monitor-cockroachdb-kubernetes.md
@@ -278,13 +278,13 @@ Active monitoring helps you spot problems early, but it is also essential to sen
 <section class="filter-content" markdown="1" data-scope="operator">
 ## Configure logging
 
-When running CockroachDB v21.1 and later, you can use the Operator to configure the CockroachDB logging system. This allows you to output logs to specified [file or network log sinks](configure-logs.html#configure-log-sinks). For more information about the logging system, see [Configure log sinks](configure-logs.html#configure-log-sinks).
+When running CockroachDB v21.1 and later, you can use the Operator to configure the CockroachDB logging system. This allows you to output logs to [configurable log sinks] (configure-logs.html#configure-log-sinks) such as file or network logging destinations.
 
 {{site.data.alerts.callout_info}}
 By default, Kubernetes deployments running CockroachDB v20.2 or earlier output all logs to `stderr`.
 {{site.data.alerts.end}}
 
-The logging configuration is defined in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) object, using the key `logging.yaml`. For example:
+The logging configuration is defined in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) object, using a key named `logging.yaml`. For example:
 
 ~~~ yaml
 apiVersion: v1
@@ -314,10 +314,10 @@ metadata:
 
 The above configuration overrides the [default logging configuration](configure-logs.html#default-logging-configuration) and reflects our recommended Kubernetes logging configuration:
 
-- Save [`DEV`](logging.html#dev) channel logs to disk for troubleshooting.
-- Send operational- and security-related logs to a [network collector](logging-use-cases.html#network-logging).
+- Save debug-level logs (the `DEV` [log channel](logging-overview.html#logging-channels)) to disk for troubleshooting.
+- Send operational- and security-level logs to a [network collector](logging-use-cases.html#network-logging), in this case [Fluentd](configure-logs.html#fluentd-logging-format).
 
-The ConfigMap `name` is specified in the `logConfigMap` object of the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+The ConfigMap `name` must match the `logConfigMap` object of the Operator's custom resource, which is used to [deploy the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
 
 ~~~ yaml
 spec:
@@ -358,13 +358,17 @@ In this example, CockroachDB has already been deployed on a Kubernetes cluster. 
 
     For simplicity, also name the YAML file `logconfig.yaml`.
 
-    This configuration outputs `DEV` logs with severity [`WARNING`](logging.html#logging-levels-severities) to a `cockroach-dev.log` file on each pod.
+    {{site.data.alerts.callout_info}}
+    The ConfigMap key is not related to the ConfigMap `name` or YAML filename, and **must** be named `logging.yaml`.
+    {{site.data.alerts.end}}
+
+    This configuration outputs `DEV` logs that have severity [`WARNING`](logging.html#logging-levels-severities) to a `cockroach-dev.log` file on each pod.
 
 1. Apply the ConfigMap to the cluster:
 
     {% include copy-clipboard.html %}
     ~~~
-    kubectl apply -f log.yaml
+    kubectl apply -f logconfig.yaml
     ~~~
 
     ~~~
@@ -387,7 +391,7 @@ In this example, CockroachDB has already been deployed on a Kubernetes cluster. 
 
     The changes will be rolled out to each pod.
 
-1. See the log files on a pod:
+1. See the log files available on a pod:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -410,7 +414,7 @@ In this example, CockroachDB has already been deployed on a Kubernetes cluster. 
     ...
     ~~~
 
-1. View a log file:
+1. View a specific log file:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell


### PR DESCRIPTION
Fixes DOC-2994.

- Document K8s logging configuration using the Operator on v21.2 and v22.1.
- Also updated the Operator image version.