### PR TITLE
Simplify/clarify deprecation for node drain

### DIFF
--- a/_includes/releases/v22.1/v22.1.0.md
+++ b/_includes/releases/v22.1/v22.1.0.md
@@ -124,7 +124,7 @@ Before [upgrading to CockroachDB v22.1](../v22.1/upgrade-cockroach-version.html)
 
 <h4 id="v22-1-0-deprecations">Deprecations</h4>
 
-- The [`cockroach node drain`](../v22.1/cockroach-node.html) command is now able to drain a node by ID, specified on the command line, from another node in the cluster. It now also supports the flag `--self` for symmetry with [`node decommission`](../v22.1/cockroach-node.html#node-decommission). Using `node drain` without either `--self` or a node ID is now deprecated. [#73991][#73991]
+- Using the [`cockroach node drain`](../v22.1/cockroach-node.html) command without specifying a node ID is deprecated. [#73991][#73991]
 - The flag `--self` of the [`cockroach node decommission` command](../v22.1/cockroach-node.html) is deprecated. Instead, operators should specify the node ID of the target node as an explicit argument. The node that the command is connected to should not be a target node. [#74319][#74319]
 - The `experimental_enable_hash_sharded_indexes` session variable is deprecated as hash-sharded indexes are enabled by default. Enabling this setting results in a noop. [#78038][#78038]
 - The [`BACKUP TO`](../v22.1/) syntax to take backups is deprecated, and will be removed in a future release. Create a backup collection using the `BACKUP INTO` syntax. [#78250][#78250]


### PR DESCRIPTION
The original note mixed new functionality with deprecations.