### PR TITLE
DOC-3006 add metric snapshot bytes sent/recv

### DIFF
--- a/_includes/v22.1/metric-names.md
+++ b/_includes/v22.1/metric-names.md
@@ -136,6 +136,8 @@ Name | Help
 `range.snapshots.generated` | Number of generated snapshots
 `range.snapshots.normal-applied` | Number of applied snapshots
 `range.snapshots.preemptive-applied` | Number of applied pre-emptive snapshots
+`range.snapshots.rcvd-bytes` | Number of snapshot bytes received
+`range.snapshots.sent-bytes` | Number of snapshot bytes sent
 `range.splits` | Number of range splits
 `ranges.unavailable` | Number of ranges with fewer live replicas than needed for quorum
 `ranges.underreplicated` | Number of ranges with fewer live replicas than the replication target


### PR DESCRIPTION
Addresses: DOC-3006

- Adds `range.snapshots.rcvd-bytes` and `range.snapshots.sent-bytes` to `v22.1` metrics listing. This is the only place in the corpus we list / refer to these raw metrics, so this is a tiny PR.

**Note:** the table housing these metrics is prefaced by a [note](https://www.cockroachlabs.com/docs/stable/ui-custom-chart-debug-page.html#available-metrics) that explains: `This list is taken directly from the source code ...` Does this indicate that this list is programmatically generated elsewhere and that I should instead be editing the source script?

[metric-names.md](https://deploy-preview-13968--cockroachdb-docs.netlify.app/docs/v22.1/ui-custom-chart-debug-page#available-metrics)