### PR TITLE
Sso updates

### DIFF
--- a/_includes/cockroachcloud/prefer-sso.md
+++ b/_includes/cockroachcloud/prefer-sso.md
@@ -1,7 +1,7 @@
     {{site.data.alerts.callout_info}}
-    We recommend that {{ site.data.products.db }} Console users login with Single Sign-On (SSO), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
+    We recommend that {{ site.data.products.db }} Console users login with [Single Sign-On (SSO)](cloud-sso.html), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
 
-    {{ site.data.products.db }} currently supports SSO with GitHub, and will be adding more SSO providers in the near future.
+    {{ site.data.products.db }} currently supports SSO with GitHub, Google and Microsoft.
 
     Visit your {{ site.data.products.db }} Console's [account settings page](https://cockroachlabs.cloud/account/profile) and switch to SSO to improve the security of your cluster.
     {{site.data.alerts.end}}

--- a/_includes/cockroachcloud/prefer-sso.md
+++ b/_includes/cockroachcloud/prefer-sso.md
@@ -1,7 +1,7 @@
     {{site.data.alerts.callout_info}}
-    We recommend that {{ site.data.products.db }} Console users login with [Single Sign-On (SSO)](cloud-sso.html), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
+    We recommend that {{ site.data.products.db }} Console users log in with [Single Sign-On (SSO)](cloud-sso.html), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
 
-    {{ site.data.products.db }} currently supports SSO with GitHub, Google and Microsoft.
+    {{ site.data.products.db }} currently supports SSO with GitHub, Google, and Microsoft.
 
     Visit your {{ site.data.products.db }} Console's [account settings page](https://cockroachlabs.cloud/account/profile) and switch to SSO to improve the security of your cluster.
     {{site.data.alerts.end}}

--- a/cockroachcloud/authentication.md
+++ b/cockroachcloud/authentication.md
@@ -12,7 +12,7 @@ Users may connect with {{ site.data.products.db }} in two ways:
 
 ## Cloud Console authentication
 
-You may login to the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/) with a username and password, or using SSO.
+You may login to the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/) with a username and password, or using [Single Sign-On (SSO) for Cockroach Cloud](cloud-sso.html).
 
 {% include cockroachcloud/prefer-sso.md %}
 

--- a/cockroachcloud/authentication.md
+++ b/cockroachcloud/authentication.md
@@ -10,7 +10,7 @@ Users may connect with {{ site.data.products.db }} in two ways:
 - The [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/) provides an overview of your {{ site.data.products.db }} account, and offers functionality for administrating or connecting to clusters.
 - SQL clients, including the CockroachDB CLI client and the [various supported drivers and ORMs](../{{site.versions["stable"]}}/install-client-drivers.html), connect directly to CockroachDB clusters using the [CockroachDB SQL interface](../{{site.versions["stable"]}}/sql-feature-support.html).
 
-## Cloud Console authentication
+## {{ site.data.products.db }} authentication
 
 You may login to the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/) with a username and password, or using [Single Sign-On (SSO) for Cockroach Cloud](cloud-sso.html).
 

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -9,18 +9,17 @@ Users may authenticate to the Cockroach [Cloud Console](https://cockroachlabs.cl
 
 Authentication users with a centralized identity managed by a dedicated provider offers several security advantages to users of Cockroach Cloud:
 
-- All supported SSO providers support multi-factor authentication MFA.
+- All supported SSO providers (Google, Microsoft, and Github) support multi-factor authentication MFA.
 - Administrators avoid having to manage an additional set of credentials and tie those to other identities and credentials. Every additional credential or identity management operation introduces risk as well as costing effort, so minimizing these is a double win.
-- Administrators can more easily onboard and offboard.
-
-Enterprise users of GSuite (or users who can integrate their own identity provider with GSuite) can 
+- Administrators can rapidly and simply onboard and offboard users.
 
 Cockroach Cloud Console SSO is powered by [Auth0 B2B](https://auth0.com/b2b-saas).	
+
 ## Frequently Asked Questions (FAQ)
 
 ### How can I find out more about SSO for Cockroach Cloud?
 
-Contact our [support team](support-resources.html).
+Contact our [support team](../{{site.versions["stable"]}}/support-resources.html).
 
 ### Will it work if I try to sign in with SSO without setting it up, if I already use an email from an SSO Provider?
 
@@ -32,13 +31,20 @@ To change your SSO method to use that provider, visit **“My Account”** in th
 
 No. Only one authentication method can be active for each Cockroach Cloud Console user at a time. Visit **“My Account”** in the Cockroach Cloud Console to configure which authentication method is active.
 
-### Now that we support Google and Microsoft based SSO, would an admin in an enterprise using that feature still need to invite other users to the organization?
+### Does this change how administrators invite users?
 
-Yes, the current mechanism to add new users is through the indicated invite flow. With the second preview release scheduled for ~mid-July, we would provide an auto-onboarding feature. That would allow customer admins to skip the invite flow and just share the organization-specific sign-in URL with their target users internally. When a new user tries to sign-in using the allowed SSO login method for the first time, their identity would be auto-created in their CC organization.
+At the moment, no. The [workflow for inviting team members](console-access-management.html#invite-team-members-to-cockroachdb-cloud) to {{ site.data.products.db }} remains the same.
+
+A future release will provide an auto-onboarding feature allowing administrators to share an organization-specific sign-in URL, which will generate a new {{ site.data.products.db }} identity when it is first used.
+n their CC organization.
 
 ### As an admin, how do I deprovision a user's access to Cockroach Cloud Console if they leave the relevant project?
 
-If the user is leaving the customer company, the admins don’t need to do anything to remove them from the CC organization, provided they’re using one of the new SSO login methods. Once their IT team removes the user from their identity provider, that will automatically remove the access to the CC organization as well. But if the user is staying in the customer company and just won’t access CC anymore, then that deboarding still has to be done manually as today. We can make that seamless once we support SCIM API in the future that would allow seamless integration with the customer's identity provider.
+If a user is using SSO, deleting the user's identity at the level of the SSO provider (e.g., deleting their work Google account), will remove their access to the {{ site.data.products.db }} organization.
+
+To remove a user's access to {{ site.data.products.db }} without deleting their SSO identity, you can [delete their {{ site.data.products.db }} team member user identity](console-access-management.html#delete-a-team-member) in the console.
+
+If the user is leaving the customer company, the admins don’t need to do anything to remove them from the CC organization, provided they’re using one of the new SSO login methods.
 
 ### Can admins require a particular login method for their Cockroach Cloud organization?
 

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -1,0 +1,20 @@
+---
+title: Single Sign-On (SSO) for Cockroach Cloud
+summary: Learn about SSO Authentication for the Cockroach Cloud COnsole
+toc: true
+docs_area: manage
+---
+
+Users may authenticate to the Cockroach [Cloud Console](https://cockroachlabs.cloud) using Single Sign-On (SSO) with Github, Google, or Microsoft as identity providers.
+
+Using authentication credentials tied to a centralized identity offers several advantages to users of Cockroach Cloud:
+
+- Avoid having to manage another set of credentials for another service provider and having to manage risks and guardrails for those (sic)
+
+- Provides a mechnaism for ent admins to easily onboard and offboard users
+
+Enterprise users of GSuite (or users who can integrate their own identity provider with GSuite) can 
+
+
+Frequently Asked Questions (FAQ)
+

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -5,44 +5,37 @@ toc: true
 docs_area: manage
 ---
 
-Users may authenticate to the Cockroach [Cloud Console](https://cockroachlabs.cloud) using Single Sign-On (SSO) with Github, Google, or Microsoft as identity providers.
+Users may authenticate to the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud) using Single Sign-On (SSO) with GitHub, Google, or Microsoft as identity providers.
 
-Authentication users with a centralized identity managed by a dedicated provider offers several security advantages to users of Cockroach Cloud:
+Authentication with a centralized identity managed by a dedicated provider offers several security advantages:
 
-- All supported SSO providers (Google, Microsoft, and Github) support multi-factor authentication MFA.
-- Administrators avoid having to manage an additional set of credentials and tie those to other identities and credentials. Every additional credential or identity management operation introduces risk as well as costing effort, so minimizing these is a double win.
-- Administrators can rapidly and simply onboard and offboard users.
-
-Cockroach Cloud Console SSO is powered by [Auth0 B2B](https://auth0.com/b2b-saas).	
+- All supported SSO providers (Google, Microsoft, and GitHub) support multi-factor authentication (MFA).
+- Administrators avoid having to manage an additional set of credentials and tie those to other identities and credentials. Every additional credential or identity management operation introduces risk as well as costing effort, so minimizing these is doubly advantageous.
+- Administrators can onboard and offboard users quickly and efficiently
 
 ## Frequently Asked Questions (FAQ)
 
-### How can I find out more about SSO for Cockroach Cloud?
 
-Contact our [support team](../{{site.versions["stable"]}}/support-resources.html).
+### Will it work if I try to sign in with SSO without explicitly setting it up for my account, if I already use an email from an SSO Provider (e.g., my-example-account@gmail.com)?
 
-### Will it work if I try to sign in with SSO without setting it up, if I already use an email from an SSO Provider?
+No, that won't work until you set up SSO for your account with that specific identity provider. Using an email associated with an SSO provider (Google, GitHub, or Microsoft) does not automatically enable SSO.
 
-No, that won't work until you set up SSO for that identity provider. You may be using an email associated with an SSO provider (Google or Microsoft), but it's still just an email and doesn't automatically enable SSO.
+To change your SSO method to use that provider, visit **My Account** in the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud).
 
-To change your SSO method to use that provider, visit **“My Account”** in the Cockroach Cloud Console. 
+### Once I change my active login method to a new SSO provider, can I still sign in using my email/password combination or my GitHub identity?
 
-### Once I change my active login method to a new SSO (Google / Microsoft), can I still sign in using my email/password combination or my Github identity?
-
-No. Only one authentication method can be active for each Cockroach Cloud Console user at a time. Visit **“My Account”** in the Cockroach Cloud Console to configure which authentication method is active.
+No. Only one authentication method can be active for each {{ site.data.products.db }} Console user at a time. Visit **My Account** in the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud) to configure which authentication method is active.
 
 ### Does this change how administrators invite users?
 
 At the moment, no. The [workflow for inviting team members](console-access-management.html#invite-team-members-to-cockroachdb-cloud) to {{ site.data.products.db }} remains the same.
 
-A future release will provide an auto-onboarding feature allowing administrators to share an organization-specific sign-in URL, which will generate a new {{ site.data.products.db }} identity when it is first used.
+### As an admin, how do I deprovision a user's access to {{ site.data.products.db }} Console if they leave the relevant project?
 
-### As an admin, how do I deprovision a user's access to Cockroach Cloud Console if they leave the relevant project?
-
-If a user is using SSO, deleting the user's identity at the level of the SSO provider (e.g., deleting their work Google account), will remove their access to the {{ site.data.products.db }} organization.
+If a user is using SSO, deleting the user's identity at the level of the SSO provider (e.g., deleting their Google account), will remove their access to the {{ site.data.products.db }} organization.
 
 To remove a user's access to {{ site.data.products.db }} without deleting their SSO identity, you can [remove their {{ site.data.products.db }} user identity from your org](console-access-management.html#delete-a-team-member) in the console.
 
-### Can admins require a particular login method for their Cockroach Cloud organization?
+### Can admins require a particular login method for their {{ site.data.products.db }} organization?
 
-Currently, no. That feature is planned for release late.
+Currently, no.

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -1,6 +1,6 @@
 ---
 title: Single Sign-On (SSO) for Cockroach Cloud
-summary: Learn about SSO Authentication for the Cockroach Cloud COnsole
+summary: Learn about SSO Authentication for the Cockroach Cloud Console
 toc: true
 docs_area: manage
 ---
@@ -36,15 +36,12 @@ No. Only one authentication method can be active for each Cockroach Cloud Consol
 At the moment, no. The [workflow for inviting team members](console-access-management.html#invite-team-members-to-cockroachdb-cloud) to {{ site.data.products.db }} remains the same.
 
 A future release will provide an auto-onboarding feature allowing administrators to share an organization-specific sign-in URL, which will generate a new {{ site.data.products.db }} identity when it is first used.
-n their CC organization.
 
 ### As an admin, how do I deprovision a user's access to Cockroach Cloud Console if they leave the relevant project?
 
 If a user is using SSO, deleting the user's identity at the level of the SSO provider (e.g., deleting their work Google account), will remove their access to the {{ site.data.products.db }} organization.
 
-To remove a user's access to {{ site.data.products.db }} without deleting their SSO identity, you can [delete their {{ site.data.products.db }} team member user identity](console-access-management.html#delete-a-team-member) in the console.
-
-If the user is leaving the customer company, the admins don’t need to do anything to remove them from the CC organization, provided they’re using one of the new SSO login methods.
+To remove a user's access to {{ site.data.products.db }} without deleting their SSO identity, you can [remove their {{ site.data.products.db }} user identity from your org](console-access-management.html#delete-a-team-member) in the console.
 
 ### Can admins require a particular login method for their Cockroach Cloud organization?
 

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -1,5 +1,5 @@
 ---
-title: Single Sign-On (SSO) for Cockroach Cloud
+title: Single Sign-On (SSO) for CockroachDB Cloud
 summary: Learn about SSO Authentication for the Cockroach Cloud Console
 toc: true
 docs_area: manage
@@ -11,7 +11,7 @@ Authentication with a centralized identity managed by a dedicated provider offer
 
 - All supported SSO providers (Google, Microsoft, and GitHub) support multi-factor authentication (MFA).
 - Administrators avoid having to manage an additional set of credentials and tie those to other identities and credentials. Every additional credential or identity management operation introduces risk as well as costing effort, so minimizing these is doubly advantageous.
-- Administrators can onboard and offboard users quickly and efficiently
+- Administrators can onboard and offboard users quickly and efficiently.
 
 ## Frequently Asked Questions (FAQ)
 

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -7,14 +7,39 @@ docs_area: manage
 
 Users may authenticate to the Cockroach [Cloud Console](https://cockroachlabs.cloud) using Single Sign-On (SSO) with Github, Google, or Microsoft as identity providers.
 
-Using authentication credentials tied to a centralized identity offers several advantages to users of Cockroach Cloud:
+Authentication users with a centralized identity managed by a dedicated provider offers several security advantages to users of Cockroach Cloud:
 
-- Avoid having to manage another set of credentials for another service provider and having to manage risks and guardrails for those (sic)
-
-- Provides a mechnaism for ent admins to easily onboard and offboard users
+- All supported SSO providers support multi-factor authentication MFA.
+- Administrators avoid having to manage an additional set of credentials and tie those to other identities and credentials. Every additional credential or identity management operation introduces risk as well as costing effort, so minimizing these is a double win.
+- Administrators can more easily onboard and offboard.
 
 Enterprise users of GSuite (or users who can integrate their own identity provider with GSuite) can 
 
+Cockroach Cloud Console SSO is powered by [Auth0 B2B](https://auth0.com/b2b-saas).	
+## Frequently Asked Questions (FAQ)
 
-Frequently Asked Questions (FAQ)
+### How can I find out more about SSO for Cockroach Cloud?
 
+Contact our [support team](support-resources.html).
+
+### Will it work if I try to sign in with SSO without setting it up, if I already use an email from an SSO Provider?
+
+No, that won't work until you set up SSO for that identity provider. You may be using an email associated with an SSO provider (Google or Microsoft), but it's still just an email and doesn't automatically enable SSO.
+
+To change your SSO method to use that provider, visit **“My Account”** in the Cockroach Cloud Console. 
+
+### Once I change my active login method to a new SSO (Google / Microsoft), can I still sign in using my email/password combination or my Github identity?
+
+No. Only one authentication method can be active for each Cockroach Cloud Console user at a time. Visit **“My Account”** in the Cockroach Cloud Console to configure which authentication method is active.
+
+### Now that we support Google and Microsoft based SSO, would an admin in an enterprise using that feature still need to invite other users to the organization?
+
+Yes, the current mechanism to add new users is through the indicated invite flow. With the second preview release scheduled for ~mid-July, we would provide an auto-onboarding feature. That would allow customer admins to skip the invite flow and just share the organization-specific sign-in URL with their target users internally. When a new user tries to sign-in using the allowed SSO login method for the first time, their identity would be auto-created in their CC organization.
+
+### As an admin, how do I deprovision a user's access to Cockroach Cloud Console if they leave the relevant project?
+
+If the user is leaving the customer company, the admins don’t need to do anything to remove them from the CC organization, provided they’re using one of the new SSO login methods. Once their IT team removes the user from their identity provider, that will automatically remove the access to the CC organization as well. But if the user is staying in the customer company and just won’t access CC anymore, then that deboarding still has to be done manually as today. We can make that seamless once we support SCIM API in the future that would allow seamless integration with the customer's identity provider.
+
+### Can admins require a particular login method for their Cockroach Cloud organization?
+
+Currently, no. That feature is planned for release late.

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -11,23 +11,27 @@ Before you [create a {{ site.data.products.db }} cluster](create-your-cluster.ht
 
 To register a new account, navigate to the [{{ site.data.products.db }} registration page](https://cockroachlabs.cloud/signup?referralId=docs_create_account).
 
+### Choose an authentication method
+{{site.data.alerts.callout_info}}
+You may authenticate with Cockroach Cloud using an email and password, or with [Single Sign-on (SSO)](cloud-sso.html). Cockroach Cloud supports SSO provided by Github, Google, and Microsoft.
+
+Single-Sign on provides security benefits. This includes not having to manage an additional credential, and perhaps most importantly, that SSO providers support multi-factor authentication (MFA). For best security, we recommend that all Cockroach Cloud users authenticate with SSO, with MFA enabled.
+{{site.data.alerts.end}}
+
 <div class="filters clearfix">
-  <button class="filter-button page-level" data-scope="github">Register with GitHub</button>
+  <button class="filter-button page-level" data-scope="github">Register with Single Sign-On (SSO)</button>
   <button class="filter-button page-level" data-scope="email">Register with email</button>
 </div>
 <p></p>
 
 <section class="filter-content" markdown="1" data-scope="github">
 
-1. Click **Sign up with GitHub**.
+1. Click **Sign up with...** for your chosen SSO Provider.
 1. Select the checkbox to accept the [terms of service](https://www.cockroachlabs.com/cloud-terms-and-conditions) and [privacy policy](https://www.cockroachlabs.com/privacy).
-1. Log in to GitHub if you haven't already.
-1. Click **Authorize {{ site.data.products.db }} by Cockroach Labs**.
-
-    A confirmation email will be sent.
+1. Log in to your account with your SSO provider and respond to the email or other notification inviting you to  **Authorize {{ site.data.products.db }} by Cockroach Labs**
 
 {{site.data.alerts.callout_info}}
-GitHub will verify your identity using [GitHub 2FA](https://docs.github.com/en/github/authenticating-to-github/about-two-factor-authentication), if you have it enabled.
+We highly recommend enabling multi-factor authentication (MFA) with your SSO provider, if you have not done so.
 {{site.data.alerts.end}}
 </section>
 
@@ -48,21 +52,16 @@ GitHub will verify your identity using [GitHub 2FA](https://docs.github.com/en/g
 ## Log in to your account
 
 <div class="filters clearfix">
-  <button class="filter-button page-level" data-scope="github">Log in with GitHub</button>
+  <button class="filter-button page-level" data-scope="github">Log in with Single Sign-On (SSO)</button>
   <button class="filter-button page-level" data-scope="email">Log in with email</button>
 </div>
 <p></p>
 
 <section class="filter-content" markdown="1" data-scope="github">
 
-If you have already [registered a new {{ site.data.products.db }} account](#register-a-new-account) using GitHub, you can log in to {{ site.data.products.db }}:
-
 1. Navigate to the [{{ site.data.products.db }} Log In page](https://cockroachlabs.cloud/clusters).
-1. Click **Log in with GitHub**.
-1. Follow the GitHub prompts to log in.
-
-    The [**Clusters** page](cluster-management.html) displays.
-</section>
+1. Click **Log in with...** for your chosen SSO provider.
+1. Watch for a pop-up or modal from your SSO Provider and follow the prompts to log in.
 
 <section class="filter-content" markdown="1" data-scope="email">
 If you have already [registered a new {{ site.data.products.db }} account](#register-a-new-account) using an email address, you can log in to {{ site.data.products.db }}:

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -7,18 +7,15 @@ docs_area: deploy
 
 Before you [create a {{ site.data.products.db }} cluster](create-your-cluster.html), you must first create a {{ site.data.products.db }} account. You can register for {{ site.data.products.db }} using a GitHub, Google, or Microsoft account or an email address and password.
 
-{% include cockroachcloud/prefer-sso.md %}
+## Choose an authentication method
+
+You may authenticate to {{ site.data.products.db }} console using an email and password, or with [Single Sign-on (SSO)](cloud-sso.html). The console supports SSO provided by Github, Google, and Microsoft.
+
+SSO provides security benefits. This includes not having to manage an additional credential, and perhaps most importantly, that SSO providers support multi-factor authentication (MFA). For best security, we recommend that all {{ site.data.products.db }} users authenticate with SSO, with MFA enabled.
 
 ## Register a new account
 
 To register a new account, navigate to the [{{ site.data.products.db }} registration page](https://cockroachlabs.cloud/signup?referralId=docs_create_account).
-
-### Choose an authentication method
-{{site.data.alerts.callout_info}}
-You may authenticate with Cockroach Cloud using an email and password, or with [Single Sign-on (SSO)](cloud-sso.html). Cockroach Cloud supports SSO provided by Github, Google, and Microsoft.
-
-Single-Sign on provides security benefits. This includes not having to manage an additional credential, and perhaps most importantly, that SSO providers support multi-factor authentication (MFA). For best security, we recommend that all Cockroach Cloud users authenticate with SSO, with MFA enabled.
-{{site.data.alerts.end}}
 
 <div class="filters clearfix">
   <button class="filter-button page-level" data-scope="github">Register with Single Sign-On (SSO)</button>
@@ -61,14 +58,14 @@ We highly recommend enabling multi-factor authentication (MFA) with your SSO pro
 
 <section class="filter-content" markdown="1" data-scope="github">
 
-1. Navigate to the [{{ site.data.products.db }} Log In page](https://cockroachlabs.cloud/clusters).
+1. Navigate to the {{ site.data.products.db }} [log in page](https://cockroachlabs.cloud/clusters).
 1. Click **Log in with...** for your chosen SSO provider.
 1. Watch for a pop-up or modal from your SSO Provider and follow the prompts to log in.
+</section>
 
 <section class="filter-content" markdown="1" data-scope="email">
-If you have already [registered a new {{ site.data.products.db }} account](#register-a-new-account) using an email address, you can log in to {{ site.data.products.db }}:
 
-1. Navigate to the [{{ site.data.products.db }} Log In page](https://cockroachlabs.cloud/clusters).
+1. Navigate to the {{ site.data.products.db }} [log in page](https://cockroachlabs.cloud/clusters).
 1. Enter your **Email** and **Password**.
 1. Click **Continue**.
 
@@ -81,6 +78,7 @@ If you have already [registered a new {{ site.data.products.db }} account](#regi
 - [Change your email](#change-your-email)
 - [Change your account password](#change-your-account-password)
 - [Change your organization name](#change-your-organization-name)
+- [Change your login method](#change-your-login-method)
 
 ### Change your account name
 
@@ -130,8 +128,8 @@ If you are a [Console Admin](console-access-management.html#console-admin), you 
 1. In the **Edit organization name** dialog, enter the new **Organization name**.
 1. Click **Save**.
 
-## Change your login method
+### Change your login method
 
-You can change your method of login authentication (email/password or SSO with a specific provider), in the [Cockroach Cloud Console **“My Account”** page](https://cockroachlabs.cloud/account/profile).
+You can change your method of login authentication (email/password or SSO with a specific provider), in the [**My Account** page in the {{ site.data.products.db }} Console](https://cockroachlabs.cloud/account/profile).
 
-You will receive a confirmation email.
+Once you have changed your authentication method, you will receive a confirmation email."

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -9,7 +9,7 @@ Before you [create a {{ site.data.products.db }} cluster](create-your-cluster.ht
 
 ## Choose an authentication method
 
-You may authenticate to {{ site.data.products.db }} console using an email and password, or with [Single Sign-on (SSO)](cloud-sso.html). The console supports SSO provided by Github, Google, and Microsoft.
+You may authenticate to {{ site.data.products.db }} console using an email and password, or with [Single Sign-on (SSO)](cloud-sso.html). The console supports SSO provided by GitHub, Google, and Microsoft.
 
 SSO provides security benefits. This includes not having to manage an additional credential, and perhaps most importantly, that SSO providers support multi-factor authentication (MFA). For best security, we recommend that all {{ site.data.products.db }} users authenticate with SSO, with MFA enabled.
 

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -5,7 +5,9 @@ toc: true
 docs_area: deploy
 ---
 
-Before you [create a {{ site.data.products.db }} cluster](create-your-cluster.html), you must first create a {{ site.data.products.db }} account. You can register for {{ site.data.products.db }} using a GitHub account or an email address.
+Before you [create a {{ site.data.products.db }} cluster](create-your-cluster.html), you must first create a {{ site.data.products.db }} account. You can register for {{ site.data.products.db }} using a GitHub, Google, or Microsoft account or an email address and password.
+
+{% include cockroachcloud/prefer-sso.md %}
 
 ## Register a new account
 
@@ -130,34 +132,6 @@ If you are a [Console Admin](console-access-management.html#console-admin), you 
 
 ## Change your login method
 
-If you want to change your login method, you can do so at any time:
+You can change your method of login authentication (email/password or SSO with a specific provider), in the [Cockroach Cloud Console **“My Account”** page](https://cockroachlabs.cloud/account/profile).
 
-- [Switch from a GitHub login to email](#switch-from-a-github-login-to-email)
-- [Switch from an email login to GitHub](#switch-from-an-email-login-to-github)
-
-### Switch from a GitHub login to email
-
-1. Click the account icon in the top right corner.
-1. From the dropdown, select **My Account**.
-1. Click **Switch to email login**.
-1. In the **Log in with email and password** dialog, click **Continue**.
-1. Enter a **Password**.
-1. Click **Save**.
-
-    A confirmation email will be sent.
-
-{{site.data.alerts.callout_info}}
-As a best security practice, you can also [remove {{ site.data.products.db }}'s access to your GitHub account details](https://docs.github.com/en/developers/apps/deleting-an-oauth-app).
-{{site.data.alerts.end}}
-
-### Switch from an email login to GitHub
-
-1. Click the account icon in the top right corner.
-1. From the dropdown, select **My Account**.
-1. Click **Switch to GitHub login**.
-1. In the **Log in with GitHub** dialog, enter your **Password**.
-1. Click **Continue**.
-1. Log in to GitHub if you haven't already.
-1. Click **Authorize {{ site.data.products.db }} by Cockroach Labs**.
-
-    A confirmation email will be sent.
+You will receive a confirmation email.


### PR DESCRIPTION
Adds an SSO explainer page with FAQ, and points to it from authentication related pages.
Updates mentions of Github as SSO provider to include Microsoft and Google.


https://cockroachlabs.atlassian.net/jira/software/c/projects/DOC/boards/239?modal=detail&selectedIssue=DOC-2847