### PR TITLE
DOC-2462 debug zip incl repl reports

### DIFF
--- a/v21.2/cockroach-debug-zip.md
+++ b/v21.2/cockroach-debug-zip.md
@@ -61,6 +61,7 @@ The following information is also contained in the `.zip` file, and cannot be fi
 - Jobs
 - [Cluster Settings](cluster-settings.html)
 - [Metrics](ui-custom-chart-debug-page.html#available-metrics)
+- [Replication Reports](query-replication-reports.html)
 - Problem ranges
 - CPU profiles
 - A script (`hot-ranges.sh`) that summarizes the hottest ranges (ranges receiving a high number of reads or writes)

--- a/v22.1/cockroach-debug-zip.md
+++ b/v22.1/cockroach-debug-zip.md
@@ -61,6 +61,7 @@ The following information is also contained in the `.zip` file, and cannot be fi
 - Jobs
 - [Cluster Settings](cluster-settings.html)
 - [Metrics](ui-custom-chart-debug-page.html#available-metrics)
+- [Replication Reports](query-replication-reports.html)
 - Problem ranges
 - CPU profiles
 - A script (`hot-ranges.sh`) that summarizes the hottest ranges (ranges receiving a high number of reads or writes)


### PR DESCRIPTION
Addresses: DOC-2462
CRDB: [#75239](https://github.com/cockroachdb/cockroach/pull/75239)

- Added entry to `cockroach debug zip` reference page under `Files` to indicate that Replication Reports are now also included in the resulting zip file.
- EDIT: Just noticed [#75794](https://github.com/cockroachdb/cockroach/pull/75794), so performed this also for `v21.2`

[cockroach-debug-zip.html](https://deploy-preview-13827--cockroachdb-docs.netlify.app/docs/v22.1/cockroach-debug-zip#files)