### PR TITLE
Correction to error heading on Core changefeed page

### DIFF
--- a/v22.1/changefeed-for.md
+++ b/v22.1/changefeed-for.md
@@ -123,8 +123,6 @@ EXPERIMENTAL CHANGEFEED FOR TABLE cdc_test WITH split_column_families;
 
 For step-by-step guidance creating a Core changefeed on a table with multiple column families, see [Changefeed Examples](changefeed-examples.html).
 
-### Create a changefeed with
-
 ## See also
 
 - [Change Data Capture Overview](change-data-capture-overview.html)


### PR DESCRIPTION
This is a quick fix for a header that should not be on the experimental changefeed page 

https://www.cockroachlabs.com/docs/stable/changefeed-for.html#create-a-changefeed-with 