### PR TITLE
Hashicorp Vault database secrets engine tutorial

### DIFF
--- a/_includes/v22.1/sidebar-data/manage.json
+++ b/_includes/v22.1/sidebar-data/manage.json
@@ -189,12 +189,6 @@
               ]
             },
             {
-              "title": "Configure SQL Authentication for Hardened Serverless Cluster Security",
-              "urls": [
-                "/${VERSION}/security-reference/config-secure-hba.html"
-              ]
-            },
-            {
               "title": "User Authorization",
               "urls": [
                 "/cockroachcloud/user-authorization.html"
@@ -263,6 +257,23 @@
               "title": "Rotate Security Certificates",
               "urls": [
                 "/${VERSION}/rotate-certificates.html"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "CockroachDB General Security Tutorials",
+          "items": [
+            {
+              "title": "Configure SQL Authentication for Hardened Serverless Cluster Security",
+              "urls": [
+                "/${VERSION}/security-reference/config-secure-hba.html"
+              ]
+            },
+            {
+              "title": "Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security",
+              "urls": [
+                "/${VERSION}/vault-db-secrets-tutorial.html"
               ]
             }
           ]

--- a/v22.1/hashicorp-database-secrets.md
+++ b/v22.1/hashicorp-database-secrets.md
@@ -1,0 +1,116 @@
+---
+title: Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security
+summary: Learn how to achieve enhanced credential security using Hashicorp Vault's Dynamic Secrets functionality.
+toc: true
+docs_area: manage
+---
+
+This tutorial discusses and demonstrates best security practices for managing CockroachDB database credentials with Hashicorp Vault.
+
+
+**Goals**:
+
+**Prerequisites**:
+
+- Access as `root` SQL user to a CockroachDB cluster. You could either [spin up a {{ site.data.products.serverless }} cluster]() or [Start a Development Cluster locally](). In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
+
+- Access to a Vault cluster. You can spin up a free cluster in Hashicorp cloud (!!!) or start a development cluster locally... !!! hashicorp docs links
+
+## Introduction
+
+Sound strategy and proper tooling for managing database credentials are essential to the overall strength of your security posture. Managing your CockroachDB database credentials with Hashicorp Vault affords several distinct advantages:
+
+- General advantages of delegated, consolidated secrets management, as opposed to the industry standard of the past, which involves storing credentials in a variety of shared and individually owned file-systems, repositories and data stores, and sharing them via email, messaging, and other means of network communication:
+	- Access is managed by a single coherent set of policies.
+	- Access events leave an audit trail.
+	- Secrets are properly encrypted in flight and in transit.
+
+- Advantages of Vault's Database Dynamic Secrets Engine:
+	- Database credentials are generated and issued only on demand, from pre-configured templates, for specific clients and short validity durations, further minimizing both probability of credential compromise and possible impact of any compromise that does occur.
+	- Diligent rotation and revocation practices are automated by implication, requiring no additional effort or oversight.
+
+
+
+
+
+## Administrating Vault and CRDB
+
+
+In this phase of the tutorial we will act as an administrator for our organization, provisioning access for a class of database clients.
+
+Initialize your shell for Vault by setting your target and authenticating with an admin 
+
+{% include_cached copy-clipboard.html %}
+```shell
+$ export VAULT_ADDR= # your Vault cluster URL
+$ vault login
+```
+
+
+### Binding your Vault to your CRDB cluster
+
+The connection lies in a Vault configuration, which will store your CRDB admin credentials, allowing Vault to administrate CRDB credentials.
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault write database/config/crdb-config \
+  plugin_name=postgresql-database-plugin \
+  allowed_roles="crdb-role" \
+  username="vault" \
+  password="password" \
+  connection_url="postgresql://{{username}}:{{password}}@patrick-vault-gdk.gcp-europe-west1.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full&sslrootcert=${path_to_ca_crt}"
+```
+
+```txt
+
+```
+
+
+### Create a Vault Policy for clients to access their CRDB 
+
+
+Tokens issues for this policy will grant access to read credentials...
+
+{% include_cached copy-clipboard.html %}
+```shell
+$ vault policy write my-policy - << EOF
+path "database/creds/roach-app1-client-policy" {
+  capabilities = [ "read" ]
+}
+EOF
+```
+
+```txt
+
+```
+
+### Provision a Dynamic Secret for SQL client access credentials
+
+{% include_cached copy-clipboard.html %}
+```shell
+ vault write database/roles/crdb-role \
+    db_name=defaultdb \
+    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
+        GRANT ALL ON DATABASE defaultdb TO \"{{name}}\";" \
+    default_ttl="1h" \
+    max_ttl="24h"
+
+```
+
+```txt
+
+```
+
+## Client Access
+
+
+
+
+
+
+
+
+
+
+
+

--- a/v22.1/hashicorp-integration.md
+++ b/v22.1/hashicorp-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Hashicorp Vault Integration
+title: CockroachDB - Hashicorp Vault Integration
 summary: Overview of uses cases for integrating CockroachDB with HashiCorp Vault
 toc: true
 docs_area: reference.third_party_support
@@ -43,3 +43,5 @@ CockroachDB users can use Vault's PostgreSQL Database Secrets Engine to handle t
 - As [Static Roles](https://www.vaultproject.io/docs/secrets/databases#static-roles), meaning that a single SQL user/role is mapped to a Vault role.
 
 - As [Dynamic Secrets](https://www.vaultproject.io/use-cases/dynamic-secrets), meaning that credentials are generated and issued on demand from pre-configured templates, rather than created and persisted. Credentials are issued for specific clients and for short validity durations, further minimizing both the likelihood of a credential compromise, and the possible impact of any compromise that might occur.
+
+Try the tutorial: [Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security in CockroachDB](vault-db-secrets-tutorial.html)

--- a/v22.1/hashicorp-integration.md
+++ b/v22.1/hashicorp-integration.md
@@ -1,5 +1,5 @@
 ---
-title: CockroachDB - Hashicorp Vault Integration
+title: CockroachDB - HashiCorp Vault Integration
 summary: Overview of uses cases for integrating CockroachDB with HashiCorp Vault
 toc: true
 docs_area: reference.third_party_support
@@ -44,4 +44,4 @@ CockroachDB users can use Vault's PostgreSQL Database Secrets Engine to handle t
 
 - As [Dynamic Secrets](https://www.vaultproject.io/use-cases/dynamic-secrets), meaning that credentials are generated and issued on demand from pre-configured templates, rather than created and persisted. Credentials are issued for specific clients and for short validity durations, further minimizing both the likelihood of a credential compromise, and the possible impact of any compromise that might occur.
 
-Try the tutorial: [Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security in CockroachDB](vault-db-secrets-tutorial.html)
+Try the tutorial: [Using HashiCorp Vault's Dynamic Secrets for Enhanced Database Credential Security in CockroachDB](vault-db-secrets-tutorial.html)

--- a/v22.1/vault-db-secrets-tutorial.md
+++ b/v22.1/vault-db-secrets-tutorial.md
@@ -7,466 +7,431 @@ docs_area: manage
 
 This tutorial discusses and demonstrates best security practices for managing CockroachDB database credentials with [HashiCorp Vault's database secrets engine PostgreSQL plugin](https://www.vaultproject.io/docs/secrets/databases/postgresql).
 
+In the first phase of the tutorial, we will act as administrators, provisioning access to a Vault dynamic secret endpoint for a CockroachDB client operator to use to provision credentials for an app that needs to access the CockroachDB database.
+
+In the second phase, acting as client operator, we will pull credentials from Vault and use them to access the database via the CockroachDB client CLI.
+
 See also: 
 
 - [CockroachDB - HashiCorp Vault integration overview page](hashicorp-integration.html)
 - [HashiCorp Vault database secrets engine tutorial](https://learn.hashicorp.com/tutorials/vault/database-secrets).
 
-**Prerequisites**:
+## Prerequisites
 
 To follow along with this tutorial you will need the following:
 
-- The CockroachDB CLI installed locally. [Install CockroachDB](install-cockroachdb-mac.html)
-- The Vault CLI installed locally. [Install Vault](https://www.vaultproject.io/downloads)
-- Access as [`admin` SQL user](security-reference/authorization.html#admin-role) to a CockroachDB cluster. You may either [Create a {{ site.data.products.serverless }} cluster](../cockroachcloud/create-a-serverless-cluster.html) or [Start a Local Cluster (secure)](../{{site.versions["stable"]}}/start-a-local-cluster.html), however, for simplicity, this tutorial will demonstrate the procedure using {{ site.data.products.db }} and assume the user is doing the same. In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
-  You can create a {{ site.data.products.db }} cluster through the [{{ site.data.products.db }} console](https://cockroachlabs.cloud/).
-- Access to a Vault cluster with an admin token. You may either spin up a [free cluster in HashiCorp cloud](https://learn.hashicorp.com/collections/vault/cloud) or [start a development cluster locally](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server).
-  You can create a Vault cluster through the [HashiCorp Vault Cloud console](https://portal.cloud.HashiCorp.com/services/vault).
-
+- The CockroachDB CLI [installed locally](install-cockroachdb-mac.html).
+- The Vault CLI [installed locally](https://www.vaultproject.io/downloads).
+- Access to CockroachDB cluster as [`admin` SQL user](security-reference/authorization.html#admin-role) to a CockroachDB cluster. This tutorial will use a {{ site.data.products.serverless }} cluster, but you may either [Create a {{ site.data.products.serverless }} cluster](../cockroachcloud/create-a-serverless-cluster.html) or [Start a Local Cluster (secure)](../{{site.versions["stable"]}}/start-a-local-cluster.html) in order to follow along. In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
+- Access to a Vault cluster with an admin token. This tutorial will use Hashicorp Cloud Platform, but you may either [spin up a free cluster in HashiCorp Cloud Platform](https://learn.hashicorp.com/collections/vault/cloud) or [start a development cluster locally](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server).
 
 ## Introduction
 
 Sound strategy and proper tooling for managing database credentials are essential to the overall strength of your security posture. Managing your CockroachDB database credentials with HashiCorp Vault affords several security advantages:
 
-- General advantages of delegated, consolidated secrets management, as opposed to the industry standard of the past, which involves storing credentials in a variety of shared and individually owned file-systems, repositories and data stores, and sharing them via email, messaging, and other means of network communication:
-	- Access is managed by a single coherent set of policies.
-	- Access events leave an audit trail.
-	- Secrets are properly encrypted in flight and in transit.
+The general advantages of using a delegated, consolidated secrets management solution include:
+- Access is managed by a single coherent set of policies.
+- Access events leave an audit trail.
+- Secrets are properly encrypted in flight and in transit.
+- There is no need to store or transmit secrets with multiple tools or tools not designed for the purpose, as typically done in the past.
 
-- Advantages of Vault's [Dynamic Secrets](https://www.vaultproject.io/use-cases/dynamic-secrets):
-	- Database credentials are generated and issued only on demand, from pre-configured templates, for specific clients and short validity durations, further minimizing both probability of credential compromise and possible impact of any compromise that does occur.
-	- Diligent rotation and revocation practices are automated by implication, requiring no additional effort or oversight.
+Advantages of Vault's [Dynamic Secrets](https://www.vaultproject.io/use-cases/dynamic-secrets) model:
+- Database credentials are generated and issued only on demand, from pre-configured templates, for specific clients and short validity durations, further minimizing both probability of credential compromise and possible impact of any compromise that does occur.
+- Diligent rotation and revocation practices are automated by implication, requiring no additional effort or oversight.
 
-## Preparing your shell for CockroachDB and Vault admin tasks
+## Step 1: Prepare your shell for CockroachDB and Vault admin tasks
 
-In this phase of the tutorial we will act as an administrator for our organization, provisioning access for a class of database clients.
+In this phase of the tutorial we will act as an administrator for our organization, provisioning access for a class of database clients. We'll need admin credentials for both a Vault cluster and a CockroachDB cluster, allowing you to create and manage access for roles in both domains.
 
-You'll need admin credentials for both a Vault cluster and a CockroachDB cluster, allowing you to create and manage access for roles in both domains.
+1. Connect to CockroachDB
 
-In the first phase of the tutorial, we will act as administrators, provisioning access to a Vault dynamic secret endpoint for a CockroachDB client operator to use to provision credentials for an app that needs to access the CockroachDB database.
+    Set your CockroachDB cluster credentials and other configuration information as environment variables. If you're using a {{ site.data.products.db }} cluster, you can find this information in the [CockroachDB Cloud Console's cluster page.](https://cockroachlabs.cloud/cluster/)
 
-In the second phase, acting as client operator, we will pull credentials from Vault and use them to access the database via the CockroachDB client CLI.
+    {{site.data.alerts.callout_info}}
+    Your cluster name must include the numerical suffic, which is included in the connection string under the **Connect** tab in the console, but is not included when the cluster name is displayed in the console.
+    {{site.data.alerts.end}}
+    
+    1. Export the variables to your shell:
 
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        export USER_NAME=tutorialadmin # replace with CockroachDB admin username
+        export PASSWORD=1234asdf # replace with CockroachDB admin password
+        export DB_NAME=defaultdb # replace with CockroachDB database name if different
+        export CLUSTER_NAME=lilac-grizzly-684 # replace with CockroachDB cluster name
+        export HOST=free-tier123.aws-us-west-2.crdb.io # replace with CockroachDB cluster host
+        ~~~
 
-### Connect to CockroachDB
+    1. Construct a database connection URL for your CockroachDB CLI to connect to the cluster, using your admin credentials. 
+        {{site.data.alerts.callout_info}}
+        You must place the CockroachDB cluster's CA public certificate on the path specified by `sslrootcert`. In the following example, this is a file named `root.crt` in the current directory.
+        {{site.data.alerts.end}}
+    
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        export TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
+        export CLI_DB_CONNECTION_URL="postgresql://${USER_NAME}:${PASSWORD}@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
+        ~~~
 
-Set your CockroachDB cluster credentials and other configuration information as environment variables. If you're using a {{ site.data.products.db }} cluster, you can find this information in the [CockroachDB Cloud Console's cluster page.](https://cockroachlabs.cloud/cluster/)
+    1. Obtain your CockroachDB cluster's CA public certificate
 
+        1. Visit the [CockroachDB Cloud Console's cluster page](https://cockroachlabs.cloud/cluster/). 
+        1. Select your cluster.
+        1. Click the **Connect** button.
+        1. Select **"Download CA Cert (Required only once)"** and use the generated `curl` command to download the certificate.
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-export USER_NAME=tutorialadmin # replace with CockroachDB admin username
-export PASSWORD=1234asdf # replace with CockroachDB admin password
-export DB_NAME=defaultdb # replace with CockroachDB database name if different
-export CLUSTER_NAME=lilac-grizzly-684 # replace with CockroachDB cluster name
-export HOST=free-tier123.aws-us-west-2.crdb.io # replace with CockroachDB cluster host
-~~~
+        ~~~shell
+        curl --create-dirs -o root.crt -O https://management-staging.crdb.io/clusters/505a138c-37ff-46b7-9c50-4119cf0881f6/cert
+        ~~~
 
-Construct a database connection URL for your CockroachDB CLI to connect to the cluster, using your admin credentials. Note that you must place the CockroachDB cluster's CA public certificate on the path specified by `sslrootcert`, in the following example to a file in the current directory.
+1. Prove that your connection works by executing a SQL statement
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-export TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
-export CLI_DB_CONNECTION_URL="postgresql://${USER_NAME}:${PASSWORD}@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
-~~~
+    Recall that this command must be run in the directory where `root.crt` is located, as specified in the connection URL.
 
-#### Obtain your CockroachDB cluster's CA public certificate
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
+    ~~~
+    ~~~txt
+    SHOW TABLES 0
 
-1. Visit the [CockroachDB Cloud Console's cluster page.](https://cockroachlabs.cloud/cluster/). 
-1. Select your cluster.
-1. Click the **Connect** button.
-1. Select **"Download CA Cert (Required only once)"** and use the generated `curl` command to download the certificate.
+    Time: 107ms
+    ~~~
 
-~~~shell
-curl --create-dirs -o root.crt -O https://management-staging.crdb.io/clusters/505a138c-37ff-46b7-9c50-4119cf0881f6/cert
-~~~
+1.  Connect to Vault
 
-#### Prove that your connection works by executing a SQL statement
+    1. Set your Vault target and the `admin` Vault namespace.
 
-Recall that this command must be run in the directory where `root.crt` is located, as specified in the connection URL.
+        You can fetch your target URL and generate a token from the [HashiCorp Vault console](https://portal.cloud.HashiCorp.com/services/vault), under the **Access Vault** tab.
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
-~~~
-~~~txt
-SHOW TABLES 0
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        export VAULT_ADDR=https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.HashiCorp.cloud:8200 # your Vault cluster URL
+        export VAULT_NAMESPACE=admin
+        ~~~
 
-Time: 107ms
-~~~
+    1. Authenticate to your Vault, providing the admin token when prompted:
 
-### Connect to Vault
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        vault login
+        ~~~
+        ~~~
+        Success! You are now authenticated...
+        ~~~
 
-Set your Vault target and the `admin` Vault namespace.
+1. Enable the Vault database secrets engine
 
-You can fetch your target URL and generate a token from the [HashiCorp Vault console](https://portal.cloud.HashiCorp.com/services/vault), under the **Access Vault** tab.
+    This only needs to be done once for an individual Vault cluster. For more information on using the Vault Secrets CLI, see [Vault's documentation](https://www.vaultproject.io/docs/commands/secrets).
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-export VAULT_ADDR=https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.HashiCorp.cloud:8200 # your Vault cluster URL
-export VAULT_NAMESPACE=admin
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault secrets enable database
+    ~~~
+    ~~~txt
+    Success! Enabled the database secrets engine at: database/
+    ~~~
 
-Authenticate to your Vault, providing the admin token when prompted.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault login
-~~~
-~~~shell
-Success! You are now authenticated...
-~~~
-
-### Enable the Vault database secrets engine
-
-This only needs to be done once for an individual Vault cluster.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault secrets enable database
-~~~
-
-~~~txt
-Success! Enabled the database secrets engine at: database/
-~~~
-
-## Binding your Vault cluster to your CockroachDB cluster
+## Step 2: Bind your Vault cluster to your CockroachDB cluster
 
 The connection lies in a Vault configuration, which will store your CockroachDB admin credentials, allowing Vault to administrate CockroachDB credentials.
 
-### Create a Vault database configuration
+1. Create a Vault database configuration
 
-First, tweak the connection string to skip TLS server authentication, as there's no way to provision the Vault server with the cluster CA cert.
+    1. First, tweak the connection string to skip TLS server authentication, as there's no way to provision the Vault server with the cluster CA cert.
 
-{% include_cached copy-clipboard.html %}
-<!-- the "raw" block prevents the double curly braces of Vault's interpolation syntax from being interpreted by Jekyll  -->
-~~~shell
-{% raw %}
-export VAULT_TLS_OPTS="sslmode=require&options=--cluster=${CLUSTER_NAME}"
-export VAULT_DB_CONNECTION_URL="postgresql://{{username}}:{{password}}@${HOST}:26257/${DB_NAME}?${VAULT_TLS_OPTS}"
-{% endraw %}
-~~~
+        {% include_cached copy-clipboard.html %}
+        <!-- the "raw" block prevents the double curly braces of Vault's interpolation syntax from being interpreted by Jekyll  -->
+        ~~~shell
+        {% raw %}
+        export VAULT_TLS_OPTS="sslmode=require&options=--cluster=${CLUSTER_NAME}"
+        export VAULT_DB_CONNECTION_URL="postgresql://{{username}}:{{password}}@${HOST}:26257/${DB_NAME}?${VAULT_TLS_OPTS}"
+        {% endraw %}
+        ~~~
 
+    1. Write the `crdb-config` database configuration to Vault, specifying admin credentials that will be used by Vault to create credentials for your defined role.
 
-Write the `crdb-config` database configuration to Vault, specifying admin credentials that will be used by Vault to create credentials for your defined role.
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        vault write database/config/crdb-config \
+        plugin_name=postgresql-database-plugin \
+        allowed_roles="crdb-role" \
+        username=${USER_NAME} \
+        password=${PASSWORD} \
+        connection_url=${VAULT_DB_CONNECTION_URL}
+        ~~~
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault write database/config/crdb-config \
-plugin_name=postgresql-database-plugin \
-allowed_roles="crdb-role" \
-username=${USER_NAME} \
-password=${PASSWORD} \
-connection_url=${VAULT_DB_CONNECTION_URL}
-~~~
+        ~~~txt
+        Success! Data written to: database/config/crdb-config
+        ~~~
 
-~~~txt
-Success! Data written to: database/config/crdb-config
-~~~
+## Step 3: Provisions Dynamic Secrets for SQL credentials
 
-## Using Dynamic Secrets for SQL credentials
-
-A 'dynamic secret' is really a secret template, which will be used to generate particular short lived secrets on demand, according to the template. The secret type we'll be using is `/database/role`. A Vault database role does not correspond to a single role or user in SQL, but a template for creating short-lived roles or users.
+A *dynamic secret* is a secret template, which will be used to generate particular short-lived secrets on demand, according to the template. The secret type we'll be using is `/database/role`. A Vault database role does not correspond to a single role or user in SQL, but a template for creating short-lived roles or users.
 
 For a SQL role, the template is defined by its `creation_statements`, SQL statements that create the role, define its options and grant its permissions.
 
-### Create a Vault database role
+1. Create a Vault database role
 
-For, example, let's create a role that has all privileges on the `defaultdb` database.
+    For example, let's create a role that has all privileges on the `defaultdb` database.
+    {{site.data.alerts.callout_info}}
+    `db_name` is actually not the database name but the Vault database secrets engine namespace (i.e. `crdb-config` in the example).
+    {{site.data.alerts.end}}
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
 
-NOTE: `db_name` is actually not the database name but the Vault database secrets engine namespace (i.e. `crdb-config` in the example).
+    {% raw %}vault write database/roles/crdb-role \
+        db_name=crdb-config \
+        creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
+            GRANT ALL ON DATABASE defaultdb TO \"{{name}}\";" \
+        default_ttl="1h" \
+        max_ttl="24h"{% endraw %}
+    ~~~
+    ~~~txt
+    Success! Data written to: database/roles/crdb-role
+    ~~~
 
-{% include_cached copy-clipboard.html %}
-~~~shell
+1. Query Vault for a list of database roles, revealing the newly created `crdb-role`.
 
-{% raw %}vault write database/roles/crdb-role \
-    db_name=crdb-config \
-    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
-        GRANT ALL ON DATABASE defaultdb TO \"{{name}}\";" \
-    default_ttl="1h" \
-    max_ttl="24h"{% endraw %}
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault list database/roles/
+    ~~~
+    ~~~txt
+    Keys
+    ----
+    crdb-role
+    ~~~
 
-~~~txt
-Success! Data written to: database/roles/crdb-role
-~~~
+1. Inspect the role, revealing the values we set for the role when creating it.
 
-### List roles
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault read database/roles/crdb-role
+    ~~~
+    ~~~txt
+    Key                      Value
+    ---                      -----
+    creation_statements      [CREATE ROLE "{% raw %}{{name}}{% endraw %}" WITH LOGIN PASSWORD '{% raw %}{{password}}{% endraw %}' VALID UNTIL '{% raw %}{{expiration}}{% endraw %}'; GRANT ALL ON DATABASE defaultdb TO "{% raw %}{{name}}{% endraw %}";]
+    db_name                  crdb-config
+    default_ttl              1h
+    max_ttl                  24h
+    renew_statements         []
+    revocation_statements    []
+    rollback_statements      []
+    ~~~
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault list database/roles/
-~~~
+1. Generate credential pairs
 
-~~~txt
-Keys
-----
-crdb-role
-~~~
+    Recall that a *role* in Vault does not correspond exactly to a *role* in CockroachDB (i.e., a [SQL role or user](security-reference/authorization.html#users-and-roles)).
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault read database/roles/crdb-role
-~~~
+    A Vault role is a defined *template* for credential pairs (SQL user/role name and password), which will be generated on demand and quickly expired.
 
-~~~txt
-Key                      Value
----                      -----
-creation_statements      [CREATE ROLE "{% raw %}{{name}}{% endraw %}" WITH LOGIN PASSWORD '{% raw %}{{password}}{% endraw %}' VALID UNTIL '{% raw %}{{expiration}}{% endraw %}'; GRANT ALL ON DATABASE defaultdb TO "{% raw %}{{name}}{% endraw %}";]
-db_name                  crdb-config
-default_ttl              1h
-max_ttl                  24h
-renew_statements         []
-revocation_statements    []
-rollback_statements      []
-~~~
+    When we "read" the Vault role called `crdb-role`, we are therefore not fetching credentials for a pre-existing SQL user, but requesting that Vault create a user for us, according to the template.
 
-### Generate credential pairs
+    1. To see this, first execute a SQL statement via the CockroachDB CLI to list existing users.
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
+        ~~~
+        ~~~txt
+        username | options | member_of
+        ---------+---------+------------
+        admin    |         | {}
+        docsrule |         | {admin}
+        root     |         | {admin}
+        ~~~
 
-Recall that a *role* in Vault does not correspond exactly to a *role* in CockroachDB (i.e., a [SQL role or user](security-reference/authorization.html#users-and-roles)).
+    1. Now, let's read some credentials from Vault, which will cause Vault to create SQL users on our CockroachDB cluster.
+        Run the following command several times to generate several credential pairs.
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        vault read database/creds/crdb-role
+        ~~~
+        Notice that the validity duration is the default value of 1 hour.
+        ~~~txt
+        Key                Value
+        ---                -----
+        lease_id           database/creds/crdb-role/5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
+        lease_duration     1h
+        lease_renewable    true
+        password           a1qKnD-ZjFG-oUMcSFtx
+        username           v-token-hc-crdb-rol-1pcS5YcSaSS4Fgy4BiXp-1653512968
+        ~~~
 
-A Vault role is a defined *template* for credential pairs (SQL user/role name and password), which will be generated on demand and quickly expired.
+    1. List the active credentials (or *leases*, in Vault terms) for the Vault role:\
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        vault list sys/leases/lookup/database/creds/crdb-role/
+        ~~~
+        ~~~txt
+        Keys
+        ----
+        5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
+        ATKZIXMXMTcNQBkR4vwzvyd8.iMXtW
+        WHtZ4JKGLC8KYssMn5mCxKqU.iMXtW
+        lcAOenZ7s03BpPi8XKS0vsK3.iMXtW
+        yyufcaLu4eKWcnGzhes30t6M.iMXtW
+        ~~~
 
-When we "read" the Vault role called "crdb-role", we are therefore not fetching credentials for a pre-existing SQL user, but requesting that Vault create a user for us, according to the template.
+    1. Now fetch the list of currently active SQL roles from the CockroachDB client:
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
+        ~~~
+        ~~~txt
+                               username                       |                options                | member_of
+        ------------------------------------------------------+---------------------------------------+------------
+          admin                                               |                                       | {}
+          root                                                |                                       | {admin}
+          v-token-hc-crdb-rol-uqtqyca6neplilakhv55-1653513157 | VALID UNTIL=2022-05-25 22:12:42+00:00 | {}
+          v-token-hc-crdb-rol-0gzk3hwi7k7a9w1ggggq-1653515525 | VALID UNTIL=2022-05-25 22:52:10+00:00 | {}
+          v-token-hc-crdb-rol-varnevyjgjg9zgf62kps-1653515522 | VALID UNTIL=2022-05-25 22:52:07+00:00 | {}
+          v-token-hc-crdb-rol-wltbv25napuroomvzmok-1653515524 | VALID UNTIL=2022-05-25 22:52:09+00:00 | {}
+        ~~~
 
-To see this, first execute a SQL statement via the CockroachDB CLI to list existing users.
+1. Revoke credentials
+    Try revoking a lease. Recall that a *lease* on a *role* in Vault terms corresponds to an actual credential pair on the CockroachDB cluster, i.e., a username/password combination for a SQL user.
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault lease revoke database/creds/crdb-role/XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
+    ~~~
+    ~~~txt
+    All revocation operations queued successfully!
+    ~~~
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
-~~~
+1. Provision a CockroachDB-client Vault policy
+    As admin, provision a Vault policy for CockroachDB client operators to access the client credentials.
 
-If you using a freshly created database, you may see only the `admin` and `root` roles.
+    The purpose of the previous work is to make a dynamic secret that can be used to access the CockroachDB database by generating credentials on demand. Performing the above work (establishing the connection between the CockroachDB cluster and the Vault cluster, creating the template for database client credentials, etc.) required admin privileges. But for the work to be meaningful, a Vault user with more limited permissions must be able to access the generated credentials.
 
-~~~txt
-------------------------------------------------------+---------------------------------------+------------
-  admin                                               |                                       | {}
-  root                                                |                                       | {admin}
-~~~
+    This policy will be used to access CockroachDB client credentials. In keeping with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), let's give it only the required ability to read the required credential. 
 
-Now, let's read some credentials from Vault, which will cause Vault to create SQL users on our CockroachDB cluster.
+    Vault policies are specified using HashiCorp Configuration Language (HCL). The following configuration specifies a policy of read access for the `crdb-role` credential.
 
-Run the following command several times to generate several credential pairs.
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault policy write roach-client - <<hcl
+    path "database/creds/crdb-role" {
+      capabilities = [ "read" ]
+    }
+    hcl
+    ~~~
+    ~~~
+    Success! Uploaded policy: roach-client
+    ~~~
 
-Notice that the validity duration is the default value of 1 hour.
+1. Generate an authentication token for the `crdb-role` Vault user
+    Our final act as Vault admin will be to provision an authentication token to assume the `crdb-role`, the Vault role with the sole purpose of providing credentials to a CockroachDB client.
 
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+     vault token create -policy=roach-client
+    ~~~
+    ~~~txt
+    Key                  Value
+    ---                  -----
+    token                hvs.CAESIK4TK7JcSJuKxOgwEa3mYhvfN356Uhikij821K4E4XnWGigKImh2cy5MeUJ5dGNxMjRzNk9qNmVDYWtFYjRUd2QuaU1YdFcQ1cAT
+    token_accessor       36udxC5m0hmA0niBYyCThk0k.iMXtW
+    token_duration       1h
+    token_renewable      true
+    token_policies       ["default" "roach-client"]
+    identity_policies    []
+    policies             ["default" "roach-client"]
+    ~~~
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault read database/creds/crdb-role
-~~~
+    You can either copy the `token` from the output of the previous command, or capture a token with the following command (which requires the shell utility [jq](https://stedolan.github.io/jq/)).
 
-~~~txt
-Key                Value
----                -----
-lease_id           database/creds/crdb-role/5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
-lease_duration     1h
-lease_renewable    true
-password           a1qKnD-ZjFG-oUMcSFtx
-username           v-token-hc-crdb-rol-1pcS5YcSaSS4Fgy4BiXp-1653512968
-~~~
+    ~~~shell
+     VAULT_CLIENT_TOKEN=`vault token create -policy=roach-client -format=json | jq .auth.client_token | tr -d '"'`
+    ~~~
 
-List the active credentials (or *leases*, in Vault terms) for the Vault role:
+## Step 4: Connect to CockroachDB with Vault-provisioned credentials
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault list sys/leases/lookup/database/creds/crdb-role/
-~~~
+In this phase of the tutorial, we will use credentials provisioned by Vault to access our CockroachDB cluster, emulating the flow that an application dev ops engineer or application service account might use to achieve database access. Therefore, unlike in the first phase, we will not use Vault admin credentials or CockroachDB credentials aquired other than through Vault, since these should not be required.
 
-~~~txt
-Keys
-----
-5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
-ATKZIXMXMTcNQBkR4vwzvyd8.iMXtW
-WHtZ4JKGLC8KYssMn5mCxKqU.iMXtW
-lcAOenZ7s03BpPi8XKS0vsK3.iMXtW
-yyufcaLu4eKWcnGzhes30t6M.iMXtW
-~~~
+1. Authenticate to Vault as the CockroachDB user
+    Use the client token to authenticate to Vault with limited permissions.
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault login $VAULT_CLIENT_TOKEN
+    ~~~
+    ~~~txt
+    Success! You are now authenticated. The token information displayed below
+    is already stored in the token helper. You do NOT need to run "vault login"
+    again. Future Vault requests will automatically use this token.
+    ~~~
 
-Now fetch the list of currently active SQL roles from the CockroachDB client:
+1. Confirm the limited permissions of the role
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
-~~~
+    To confirm that you have assumed a role with limited permissions, try listing the current leases on the `crdb-role`, as we did [previously](#). You should see a permissions error.
 
-~~~txt
-                       username                       |                options                | member_of
-------------------------------------------------------+---------------------------------------+------------
-  admin                                               |                                       | {}
-  root                                                |                                       | {admin}
-  v-token-hc-crdb-rol-uqtqyca6neplilakhv55-1653513157 | VALID UNTIL=2022-05-25 22:12:42+00:00 | {}
-  v-token-hc-crdb-rol-0gzk3hwi7k7a9w1ggggq-1653515525 | VALID UNTIL=2022-05-25 22:52:10+00:00 | {}
-  v-token-hc-crdb-rol-varnevyjgjg9zgf62kps-1653515522 | VALID UNTIL=2022-05-25 22:52:07+00:00 | {}
-  v-token-hc-crdb-rol-wltbv25napuroomvzmok-1653515524 | VALID UNTIL=2022-05-25 22:52:09+00:00 | {}
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault list sys/leases/lookup/database/creds/crdb-role/
+    ~~~
+    ~~~txt
+    Error listing sys/leases/lookup/database/creds/crdb-role: Error making API request.
 
-### Revoke credentials
+    Namespace: admin/
+    URL: GET https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.hashicorp.cloud:8200/v1/sys/leases/lookup/database/creds/crdb-role?list=true
+    Code: 403. Errors:
 
-Revoke a lease or two just for the feeling of raw power. Recall that a "lease" on a "role" in Vault terms corresponds to an actual credential pair on the CockroachDB cluster, i.e., a username/password combination for a SQL user.
+    * 1 error occurred:
+      * permission denied
+    ~~~
 
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault lease revoke database/creds/crdb-role/XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
-~~~
+1. Pull the CockroachDB credentials
 
-~~~txt
-All revocation operations queued successfully!
-~~~
+    The only thing this policy does have permission to do is pull credentials for the CockroachDB cluster. Let's do that.
 
-### Provision a CockroachDB-client Vault policy
-
-As admin, provision a Vault policy for CockroachDB client operators to access the client credentials.
-
-The purpose of the previous work is to make a dynamic secret that can be used to access the CockroachDB database by generating credentials on demand. Performing the above work (establishing the connection between the CockroachDB cluster and the Vault cluster, creating the template for database client credentials, etc.) required admin privileges. But for the work to be meaningful, a Vault user with more limited permisions must be able to access the generated credentials.
-
-This policy will be used to access CockroachDB client credentials. In keeping with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), let's give it only the required ability to read the required credential. 
-
-Vault policies are specified using HashiCorp Configuration Language (HCL). The following configuration specifies a policy of read access for the `crdb-role` credential.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault policy write roach-client - <<hcl
-path "database/creds/crdb-role" {
-  capabilities = [ "read" ]
-}
-hcl
-~~~
-
-~~~shell
-Success! Uploaded policy: roach-client
-~~~
-
-### Generate an authentication token for the `crdb-role` Vault user
-
-Our final act as Vault admin will be to provision an authentication token to assume the `crdb-role`, which represents the Vault role with the sole purpose of providing credentials ot a CockroachDB client.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
- vault token create -policy=roach-client
-~~~
-
-~~~txt
-Key                  Value
----                  -----
-token                hvs.CAESIK4TK7JcSJuKxOgwEa3mYhvfN356Uhikij821K4E4XnWGigKImh2cy5MeUJ5dGNxMjRzNk9qNmVDYWtFYjRUd2QuaU1YdFcQ1cAT
-token_accessor       36udxC5m0hmA0niBYyCThk0k.iMXtW
-token_duration       1h
-token_renewable      true
-token_policies       ["default" "roach-client"]
-identity_policies    []
-policies             ["default" "roach-client"]
-~~~
-
-You can either copy the `token` from the output of the previous command, or capture a token with the following command.
-
-~~~shell
- VAULT_CLIENT_TOKEN=`vault token create -policy=roach-client -format=json | jq .auth.client_token | tr -d '"'`
-~~~
-
-## Connecting to CockroachDB with Vault-provisioned credentials
-
-### Authenticate to Vault as the CockroachDB user
-
-Use the client token to authenticate to Vault with limited permissions.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault login $VAULT_CLIENT_TOKEN
-~~~
-
-~~~txt
-Success! You are now authenticated. The token information displayed below
-is already stored in the token helper. You do NOT need to run "vault login"
-again. Future Vault requests will automatically use this token.
-~~~
-
-### Confirm the limited permissions of the role
-
-To confirm that you have assumed a role with limited permissions, try listing the current leases on the `crdb-role`, as we did [previously](#). You should see a permissions error.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault list sys/leases/lookup/database/creds/crdb-role/
-~~~
-
-~~~txt
-Error listing sys/leases/lookup/database/creds/crdb-role: Error making API request.
-
-Namespace: admin/
-URL: GET https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.hashicorp.cloud:8200/v1/sys/leases/lookup/database/creds/crdb-role?list=true
-Code: 403. Errors:
-
-* 1 error occurred:
-  * permission denied
-~~~
-
-### Pull the CockroachDB credentials
-
-The only thing this policy *does* have permission to do is pull credentials for the CockroachDB cluster. Let's do that.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-vault read database/creds/crdb-role
-~~~
-
-~~~txt
-Key                Value
----                -----
-lease_id           database/creds/crdb-role/V3T4UVxeQ9RYsJAk3jZF1Dhl.iMXtW
-lease_duration     1h
-lease_renewable    true
-password           FlOo0p7jMTXjT27hlZZ-H
-username           v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    vault read database/creds/crdb-role
+    ~~~
+    ~~~txt
+    Key                Value
+    ---                -----
+    lease_id           database/creds/crdb-role/V3T4UVxeQ9RYsJAk3jZF1Dhl.iMXtW
+    lease_duration     1h
+    lease_renewable    true
+    password           FlOo0p7jMTXjT27hlZZ-H
+    username           v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652
+    ~~~
   
-### Connect to the CockroachDB cluster with your Vault-generated dynamic secret credentials
+1. Connect to the CockroachDB cluster with your Vault-generated dynamic secret credentials
 
-List all the tables in database `defaultdb` to confirm you can connect to your CockroachDB cluster.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # generated CockroachDB client username
-PASSWORD=FlOo0p7jMTXjT27hlZZ-H # generated CockroachDB client password
-DB_NAME=defaultdb
-CLUSTER_NAME=lilac-grizzly-684 # generated CockroachDB client password
-HOST=free-tier21.aws-us-west-2.crdb.io
-TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
-export CLI_DB_CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
-cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
-~~~
-
-~~~sql
-SHOW TABLES 0
-
-
-Time: 120ms
-~~~
-
-To confirm that the credentials have been properly limited, attempt a forbidden operation. `crdb-role`  does not have permission to list users, so try that in order to generated a permissions error.
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show users;"
-~~~
-
-~~~txt
-ERROR: user v-token-crdb-rol-thflplfwex0k9op0p8qa-1653528652 does not have SELECT privilege on relation users
-SQLSTATE: 42501
-Failed running "sql"
-~~~
+    1. Using the previous output, add the crdb-role credentials to your environment:
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        export USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # generated CockroachDB client username
+        export PASSWORD=FlOo0p7jMTXjT27hlZZ-H # generated CockroachDB client password
+        export DB_NAME=defaultdb
+        export CLUSTER_NAME=lilac-grizzly-684 # generated CockroachDB client password
+        export HOST=free-tier21.aws-us-west-2.crdb.io
+        export TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
+        export CLI_DB_CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
+        ~~~    
+        
+    1. List all the tables in database `defaultdb` to confirm you can connect to your CockroachDB cluster:
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
+        ~~~
+        ~~~txt
+        SHOW TABLES 0
 
 
+        Time: 120ms
+        ~~~
 
-
-
-
-
-
-
-
-
-
-
-
-
+    1. To confirm that the credentials have been properly limited, attempt a forbidden operation. `crdb-role`  does not have permission to list users, so try that in order to generate a permissions error.
+        {% include_cached copy-clipboard.html %}
+        ~~~shell
+        cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show users;"
+        ~~~
+        ~~~txt
+        ERROR: user v-token-crdb-rol-thflplfwex0k9op0p8qa-1653528652 does not have SELECT privilege on relation users
+        SQLSTATE: 42501
+        Failed running "sql"
+        ~~~

--- a/v22.1/vault-db-secrets-tutorial.md
+++ b/v22.1/vault-db-secrets-tutorial.md
@@ -13,7 +13,7 @@ See also: [Hashicorp Vault database secrets engine tutorial](https://learn.hashi
 
 To follow along with this tutorial you will need the following:
 
-- Access as `root` SQL user to a CockroachDB cluster. You may either [spin up a {{ site.data.products.serverless }} cluster](../cockroachcoud/create-a-serverless-cluster.html) or [Start a Development Cluster locally](../{{site.versions["stable"]}}/start-a-local-cluster.html). In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
+- Access as `root` SQL user to a CockroachDB cluster. You may either [spin up a {{ site.data.products.serverless }} cluster](../cockroachcloud/create-a-serverless-cluster.html) or [Start a Development Cluster locally](../{{site.versions["stable"]}}/start-a-local-cluster.html). In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
 - Access to a Vault cluster with an admin token. You may either spin up a [free cluster in Hashicorp cloud](https://learn.hashicorp.com/collections/vault/cloud) or [start a development cluster locally](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server).
 
 ## Introduction
@@ -395,8 +395,8 @@ List all the tables in database `defaultdb` to confirm you can connect to your C
 
 {% include_cached copy-clipboard.html %}
 ```shell
-USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # CRDB admin username
-PASSWORD=FlOo0p7jMTXjT27hlZZ-H # CRDB admin password
+USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # generated CRDB client username
+PASSWORD=FlOo0p7jMTXjT27hlZZ-H # generated CRDB client password
 DB_NAME=defaultdb
 CLUSTER_NAME=lilac-grizzly-684
 HOST=free-tier21.aws-us-west-2.crdb.io

--- a/v22.1/vault-db-secrets-tutorial.md
+++ b/v22.1/vault-db-secrets-tutorial.md
@@ -5,9 +5,9 @@ toc: true
 docs_area: manage
 ---
 
-This tutorial discusses and demonstrates best security practices for managing CockroachDB database credentials with Hashicorp Vault.
+This tutorial discusses and demonstrates best security practices for managing CockroachDB database credentials with [Hashicorp Vault's database secrets engine PostgreSQL plugin](https://www.vaultproject.io/docs/secrets/databases/postgresql).
 
-**Goals**:
+See also: [Hashicorp Vault database secrets engine tutorial](https://learn.hashicorp.com/tutorials/vault/database-secrets).
 
 **Prerequisites**:
 
@@ -25,7 +25,7 @@ Sound strategy and proper tooling for managing database credentials are essentia
 	- Access events leave an audit trail.
 	- Secrets are properly encrypted in flight and in transit.
 
-- Advantages of Vault's Database Dynamic Secrets Engine:
+- Advantages of Vault's [Dynamic Secrets](https://www.vaultproject.io/use-cases/dynamic-secrets):
 	- Database credentials are generated and issued only on demand, from pre-configured templates, for specific clients and short validity durations, further minimizing both probability of credential compromise and possible impact of any compromise that does occur.
 	- Diligent rotation and revocation practices are automated by implication, requiring no additional effort or oversight.
 
@@ -43,11 +43,19 @@ In the second phase, acting as client operator, we will pull credentials from Va
 ### Initize your shell for Vault
 
 Set your Vault target and authenticate with an admin token.
+You can fetch your target URL and generate a token from the [Hashicorp Vault console](https://portal.cloud.hashicorp.com/services/vault).
+
 
 {% include_cached copy-clipboard.html %}
 ```shell
-export VAULT_ADDR= # your Vault cluster URL
+export VAULT_ADDR=https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.hashicorp.cloud:8200 # your Vault cluster URL
+export VAULT_NAMESPACE=admin
 vault login
+```
+```shell
+Success! You are now authenticated. The token information displayed below
+is already stored in the token helper. You do NOT need to run "vault login"
+again. Future Vault requests will automatically use this token.
 ```
 
 ### Enable the database secrets engine
@@ -89,8 +97,8 @@ curl --create-dirs -o root.crt -O https://management-staging.crdb.io/clusters/50
 {% include_cached copy-clipboard.html %}
 ```shell
 TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
-CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
-cockroach sql --url $CONNECTION_URL --execute "show tables;"
+export CLI_DB_CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
+cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
 ```
 
 ```txt
@@ -103,55 +111,23 @@ Time: 107ms
 
 The connection lies in a Vault configuration, which will store your CRDB admin credentials, allowing Vault to administrate CRDB credentials.
 
-
-Create the `crdb-config` database configuration in Vault, specifying admin credentials that will be used by Vault to 
-{% include_cached copy-clipboard.html %}
-```shell
-
-
-
-
-```
-
-
-
-{% include_cached copy-clipboard.html %}
-```shell
-
-```
-
+Create the `crdb-config` database configuration in Vault, specifying admin credentials that will be used by Vault to create credentials for your defined role.
 
 {% include_cached copy-clipboard.html %}
 ```shell
 TLS_OPTS="sslmode=require&options=--cluster=${CLUSTER_NAME}"
-CONNECTION_URL="postgresql://{{username}}:{{password}}@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
+export VAULT_DB_CONNECTION_URL="postgresql://{{username}}:{{password}}@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
 
 vault write database/config/crdb-config \
 plugin_name=postgresql-database-plugin \
 allowed_roles="crdb-role" \
 username=${USER_NAME} \
 password=${PASSWORD} \
-connection_url=$CONNECTION_URL
-
+connection_url=${VAULT_DB_CONNECTION_URL}
 ```
 
 ```txt
 Success! Data written to: database/config/crdb-config
-```
-
-### Create a Vault policy for use by the CRDB client operator
-
-This policy will be used to access CRDB client credentials. In keeping with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), let's give it only the required ability to read the required credential. 
-
-Vault policies are specified using HashiCorp Configuration Language (HCL). The following configuration specifies a policy of read access for the `crdb-role` credential.
-
-{% include_cached copy-clipboard.html %}
-```shell
-vault policy write roach-client - <<hcl
-path "database/creds/crdb-role" {
-  capabilities = [ "read" ]
-}
-hcl
 ```
 
 ### Provision a Dynamic Secret for SQL client access credentials
@@ -160,7 +136,7 @@ A 'dynamic secret' is really a secret template, which will be used to generate p
 
 The template is defined by its `creation_statements`, SQL statements that create the role.
 
-For, example, let's create a 'default role'
+For, example, let's create a role that has all privileges on the `defaultdb` database.
 
 NOTE: `db_name` is actually not the database name but the vault secrets engine thingy (i.e. `crdb-config` in the example)
 
@@ -176,14 +152,10 @@ NOTE: `db_name` is actually not the database name but the vault secrets engine t
 ```
 
 ```txt
-
+Success! Data written to: database/roles/crdb-role
 ```
 
-## Client
-
-### Login to vault as the client
-
-### Pull the credentials
+### List roles
 
 {% include_cached copy-clipboard.html %}
 ```shell
@@ -191,72 +163,269 @@ vault list database/roles/
 ```
 
 ```txt
-
-```
-  
-### Hey look at that you can do whatever
-
-
-## Admin
-
-### Look at the list of credential pairs
-
-{% include_cached copy-clipboard.html %}
-```sql
-bloop@free-tier21.aws-us-west-2.crdb.io:26257/defaultdb> show users;
-                       username                       |                options                | member_of
-------------------------------------------------------+---------------------------------------+------------
-  admin                                               |                                       | {}
-  bloop                                               |                                       | {admin}
-  root                                                |                                       | {admin}
-  v-token-hc-crdb-rol-faxnxdvj4ftbprhzdscy-1652201047 | VALID UNTIL=2022-05-10 17:44:12+00:00 | {}
-  v-token-hc-crdb-rol-kilx5y52lmb8bsbopjzt-1652201135 | VALID UNTIL=2022-05-10 17:45:40+00:00 | {}
-  v-token-hc-crdb-rol-naz7oa5ttrw0cjqjr19h-1652201138 | VALID UNTIL=2022-05-10 17:45:43+00:00 | {}
-  v-token-hc-crdb-rol-oqfy7u6s10rqvduduf5c-1652201055 | VALID UNTIL=2022-05-10 17:44:20+00:00 | {}
-  v-token-hc-crdb-rol-pswf90wx3tqqjdpw91gi-1652201136 | VALID UNTIL=2022-05-10 17:45:41+00:00 | {}
-(9 rows)
-```
-
-```
-:) vault list sys/leases/lookup/database/creds
 Keys
 ----
-crdb-role/
-~/roachspace/deploys/vault :) vault list sys/leases/lookup/database/creds/crdb-role
-Keys
-----
-6qaPBNBl0Qdr3uPUoogF0gnk.iMXtW
-GOnn6AiJsFweviaG86egTpJd.iMXtW
-XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
-f0517hY8diWwzstrgMAW3M0I.iMXtW
-fXFg27X3BhOp8wy8u8lb18yI.iMXtW
-hJ1BCqE0UfiZVOXxxBvTcc0g.iMXtW
-pP9yFeh8ZzmoeOEXjPkWobmT.iMXtW
+crdb-role
+~/roachspace/d
 ```
-
-### Revoke some creds
 
 {% include_cached copy-clipboard.html %}
 ```shell
-~/roachspace/deploys/vault :) vault lease revoke database/creds/readonly/XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
-All revocation operations queued successfully!
-~/roachspace/deploys/vault :) vault list sys/leases/lookup/database/creds/crdb-role
-Keys
-----
-6qaPBNBl0Qdr3uPUoogF0gnk.iMXtW
-GOnn6AiJsFweviaG86egTpJd.iMXtW
-XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
-f0517hY8diWwzstrgMAW3M0I.iMXtW
-fXFg27X3BhOp8wy8u8lb18yI.iMXtW
-hJ1BCqE0UfiZVOXxxBvTcc0g.iMXtW
-pP9yFeh8ZzmoeOEXjPkWobmT.iMXtW
+vault read database/roles/crdb-role
 ```
 
-## Client
+```txt
+Key                      Value
+---                      -----
+creation_statements      [CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';         GRANT ALL ON DATABASE defaultdb TO "{{name}}";]
+db_name                  crdb-config
+default_ttl              1h
+max_ttl                  24h
+renew_statements         []
+revocation_statements    []
+rollback_statements      []
+```
 
 
 
-### oh no I can't do whatever anymore
+### Generate credential pairs
+
+Recall that a *role* in Vault does not correspond exactly to a *role* in CockroachDB (i.e., a [SQL role or user](security-reference/authorization.html#users-and-roles)).
+
+A Vault role is a defined *template* for credential pairs (SQL user/role name and password), which will be generated on demand and quickly expired.
+
+When we "read" the Vault role called "crdb-role", we are therefore not fetching credentials for a pre-existing SQL user, but requesting that Vault create a user for us, according to the template.
+
+To see this, first execute a SQL statement via the CockroachDB CLI to list existing users.
+
+{% include_cached copy-clipboard.html %}
+```shell
+cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
+```
+
+If you using a freshly created database, you may see only the `admin` and `root` roles.
+
+```txt
+------------------------------------------------------+---------------------------------------+------------
+  admin                                               |                                       | {}
+  root                                                |                                       | {admin}
+```
+
+
+Now, let's read some credentials from Vault, which will cause Vault to create SQL users on our CockroachDB cluster.
+
+Run the following command several times to generate several credential pairs.
+
+Notice that the validity duration is the default value of 1 hour.
+
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault read database/creds/crdb-role
+```
+
+```txt
+Key                Value
+---                -----
+lease_id           database/creds/crdb-role/5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
+lease_duration     1h
+lease_renewable    true
+password           a1qKnD-ZjFG-oUMcSFtx
+username           v-token-hc-crdb-rol-1pcS5YcSaSS4Fgy4BiXp-1653512968
+```
+
+List the active credentials (or *leases*, in Vault terms) for the Vault role:
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault list sys/leases/lookup/database/creds/crdb-role/
+```
+
+```txt
+Keys
+----
+5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
+ATKZIXMXMTcNQBkR4vwzvyd8.iMXtW
+WHtZ4JKGLC8KYssMn5mCxKqU.iMXtW
+lcAOenZ7s03BpPi8XKS0vsK3.iMXtW
+yyufcaLu4eKWcnGzhes30t6M.iMXtW
+```
+
+
+Now fetch the list of currently active SQL roles from the CockroachDB client:
+
+{% include_cached copy-clipboard.html %}
+```shell
+cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
+```
+
+```txt
+                       username                       |                options                | member_of
+------------------------------------------------------+---------------------------------------+------------
+  admin                                               |                                       | {}
+  root                                                |                                       | {admin}
+  v-token-hc-crdb-rol-uqtqyca6neplilakhv55-1653513157 | VALID UNTIL=2022-05-25 22:12:42+00:00 | {}
+  v-token-hc-crdb-rol-0gzk3hwi7k7a9w1ggggq-1653515525 | VALID UNTIL=2022-05-25 22:52:10+00:00 | {}
+  v-token-hc-crdb-rol-varnevyjgjg9zgf62kps-1653515522 | VALID UNTIL=2022-05-25 22:52:07+00:00 | {}
+  v-token-hc-crdb-rol-wltbv25napuroomvzmok-1653515524 | VALID UNTIL=2022-05-25 22:52:09+00:00 | {}
+```
+
+
+### Revoke credentials
+
+Revoke a lease or two just for the feeling of raw power. Recall that a "lease" on a "role" in Vault terms corresponds to an actual credential pair on the CockroachDB cluster, i.e., a username/password combination for a SQL user.
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault lease revoke database/creds/crdb-role/XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
+```
+
+```txt
+All revocation operations queued successfully!
+```
+
+
+### As admin, provision a Vault policy for CRDB client operators to access the client credentials
+
+
+The purpose of the above work is to make a dynamic secret that can be used to access the CRDB database by generating credentials on demand. Performing the above work (establishing the connection between the CockroachDB cluster and the Vault cluster, creating the template for database client credentials, etc.) required admin privileges. But for the work to be meaningful, a Vault user with more limited permisions must be able to access the generated credentials.
+
+This policy will be used to access CRDB client credentials. In keeping with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), let's give it only the required ability to read the required credential. 
+
+Vault policies are specified using HashiCorp Configuration Language (HCL). The following configuration specifies a policy of read access for the `crdb-role` credential.
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault policy write roach-client - <<hcl
+path "database/creds/crdb-role" {
+  capabilities = [ "read" ]
+}
+hcl
+```
+
+```shell
+Success! Uploaded policy: roach-client
+```
+
+
+### Generate an authentication token for the `crdb-role` Vault user
+
+{% include_cached copy-clipboard.html %}
+```shell
+ vault token create -policy=roach-client
+```
+
+```txt
+Key                  Value
+---                  -----
+token                hvs.CAESIK4TK7JcSJuKxOgwEa3mYhvfN356Uhikij821K4E4XnWGigKImh2cy5MeUJ5dGNxMjRzNk9qNmVDYWtFYjRUd2QuaU1YdFcQ1cAT
+token_accessor       36udxC5m0hmA0niBYyCThk0k.iMXtW
+token_duration       1h
+token_renewable      true
+token_policies       ["default" "roach-client"]
+identity_policies    []
+policies             ["default" "roach-client"]
+```
+
+You can either copy the `token` from the output of the previous command, or capture a token with the following command.
+
+```shell
+ VAULT_CLIENT_TOKEN=`vault token create -policy=roach-client -format=json | jq .auth.client_token | tr -d '"'`
+```
+
+### Assume the CockroachDB role
+
+## Login to vault as the client
+
+Use the 
+{% include_cached copy-clipboard.html %}
+```shell
+vault login $VAULT_CLIENT_TOKEN
+```
+
+```txt
+Success! You are now authenticated. The token information displayed below
+```
+
+
+### Confirm the limited credentials
+
+To confirm that you have assumed a role with limited credentials, try listing the current leases on the `crdb-role`, as we did [previously](#). You should see a permissions error.
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault list sys/leases/lookup/database/creds/crdb-role/
+```
+
+```txt
+Error listing sys/leases/lookup/database/creds/crdb-role: Error making API request.
+
+Namespace: admin/
+URL: GET https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.hashicorp.cloud:8200/v1/sys/leases/lookup/database/creds/crdb-role?list=true
+Code: 403. Errors:
+
+* 1 error occurred:
+  * permission denied
+```
+
+
+### Pull the credentials
+
+The only thing this policy *does* have permission to do is pull credentials for the CockroachDB cluster. Let's do that.
+
+
+{% include_cached copy-clipboard.html %}
+```shell
+vault read database/creds/crdb-role
+```
+
+```txt
+Key                Value
+---                -----
+lease_id           database/creds/crdb-role/V3T4UVxeQ9RYsJAk3jZF1Dhl.iMXtW
+lease_duration     1h
+lease_renewable    true
+password           hMTFjjMTXjBT27hlZZ-H
+username           v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652
+```
+  
+### Connect to the CockroachDB cluster with your Vault-generated dynamic secret credentials
+
+List all the tables in database `defaultdb` to confirm you can connect to your CockroachDB cluster.
+
+{% include_cached copy-clipboard.html %}
+```shell
+USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # CRDB admin username
+PASSWORD=hMTFjjMTXjBT27hlZZ-H # CRDB admin password
+DB_NAME=defaultdb
+CLUSTER_NAME=lilac-grizzly-684
+HOST=free-tier21.aws-us-west-2.crdb.io
+TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
+export CLI_DB_CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
+cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
+```
+
+```sql
+SHOW TABLES 0
+
+
+Time: 120ms
+```
+
+To confirm that the credentials have been properly limited, attempt a forbidden operation. `crdb-role`  does not have permission to list users, so try that in order to generated a permissions error.
+
+{% include_cached copy-clipboard.html %}
+```shell
+cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show users;"
+```
+
+```txt
+ERROR: user v-token-crdb-rol-thflplfwex0k9op0p8qa-1653528652 does not have SELECT privilege on relation users
+SQLSTATE: 42501
+Failed running "sql"
+```
+
+
 
 
 

--- a/v22.1/vault-db-secrets-tutorial.md
+++ b/v22.1/vault-db-secrets-tutorial.md
@@ -1,24 +1,32 @@
 ---
-title: Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security
-summary: Learn how to achieve enhanced credential security using Hashicorp Vault's Dynamic Secrets functionality.
+title: Using HashiCorp Vault's Dynamic Secrets for Enhanced Database Credential Security in CockroachDB
+summary: Learn how to achieve enhanced credential security using HashiCorp Vault's Dynamic Secrets functionality.
 toc: true
 docs_area: manage
 ---
 
-This tutorial discusses and demonstrates best security practices for managing CockroachDB database credentials with [Hashicorp Vault's database secrets engine PostgreSQL plugin](https://www.vaultproject.io/docs/secrets/databases/postgresql).
+This tutorial discusses and demonstrates best security practices for managing CockroachDB database credentials with [HashiCorp Vault's database secrets engine PostgreSQL plugin](https://www.vaultproject.io/docs/secrets/databases/postgresql).
 
-See also: [Hashicorp Vault database secrets engine tutorial](https://learn.hashicorp.com/tutorials/vault/database-secrets).
+See also: 
+
+- [CockroachDB - HashiCorp Vault integration overview page](hashicorp-integration.html)
+- [HashiCorp Vault database secrets engine tutorial](https://learn.hashicorp.com/tutorials/vault/database-secrets).
 
 **Prerequisites**:
 
 To follow along with this tutorial you will need the following:
 
-- Access as `root` SQL user to a CockroachDB cluster. You may either [spin up a {{ site.data.products.serverless }} cluster](../cockroachcloud/create-a-serverless-cluster.html) or [Start a Development Cluster locally](../{{site.versions["stable"]}}/start-a-local-cluster.html). In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
-- Access to a Vault cluster with an admin token. You may either spin up a [free cluster in Hashicorp cloud](https://learn.hashicorp.com/collections/vault/cloud) or [start a development cluster locally](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server).
+- The CockroachDB CLI installed locally. [Install CockroachDB](install-cockroachdb-mac.html)
+- The Vault CLI installed locally. [Install Vault](https://www.vaultproject.io/docs/install)
+- Access as [`admin` SQL user](security-reference/authorization.html#admin-role) to a CockroachDB cluster. You may either [Create a {{ site.data.products.serverless }} cluster](../cockroachcloud/create-a-serverless-cluster.html) or [Start a Local Cluster (secure)](../{{site.versions["stable"]}}/start-a-local-cluster.html). This tutorial will demonstrate the procedure using {{ site.data.products.db }}. In either case you must have the public CA certificate for your cluster, and a username/password combination for the root SQL user (or another SQL user with the admin role).
+  You can create a {{ site.data.products.db }} cluster through the [{{ site.data.products.db }} console](https://cockroachlabs.cloud/).
+- Access to a Vault cluster with an admin token. You may either spin up a [free cluster in HashiCorp cloud](https://learn.hashicorp.com/collections/vault/cloud) or [start a development cluster locally](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server).
+  You can create a Vault cluster through the [HashiCorp Vault Cloud console](https://portal.cloud.HashiCorp.com/services/vault).
+
 
 ## Introduction
 
-Sound strategy and proper tooling for managing database credentials are essential to the overall strength of your security posture. Managing your CockroachDB database credentials with Hashicorp Vault affords several security advantages:
+Sound strategy and proper tooling for managing database credentials are essential to the overall strength of your security posture. Managing your CockroachDB database credentials with HashiCorp Vault affords several security advantages:
 
 - General advantages of delegated, consolidated secrets management, as opposed to the industry standard of the past, which involves storing credentials in a variety of shared and individually owned file-systems, repositories and data stores, and sharing them via email, messaging, and other means of network communication:
 	- Access is managed by a single coherent set of policies.
@@ -29,7 +37,7 @@ Sound strategy and proper tooling for managing database credentials are essentia
 	- Database credentials are generated and issued only on demand, from pre-configured templates, for specific clients and short validity durations, further minimizing both probability of credential compromise and possible impact of any compromise that does occur.
 	- Diligent rotation and revocation practices are automated by implication, requiring no additional effort or oversight.
 
-## Preparing your shell for CRDB and Vault admin tasks
+## Preparing your shell for CockroachDB and Vault admin tasks
 
 In this phase of the tutorial we will act as an administrator for our organization, provisioning access for a class of database clients.
 
@@ -40,84 +48,91 @@ In the first phase of the tutorial, we will act as administrators, provisioning 
 In the second phase, acting as client operator, we will pull credentials from Vault and use them to access the database via the CockroachDB client CLI.
 
 
-### Connect to CRDB
+### Connect to CockroachDB
 
-Set your CRDB cluster credentials and other configuration information as environment variables
+Set your CockroachDB cluster credentials and other configuration information as environment variables
 {% include_cached copy-clipboard.html %}
-```shell
-USER_NAME= # CRDB admin username
-PASSWORD= # CRDB admin password
-DB_NAME=defaultdb
-CLUSTER_NAME=lilac-grizzly-684
-HOST=free-tier123.aws-us-west-2.crdb.io
+~~~shell
+export USER_NAME= # CockroachDB admin username
+export PASSWORD= # CockroachDB admin password
+export DB_NAME=defaultdb
+export CLUSTER_NAME=lilac-grizzly-684
+export HOST=free-tier123.aws-us-west-2.crdb.io
 
-```
-#### Obtain your CRDB cluster's CA public certificate
+~~~
+#### Obtain your CockroachDB cluster's CA public certificate
 
 1. Visit the [CockroachDB Cloud Console's cluster page.](https://cockroachlabs.cloud/cluster/). 
 1. Select your cluster.
 1. Click the **Connect** button.
 1. Select **"Download CA Cert (Required only once)"** and use the generated `curl` command to download the certificate.
-```shell
+~~~shell
 curl --create-dirs -o root.crt -O https://management-staging.crdb.io/clusters/505a138c-37ff-46b7-9c50-4119cf0881f6/cert
-```
-1. Place the certificate on the path specified by `sslrootcert` in the following command, the run it. A successful display of the output of "show tables;" proves that our connection works.
+~~~
+#### Prove you can connect
+
+1. Construct a database connection URL for your CockroachDB CLI to connect to the cluster, using your admin credentials. Note that you must place the CockroachDB cluster's CA public certificate on the path specified by `sslrootcert`, in the following example to a file in the current directory.
 
 {% include_cached copy-clipboard.html %}
-```shell
-TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
-export CLI_DB_CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
-cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
-```
+~~~shell
+export TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
+export CLI_DB_CONNECTION_URL="postgresql://${USER_NAME}:${PASSWORD}@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
+~~~
 
-```txt
+Prove that your connection works by executing a SQL statement.
+
+~~~shell
+cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
+~~~
+
+~~~txt
 SHOW TABLES 0
 
 Time: 107ms
-```
+~~~
 
 
 ### Connect to Vault
 
 Set your Vault target and authenticate with an admin token.
-You can fetch your target URL and generate a token from the [Hashicorp Vault console](https://portal.cloud.hashicorp.com/services/vault).
+You can fetch your target URL and generate a token from the [HashiCorp Vault console](https://portal.cloud.HashiCorp.com/services/vault).
 
 
 {% include_cached copy-clipboard.html %}
-```shell
-export VAULT_ADDR=https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.hashicorp.cloud:8200 # your Vault cluster URL
+~~~shell
+export VAULT_ADDR=https://roach-test-vault.vault.bfb2290a-670b-4a10-bedf-5aab18e84d69.aws.HashiCorp.cloud:8200 # your Vault cluster URL
 export VAULT_NAMESPACE=admin
 vault login
-```
-```shell
+~~~
+~~~shell
 Success! You are now authenticated. The token information displayed below
 is already stored in the token helper. You do NOT need to run "vault login"
 again. Future Vault requests will automatically use this token.
-```
+~~~
 
 ### Enable the Vault database secrets engine
 
 This only needs to be done once for an individual Vault cluster.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault secrets enable database
-```
+~~~
 
-```txt
+~~~txt
 Success! Enabled the database secrets engine at: database/
-```
+~~~
 
-## Binding your Vault cluster to your CRDB cluster
+## Binding your Vault cluster to your CockroachDB cluster
 
-The connection lies in a Vault configuration, which will store your CRDB admin credentials, allowing Vault to administrate CRDB credentials.
+The connection lies in a Vault configuration, which will store your CockroachDB admin credentials, allowing Vault to administrate CockroachDB credentials.
 
 ### Create a Vault database configuration
 
 Create the `crdb-config` database configuration in Vault, specifying admin credentials that will be used by Vault to create credentials for your defined role.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 TLS_OPTS="sslmode=require&options=--cluster=${CLUSTER_NAME}"
 export VAULT_DB_CONNECTION_URL="postgresql://{{username}}:{{password}}@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
 
@@ -127,11 +142,11 @@ allowed_roles="crdb-role" \
 username=${USER_NAME} \
 password=${PASSWORD} \
 connection_url=${VAULT_DB_CONNECTION_URL}
-```
+~~~
 
-```txt
+~~~txt
 Success! Data written to: database/config/crdb-config
-```
+~~~
 
 ## Using Dynamic Secrets for SQL credentials
 
@@ -147,38 +162,38 @@ NOTE: `db_name` is actually not the database name but the Vault database secrets
 
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
  vault write database/roles/crdb-role \
     db_name=crdb-config \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
         GRANT ALL ON DATABASE defaultdb TO \"{{name}}\";" \
     default_ttl="1h" \
     max_ttl="24h"
-```
+~~~
 
-```txt
+~~~txt
 Success! Data written to: database/roles/crdb-role
-```
+~~~
 
 ### List roles
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault list database/roles/
-```
+~~~
 
-```txt
+~~~txt
 Keys
 ----
 crdb-role
-```
+~~~
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault read database/roles/crdb-role
-```
+~~~
 
-```txt
+~~~txt
 Key                      Value
 ---                      -----
 creation_statements      [CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';         GRANT ALL ON DATABASE defaultdb TO "{{name}}";]
@@ -188,7 +203,7 @@ max_ttl                  24h
 renew_statements         []
 revocation_statements    []
 rollback_statements      []
-```
+~~~
 
 ### Generate credential pairs
 
@@ -201,17 +216,17 @@ When we "read" the Vault role called "crdb-role", we are therefore not fetching 
 To see this, first execute a SQL statement via the CockroachDB CLI to list existing users.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
-```
+~~~
 
 If you using a freshly created database, you may see only the `admin` and `root` roles.
 
-```txt
+~~~txt
 ------------------------------------------------------+---------------------------------------+------------
   admin                                               |                                       | {}
   root                                                |                                       | {admin}
-```
+~~~
 
 Now, let's read some credentials from Vault, which will cause Vault to create SQL users on our CockroachDB cluster.
 
@@ -221,11 +236,11 @@ Notice that the validity duration is the default value of 1 hour.
 
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault read database/creds/crdb-role
-```
+~~~
 
-```txt
+~~~txt
 Key                Value
 ---                -----
 lease_id           database/creds/crdb-role/5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
@@ -233,16 +248,16 @@ lease_duration     1h
 lease_renewable    true
 password           a1qKnD-ZjFG-oUMcSFtx
 username           v-token-hc-crdb-rol-1pcS5YcSaSS4Fgy4BiXp-1653512968
-```
+~~~
 
 List the active credentials (or *leases*, in Vault terms) for the Vault role:
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault list sys/leases/lookup/database/creds/crdb-role/
-```
+~~~
 
-```txt
+~~~txt
 Keys
 ----
 5rPhNN6aG0dNRs97UmRYMmJH.iMXtW
@@ -250,16 +265,16 @@ ATKZIXMXMTcNQBkR4vwzvyd8.iMXtW
 WHtZ4JKGLC8KYssMn5mCxKqU.iMXtW
 lcAOenZ7s03BpPi8XKS0vsK3.iMXtW
 yyufcaLu4eKWcnGzhes30t6M.iMXtW
-```
+~~~
 
 Now fetch the list of currently active SQL roles from the CockroachDB client:
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
-```
+~~~
 
-```txt
+~~~txt
                        username                       |                options                | member_of
 ------------------------------------------------------+---------------------------------------+------------
   admin                                               |                                       | {}
@@ -268,54 +283,54 @@ cockroach sql --url $CLI_DB_CONNECTION_URL --execute "show users;"
   v-token-hc-crdb-rol-0gzk3hwi7k7a9w1ggggq-1653515525 | VALID UNTIL=2022-05-25 22:52:10+00:00 | {}
   v-token-hc-crdb-rol-varnevyjgjg9zgf62kps-1653515522 | VALID UNTIL=2022-05-25 22:52:07+00:00 | {}
   v-token-hc-crdb-rol-wltbv25napuroomvzmok-1653515524 | VALID UNTIL=2022-05-25 22:52:09+00:00 | {}
-```
+~~~
 
 ### Revoke credentials
 
 Revoke a lease or two just for the feeling of raw power. Recall that a "lease" on a "role" in Vault terms corresponds to an actual credential pair on the CockroachDB cluster, i.e., a username/password combination for a SQL user.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault lease revoke database/creds/crdb-role/XIpIBRM8FkQxD5B0ndB1lszY.iMXtW
-```
+~~~
 
-```txt
+~~~txt
 All revocation operations queued successfully!
-```
+~~~
 
-### Provision a CRDB-client Vault policy
+### Provision a CockroachDB-client Vault policy
 
-As admin, provision a Vault policy for CRDB client operators to access the client credentials.
+As admin, provision a Vault policy for CockroachDB client operators to access the client credentials.
 
-The purpose of the previous work is to make a dynamic secret that can be used to access the CRDB database by generating credentials on demand. Performing the above work (establishing the connection between the CockroachDB cluster and the Vault cluster, creating the template for database client credentials, etc.) required admin privileges. But for the work to be meaningful, a Vault user with more limited permisions must be able to access the generated credentials.
+The purpose of the previous work is to make a dynamic secret that can be used to access the CockroachDB database by generating credentials on demand. Performing the above work (establishing the connection between the CockroachDB cluster and the Vault cluster, creating the template for database client credentials, etc.) required admin privileges. But for the work to be meaningful, a Vault user with more limited permisions must be able to access the generated credentials.
 
-This policy will be used to access CRDB client credentials. In keeping with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), let's give it only the required ability to read the required credential. 
+This policy will be used to access CockroachDB client credentials. In keeping with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), let's give it only the required ability to read the required credential. 
 
 Vault policies are specified using HashiCorp Configuration Language (HCL). The following configuration specifies a policy of read access for the `crdb-role` credential.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault policy write roach-client - <<hcl
 path "database/creds/crdb-role" {
   capabilities = [ "read" ]
 }
 hcl
-```
+~~~
 
-```shell
+~~~shell
 Success! Uploaded policy: roach-client
-```
+~~~
 
 ### Generate an authentication token for the `crdb-role` Vault user
 
 Our final act as Vault admin will be to provision an authentication token to assume the `crdb-role`, which represents the Vault role with the sole purpose of providing credentials ot a CockroachDB client.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
  vault token create -policy=roach-client
-```
+~~~
 
-```txt
+~~~txt
 Key                  Value
 ---                  -----
 token                hvs.CAESIK4TK7JcSJuKxOgwEa3mYhvfN356Uhikij821K4E4XnWGigKImh2cy5MeUJ5dGNxMjRzNk9qNmVDYWtFYjRUd2QuaU1YdFcQ1cAT
@@ -325,41 +340,41 @@ token_renewable      true
 token_policies       ["default" "roach-client"]
 identity_policies    []
 policies             ["default" "roach-client"]
-```
+~~~
 
 You can either copy the `token` from the output of the previous command, or capture a token with the following command.
 
-```shell
+~~~shell
  VAULT_CLIENT_TOKEN=`vault token create -policy=roach-client -format=json | jq .auth.client_token | tr -d '"'`
-```
+~~~
 
-## Connecting to CRDB with Vault-provisioned credentials
+## Connecting to CockroachDB with Vault-provisioned credentials
 
 ### Authenticate to Vault as the CockroachDB user
 
 Use the client token to authenticate to Vault with limited permissions.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault login $VAULT_CLIENT_TOKEN
-```
+~~~
 
-```txt
+~~~txt
 Success! You are now authenticated. The token information displayed below
 is already stored in the token helper. You do NOT need to run "vault login"
 again. Future Vault requests will automatically use this token.
-```
+~~~
 
 ### Confirm the limited permissions of the role
 
 To confirm that you have assumed a role with limited permissions, try listing the current leases on the `crdb-role`, as we did [previously](#). You should see a permissions error.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault list sys/leases/lookup/database/creds/crdb-role/
-```
+~~~
 
-```txt
+~~~txt
 Error listing sys/leases/lookup/database/creds/crdb-role: Error making API request.
 
 Namespace: admin/
@@ -368,18 +383,18 @@ Code: 403. Errors:
 
 * 1 error occurred:
   * permission denied
-```
+~~~
 
 ### Pull the CockroachDB credentials
 
 The only thing this policy *does* have permission to do is pull credentials for the CockroachDB cluster. Let's do that.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 vault read database/creds/crdb-role
-```
+~~~
 
-```txt
+~~~txt
 Key                Value
 ---                -----
 lease_id           database/creds/crdb-role/V3T4UVxeQ9RYsJAk3jZF1Dhl.iMXtW
@@ -387,43 +402,43 @@ lease_duration     1h
 lease_renewable    true
 password           FlOo0p7jMTXjT27hlZZ-H
 username           v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652
-```
+~~~
   
 ### Connect to the CockroachDB cluster with your Vault-generated dynamic secret credentials
 
 List all the tables in database `defaultdb` to confirm you can connect to your CockroachDB cluster.
 
 {% include_cached copy-clipboard.html %}
-```shell
-USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # generated CRDB client username
-PASSWORD=FlOo0p7jMTXjT27hlZZ-H # generated CRDB client password
+~~~shell
+USER_NAME=v-token-crdb-rol-thfLPlFwex0k9Op0P8qA-1653528652 # generated CockroachDB client username
+PASSWORD=FlOo0p7jMTXjT27hlZZ-H # generated CockroachDB client password
 DB_NAME=defaultdb
 CLUSTER_NAME=lilac-grizzly-684
 HOST=free-tier21.aws-us-west-2.crdb.io
 TLS_OPTS="sslrootcert=root.crt&sslmode=verify-full&options=--cluster=${CLUSTER_NAME}"
 export CLI_DB_CONNECTION_URL="postgresql://$USER_NAME:$PASSWORD@${HOST}:26257/${DB_NAME}?${TLS_OPTS}"
 cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show tables;"
-```
+~~~
 
-```sql
+~~~sql
 SHOW TABLES 0
 
 
 Time: 120ms
-```
+~~~
 
 To confirm that the credentials have been properly limited, attempt a forbidden operation. `crdb-role`  does not have permission to list users, so try that in order to generated a permissions error.
 
 {% include_cached copy-clipboard.html %}
-```shell
+~~~shell
 cockroach sql --url "${CLI_DB_CONNECTION_URL}" --execute "show users;"
-```
+~~~
 
-```txt
+~~~txt
 ERROR: user v-token-crdb-rol-thflplfwex0k9op0p8qa-1653528652 does not have SELECT privilege on relation users
 SQLSTATE: 42501
 Failed running "sql"
-```
+~~~
 
 
 


### PR DESCRIPTION
Create a tutorial on using Vault dynamic secrets for CRDB credentials, as part of our integration with Vault.

https://cockroachlabs.atlassian.net/browse/DOC-3308