### PR TITLE
DOC-3681: Update location of AWS DMS doc in sidebar

### DIFF
--- a/_includes/v22.1/misc/tooling.md
+++ b/_includes/v22.1/misc/tooling.md
@@ -67,9 +67,14 @@ For a list of tools supported by the CockroachDB community, see [Third-Party Too
 | Tool | Latest tested version | Support level | Tutorial |
 |-----+------------------------+----------------+----------|
 | [Alembic](https://alembic.sqlalchemy.org/en/latest/) | 1.7 | Full | [Migrate CockroachDB Schemas with Alembic](alembic.html)
-| [AWS DMS](https://aws.amazon.com/dms/) | 3.4.6 | Beta | [Migrate your database to CockroachDB with AWS DMS](aws-dms.html)
 | [Flyway](https://flywaydb.org/documentation/commandline/#download-and-installation) | 7.1.0 | Full | [Migrate CockroachDB Schemas with Flyway](flyway.html)
 | [Liquibase](https://www.liquibase.org/download) | 4.2.0 | Full | [Migrate CockroachDB Schemas with Liquibase](liquibase.html)
+
+## Data migration tools
+
+| Tool | Latest tested version | Support level | Tutorial |
+|-----+------------------------+----------------+----------|
+| [AWS DMS](https://aws.amazon.com/dms/) | 3.4.6 | Beta | [Migrate your database to CockroachDB with AWS DMS](aws-dms.html)
 
 ## Other tools
 

--- a/_includes/v22.1/sidebar-data/develop.json
+++ b/_includes/v22.1/sidebar-data/develop.json
@@ -447,12 +447,6 @@
               ]
             },
             {
-              "title": "AWS DMS",
-              "urls": [
-                "/${VERSION}/aws-dms.html"
-              ]
-            },
-            {
               "title": "Flyway",
               "urls": [
                 "/${VERSION}/flyway.html"

--- a/_includes/v22.1/sidebar-data/migrate.json
+++ b/_includes/v22.1/sidebar-data/migrate.json
@@ -69,6 +69,12 @@
       ]
     },
     {
+      "title": "Migrate to CockroachDB using AWS DMS",
+      "urls": [
+        "/${VERSION}/aws-dms.html"
+      ]
+    },
+    {
       "title": "Export Spatial Data",
       "urls": [
         "/${VERSION}/export-spatial-data.html"

--- a/v22.1/aws-dms.md
+++ b/v22.1/aws-dms.md
@@ -1,11 +1,11 @@
 ---
-title: Migrate CockroachDB Schemas with AWS Database Migration Service (DMS)
-summary: Learn how to use AWS Database Migration Service (DMS) to migrate to a CockroachDB target cluster.
+title: Migrate with AWS Database Migration Service (DMS)
+summary: Learn how to use AWS Database Migration Service (DMS) to migrate data to a CockroachDB target cluster.
 toc: true
 docs_area: develop
 ---
 
-This page has instructions for setting up [AWS DMS](https://aws.amazon.com/dms/) to migrate data from an existing database to CockroachDB.
+This page has instructions for setting up [AWS DMS](https://aws.amazon.com/dms/) to migrate data to CockroachDB from an existing, publicly-hosted database containing application data such as MySQL, Oracle, or PostgreSQL.
 
 For a detailed tutorial about using AWS DMS and information about specific migration tasks, see the [AWS DMS documentation site](https://docs.aws.amazon.com/dms/latest/userguide/Welcome.html).
 

--- a/v22.1/migrate-from-mysql.md
+++ b/v22.1/migrate-from-mysql.md
@@ -11,6 +11,10 @@ The examples use the [employees data set](https://github.com/datacharmer/test_db
 
 {% include {{ page.version.version }}/misc/import-perf.md %}
 
+{{site.data.alerts.callout_info}}
+To migrate from MySQL to CockroachDB using the AWS Database Migration Service, see [Migrate with AWS Database Migration Service (DMS)](aws-dms.html).
+{{site.data.alerts.end}}
+
 ## Considerations
 
 In addition to the general considerations listed in the [Migration Overview](migration-overview.html), there is also the following MySQL-specific information to consider as you prepare your migration.
@@ -148,7 +152,7 @@ The simplest way to import a table dump is to run [`IMPORT`][import].  It reads 
 ~~~
 
 ~~~
-       job_id       |  status   | fraction_completed |  rows  | index_entries | system_records |  bytes   
+       job_id       |  status   | fraction_completed |  rows  | index_entries | system_records |  bytes
 --------------------+-----------+--------------------+--------+---------------+----------------+----------
  383855569817436161 | succeeded |                  1 | 300024 |             0 |              0 | 11534293
 (1 row)

--- a/v22.1/migrate-from-oracle.md
+++ b/v22.1/migrate-from-oracle.md
@@ -15,6 +15,10 @@ To illustrate this process, we use the following sample data and tools:
 
 {% include {{ page.version.version }}/misc/import-perf.md %}
 
+{{site.data.alerts.callout_info}}
+To migrate from Oracle to CockroachDB using the AWS Database Migration Service, see [Migrate with AWS Database Migration Service (DMS)](aws-dms.html).
+{{site.data.alerts.end}}
+
 ## Step 1. Export the Oracle schema
 
 Using [Oracle's Data Pump Export utility](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sutil/oracle-data-pump-export-utility.html), export the schema:
@@ -251,7 +255,7 @@ For more information and examples, refer to the following:
 
 ### Privileges for users and roles
 
-The Oracle privileges for [users](create-user.html) and [roles](create-role.html) must be rewritten for CockroachDB. Once the CockroachDB cluster is [secured](security-reference/security-overview.html), CockroachDB follows the same [role-based access control](authorization.html) methodology as Oracle.   
+The Oracle privileges for [users](create-user.html) and [roles](create-role.html) must be rewritten for CockroachDB. Once the CockroachDB cluster is [secured](security-reference/security-overview.html), CockroachDB follows the same [role-based access control](authorization.html) methodology as Oracle.
 
 
 ## Step 8. Import the CSV
@@ -294,7 +298,7 @@ For example, to import the data from `CUSTOMERS.csv.gz` into a new `CUSTOMERS` t
 ~~~
 
 ~~~
-       job_id       |  status   | fraction_completed |  rows  | index_entries | system_records |  bytes   
+       job_id       |  status   | fraction_completed |  rows  | index_entries | system_records |  bytes
 --------------------+-----------+--------------------+--------+---------------+----------------+----------
  381866942129111041 | succeeded |                  1 | 300024 |             0 |              0 | 13258389
 (1 row)
@@ -323,9 +327,9 @@ The last phase of the migration process is to change the [transactional behavior
 
 Both Oracle and CockroachDB support [multi-statement transactions](transactions.html), which are atomic and guarantee ACID semantics. However, CockroachDB operates in a serializable isolation mode while Oracle defaults to read committed, which can create both non-repeatable reads and phantom reads when a transaction reads data twice. It is typical that Oracle developers will use `SELECT FOR UPDATE` to work around read committed issues. The [`SELECT FOR UPDATE`](select-for-update.html) statement is also supported in CockroachDB.
 
-Regarding locks, Cockroach utilizes a [lightweight latch](architecture/transaction-layer.html#latch-manager) to serialize access to common keys across concurrent transactions. Oracle and CockroachDB transaction control flows only have a few minor differences; for more details, refer to [Transactions - SQL statements](transactions.html#sql-statements).  
+Regarding locks, Cockroach utilizes a [lightweight latch](architecture/transaction-layer.html#latch-manager) to serialize access to common keys across concurrent transactions. Oracle and CockroachDB transaction control flows only have a few minor differences; for more details, refer to [Transactions - SQL statements](transactions.html#sql-statements).
 
-As CockroachDB does not allow serializable anomalies, [transactions](begin-transaction.html) may experience deadlocks or [read/write contention](performance-best-practices-overview.html#transaction-contention). This is expected during concurrency on the same keys. These can be addressed with either [automatic retries](transactions.html#automatic-retries) or [client-side intervention techniques](transactions.html#client-side-intervention).  
+As CockroachDB does not allow serializable anomalies, [transactions](begin-transaction.html) may experience deadlocks or [read/write contention](performance-best-practices-overview.html#transaction-contention). This is expected during concurrency on the same keys. These can be addressed with either [automatic retries](transactions.html#automatic-retries) or [client-side intervention techniques](transactions.html#client-side-intervention).
 
 ### SQL dialect
 
@@ -358,7 +362,7 @@ You will have to refactor Oracle SQL and functions that do not comply with [ANSI
         customer string,
         address string
       );
-    ~~~  
+    ~~~
 
 - [Subqueries](subqueries.html)
 - `SYSDATE`

--- a/v22.1/migrate-from-postgres.md
+++ b/v22.1/migrate-from-postgres.md
@@ -11,6 +11,10 @@ The examples pull real data from [Amazon S3](https://aws.amazon.com/s3/). They u
 
 {% include {{ page.version.version }}/misc/import-perf.md %}
 
+{{site.data.alerts.callout_info}}
+To migrate from PostgreSQL to CockroachDB using the AWS Database Migration Service, see [Migrate with AWS Database Migration Service (DMS)](aws-dms.html).
+{{site.data.alerts.end}}
+
 ## Step 1. Dump the PostgreSQL database
 
 There are several ways to dump data from PostgreSQL to be imported into CockroachDB:
@@ -125,7 +129,7 @@ The simplest way to import a table dump is to run [`IMPORT`][import]. It reads t
 ~~~
 
 ~~~
-       job_id       |  status   | fraction_completed |  rows  | index_entries | system_records |  bytes   
+       job_id       |  status   | fraction_completed |  rows  | index_entries | system_records |  bytes
 --------------------+-----------+--------------------+--------+---------------+----------------+----------
  383855569817436161 | succeeded |                  1 | 300024 |             0 |              0 | 11534293
 (1 row)


### PR DESCRIPTION
Fixes DOC-3681

Also adds references to AWS DMS inside existing DB migration docs