### PR TITLE
Show 22.1 as "stable" in version switcher

### DIFF
--- a/_config_cockroachdb.yml
+++ b/_config_cockroachdb.yml
@@ -2,5 +2,5 @@ baseurl: /docs
 destination: _site/docs
 homepage_title: CockroachDB Docs
 versions:
-  dev: v22.1
   stable: v22.1
+  dev: v22.1

--- a/_config_cockroachdb_local.yml
+++ b/_config_cockroachdb_local.yml
@@ -6,6 +6,7 @@ exclude:
 - "v19.1"
 - "v19.2"
 - "v20.1"
+- "v20.2"
 - "ci"
 - "scripts"
 - "vendor"


### PR DESCRIPTION
Also remove 20.2, which is EOL, from local builds.