### PR TITLE
add `connection_wait` setting to connection pooling doc

### DIFF
--- a/v22.1/connection-pooling.md
+++ b/v22.1/connection-pooling.md
@@ -123,3 +123,5 @@ For a full list of connection pool configuration parameters for pgxpool, see [th
 Some operational processes involve [node shutdown](node-shutdown.html). During the shutdown sequence, the server forcibly closes all SQL client connections to the node. If any open transactions were interrupted or not admitted by the server because of the connection closure, they will fail with a connection error.
 
 To be resilient to connection closures, your application should use a retry loop to reissue transactions that were open when a connection was closed. This allows procedures such as [rolling upgrades](upgrade-cockroach-version.html) to complete without interrupting your service. For details, see [Connection retry loop](node-shutdown.html#connection-retry-loop).
+
+If you cannot tolerate connection errors during node drain, you can change the `server.shutdown.connection_wait` [cluster setting](cluster-settings.html) to allow SQL client connections to gracefully close before CockroachDB forcibly closes them. For guidance, see [Node Shutdown](node-shutdown.html#server-shutdown-connection_wait).


### PR DESCRIPTION
Fixes DOC-2877.

Added `connection_wait` guidance to the Connection Pooling doc. It echoes the existing Node Shutdown guidance and links out to that doc for more in-depth considerations.