### PR TITLE
PGwire query cancellation is now supported

### DIFF
--- a/_includes/v22.1/metric-names.md
+++ b/_includes/v22.1/metric-names.md
@@ -200,6 +200,9 @@ Name | Help
 `sql.mem.txn.current` | Current sql transaction memory usage
 `sql.mem.txn.max` | Memory usage per sql transaction
 `sql.misc.count` | Number of other SQL statements
+`sql.pgwire_cancel.total` | Counter of the number of pgwire query cancel requests
+`sql.pgwire_cancel.ignored` | Counter of the number of pgwire query cancel requests that were ignored due to rate limiting
+`sql.pgwire_cancel.successful` | Counter of the number of pgwire query cancel requests that were successful
 `sql.query.count` | Number of SQL queries
 `sql.select.count` | Number of SQL SELECT statements
 `sql.service.latency` | Latency in nanoseconds of SQL request execution, including the time to parse and plan the statement.

--- a/v22.1/cancel-query.md
+++ b/v22.1/cancel-query.md
@@ -12,6 +12,10 @@ The `CANCEL QUERY` [statement](sql-statements.html) cancels a running SQL query.
 
 - Schema changes are treated differently than other SQL queries. You can use <a href="show-jobs.html"><code>SHOW JOBS</code></a> to monitor the progress of schema changes and <a href="cancel-job.html"><code>CANCEL JOB</code></a> to cancel schema changes that are taking longer than expected.
 - In rare cases where a query is close to completion when a cancellation request is issued, the query may run to completion.
+- In addition to the `CANCEL QUERY` statement, CockroachDB also supports query cancellation by [client drivers and ORMs](install-client-drivers.html) using the Postgres wire protocol (pgwire). This allows CockroachDB to stop executing queries that your application is no longer waiting for, thereby reducing load on the cluster. pgwire query cancellation differs from the `CANCEL QUERY` statement in the following ways:
+  - It is how most client drivers and ORMS implement query cancellation. For example, it is [used by PGJDBC](https://github.com/pgjdbc/pgjdbc/blob/3a54d28e0b416a84353d85e73a23180a6719435e/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java#L171) to implement the [`setQueryTimeout` method](https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/jdbc/PgStatement.html#setQueryTimeout-int-).
+  - The cancellation request is sent over a different network connection than is used by SQL connections.
+  - If there are too many unsuccessful cancellation attempts, CockroachDB will start rejecting pgwire cancellations.
 
 ## Required privileges
 

--- a/v22.1/postgresql-compatibility.md
+++ b/v22.1/postgresql-compatibility.md
@@ -28,7 +28,6 @@ The following PostgreSQL features are not supported in CockroachDB {{ page.versi
 The following features of the PostgreSQL wire protocol are not supported in CockroachDB {{ page.version.version }}:
 
 - [Multiple active portals](https://github.com/cockroachdb/cockroach/issues/40195)
-- [Query cancellation](https://github.com/cockroachdb/cockroach/issues/41335)
 
 ## Features that differ from PostgreSQL
 


### PR DESCRIPTION
Fixes DOC-2590

Summary of changes:

- Update the 'Postgres compatibility' page to remove pgwire query
  cancellation from the list of unsupported features

- Add `sql.pgwire_cancel.*` metrics to 'Custom Chart Debug Page'