### PR TITLE
Update create-security-certificates-openssl.md

### DIFF
--- a/v21.2/create-security-certificates-openssl.md
+++ b/v21.2/create-security-certificates-openssl.md
@@ -187,6 +187,7 @@ In the following steps, replace the placeholder text in the code with the actual
 
     [ distinguished_name ]
     organizationName = Cockroach
+    commonName = node
 
     [ extensions ]
     subjectAltName = critical,DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>


### PR DESCRIPTION
The `node.cnf` file used with `openssl` to generate the node certificates misses the `commonName = node` directive.

In fact, if you follow the current instructions, you end up with a certificate for the node that misses the `CN` attribute, and that in turn makes the Cockroach node to exit with this error:

     client/server node certificate has principals ["" "roach0"], expected "node"

In the other hand, adding the `commonName` directive, which value have to be `node`, you get a certificate with CN=node and that is needed for the node to start.