### PR TITLE
Update SQL feature and pgcompat docs for v22.1

### DIFF
--- a/v21.1/postgresql-compatibility.md
+++ b/v21.1/postgresql-compatibility.md
@@ -6,7 +6,7 @@ toc: true
 
 CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
 
-CockroachDB is wire-compatible with PostgreSQL 13 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](hello-world-example-apps.html).
+CockroachDB is compatible with version 3.0 of the Postgres wire protocol (pgwire) and works with the majority of PostgreSQL database tools such as [DBeaver](dbeaver.html), [Intellij](intellij-idea.html), and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](example-apps.html).
 
 However, CockroachDB does not support some of the PostgreSQL features or behaves differently from PostgreSQL because not all features can be easily implemented in a distributed system. This page documents the known list of differences between PostgreSQL and CockroachDB for identical input. That is, a SQL statement of the type listed here will behave differently than in PostgreSQL. Porting an existing application to CockroachDB will require changing these expressions.
 

--- a/v21.2/postgresql-compatibility.md
+++ b/v21.2/postgresql-compatibility.md
@@ -7,7 +7,7 @@ docs_area: reference.sql
 
 CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
 
-CockroachDB is wire-compatible with PostgreSQL 13 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](example-apps.html).
+CockroachDB is compatible with version 3.0 of the Postgres wire protocol (pgwire) and works with the majority of PostgreSQL database tools such as [DBeaver](dbeaver.html), [Intellij](intellij-idea.html), and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](example-apps.html).
 
 However, CockroachDB does not support some of the PostgreSQL features or behaves differently from PostgreSQL because not all features can be easily implemented in a distributed system. This page documents the known list of differences between PostgreSQL and CockroachDB for identical input. That is, a SQL statement of the type listed here will behave differently than in PostgreSQL. Porting an existing application to CockroachDB will require changing these expressions.
 

--- a/v22.1/postgresql-compatibility.md
+++ b/v22.1/postgresql-compatibility.md
@@ -7,7 +7,7 @@ docs_area: reference.sql
 
 CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
 
-CockroachDB is wire-compatible with PostgreSQL 13 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](example-apps.html).
+CockroachDB is compatible with version 3.0 of the Postgres wire protocol (pgwire) and works with the majority of PostgreSQL database tools such as [DBeaver](dbeaver.html), [Intellij](intellij-idea.html), and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](example-apps.html).
 
 However, CockroachDB does not support some of the PostgreSQL features or behaves differently from PostgreSQL because not all features can be easily implemented in a distributed system. This page documents the known list of differences between PostgreSQL and CockroachDB for identical input. That is, a SQL statement of the type listed here will behave differently than in PostgreSQL. Porting an existing application to CockroachDB will require changing these expressions.
 

--- a/v22.1/sql-feature-support.md
+++ b/v22.1/sql-feature-support.md
@@ -89,6 +89,7 @@ table tr td:nth-child(2) {
  Expression indexes | ✓ | Common Extension | [Expression indexes](expression-indexes.html)
  Prefix indexes | ✗ | Common Extension | Implement using [Expression indexes](expression-indexes.html)
  Hash indexes | ✗ | Common Extension | Improves performance of queries looking for single, exact values
+ Hash-sharded indexes | ✓ | CockroachDB Extension | [Hash-sharded Indexes documentation](hash-sharded-indexes.html)
 
 ### Schema changes
 
@@ -136,7 +137,7 @@ table tr td:nth-child(2) {
 -----------|-----------|------|---------
  Table and View references | ✓ | Standard | [Table expressions documentation](table-expressions.html#table-or-view-names)
  `AS` in table expressions | ✓ | Standard | [Aliased table expressions documentation](table-expressions.html#aliased-table-expressions)
- `JOIN` (`INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`) | [Functional](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/) | Standard | [`JOIN` expressions documentation](table-expressions.html#join-expressions)
+ `JOIN` (`INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`) | ✓ | Standard | [`JOIN` expressions documentation](table-expressions.html#join-expressions)
  Sub-queries as table expressions | Partial | Standard | Non-correlated subqueries are [supported](table-expressions.html#subqueries-as-table-expressions), as are most [correlated subqueries](subqueries.html#correlated-subqueries).
  Table generator functions | Partial | PostgreSQL Extension | [Table generator functions documentation](table-expressions.html#table-generator-functions)
  `WITH ORDINALITY` | ✓ | CockroachDB Extension | [Ordinality annotation documentation](table-expressions.html#ordinality-annotation)
@@ -169,7 +170,7 @@ table tr td:nth-child(2) {
  Roles | ✓ | Standard | [Roles documentation](security-reference/authorization.html#roles)
  Object ownership | ✓ | Common Extension | [Ownership documentation](security-reference/authorization.html#object-ownership)
  Privileges | ✓ | Standard | [Privileges documentation](security-reference/authorization.html#managing-privileges)
- Default privileges | Partial | PostgreSQL Extension | [Default privileges documentation](security-reference/authorization.html#default-privileges)
+ Default privileges | ✓ | PostgreSQL Extension | [Default privileges documentation](security-reference/authorization.html#default-privileges)
 
 ### Miscellaneous
 


### PR DESCRIPTION
Fixes DOC-3354
Fixes DOC-3086

Summary of changes:

- Clarify pgwire version 3.0 compat

  - ... in the docs for the following versions: v21.1, v21.2, v22.1 (but
    not v20.2 and earlier since they are no longer supported per
    https://www.cockroachlabs.com/docs/releases/release-support-policy)

- Hash-sharded indexes supported

- JOINs in table expressions supported

- Default privileges are supported
