### PR TITLE
Add example on authenticating to different org to ccloud auth docs.

### DIFF
--- a/cockroachcloud/ccloud-get-started.md
+++ b/cockroachcloud/ccloud-get-started.md
@@ -41,6 +41,13 @@ In order to use the `ccloud` commands to configure and manage your clusters, you
 
 1. Close the browser window and return to your terminal.
 
+If you are a member of more than one [CockroachDB Cloud organization](console-access-management.html#organization), use the `--org` flag to set the organization name when authenticating.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+ccloud auth login --org <organization ID>
+~~~
+
 ## Create a new cluster using `ccloud cluster create`
 
 There are two ways to create clusters using `ccloud`: `ccloud quickstart create` and `ccloud cluster create`.

--- a/cockroachcloud/ccloud-get-started.md
+++ b/cockroachcloud/ccloud-get-started.md
@@ -45,8 +45,10 @@ If you are a member of more than one [CockroachDB Cloud organization](console-ac
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-ccloud auth login --org <organization ID>
+ccloud auth login --org <organization label>
 ~~~
+
+The organization label is found on the **Settings** page of the CockroachDB Cloud Console.
 
 ## Create a new cluster using `ccloud cluster create`
 

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -18,6 +18,8 @@ To switch between the organizations:
 1. [Log in](https://cockroachlabs.cloud/).
 2. From the drop-down box in the top-right corner, select the organization you want to access.
 
+The settings and information about the organization are found on the **Settings** page. The organization ID and organization label used by the `ccloud` CLI are listed under **Organization settings**. 
+
 ## SQL users
 
 [Console Admins](#console-admin) can [create and manage SQL users](user-authorization.html#create-a-sql-user). A SQL user can interact with a CockroachDB database using the built-in SQL shell or through an application.


### PR DESCRIPTION
Fixes CC-7044.