### PR TITLE
Update some vectorized execution docs

### DIFF
--- a/_includes/v21.2/known-limitations/unordered-distinct-operations.md
+++ b/_includes/v21.2/known-limitations/unordered-distinct-operations.md
@@ -1,8 +1,0 @@
-Disk spilling [isn't supported](https://github.com/cockroachdb/cockroach/issues/61411) when running `UPSERT` statements that have `nulls are distinct` and `error on duplicate` markers. You can check this by using `EXPLAIN` and looking at the statement plan.
-
-~~~
-        ├── distinct                     |                     |
-        │    │                           | distinct on         | ...
-        │    │                           | nulls are distinct  |
-        │    │                           | error on duplicate  |
-~~~

--- a/_includes/v21.2/misc/session-vars.html
+++ b/_includes/v21.2/misc/session-vars.html
@@ -685,19 +685,6 @@
 
   <tr>
    <td>
-    <code>vectorize_row_count_threshold</code>
-   </td>
-   <td>The minimum number of rows required to use the vectorized engine to execute a query plan.
-   </td>
-   <td>
-    <code>1000</code>
-   </td>
-   <td>Yes</td>
-   <td>Yes</td>
-  </tr>
-
-  <tr>
-   <td>
     <code>backslash_quote</code>
    </td>
    <td>(Reserved; exposed only for ORM compatibility.)</td>

--- a/_includes/v22.1/known-limitations/unordered-distinct-operations.md
+++ b/_includes/v22.1/known-limitations/unordered-distinct-operations.md
@@ -1,8 +1,0 @@
-Disk spilling [isn't supported](https://github.com/cockroachdb/cockroach/issues/61411) when running `UPSERT` statements that have `nulls are distinct` and `error on duplicate` markers. You can check this by using `EXPLAIN` and looking at the statement plan.
-
-~~~
-        ├── distinct                     |                     |
-        │    │                           | distinct on         | ...
-        │    │                           | nulls are distinct  |
-        │    │                           | error on duplicate  |
-~~~

--- a/_includes/v22.1/misc/session-vars.md
+++ b/_includes/v22.1/misc/session-vars.md
@@ -57,7 +57,6 @@
 | <a name="transaction-rows-written-log"></a> `transaction_rows_written_log` | The threshold for the number of rows written by a SQL transaction. If this value is exceeded, the event will be logged to `SQL_PERF` (or `SQL_INTERNAL_PERF` for internal transactions). | `0` | Yes | Yes |
 | <a name="transaction-status"></a> `transaction_status` | The state of the current transaction. See [Transactions](transactions.html) for more details. This session variable was called `transaction status` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `NoTxn` | No | Yes |
 | <a name="vectorize"></a> `vectorize` | The vectorized execution engine mode. Options include `on` and `off`. For more details, see [Configure vectorized execution for CockroachDB](vectorized-execution.html#configure-vectorized-execution). | `on` | Yes | Yes |
-| <a name="vectorize-row-count-threshold"></a> `vectorize_row_count_threshold` | The minimum number of rows required to use the vectorized engine to execute a query plan. | `1000` | Yes | Yes |
 
 The following session variables are exposed only for backwards compatibility with earlier CockroachDB releases and have no impact on how CockroachDB runs:
 

--- a/v21.2/explain.md
+++ b/v21.2/explain.md
@@ -22,8 +22,6 @@ Using `EXPLAIN` output, you can optimize your queries as follows:
 
      The statement planner uses the [cost-based optimizer](cost-based-optimizer.html) to create statement plans. Even after adding secondary indexes, the optimizer may decide that a full table scan will be faster. For example, if you add a secondary index to a table with a large number of rows and see that a statement plan isn't using the secondary index, it is likely that performing a full table scan using the primary key is faster than doing a secondary index scan plus an [index join](indexes.html).
 
-- Enable row-oriented execution if you are querying a table with a small number of rows. Since the [vectorized execution](vectorized-execution.html) engine is enabled for all [supported operations](vectorized-execution.html#disk-spilling-operations) you can use the `vectorize_row_count_threshold` [cluster setting](cluster-settings.html) to specify the minimum number of rows required to use the vectorized engine to execute a statement plan.
-
 You can find out if your queries are performing entire table scans by using `EXPLAIN` to see which:
 
 - Indexes the query uses; shown as the value of the `table` property.

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -594,7 +594,3 @@ If you think a rollback of a column-dropping schema change has occurred, check t
 If the execution of a [join](joins.html) query exceeds the limit set for memory-buffering operations (i.e., the value set for the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html)), CockroachDB will spill the intermediate results of computation to disk. If the join operation spills to disk, and at least one of the equality columns is of type [`JSON`](jsonb.html), CockroachDB returns the error `unable to encode table key: *tree.DJSON`. If the memory limit is not reached, then the query will be processed without error.
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/35706)
-
-### Disk-spilling not supported for some unordered distinct operations
-
-{% include {{ page.version.version }}/known-limitations/unordered-distinct-operations.md %}

--- a/v21.2/vectorized-execution.md
+++ b/v21.2/vectorized-execution.md
@@ -17,7 +17,7 @@ You can configure vectorized execution with the `vectorize` [session variable](s
 
 Option    | Description
 ----------|------------
-`on`   | Turns on vectorized execution for all queries on rows over the [`vectorize_row_count_threshold`](#set-the-row-threshold-for-vectorized-execution) (0 rows, by default, meaning all queries will use the vectorized engine).<br><br>**Default:** `vectorize=on`
+`on`   | Turns on vectorized execution for all queries.<br><br>**Default:** `vectorize=on`
 `off`  | Turns off vectorized execution for all queries.
 
 For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
@@ -25,14 +25,6 @@ For information about setting session variables, see [`SET` &lt;session variable
 {{site.data.alerts.callout_success}}
 To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
 {{site.data.alerts.end}}
-
-### Set the row threshold for vectorized execution
-
-The efficiency of vectorized execution increases with the number of rows processed. If you are querying a table with a small number of rows, it is more efficient to use row-oriented execution.
-
-By default, vectorized execution is enabled for all queries.
-
-For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan in the current session with the `vectorize_row_count_threshold` [session variable](set-vars.html).
 
 ## How vectorized execution works
 

--- a/v21.2/vectorized-execution.md
+++ b/v21.2/vectorized-execution.md
@@ -75,10 +75,6 @@ The vectorized engine does not support queries containing:
 
 The vectorized engine does not support [working with spatial data](spatial-data.html). Queries with [geospatial functions](functions-and-operators.html#spatial-functions) or [spatial data](spatial-data.html) will revert to the row-oriented execution engine.
 
-### Unordered distinct operations
-
-{% include {{ page.version.version }}/known-limitations/unordered-distinct-operations.md %}
-
 ## See also
 
 - [SQL Layer](architecture/sql-layer.html)

--- a/v22.1/explain.md
+++ b/v22.1/explain.md
@@ -22,8 +22,6 @@ Using `EXPLAIN` output, you can optimize your queries as follows:
 
      The statement planner uses the [cost-based optimizer](cost-based-optimizer.html) to create statement plans. Even after adding secondary indexes, the optimizer may decide that a full table scan will be faster. For example, if you add a secondary index to a table with a large number of rows and see that a statement plan isn't using the secondary index, it is likely that performing a full table scan using the primary key is faster than doing a secondary index scan plus an [index join](indexes.html#example).
 
-- Enable row-oriented execution if you are querying a table with a small number of rows. Since the [vectorized execution](vectorized-execution.html) engine is enabled for all [supported operations](vectorized-execution.html#disk-spilling-operations) you can use the `vectorize_row_count_threshold` [cluster setting](cluster-settings.html) to specify the minimum number of rows required to use the vectorized engine to execute a statement plan.
-
 You can find out if your queries are performing entire table scans by using `EXPLAIN` to see which:
 
 - Indexes the query uses; shown as the value of the `table` property.

--- a/v22.1/known-limitations.md
+++ b/v22.1/known-limitations.md
@@ -600,7 +600,3 @@ If you think a rollback of a column-dropping schema change has occurred, check t
 If the execution of a [join](joins.html) query exceeds the limit set for memory-buffering operations (i.e., the value set for the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html)), CockroachDB will spill the intermediate results of computation to disk. If the join operation spills to disk, and at least one of the equality columns is of type [`JSON`](jsonb.html), CockroachDB returns the error `unable to encode table key: *tree.DJSON`. If the memory limit is not reached, then the query will be processed without error.
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/35706)
-
-### Disk-spilling not supported for some unordered distinct operations
-
-{% include {{ page.version.version }}/known-limitations/unordered-distinct-operations.md %}

--- a/v22.1/vectorized-execution.md
+++ b/v22.1/vectorized-execution.md
@@ -17,7 +17,7 @@ You can configure vectorized execution with the `vectorize` [session variable](s
 
 Option    | Description
 ----------|------------
-`on`   | Turns on vectorized execution for all queries on rows over the [`vectorize_row_count_threshold`](#set-the-row-threshold-for-vectorized-execution) (0 rows, by default, meaning all queries will use the vectorized engine).<br><br>**Default:** `vectorize=on`
+`on`   | Turns on vectorized execution for all queries.<br><br>**Default:** `vectorize=on`
 `off`  | Turns off vectorized execution for all queries.
 
 For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
@@ -25,14 +25,6 @@ For information about setting session variables, see [`SET` &lt;session variable
 {{site.data.alerts.callout_success}}
 To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
 {{site.data.alerts.end}}
-
-### Set the row threshold for vectorized execution
-
-The efficiency of vectorized execution increases with the number of rows processed. If you are querying a table with a small number of rows, it is more efficient to use row-oriented execution.
-
-By default, vectorized execution is enabled for all queries.
-
-For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan in the current session with the `vectorize_row_count_threshold` [session variable](set-vars.html).
 
 ## How vectorized execution works
 

--- a/v22.1/vectorized-execution.md
+++ b/v22.1/vectorized-execution.md
@@ -75,10 +75,6 @@ The vectorized engine does not support queries containing:
 
 The vectorized engine does not support [working with spatial data](spatial-data.html). Queries with [geospatial functions](functions-and-operators.html#spatial-functions) or [spatial data](spatial-data.html) will revert to the row-oriented execution engine.
 
-### Unordered distinct operations
-
-{% include {{ page.version.version }}/known-limitations/unordered-distinct-operations.md %}
-
 ## See also
 
 - [SQL Layer](architecture/sql-layer.html)


### PR DESCRIPTION
**Remove mention of vectorize_row_count_threshold session variable**

This session variable has been removed in 21.2.0 release.

Fixes: #11301

**Remove known limitation of unordered distinct in the vectorized engine**

This limitation has been addressed in 21.2.0 release.

Fixes: #11348