### PR TITLE
DOC-1911 v22.1.0-rc.1 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -91,10 +91,10 @@ release_info:
     start_time: 2022-04-27 08:23:37.399384 +0000 UTC
     version: v21.2.10
   v22.1:
-    build_time: 2022-05-03 10:06:36 (go1.17)
+    build_time: 2022-05-09 00:00:00 (go1.17)
     docker_image: cockroachdb/cockroach-unstable
-    name: v22.1.0-beta.5
-    start_time: 2022-05-03 10:06:50.270056 +0000 UTC
-    version: v22.1.0-beta.5
+    name: v22.1.0-rc.1
+    start_time: 2022-05-06 11:14:49.970328 +0000 UTC
+    version: v22.1.0-rc.1
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -275,3 +275,4 @@ v22.1.0-beta.3,v22.1,2022-04-18,false,False,Testing,False,go1.17,0509bc6c07ceed6
 v22.1.0-beta.4,v22.1,2022-04-26,false,False,Testing,False,go1.17,b89ce4cb855227c93e1fff6e7367e870fc9f2fef,cockroachdb/cockroach-unstable,true
 v21.2.10,v21.2,2022-05-02,false,False,Production,False,go1.16,39511c6a4d0bbb580b7ff6f5c0e1e77664474efb,cockroachdb/cockroach,false
 v22.1.0-beta.5,v22.1,2022-05-03,false,False,Testing,False,go1.17,24ba4d7211aa9fb9cea18f856c693bc8f592c8f6,cockroachdb/cockroach-unstable,true
+v22.1.0-rc.1,v22.1,2022-05-09,false,False,Testing,False,go1.17,5b78463ed2e7106a8477b63fa837564ad02bb510,cockroachdb/cockroach-unstable,true

--- a/_includes/releases/v22.1/v22.1.0-rc.1.md
+++ b/_includes/releases/v22.1/v22.1.0-rc.1.md
@@ -1,0 +1,18 @@
+## v22.1.0-rc.1
+
+Release Date: May 9, 2022
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-1-0-rc-1-bug-fixes">Bug fixes</h3>
+
+- Fixed a very rare case where CockroachDB could incorrectly evaluate queries with an [`ORDER BY`](../v22.1/order-by.html) clause when the prefix of ordering was already provided by the index ordering of the scanned table. [#80715][#80715]
+
+- Fixed a rare crash when encountering a nil-pointer deference in `google.golang.org/grpc/internal/transport.(*Stream).Context(...)`. [#80936][#80936]
+
+<h3 id="v22-1-0-rc-1-contributors">Contributors</h3>
+
+This release includes 3 merged PRs by 3 authors.
+
+[#80715]: https://github.com/cockroachdb/cockroach/pull/80715
+[#80936]: https://github.com/cockroachdb/cockroach/pull/80936


### PR DESCRIPTION
Addresses: DOC-1911

- Release notes for `v22.1.0-rc.1`, to be released May 9th, 2022.

[releases/v22.1.html](https://deploy-preview-13823--cockroachdb-docs.netlify.app/docs/releases/v22.1.html#v22-1-0-rc-1)