### PR TITLE
Added `key` field to CDC overview docs for version selection

### DIFF
--- a/v21.2/change-data-capture-overview.md
+++ b/v21.2/change-data-capture-overview.md
@@ -3,6 +3,7 @@ title: Change Data Capture Overview
 summary: Stream data out of CockroachDB with efficient, distributed, row-level change subscriptions (changefeeds).
 toc: true
 docs_area: stream_data
+key: stream-data-out-of-cockroachdb-using-changefeeds.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level changefeeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.

--- a/v22.1/change-data-capture-overview.md
+++ b/v22.1/change-data-capture-overview.md
@@ -3,6 +3,7 @@ title: Change Data Capture Overview
 summary: Stream data out of CockroachDB with efficient, distributed, row-level change subscriptions (changefeeds).
 toc: true
 docs_area: stream_data
+key: stream-data-out-of-cockroachdb-using-changefeeds.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level changefeeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.


### PR DESCRIPTION
Fixes [DOC-3306](https://cockroachlabs.atlassian.net/browse/DOC-3306)

Added a key field so when users are on the Stream Data Out of CockroachDB page in v21.1 and earlier the version selector for 21.2+ will take them to the newer stream data section.