### PR TITLE
Make the first IMPORT INTO reference a valid link

### DIFF
--- a/v22.1/migrate-from-csv.md
+++ b/v22.1/migrate-from-csv.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: migrate
 ---
 
-This page has instructions for migrating data from CSV files into CockroachDB using [`IMPORT INTO`][import-into.html].
+This page has instructions for migrating data from CSV files into CockroachDB using [`IMPORT INTO`](import-into.html).
 
 The examples on this page use the [employees data set](https://github.com/datacharmer/test_db) that is also used in the [MySQL docs](https://dev.mysql.com/doc/employee/en/).
 


### PR DESCRIPTION
The link for the first reference IMPORT INTO reference was broken because it used brackets instead of parentheses. This replaces the brackets to make the link valid.