### PR TITLE
DOC-3631 clarify SQL overview session variables

### DIFF
--- a/_includes/v21.2/sidebar-data/reference.json
+++ b/_includes/v21.2/sidebar-data/reference.json
@@ -619,7 +619,7 @@
                 ]
               },
               {
-                "title": "<code>RESET</code> &lt;session variable&gt;",
+                "title": "<code>RESET &#123;session variable&#125;</code>",
                 "urls": [
                   "/${VERSION}/reset-vars.html"
                 ]
@@ -679,7 +679,7 @@
                 ]
               },
               {
-                "title": "<code>SET</code> &lt;session variable&gt;",
+                "title": "<code>SET &#123;session variable&#125;</code>",
                 "urls": [
                   "/${VERSION}/set-vars.html"
                 ]
@@ -715,7 +715,7 @@
                 ]
               },
               {
-                "title": "<code>SHOW</code> &lt;session variables&gt;",
+                "title": "<code>SHOW &#123;session variable&#125;</code>",
                 "urls": [
                   "/${VERSION}/show-vars.html"
                 ]

--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -637,7 +637,7 @@
                 ]
               },
               {
-                "title": "<code>RESET</code> &lt;session variable&gt;",
+                "title": "<code>RESET &#123;session variable&#125;</code>",
                 "urls": [
                   "/${VERSION}/reset-vars.html"
                 ]
@@ -697,13 +697,13 @@
                 ]
               },
               {
-                "title": "<code>SET</code> &lt;session variable&gt;",
+                "title": "<code>SET &#123;session variable&#125;</code>",
                 "urls": [
                   "/${VERSION}/set-vars.html"
                 ]
               },
               {
-                "title": "<code>SET</code> &lt;storage parameter&gt;",
+                "title": "<code>SET &lt;storage parameter&gt;</code>",
                 "urls": [
                   "/${VERSION}/set-storage-parameter.html"
                 ]
@@ -739,7 +739,7 @@
                 ]
               },
               {
-                "title": "<code>SHOW</code> &lt;session variables&gt;",
+                "title": "<code>SHOW &#123;session variable&#125;</code>",
                 "urls": [
                   "/${VERSION}/show-vars.html"
                 ]

--- a/v21.2/alter-database.md
+++ b/v21.2/alter-database.md
@@ -20,8 +20,8 @@ Subcommand | Description
 [`ADD REGION`](add-region.html) |  Add a region to a [multi-region database](multiregion-overview.html).
 [`DROP REGION`](drop-region.html) |  Drop a region from a [multi-region database](multiregion-overview.html).
 [`SET PRIMARY REGION`](set-primary-region.html) |  Set the primary region of a [multi-region database](multiregion-overview.html).
-[`SET <sessionvar>`](alter-role.html#set-default-session-variable-values-for-a-specific-database) | <span class="version-tag">New in v21.2</span>: Set the default session variable values for the database. This syntax is identical to [`ALTER ROLE ALL IN DATABASE SET <sessionvar>`](alter-role.html).
-`RESET <sessionvar>` | <span class="version-tag">New in v21.2</span>: Reset the default session variable values for the database to the system defaults. This syntax is identical to [`ALTER ROLE ALL IN DATABASE RESET <sessionvar>`](alter-role.html).
+[`SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-specific-database) | <span class="version-tag">New in v21.2</span>: Set the default session variable values for the database. This syntax is identical to [`ALTER ROLE ALL IN DATABASE SET {session variable}`](alter-role.html).
+`RESET {session variable}` | <span class="version-tag">New in v21.2</span>: Reset the default session variable values for the database to the system defaults. This syntax is identical to [`ALTER ROLE ALL IN DATABASE RESET {session variable}`](alter-role.html).
 [`SURVIVE {ZONE,REGION} FAILURE`](survive-failure.html) |  Add a survival goal to a [multi-region database](multiregion-overview.html).
 
 ## Viewing schema changes

--- a/v21.2/alter-role.md
+++ b/v21.2/alter-role.md
@@ -38,8 +38,8 @@ Parameter | Description
 ----------|-------------
 `role_name` | The name of the role to alter.
 `WITH role_option` | Apply a [role option](#role-options) to the role.
-`SET var_name ... var_value` | <span class="version-tag">New in v21.2</span>: Set default [session variable](set-vars.html) values for a role.
-`RESET session_var`<br>`RESET ALL` <a name="parameters-reset"></a> | <span class="version-tag">New in v21.2</span>: Reset one session variable or all session variables to the default value.
+`SET {session variable}` | <span class="version-tag">New in v21.2</span>: Set default [session variable](set-vars.html) values for a role.
+`RESET {session variable}`<br>`RESET ALL` <a name="parameters-reset"></a> | <span class="version-tag">New in v21.2</span>: Reset one session variable or all session variables to the default value.
 `IN DATABASE database_name` | <span class="version-tag">New in v21.2</span>: Specify a database for which to apply session variable defaults.<br>When `IN DATABASE` is not specified, the default session variable values apply for a role in all databases.<br>Note that, in order for a session to initialize session variable values to database defaults, the database must be specified as a [connection parameter](connection-parameters.html). Database default values will not appear if the database is set after connection with `USE <dbname>`/`SET database=<dbname>`.
 `ROLE ALL ...`/`USER ALL ...` | <span class="version-tag">New in v21.2</span>: Apply session variable settings to all roles.<br>Exception: The `root` user is exempt from session variable settings.
 

--- a/v21.2/cancel-session.md
+++ b/v21.2/cancel-session.md
@@ -91,6 +91,6 @@ All sessions created by `maxroach` will be cancelled.
 ## See also
 
 - [`SHOW SESSIONS`](show-sessions.html)
-- [`SET` (session variable)](set-vars.html)
-- [`SHOW` (session variable)](show-vars.html)
+- [`SET {session variable}`](set-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [SQL Statements](sql-statements.html)

--- a/v21.2/cost-based-optimizer.md
+++ b/v21.2/cost-based-optimizer.md
@@ -265,10 +265,10 @@ SELECT * FROM abc@{NO_ZIGZAG_JOIN};
 ## See also
 
 - [`JOIN` expressions](joins.html)
-- [`SET (session variable)`](set-vars.html)
+- [`SET {session variable}`](set-vars.html)
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`RESET CLUSTER SETTING`](reset-cluster-setting.html)
-- [`SHOW (session variable)`](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [`CREATE STATISTICS`](create-statistics.html)
 - [`SHOW STATISTICS`](show-statistics.html)
 - [`EXPLAIN`](explain.html)

--- a/v21.2/experimental-features.md
+++ b/v21.2/experimental-features.md
@@ -16,7 +16,7 @@ If you encounter a bug, please [file an issue](file-an-issue.html).
 
 ## Session variables
 
-The table below lists the experimental session settings that are available.  For a complete list of session variables, see [`SHOW` (session settings)](show-vars.html).
+The table below lists the experimental session settings that are available.  For a complete list of session variables, see [`SHOW {session variable}`](show-vars.html).
 
 | Variable                            | Default Value | Description                                                                                                                                                                                                                                                                                             |
 |-------------------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -176,7 +176,7 @@ For usage details, see the [Monitor and Debug Changefeeds](monitor-and-debug-cha
 
 ## See Also
 
-- [`SHOW` (session)](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [Functions and Operators](functions-and-operators.html)
 - [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html)
 - [`SHOW TRACE FOR SESSION`](show-trace.html)

--- a/v21.2/information-schema.md
+++ b/v21.2/information-schema.md
@@ -306,7 +306,7 @@ Column | Description
 
 ### session_variables
 
- `session_variables` contains information about the [session variable settings](set-vars.html) for your session. `session_variables` contains a `variable` column and a `value` column. The `value` column corresponds to the output of the [`SHOW (session settings)`](show-vars.html) statement.
+ `session_variables` contains information about the [session variable settings](set-vars.html) for your session. `session_variables` contains a `variable` column and a `value` column. The `value` column corresponds to the output of the [`SHOW {session variable}`](show-vars.html) statement.
 
 For a list of the session variables, see [supported variables](show-vars.html#supported-variables).
 

--- a/v21.2/reset-vars.md
+++ b/v21.2/reset-vars.md
@@ -1,5 +1,5 @@
 ---
-title: RESET (session variable)
+title: RESET &#123;session variable&#125;
 summary: The SET statement resets a session variable to its default value.
 toc: true
 docs_area: reference.sql
@@ -86,5 +86,5 @@ No [privileges](security-reference/authorization.html#managing-privileges) are r
 
 ## See also
 
-- [`SET` (session variable)](set-vars.html)
-- [`SHOW` (session variables)](show-vars.html)
+- [`SET {session variable}`](set-vars.html)
+- [`SHOW {session variable}`](show-vars.html)

--- a/v21.2/set-cluster-setting.md
+++ b/v21.2/set-cluster-setting.md
@@ -20,7 +20,7 @@ Only members of the `admin` role can modify cluster settings. By default, the `r
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-21.2/grammar_svg/set_cluster_setting.html %}
 </div>
 
-{{site.data.alerts.callout_info}}The <code>SET CLUSTER SETTING</code> statement is unrelated to the other <a href="set-transaction.html"><code>SET TRANSACTION</code></a> and <a href="set-vars.html"><code>SET (session variable)</code></a> statements.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}The <code>SET CLUSTER SETTING</code> statement is unrelated to the other <a href="set-transaction.html"><code>SET TRANSACTION</code></a> and <a href="set-vars.html"><code>SET {session variable}</code></a> statements.{{site.data.alerts.end}}
 
 ## Parameters
 
@@ -109,6 +109,6 @@ To opt out of [automatic diagnostic reporting](diagnostics-reporting.html) of us
 
 ## See also
 
-- [`SET` (session variable)](set-vars.html)
+- [`SET {session variable}`](set-vars.html)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
 - [Cluster settings](cluster-settings.html)

--- a/v21.2/set-vars.md
+++ b/v21.2/set-vars.md
@@ -1,5 +1,5 @@
 ---
-title: SET (session variable)
+title: SET &#123;session variable&#125;
 summary: The SET statement modifies the current configuration variables for the client session.
 toc: true
 docs_area: reference.sql
@@ -25,7 +25,7 @@ All other session variables do not require [privileges](security-reference/autho
 
 ## Synopsis
 
-The `SET` statement can set a session variable for the duration of the current session ([`SET (variable)`/`SET SESSION (variable)`](#set-session)), or for the duration of a single transaction ([`SET LOCAL (variable)`](#set-local)).
+The `SET` statement can set a session variable for the duration of the current session ([`SET {variable}`/`SET SESSION {variable}`](#set-session)), or for the duration of a single transaction ([`SET LOCAL {variable}`](#set-local)).
 
 ### SET SESSION
 
@@ -34,7 +34,7 @@ The `SET` statement can set a session variable for the duration of the current s
 </div>
 
 {{site.data.alerts.callout_info}}
-By default, session variables are set for the duration of the current session. As a result, [`SET (variable)` and `SET SESSION (variable)`](#set-session) are equivalent.
+By default, session variables are set for the duration of the current session. As a result, [`SET {variable}` and `SET SESSION {variable}`](#set-session) are equivalent.
 {{site.data.alerts.end}}
 
 ### SET LOCAL
@@ -453,9 +453,9 @@ When setting a time zone, note the following:
 
 ## See also
 
-- [`RESET`](reset-vars.html)
+- [`RESET {session variable}`](reset-vars.html)
 - [`SET TRANSACTION`](set-transaction.html)
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
-- [`SHOW` (session variables)](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [The `TIMESTAMP` and `TIMESTAMPTZ` data types.](timestamp.html)
 - [`SHOW TRACE FOR SESSION`](show-trace.html)

--- a/v21.2/show-cluster-setting.md
+++ b/v21.2/show-cluster-setting.md
@@ -10,7 +10,7 @@ The `SHOW CLUSTER SETTING` [statement](sql-statements.html) displays the values 
 To configure cluster settings, use [`SET CLUSTER SETTING`](set-cluster-setting.html).
 
 {{site.data.alerts.callout_info}}
-The `SHOW` statement for cluster settings is unrelated to the other `SHOW` statements: <a href="show-vars.html"><code>SHOW (session variable)</code></a>, <a href="show-create.html"><code>SHOW CREATE</code></a>, <a href="show-users.html"><code>SHOW USERS</code></a>, <a href="show-databases.html"><code>SHOW DATABASES</code></a>, <a href="show-columns.html"><code>SHOW COLUMNS</code></a>, <a href="show-grants.html"><code>SHOW GRANTS</code></a>, and <a href="show-constraints.html"><code>SHOW CONSTRAINTS</code></a>.
+The `SHOW` statement for cluster settings is unrelated to the other `SHOW` statements: <a href="show-vars.html"><code>SHOW {session variable}</code></a>, <a href="show-create.html"><code>SHOW CREATE</code></a>, <a href="show-users.html"><code>SHOW USERS</code></a>, <a href="show-databases.html"><code>SHOW DATABASES</code></a>, <a href="show-columns.html"><code>SHOW COLUMNS</code></a>, <a href="show-grants.html"><code>SHOW GRANTS</code></a>, and <a href="show-constraints.html"><code>SHOW CONSTRAINTS</code></a>.
 {{site.data.alerts.end}}
 
 ## Details
@@ -126,7 +126,7 @@ Field | Description
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`RESET CLUSTER SETTING`](reset-cluster-setting.html)
 - [Cluster settings](cluster-settings.html)
-- [`SHOW` (session variable)](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [`SHOW COLUMNS`](show-columns.html)
 - [`SHOW CONSTRAINTS`](show-constraints.html)
 - [`SHOW CREATE`](show-create.html)

--- a/v21.2/show-vars.md
+++ b/v21.2/show-vars.md
@@ -1,5 +1,5 @@
 ---
-title: SHOW (session variables)
+title: SHOW &#123;session variable&#125;
 summary: The SHOW statement displays the current settings for the client session.
 toc: true
 docs_area: reference.sql
@@ -77,7 +77,7 @@ Special syntax cases supported for compatibility:
 
 ## See also
 
-- [`SET` (session variable)](set-vars.html)
+- [`SET {session variable}`](set-vars.html)
 - [Transactions](transactions.html), including [Priority levels](transactions.html#transaction-priorities)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
 - [`SHOW COLUMNS`](show-columns.html)

--- a/v21.2/sql-statements.md
+++ b/v21.2/sql-statements.md
@@ -137,11 +137,11 @@ Statement | Usage
 
 Statement | Usage
 ----------|------------
-[`RESET`](reset-vars.html) | Reset a session variable to its default value.
-[`SET`](set-vars.html) | Set a current session variable.
+[`RESET {session variable}`](reset-vars.html) | Reset a session variable to its default value.
+[`SET {session variable}`](set-vars.html) | Set a current session variable.
 [`SET TRANSACTION`](set-transaction.html) | Set the priority for an individual [transaction](transactions.html).
 [`SHOW TRACE FOR SESSION`](show-trace.html) | Return details about how CockroachDB executed a statement or series of statements recorded during a session.
-[`SHOW`](show-vars.html) | List the current session or transaction settings.
+[`SHOW {session variable}`](show-vars.html) | List the current session or transaction settings.
 
 ## Cluster management statements
 

--- a/v21.2/vectorized-execution.md
+++ b/v21.2/vectorized-execution.md
@@ -20,7 +20,7 @@ Option    | Description
 `on`   | Turns on vectorized execution for all queries on rows over the [`vectorize_row_count_threshold`](#set-the-row-threshold-for-vectorized-execution) (0 rows, by default, meaning all queries will use the vectorized engine).<br><br>**Default:** `vectorize=on`
 `off`  | Turns off vectorized execution for all queries.
 
-For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
+For information about setting session variables, see [`SET {session variable}`](set-vars.html).
 
 {{site.data.alerts.callout_success}}
 To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
@@ -90,5 +90,5 @@ The vectorized engine does not support [working with spatial data](spatial-data.
 ## See also
 
 - [SQL Layer](architecture/sql-layer.html)
-- [`SET` &lt;session variable&gt;](set-vars.html)
-- [`SHOW` &lt;session variable&gt;](show-vars.html)
+- [`SET {session variable}`](set-vars.html)
+- [`SHOW {session variable}`](show-vars.html)

--- a/v22.1/alter-database.md
+++ b/v22.1/alter-database.md
@@ -22,8 +22,8 @@ Subcommand | Description
 [`ADD SUPER REGION`](add-super-region.html) | <span class="version-tag">New in v22.1:</span> Add a super region made up of a set of [database regions](multiregion-overview.html#super-regions) such that data from [regional tables](regional-tables.html) will be stored in only those regions.
 [`DROP SUPER REGION`](drop-super-region.html) | <span class="version-tag">New in v22.1:</span> Drop a super region made up of a set of [database regions](multiregion-overview.html#super-regions).
 [`ALTER SUPER REGION`](alter-super-region.html) | <span class="version-tag">New in v22.1:</span> Alter an existing [super region](multiregion-overview.html#super-regions) to include a different set of regions. A super region is made up of a set of regions added with [`ADD REGION`](add-region.html) such that data from [regional tables](regional-tables.html) will be stored in only those regions.
-[`SET <sessionvar>`](alter-role.html#set-default-session-variable-values-for-a-specific-database) |  Set the default session variable values for the database. This syntax is identical to [`ALTER ROLE ALL IN DATABASE SET <sessionvar>`](alter-role.html).
-`RESET <sessionvar>` |  Reset the default session variable values for the database to the system defaults. This syntax is identical to [`ALTER ROLE ALL IN DATABASE RESET <sessionvar>`](alter-role.html).
+[`SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-specific-database) |  Set the default session variable values for the database. This syntax is identical to [`ALTER ROLE ALL IN DATABASE SET {session variable}`](alter-role.html).
+`RESET {session variable}` |  Reset the default session variable values for the database to the system defaults. This syntax is identical to [`ALTER ROLE ALL IN DATABASE RESET {session variable}`](alter-role.html).
 [`SURVIVE {ZONE,REGION} FAILURE`](survive-failure.html) |  Add a survival goal to a [multi-region database](multiregion-overview.html).
 
 ## Viewing schema changes

--- a/v22.1/alter-role.md
+++ b/v22.1/alter-role.md
@@ -38,8 +38,8 @@ Parameter | Description
 ----------|-------------
 `role_name` | The name of the role to alter.
 `WITH role_option` | Apply a [role option](#role-options) to the role.
-`SET var_name ... var_value` |  Set default [session variable](set-vars.html) values for a role.
-`RESET session_var`<br>`RESET ALL` <a name="parameters-reset"></a> |  Reset one session variable or all session variables to the default value.
+`SET {session variable}` |  Set default [session variable](set-vars.html) values for a role.
+`RESET {session variable}`<br>`RESET ALL` <a name="parameters-reset"></a> |  Reset one session variable or all session variables to the default value.
 `IN DATABASE database_name` |  Specify a database for which to apply session variable defaults.<br>When `IN DATABASE` is not specified, the default session variable values apply for a role in all databases.<br>Note that, in order for a session to initialize session variable values to database defaults, the database must be specified as a [connection parameter](connection-parameters.html). Database default values will not appear if the database is set after connection with `USE <dbname>`/`SET database=<dbname>`.
 `ROLE ALL ...`/`USER ALL ...` |  Apply session variable settings to all roles.<br>Exception: The `root` user is exempt from session variable settings.
 

--- a/v22.1/cancel-session.md
+++ b/v22.1/cancel-session.md
@@ -91,6 +91,6 @@ All sessions created by `maxroach` will be cancelled.
 ## See also
 
 - [`SHOW SESSIONS`](show-sessions.html)
-- [`SET` (session variable)](set-vars.html)
-- [`SHOW` (session variable)](show-vars.html)
+- [`SET {session variable}`](set-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [SQL Statements](sql-statements.html)

--- a/v22.1/cost-based-optimizer.md
+++ b/v22.1/cost-based-optimizer.md
@@ -295,10 +295,10 @@ SELECT * FROM abc@{NO_ZIGZAG_JOIN};
 ## See also
 
 - [`JOIN` expressions](joins.html)
-- [`SET (session variable)`](set-vars.html)
+- [`SET {session variable}`](set-vars.html)
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`RESET CLUSTER SETTING`](reset-cluster-setting.html)
-- [`SHOW (session variable)`](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [`CREATE STATISTICS`](create-statistics.html)
 - [`SHOW STATISTICS`](show-statistics.html)
 - [`EXPLAIN`](explain.html)

--- a/v22.1/experimental-features.md
+++ b/v22.1/experimental-features.md
@@ -16,7 +16,7 @@ If you encounter a bug, please [file an issue](file-an-issue.html).
 
 ## Session variables
 
-The table below lists the experimental session settings that are available.  For a complete list of session variables, see [`SHOW` (session settings)](show-vars.html).
+The table below lists the experimental session settings that are available.  For a complete list of session variables, see [`SHOW {session variable}`](show-vars.html).
 
 | Variable                            | Default Value | Description                                                                                                                                                                                                                                                                                             |
 |-------------------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -175,7 +175,7 @@ For usage details, see the [Monitor and Debug Changefeeds](monitor-and-debug-cha
 
 ## See Also
 
-- [`SHOW` (session)](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [Functions and Operators](functions-and-operators.html)
 - [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html)
 - [`SHOW TRACE FOR SESSION`](show-trace.html)

--- a/v22.1/information-schema.md
+++ b/v22.1/information-schema.md
@@ -306,7 +306,7 @@ Column | Description
 
 ### session_variables
 
- `session_variables` contains information about the [session variable settings](set-vars.html) for your session. `session_variables` contains a `variable` column and a `value` column. The `value` column corresponds to the output of the [`SHOW (session settings)`](show-vars.html) statement.
+ `session_variables` contains information about the [session variable settings](set-vars.html) for your session. `session_variables` contains a `variable` column and a `value` column. The `value` column corresponds to the output of the [`SHOW {session variable}`](show-vars.html) statement.
 
 For a list of the session variables, see [supported variables](show-vars.html#supported-variables).
 

--- a/v22.1/reset-vars.md
+++ b/v22.1/reset-vars.md
@@ -1,5 +1,5 @@
 ---
-title: RESET (session variable)
+title: RESET &#123;session variable&#125;
 summary: The SET statement resets a session variable to its default value.
 toc: true
 docs_area: reference.sql
@@ -86,5 +86,5 @@ No [privileges](security-reference/authorization.html#managing-privileges) are r
 
 ## See also
 
-- [`SET` (session variable)](set-vars.html)
-- [`SHOW` (session variables)](show-vars.html)
+- [`SET {session variable}`](set-vars.html)
+- [`SHOW {session variable}`](show-vars.html)

--- a/v22.1/set-cluster-setting.md
+++ b/v22.1/set-cluster-setting.md
@@ -20,7 +20,7 @@ Only members of the `admin` role can modify cluster settings. By default, the `r
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/set_cluster_setting.html %}
 </div>
 
-{{site.data.alerts.callout_info}}The <code>SET CLUSTER SETTING</code> statement is unrelated to the other <a href="set-transaction.html"><code>SET TRANSACTION</code></a> and <a href="set-vars.html"><code>SET (session variable)</code></a> statements.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}The <code>SET CLUSTER SETTING</code> statement is unrelated to the other <a href="set-transaction.html"><code>SET TRANSACTION</code></a> and <a href="set-vars.html"><code>SET {session variable}</code></a> statements.{{site.data.alerts.end}}
 
 ## Parameters
 
@@ -109,6 +109,6 @@ To opt out of [automatic diagnostic reporting](diagnostics-reporting.html) of us
 
 ## See also
 
-- [`SET` (session variable)](set-vars.html)
+- [`SET {session variable}`](set-vars.html)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
 - [Cluster settings](cluster-settings.html)

--- a/v22.1/set-vars.md
+++ b/v22.1/set-vars.md
@@ -1,5 +1,5 @@
 ---
-title: SET (session variable)
+title: SET &#123;session variable&#125;
 summary: The SET statement modifies the current configuration variables for the client session.
 toc: true
 docs_area: reference.sql
@@ -25,7 +25,7 @@ All other session variables do not require [privileges](security-reference/autho
 
 ## Synopsis
 
-The `SET` statement can set a session variable for the duration of the current session ([`SET (variable)`/`SET SESSION (variable)`](#set-session)), or for the duration of a single transaction ([`SET LOCAL (variable)`](#set-local)).
+The `SET` statement can set a session variable for the duration of the current session ([`SET {variable}`/`SET SESSION {variable}`](#set-session)), or for the duration of a single transaction ([`SET LOCAL {variable}`](#set-local)).
 
 ### SET SESSION
 
@@ -34,7 +34,7 @@ The `SET` statement can set a session variable for the duration of the current s
 </div>
 
 {{site.data.alerts.callout_info}}
-By default, session variables are set for the duration of the current session. As a result, [`SET (variable)` and `SET SESSION (variable)`](#set-session) are equivalent.
+By default, session variables are set for the duration of the current session. As a result, [`SET {variable}` and `SET SESSION {variable}`](#set-session) are equivalent.
 {{site.data.alerts.end}}
 
 ### SET LOCAL
@@ -456,6 +456,6 @@ When setting a time zone, note the following:
 - [`RESET`](reset-vars.html)
 - [`SET TRANSACTION`](set-transaction.html)
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
-- [`SHOW` (session variables)](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [The `TIMESTAMP` and `TIMESTAMPTZ` data types.](timestamp.html)
 - [`SHOW TRACE FOR SESSION`](show-trace.html)

--- a/v22.1/show-cluster-setting.md
+++ b/v22.1/show-cluster-setting.md
@@ -10,7 +10,7 @@ The `SHOW CLUSTER SETTING` [statement](sql-statements.html) displays the values 
 To configure cluster settings, use [`SET CLUSTER SETTING`](set-cluster-setting.html).
 
 {{site.data.alerts.callout_info}}
-The `SHOW` statement for cluster settings is unrelated to the other `SHOW` statements: <a href="show-vars.html"><code>SHOW (session variable)</code></a>, <a href="show-create.html"><code>SHOW CREATE</code></a>, <a href="show-users.html"><code>SHOW USERS</code></a>, <a href="show-databases.html"><code>SHOW DATABASES</code></a>, <a href="show-columns.html"><code>SHOW COLUMNS</code></a>, <a href="show-grants.html"><code>SHOW GRANTS</code></a>, and <a href="show-constraints.html"><code>SHOW CONSTRAINTS</code></a>.
+The `SHOW` statement for cluster settings is unrelated to the other `SHOW` statements: <a href="show-vars.html"><code>SHOW {session variable}</code></a>, <a href="show-create.html"><code>SHOW CREATE</code></a>, <a href="show-users.html"><code>SHOW USERS</code></a>, <a href="show-databases.html"><code>SHOW DATABASES</code></a>, <a href="show-columns.html"><code>SHOW COLUMNS</code></a>, <a href="show-grants.html"><code>SHOW GRANTS</code></a>, and <a href="show-constraints.html"><code>SHOW CONSTRAINTS</code></a>.
 {{site.data.alerts.end}}
 
 ## Details
@@ -126,7 +126,7 @@ Field | Description
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`RESET CLUSTER SETTING`](reset-cluster-setting.html)
 - [Cluster settings](cluster-settings.html)
-- [`SHOW` (session variable)](show-vars.html)
+- [`SHOW {session variable}`](show-vars.html)
 - [`SHOW COLUMNS`](show-columns.html)
 - [`SHOW CONSTRAINTS`](show-constraints.html)
 - [`SHOW CREATE`](show-create.html)

--- a/v22.1/show-vars.md
+++ b/v22.1/show-vars.md
@@ -1,5 +1,5 @@
 ---
-title: SHOW (session variables)
+title: SHOW &#123;session variable&#125;
 summary: The SHOW statement displays the current settings for the client session.
 toc: true
 docs_area: reference.sql
@@ -77,7 +77,7 @@ Special syntax cases supported for compatibility:
 
 ## See also
 
-- [`SET` (session variable)](set-vars.html)
+- [`SET {session variable}`](set-vars.html)
 - [Transactions](transactions.html), including [Priority levels](transactions.html#transaction-priorities)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
 - [`SHOW COLUMNS`](show-columns.html)

--- a/v22.1/sql-statements.md
+++ b/v22.1/sql-statements.md
@@ -140,11 +140,11 @@ Statement | Usage
 
 Statement | Usage
 ----------|------------
-[`RESET`](reset-vars.html) | Reset a session variable to its default value.
-[`SET`](set-vars.html) | Set a current session variable.
+[`RESET {session variable}`](reset-vars.html) | Reset a session variable to its default value.
+[`SET {session variable}`](set-vars.html) | Set a current session variable.
 [`SET TRANSACTION`](set-transaction.html) | Set the priority for an individual [transaction](transactions.html).
 [`SHOW TRACE FOR SESSION`](show-trace.html) | Return details about how CockroachDB executed a statement or series of statements recorded during a session.
-[`SHOW`](show-vars.html) | List the current session or transaction settings.
+[`SHOW {session variable}`](show-vars.html) | List the current session or transaction settings.
 
 ## Cluster management statements
 

--- a/v22.1/vectorized-execution.md
+++ b/v22.1/vectorized-execution.md
@@ -20,7 +20,7 @@ Option    | Description
 `on`   | Turns on vectorized execution for all queries on rows over the [`vectorize_row_count_threshold`](#set-the-row-threshold-for-vectorized-execution) (0 rows, by default, meaning all queries will use the vectorized engine).<br><br>**Default:** `vectorize=on`
 `off`  | Turns off vectorized execution for all queries.
 
-For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
+For information about setting session variables, see [`SET {session variable}`](set-vars.html).
 
 {{site.data.alerts.callout_success}}
 To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
@@ -90,5 +90,5 @@ The vectorized engine does not support [working with spatial data](spatial-data.
 ## See also
 
 - [SQL Layer](architecture/sql-layer.html)
-- [`SET` &lt;session variable&gt;](set-vars.html)
-- [`SHOW` &lt;session variable&gt;](show-vars.html)
+- [`SET {session variable}`](set-vars.html)
+- [`SHOW {session variable}`](show-vars.html)


### PR DESCRIPTION
Addresses: DOC-3631

- Updated all instances of `SET`, `RESET`, and `SHOW` in the corpus to follow the style guide guidance on placeholder usage:
  - Bare usage now appended with  `{session variable}`
  - Instances with `()` or `<>` now use `{}`
  - Code + placeholder text now uniformly monospaced
  - Similar text meant to indicate same thing all standardized (example: `var_name ... var_value` and `session_var`).
  - Deepest apologies for back and forth but: standardized on singular due to most usage being for single session variables at a time. Example: `SET` only sets one variable at a time, and `SHOW` only prints one variable at a time, unless used as `SHOW ALL`. 
- To accomplish this, most copy could just be updated to `{session variable}` but page titles (front matter) and left-nav entries required `&#123;session variable&#125;`

Caveat:
- `set-vars.md` uses form `SET {variable}`/`SET SESSION {variable}` for which I opted not to replace as `{session variable}` without muddying the waters too much. IMO `SET SESSION {session variable}` hurts more than it helps.
- Several of these files refer to both a `var_name` and a `var_value` in thier `## Parameters` tables. I left these alone, but replaced external references to `var_name ... var_value` with the standard `{session variable}` per above.

Thank you for your patience with this one.

[sql-statements.md](https://deploy-preview-13912--cockroachdb-docs.netlify.app/docs/stable/sql-statements.html#session-management-statements) | [set-vars.md](https://deploy-preview-13912--cockroachdb-docs.netlify.app/docs/stable/set-vars.html) | [set-cluster-setting.md](https://deploy-preview-13912--cockroachdb-docs.netlify.app/docs/stable/set-cluster-setting.html#synopsis) | etc