### PR TITLE
v22.1 upgrade docs

### DIFF
--- a/_includes/v21.2/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v21.2/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -17,11 +17,7 @@
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html?filters=helm#add-nodes) to your cluster before beginning your upgrade.
 
-{% comment %}
 1. Review the [backward-incompatible changes in v21.2](../releases/v21.2.html#v21-2-0-backward-incompatible-changes) and [deprecated features](../releases/v21.2.html#v21-2-0-deprecations). If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
-{% endcomment %}
-
-1. Review the backward-incompatible changes in v21.2 and deprecated features. If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
 
 1. Decide how the upgrade will be finalized.
 

--- a/_includes/v21.2/orchestration/kubernetes-upgrade-cluster-manual.md
+++ b/_includes/v21.2/orchestration/kubernetes-upgrade-cluster-manual.md
@@ -17,11 +17,7 @@
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html?filters=manual#add-nodes) to your cluster before beginning your upgrade.
 
-{% comment %}
 1. Review the [backward-incompatible changes in v21.2](../releases/v21.2.html#v21-2-0-backward-incompatible-changes) and [deprecated features](../releases/v21.2.html#v21-2-0-deprecations). If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
-{% endcomment %}
-
-1. Review the backward-incompatible changes in v21.2 and deprecated features. If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
 
 1. Decide how the upgrade will be finalized.
 

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -19,14 +19,9 @@
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html?filters=helm#add-nodes) to your cluster before beginning your upgrade.
 
-{% comment %}
-
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
 
 1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
-{% endcomment %}
-
-1. Review the backward-incompatible changes in {{ page.version.version }} and deprecated features. If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Decide how the upgrade will be finalized.
 
@@ -69,7 +64,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
-        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '21.1';
+        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '{{ previous_version }}';
         ~~~
 
     1. Exit the SQL shell and delete the temporary pod:

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -21,7 +21,7 @@
 
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
-1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
+1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd.release_date == "N/A" or rd.release_date > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd.release_date == "N/A" or rd.release_date > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Decide how the upgrade will be finalized.
 

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -19,7 +19,7 @@
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html?filters=helm#add-nodes) to your cluster before beginning your upgrade.
 
-{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
 1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-manual.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-manual.md
@@ -21,7 +21,7 @@
 
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
-1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
+1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd.release_date == "N/A" or rd.release_date > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd.release_date == "N/A" or rd.release_date > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Decide how the upgrade will be finalized.
 

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-manual.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-manual.md
@@ -19,15 +19,9 @@
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html?filters=manual#add-nodes) to your cluster before beginning your upgrade.
 
-
-{% comment %}
-
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
 
 1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
-{% endcomment %}
-
-1. Review the backward-incompatible changes in {{ page.version.version }} and deprecated features. If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Decide how the upgrade will be finalized.
 
@@ -69,7 +63,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
-        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '21.1';
+        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '{{ previous_version }}';
         ~~~
 
     1. Exit the SQL shell and delete the temporary pod:

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-manual.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-manual.md
@@ -19,7 +19,7 @@
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html?filters=manual#add-nodes) to your cluster before beginning your upgrade.
 
-{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
 1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 

--- a/_includes/v22.1/sidebar-data/manage.json
+++ b/_includes/v22.1/sidebar-data/manage.json
@@ -412,6 +412,12 @@
                   ]
                 },
                 {
+                  "title": "Upgrade to v22.1",
+                  "urls": [
+                     "/cockroachcloud/upgrade-to-v22.1.html"
+                  ]
+                },
+                {
                   "title": "Upgrade to v21.2",
                   "urls": [
                      "/cockroachcloud/upgrade-to-v21.2.html"

--- a/cockroachcloud/upgrade-to-v22.1.md
+++ b/cockroachcloud/upgrade-to-v22.1.md
@@ -1,0 +1,134 @@
+---
+title: Upgrade to CockroachDB v22.1
+summary: Learn how to upgrade your CockroachDB cluster to v22.1.
+toc: true
+docs_area: manage
+---
+
+Now that [CockroachDB v22.1](../releases/v22.1.html) is available, a [Console Admin](console-access-management.html#console-admin) can upgrade your {{ site.data.products.dedicated }} cluster from the {{ site.data.products.db }} Console. This page walks through the process for an Admin.
+
+{{site.data.alerts.callout_success}}
+Upgrading a {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the {{ site.data.products.db }} [upgrade policy](upgrade-policy.html).
+{{site.data.alerts.end}}
+
+## Step 1. Verify that you can upgrade
+
+To upgrade to v22.1, you must be running v21.2. If you are not running v21.2, first [upgrade to v21.2](upgrade-to-v21.2.html). Then return to this page and continue to [Step 2](#step-2-select-your-cluster-size).
+
+## Step 2. Select your cluster size
+
+The upgrade process depends on the number of nodes in your cluster. Select whether your cluster has multiple nodes or a single node:
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="multi-node">Multi-node</button>
+  <button class="filter-button" data-scope="single-node">Single-node</button>
+</div>
+
+## Step 3. Understand the upgrade process
+
+<section class="filter-content" markdown="1" data-scope="multi-node">
+In a multi-node cluster, the upgrade does not interrupt the cluster's overall health and availability. One node is stopped and restarted with the new version, then the next, and so on, pausing for a few minutes between each node. This "rolling upgrade" takes approximately 4-5 minutes per node and is enabled by CockroachDB's [multi-active availability](../{{site.versions["stable"]}}/multi-active-availability.html) design.
+
+Approximately 72 hours after all nodes are running v22.1, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v22.1](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.2, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+When you start the upgrade, the cluster will be unavailable for a few minutes while the node is stopped and restarted with v22.1.
+
+Approximately 72 hours after the node has been restarted, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v22.1](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.2, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
+</section>
+
+## Step 4. Prepare to upgrade
+
+ Before starting the upgrade, complete the following steps.
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+
+### Prepare for brief unavailability
+
+Your cluster will be unavailable while its single node is stopped and restarted with v22.1. Prepare your application for this brief downtime, typically a few minutes.
+
+The [**SQL Users**](user-authorization.html#create-a-sql-user) and [**Monitoring**](monitoring-page.html) tabs in the {{ site.data.products.db }} Console will also be disabled during this time.
+
+</section>
+
+### Review breaking changes
+
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+
+Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your applications, make the necessary changes before proceeding.
+
+## Step 5. Start the upgrade
+
+To start the upgrade process:
+
+1. [Sign in](https://cockroachlabs.cloud/) to your {{ site.data.products.db }} account.
+
+2. In the **Clusters** list, select the cluster you want to upgrade.
+
+3. Select **Actions > Upgrade major version**.
+
+4. In the **Upgrade your cluster** dialog, review the pre-upgrade message and then click **Start Upgrade**.
+
+<section class="filter-content" markdown="1" data-scope="multi-node">
+Your cluster will be upgraded one node at a time without interrupting the cluster's overall health and availability. This "rolling upgrade" will take approximately 4-5 minutes per node.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+Your single-node cluster will be unavailable for a few minutes while the node is stopped and restarted with v22.1.
+</section>
+
+## Step 6. Monitor the upgrade
+
+Once your cluster is running v22.1, you will have approximately 72 hours before the upgrade is automatically finalized. During this time, it is important to [monitor your application](#monitor-your-application) and [respect temporary limitations](#respect-temporary-limitations).
+
+If you see unexpected behavior, you can [roll back](#roll-back-the-upgrade) to v21.2 during the 72-hour window.
+
+### Monitor your application
+
+Use the [DB Console](monitoring-page.html) or your own tooling to monitor your application for any unexpected behavior.
+
+- If everything looks good, you can wait for the upgrade to automatically finalize or you can [manually trigger finalization](#finalize-the-upgrade).
+
+- If you see unexpected behavior, you can [roll back to v21.2](#roll-back-the-upgrade) during the 72-hour window.
+
+### Respect temporary limitations
+
+Most v22.1 features can be used right away, but some will be enabled only after the upgrade has been finalized. Attempting to use these features before finalization will result in errors:
+
+- SCRAM authentication
+- Row-level time to live (TTL)
+- Table-level automatic statistics collection
+
+For an expanded list of features included in the v22.1 release, see the [v22.1 release notes](../releases/v22.1.html).
+
+### Roll back the upgrade
+
+If you see unexpected behavior, you can roll back the upgrade during the 72-hour window.
+
+To stop the upgrade and roll back to v21.2, click **Roll back** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Roll back upgrade**.
+
+<section class="filter-content" markdown="1" data-scope="multi-node">
+During rollback, nodes will be reverted to v21.2 one at a time without interrupting the cluster's health and availability.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+Because your cluster contains a single node, the cluster will be briefly unavailable while the node is stopped and restarted with v21.2. Be sure to [prepare for this brief unavailability](#prepare-for-brief-unavailability) before starting the rollback.
+</section>
+
+## Step 7. Complete the upgrade
+
+If everything looks good, you can wait for the upgrade to automatically finalize, or you can manually trigger finalization to lift the [temporary limitations](#respect-temporary-limitations) on the cluster more quickly.
+
+### Finalize the upgrade
+
+The upgrade is automatically finalized after 72 hours.
+
+To manually finalize the upgrade, click **Finalize** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Finalize upgrade**.
+
+After finalization, all [temporary limitations](#respect-temporary-limitations) will be lifted, and all v22.1 features are available for use. However, it will no longer be possible to roll back to v21.2. If you see unexpected behavior after the upgrade has been finalized, [contact support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+
+## See also
+
+- [Upgrade Policy](upgrade-policy.html)
+- [CockroachDB v22.1 Release Notes](../releases/v22.1.html)

--- a/cockroachcloud/upgrade-to-v22.1.md
+++ b/cockroachcloud/upgrade-to-v22.1.md
@@ -3,6 +3,7 @@ title: Upgrade to CockroachDB v22.1
 summary: Learn how to upgrade your CockroachDB cluster to v22.1.
 toc: true
 docs_area: manage
+page_version: v22.1
 ---
 
 Now that [CockroachDB v22.1](../releases/v22.1.html) is available, a [Console Admin](console-access-management.html#console-admin) can upgrade your {{ site.data.products.dedicated }} cluster from the {{ site.data.products.db }} Console. This page walks through the process for an Admin.

--- a/cockroachcloud/upgrade-to-v22.1.md
+++ b/cockroachcloud/upgrade-to-v22.1.md
@@ -96,8 +96,8 @@ Use the [DB Console](monitoring-page.html) or your own tooling to monitor your a
 
 Most v22.1 features can be used right away, but some will be enabled only after the upgrade has been finalized. Attempting to use these features before finalization will result in errors:
 
-- **SCRAM-SHA-256 authentication:** CockroachDB supports [SCRAM-SHA-256](../{{site.versions["stable"]}}/security-reference/scram-authentication.html) authentication for clients in both CockroachDB Cloud and CockroachDB Self-Hosted. For SQL client sessions, it is now possible to use the authentication methods `password` (cleartext passwords), and `cert-password` (TLS client cert or cleartext password) with either CRDB-BCRYPT or SCRAM-SHA-256 stored credentials.
-- **Row-Level Time to Live (TTL):** CockroachDB has preview support for Time to Live ("TTL") expiration on table rows, also known as [Row-Level TTL](../{{site.versions["stable"]}}/row-level-ttl.html). Row-Level TTL is a mechanism whereby rows from a table are considered "expired" and can be automatically deleted once those rows have been stored longer than a specified expiration time.
+- **SCRAM-SHA-256 authentication:** CockroachDB supports [SCRAM-SHA-256](../v22.1/security-reference/scram-authentication.html) authentication for clients in both CockroachDB Cloud and CockroachDB Self-Hosted. For SQL client sessions, it is now possible to use the authentication methods `password` (cleartext passwords), and `cert-password` (TLS client cert or cleartext password) with either CRDB-BCRYPT or SCRAM-SHA-256 stored credentials.
+- **Row-Level Time to Live (TTL):** CockroachDB has preview support for Time to Live ("TTL") expiration on table rows, also known as [Row-Level TTL](../v22.1/row-level-ttl.html). Row-Level TTL is a mechanism whereby rows from a table are considered "expired" and can be automatically deleted once those rows have been stored longer than a specified expiration time.
 
 For an expanded list of features included in the v22.1 release, see the [v22.1 release notes](../releases/v22.1.html).
 

--- a/cockroachcloud/upgrade-to-v22.1.md
+++ b/cockroachcloud/upgrade-to-v22.1.md
@@ -96,10 +96,8 @@ Use the [DB Console](monitoring-page.html) or your own tooling to monitor your a
 
 Most v22.1 features can be used right away, but some will be enabled only after the upgrade has been finalized. Attempting to use these features before finalization will result in errors:
 
-- SCRAM authentication
-- Row-level time to live (TTL)
-- Table-level automatic statistics collection
-- `DATE` and `INTERVAL` style settings available by default
+- **SCRAM-SHA-256 authentication:** CockroachDB supports [SCRAM-SHA-256](../{{site.versions["stable"]}}/security-reference/scram-authentication.html) authentication for clients in both CockroachDB Cloud and CockroachDB Self-Hosted. For SQL client sessions, it is now possible to use the authentication methods `password` (cleartext passwords), and `cert-password` (TLS client cert or cleartext password) with either CRDB-BCRYPT or SCRAM-SHA-256 stored credentials.
+- **Row-Level Time to Live (TTL):** CockroachDB has preview support for Time to Live ("TTL") expiration on table rows, also known as [Row-Level TTL](../{{site.versions["stable"]}}/row-level-ttl.html). Row-Level TTL is a mechanism whereby rows from a table are considered "expired" and can be automatically deleted once those rows have been stored longer than a specified expiration time.
 
 For an expanded list of features included in the v22.1 release, see the [v22.1 release notes](../releases/v22.1.html).
 

--- a/cockroachcloud/upgrade-to-v22.1.md
+++ b/cockroachcloud/upgrade-to-v22.1.md
@@ -29,13 +29,13 @@ The upgrade process depends on the number of nodes in your cluster. Select wheth
 <section class="filter-content" markdown="1" data-scope="multi-node">
 In a multi-node cluster, the upgrade does not interrupt the cluster's overall health and availability. One node is stopped and restarted with the new version, then the next, and so on, pausing for a few minutes between each node. This "rolling upgrade" takes approximately 4-5 minutes per node and is enabled by CockroachDB's [multi-active availability](../{{site.versions["stable"]}}/multi-active-availability.html) design.
 
-Approximately 72 hours after all nodes are running v22.1, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v22.1](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.2, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
+Approximately 72 hours after all nodes are running v22.1, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v22.1](#expect-temporary-limitations). Finalization also removes the ability to roll back to v21.2, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
 </section>
 
 <section class="filter-content" markdown="1" data-scope="single-node">
 When you start the upgrade, the cluster will be unavailable for a few minutes while the node is stopped and restarted with v22.1.
 
-Approximately 72 hours after the node has been restarted, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v22.1](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.2, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
+Approximately 72 hours after the node has been restarted, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v22.1](#expect-temporary-limitations). Finalization also removes the ability to roll back to v21.2, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
 </section>
 
 ## Step 4. Prepare to upgrade
@@ -54,9 +54,9 @@ The [**SQL Users**](user-authorization.html#create-a-sql-user) and [**Monitoring
 
 ### Review breaking changes
 
-{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.page_version" | first %}
 
-Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your applications, make the necessary changes before proceeding.
+Review the [backward-incompatible changes in {{ page.page_version }}](../releases/{{ page.page_version }}.html{% unless rd.release_date == "N/A" or rd.release_date > today %}#{{ page.page_version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.page_version }}.html#{% unless rd.release_date == "N/A" or rd.release_date > today %}{{ page.page_version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your applications, make the necessary changes before proceeding.
 
 ## Step 5. Start the upgrade
 
@@ -80,7 +80,7 @@ Your single-node cluster will be unavailable for a few minutes while the node is
 
 ## Step 6. Monitor the upgrade
 
-Once your cluster is running v22.1, you will have approximately 72 hours before the upgrade is automatically finalized. During this time, it is important to [monitor your application](#monitor-your-application) and [respect temporary limitations](#respect-temporary-limitations).
+Once your cluster is running v22.1, you will have approximately 72 hours before the upgrade is automatically finalized. During this time, it is important to [monitor your application](#monitor-your-application) and [respect temporary limitations](#expect-temporary-limitations).
 
 If you see unexpected behavior, you can [roll back](#roll-back-the-upgrade) to v21.2 during the 72-hour window.
 
@@ -92,13 +92,14 @@ Use the [DB Console](monitoring-page.html) or your own tooling to monitor your a
 
 - If you see unexpected behavior, you can [roll back to v21.2](#roll-back-the-upgrade) during the 72-hour window.
 
-### Respect temporary limitations
+### Expect temporary limitations
 
 Most v22.1 features can be used right away, but some will be enabled only after the upgrade has been finalized. Attempting to use these features before finalization will result in errors:
 
 - SCRAM authentication
 - Row-level time to live (TTL)
 - Table-level automatic statistics collection
+- `DATE` and `INTERVAL` style settings available by default
 
 For an expanded list of features included in the v22.1 release, see the [v22.1 release notes](../releases/v22.1.html).
 
@@ -118,7 +119,7 @@ Because your cluster contains a single node, the cluster will be briefly unavail
 
 ## Step 7. Complete the upgrade
 
-If everything looks good, you can wait for the upgrade to automatically finalize, or you can manually trigger finalization to lift the [temporary limitations](#respect-temporary-limitations) on the cluster more quickly.
+If everything looks good, you can wait for the upgrade to automatically finalize, or you can manually finalize the upgrade to lift the [temporary limitations](#expect-temporary-limitations) on the cluster more quickly.
 
 ### Finalize the upgrade
 
@@ -126,7 +127,7 @@ The upgrade is automatically finalized after 72 hours.
 
 To manually finalize the upgrade, click **Finalize** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Finalize upgrade**.
 
-After finalization, all [temporary limitations](#respect-temporary-limitations) will be lifted, and all v22.1 features are available for use. However, it will no longer be possible to roll back to v21.2. If you see unexpected behavior after the upgrade has been finalized, [contact support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+After finalization, all [temporary limitations](#expect-temporary-limitations) will be lifted, and all v22.1 features are available for use. However, it will no longer be possible to roll back to v21.2. If you see unexpected behavior after the upgrade has been finalized, [contact support](https://support.cockroachlabs.com/hc/en-us/requests/new).
 
 ## See also
 

--- a/v21.2/upgrade-cockroachdb-kubernetes.md
+++ b/v21.2/upgrade-cockroachdb-kubernetes.md
@@ -47,11 +47,7 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html#add-nodes) to your cluster before beginning your upgrade.
 
-{% comment %}
 1. Review the [backward-incompatible changes in v21.2](../releases/v21.2.html#v21-2-0-backward-incompatible-changes) and [deprecated features](../releases/v21.2.html#v21-2-0-deprecations). If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
-{% endcomment %}
-
-1. Review the backward-incompatible changes in v21.2 and deprecated features. If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
 
 1. Change the desired Docker image in the custom resource:
 

--- a/v22.1/upgrade-cockroach-version.md
+++ b/v22.1/upgrade-cockroach-version.md
@@ -47,7 +47,7 @@ Verify the overall health of your cluster using the [DB Console](ui-cluster-over
 
 ### Review breaking changes
 
-{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
 Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
@@ -79,6 +79,7 @@ When upgrading from {{ previous_version }} to {{ page.version.version }}, certai
 - SCRAM authentication
 - Row-level time to live (TTL)
 - Table-level automatic statistics collection
+- `DATE` and `INTERVAL` style settings available by default
 
 For an expanded list of features included in the {{ page.version.version }} release, see the [{{ page.version.version }} release notes](../releases/{{ page.version.version }}.html).
 

--- a/v22.1/upgrade-cockroach-version.md
+++ b/v22.1/upgrade-cockroach-version.md
@@ -49,7 +49,7 @@ Verify the overall health of your cluster using the [DB Console](ui-cluster-over
 
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
-Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
+Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd.release_date == "N/A" or rd.release_date > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd.release_date == "N/A" or rd.release_date > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 ## Step 3. Decide how the upgrade will be finalized
 

--- a/v22.1/upgrade-cockroach-version.md
+++ b/v22.1/upgrade-cockroach-version.md
@@ -76,10 +76,8 @@ By default, after all nodes are running the new version, the upgrade process wil
 
 When upgrading from {{ previous_version }} to {{ page.version.version }}, certain features and performance improvements will be enabled only after finalizing the upgrade, including but not limited to:
 
-- SCRAM authentication
-- Row-level time to live (TTL)
-- Table-level automatic statistics collection
-- `DATE` and `INTERVAL` style settings available by default
+- **SCRAM-SHA-256 authentication:** CockroachDB supports [SCRAM-SHA-256](security-reference/scram-authentication.html) authentication for clients in both CockroachDB Cloud and CockroachDB Self-Hosted. For SQL client sessions, it is now possible to use the authentication methods `password` (cleartext passwords), and `cert-password` (TLS client cert or cleartext password) with either CRDB-BCRYPT or SCRAM-SHA-256 stored credentials.
+- **Row-Level Time to Live (TTL):** CockroachDB has preview support for Time to Live ("TTL") expiration on table rows, also known as [Row-Level TTL](row-level-ttl.html). Row-Level TTL is a mechanism whereby rows from a table are considered "expired" and can be automatically deleted once those rows have been stored longer than a specified expiration time.
 
 For an expanded list of features included in the {{ page.version.version }} release, see the [{{ page.version.version }} release notes](../releases/{{ page.version.version }}.html).
 

--- a/v22.1/upgrade-cockroachdb-kubernetes.md
+++ b/v22.1/upgrade-cockroachdb-kubernetes.md
@@ -36,7 +36,7 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
 
     Therefore, in order to upgrade to {{ page.version.version }}, you must be on a production release of {{ previous_version }}.
 
-    1. If you are upgrading to {{ page.version.version }} from a production release earlier than {{ previous_version }}, or from a testing release (alpha/beta), first [upgrade to a production release of v21.1](../v21.1/operate-cockroachdb-kubernetes.html#upgrade-the-cluster). Be sure to complete all the steps.
+    1. If you are upgrading to {{ page.version.version }} from a production release earlier than {{ previous_version }}, or from a testing release (alpha/beta), first [upgrade to a production release of {{ previous_version }}](../v21.1/operate-cockroachdb-kubernetes.html#upgrade-the-cluster). Be sure to complete all the steps.
 
     1. Then return to this page and perform a second upgrade to {{ page.version.version }}.
 
@@ -49,11 +49,7 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html#add-nodes) to your cluster before beginning your upgrade.
 
-{% comment %}
 1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html#v21-2-0-backward-incompatible-changes) and [deprecated features](../releases/{{ page.version.version }}.html#v21-2-0-deprecations). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
-{% endcomment %}
-
-1. Review the backward-incompatible changes in {{ page.version.version }} and deprecated features. If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Change the desired Docker image in the custom resource:
 

--- a/v22.1/upgrade-cockroachdb-kubernetes.md
+++ b/v22.1/upgrade-cockroachdb-kubernetes.md
@@ -49,7 +49,7 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html#add-nodes) to your cluster before beginning your upgrade.
 
-{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
 1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 

--- a/v22.1/upgrade-cockroachdb-kubernetes.md
+++ b/v22.1/upgrade-cockroachdb-kubernetes.md
@@ -49,7 +49,9 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
         - Make sure all nodes are on the same version. If not all nodes are on the same version, upgrade them to the cluster's highest current version first, and then start this process over.
         - Make sure capacity and memory usage are reasonable for each node. Nodes must be able to tolerate some increase in case the new version uses more resources for your workload. Also go to **Metrics > Dashboard: Hardware** and make sure CPU percent is reasonable across the cluster. If there's not enough headroom on any of these metrics, consider [adding nodes](scale-cockroachdb-kubernetes.html#add-nodes) to your cluster before beginning your upgrade.
 
-1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html#v21-2-0-backward-incompatible-changes) and [deprecated features](../releases/{{ page.version.version }}.html#v21-2-0-deprecations). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
+{% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | map: "release_date" %}
+
+1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Change the desired Docker image in the custom resource:
 

--- a/v22.1/upgrade-cockroachdb-kubernetes.md
+++ b/v22.1/upgrade-cockroachdb-kubernetes.md
@@ -51,7 +51,7 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
 
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 
-1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd == "N/A" or rd > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd == "N/A" or rd > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
+1. Review the [backward-incompatible changes in {{ page.version.version }}](../releases/{{ page.version.version }}.html{% unless rd.release_date == "N/A" or rd.release_date > today %}#{{ page.version.version | replace: ".", "-" }}-0-backward-incompatible-changes{% endunless %}) and [deprecated features](../releases/{{ page.version.version }}.html#{% unless rd.release_date == "N/A" or rd.release_date > today %}{{ page.version.version | replace: ".", "-" }}-0-deprecations{% endunless %}). If any affect your deployment, make the necessary changes before starting the rolling upgrade to {{ page.version.version }}.
 
 1. Change the desired Docker image in the custom resource:
 


### PR DESCRIPTION
(WIP; not ready to merge)

Fixes DOC-3355.
Fixes DOC 3356.

- Updated the version callouts in the v22.1 upgrade docs (incl. Kubernetes docs), using new liquid variables and conditional url syntax from @nickvigilante 
- Added a provisional list of "upgrade finalization" features. Final verbiage will be taken from the GA release notes.
- Also still need to add an include for "breaking changes" list in the GA release notes.

cc @mikeCRL for visibility.

@trestman do you have availability to review this PR before next Monday, the 24th? It needs to be merged before then, ideally Friday. The PR is a WIP (see above) but the other contents to be included will be coming directly from @mikeCRL, so I think it is safe to review now.