### PR TITLE
Fixed root.crt default path typo

### DIFF
--- a/_includes/cockroachcloud/download-the-cert-free.md
+++ b/_includes/cockroachcloud/download-the-cert-free.md
@@ -4,7 +4,7 @@
     curl --create-dirs -o ~/.postgresql/root.crt -O https://cockroachlabs.cloud/clusters/<cluster-id>/cert
     ~~~
     
-    Your `cert` file will be downloaded to `~/.postgres/root.crt`.
+    Your `cert` file will be downloaded to `~/.postgresql/root.crt`.
     </section>
     
     <section class="filter-content" markdown="1" data-scope="linux">    
@@ -13,7 +13,7 @@
     curl --create-dirs -o ~/.postgresql/root.crt -O https://cockroachlabs.cloud/clusters/<cluster-id>/cert
     ~~~
     
-    Your `cert` file will be downloaded to `~/.postgres/root.crt`.
+    Your `cert` file will be downloaded to `~/.postgresql/root.crt`.
     </section>
     
     <section class="filter-content" markdown="1" data-scope="windows">
@@ -22,5 +22,5 @@
     mkdir -p $env:appdata\.postgresql\; Invoke-WebRequest -Uri https://cockroachlabs.cloud/clusters/<cluster-id>/cert -OutFile $env:appdata\.postgresql\root.crt
     ~~~
     
-    Your `cert` file will be downloaded to `%APPDATA%/.postgres/root.crt`.
+    Your `cert` file will be downloaded to `%APPDATA%/.postgresql/root.crt`.
     </section>

--- a/v21.1/build-a-csharp-app-with-cockroachdb.md
+++ b/v21.1/build-a-csharp-app-with-cockroachdb.md
@@ -112,7 +112,7 @@ connStringBuilder.SslMode = SslMode.Require;
 connStringBuilder.Username = "{username}";
 connStringBuilder.Password = "{password}";
 connStringBuilder.Database = "{cluster-name}.bank";
-connStringBuilder.RootCertificate = "~/.postgres/root.crt";
+connStringBuilder.RootCertificate = "~/.postgresql/root.crt";
 connStringBuilder.TrustServerCertificate = true;
 ~~~
 

--- a/v21.2/build-a-csharp-app-with-cockroachdb.md
+++ b/v21.2/build-a-csharp-app-with-cockroachdb.md
@@ -114,7 +114,7 @@ connStringBuilder.SslMode = SslMode.Require;
 connStringBuilder.Username = "{username}";
 connStringBuilder.Password = "{password}";
 connStringBuilder.Database = "{routing-id}.bank";
-connStringBuilder.RootCertificate = "~/.postgres/root.crt";
+connStringBuilder.RootCertificate = "~/.postgresql/root.crt";
 connStringBuilder.TrustServerCertificate = true;
 ~~~
 

--- a/v22.1/build-a-csharp-app-with-cockroachdb.md
+++ b/v22.1/build-a-csharp-app-with-cockroachdb.md
@@ -114,7 +114,7 @@ connStringBuilder.SslMode = SslMode.Require;
 connStringBuilder.Username = "{username}";
 connStringBuilder.Password = "{password}";
 connStringBuilder.Database = "{routing-id}.bank";
-connStringBuilder.RootCertificate = "~/.postgres/root.crt";
+connStringBuilder.RootCertificate = "~/.postgresql/root.crt";
 connStringBuilder.TrustServerCertificate = true;
 ~~~
 


### PR DESCRIPTION
Fixes https://cockroachlabs.atlassian.net/browse/DOC-1858.

The default path for `root.crt` should be `~/.postgresql/root.crt`, not `~/.postgres/root.crt`.

See https://www.postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES.