### PR TITLE
Add special character escaping

### DIFF
--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -681,6 +681,7 @@ $ go get -u github.com/lib/pq
 
 This is more sample text.
 ```
+Using some special characters (e.g., double `{{ ... }}`) within code blocks may require to you [escape them](#escaping-special-characters).
 
 Highlight shell and SQL commands where appropriate using the following info:
 
@@ -725,11 +726,42 @@ When you use placeholders, you usually need to define the value within the brack
 - For many placeholder values (10+), and for placeholder values with complex definitions, use a [table](#tables).
 - For large code blocks, define the placeholder values inside the code block, with an inline code comment.
 
-Ensure that placeholders are placed within backticks `(``)`: `SET {session variables}`. This signifies that placeholder values are code.
+Ensure that placeholders are placed within backticks `(``)`: `SET {session variable}`. This signifies that placeholder values are code.
 
 If the code sample you are using is sensitive to curly bracket characters (e.g., JavaScript), you can use `<>` instead.
 
+Using placeholders within code samples or in non-Markdown locations may require to you [escape them](#escaping-special-characters).
+
 For some examples, see [Connect to a CockroachDB Cluster](https://www.cockroachlabs.com/docs/stable/connect-to-the-database.html?filters=python).
+
+#### Escaping special characters
+
+Sometimes you may need to escape special characters to acheive proper rendering. This is most common in the following two cases:
+
+- You are using Jekyll-reserved characters (e.g., double `{{ ... }}`) in code blocks. To escape these, wrap the specific line you wish to escape using the following liquid syntax:
+
+  ```
+  {% raw %}summary: Instance {{ $labels.instance }} has {{ $value }} tripped per-Replica circuit breakers{% endraw %}
+  ```
+
+  **Note:** Use these tags inline within the code block. Using `{% raw %}` or `{% endraw %}` tags on their own line will render correctly, but will introduce an extra newline of whitespace for each.
+
+- You are using special characters (e.g., single `{ ... }`, `< ... >`, etc.) in non-Markdown copy, such as front matter (e.g., `title:` or `summary:`), or in the left-nav `sidebar-data` JSON files. To escape these, convert the special characters to Unicode. For example, to escape `SET {session variable}` in the front matter, use:
+
+  ```
+  title: SET &#123;session variable &#125;
+  ```
+
+  Or in one of the left-nav `sidebar-data` JSON files, use:
+
+  ```
+  {
+    "title": "<code>SET &#123;session variable&#125;</code>",
+    "urls": [
+      "/${VERSION}/set-vars.html"
+    ]
+  },
+  ```
 
 ### Examples
 

--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -738,13 +738,13 @@ For some examples, see [Connect to a CockroachDB Cluster](https://www.cockroachl
 
 Sometimes you may need to escape special characters to acheive proper rendering. This is most common in the following two cases:
 
-- You are using Jekyll-reserved characters (e.g., double `{{ ... }}`) in code blocks. To escape these, wrap the specific line you wish to escape using the following liquid syntax:
+- You are using Jekyll-reserved characters (e.g., double `{{ ... }}`) in code blocks. To escape these, wrap the specific line(s) you wish to escape using the Liquid tags `{% raw %} ... {% endraw %}`. For example:
 
   ```
   {% raw %}summary: Instance {{ $labels.instance }} has {{ $value }} tripped per-Replica circuit breakers{% endraw %}
   ```
 
-  **Note:** Use these tags inline within the code block. Using `{% raw %}` or `{% endraw %}` tags on their own line will render correctly, but will introduce an extra newline of whitespace for each.
+  **Note:** Use these tags inline within the code block. Using `{% raw %}` or `{% endraw %}` tags on their own line will render the contained text correctly, but will introduce an extra newline of whitespace for each.
 
 - You are using special characters (e.g., single `{ ... }`, `< ... >`, etc.) in non-Markdown copy, such as front matter (e.g., `title:` or `summary:`), or in the left-nav `sidebar-data` JSON files. To escape these, convert the special characters to Unicode. For example, to escape `SET {session variable}` in the front matter, use:
 


### PR DESCRIPTION
- Add _Escaping special characters_ section covering Jekyll and Unicode situations.
- Linked from _Code block_ and _Placeholders_