### PR TITLE
fix node drain flags for v21.2

### DIFF
--- a/v21.2/cockroach-node.md
+++ b/v21.2/cockroach-node.md
@@ -79,7 +79,7 @@ $ cockroach node recommission <node IDs> <flags>
 Drain nodes:
 
 ~~~ shell
-$ cockroach node drain <node ID> <flags>
+$ cockroach node drain <flags>
 ~~~
 
 View help:
@@ -129,7 +129,6 @@ The `node drain` subcommand also supports the following general flag:
 Flag | Description
 -----|------------
 `--drain-wait` | Amount of time to wait for the node to drain before returning to the client. If draining fails to complete within this duration, you must re-initiate the command to continue the drain. A very long drain may indicate an anomaly, and you should manually inspect the server to determine what blocks the drain.<br><br>**Default:** `10m`
-`--self` | Applies the operation to the node against which the command was run (e.g., via `--host`).
 
 The `node recommission` subcommand also supports the following general flag:
 

--- a/v21.2/node-shutdown.md
+++ b/v21.2/node-shutdown.md
@@ -523,11 +523,11 @@ To drain and shut down a node that was started in the foreground with [`cockroac
 
 You can use [`cockroach node drain`](cockroach-node.html) to drain a node separately from decommissioning the node or terminating the node process.
 
-1. Run the `cockroach node drain` command, specifying the ID of the node to drain (and optionally a custom [drain timeout](#drain-timeout) to allow draining more time to complete):
+1. Run the `cockroach node drain` command, specifying the address of the node to drain (and optionally a custom [drain timeout](#drain-timeout) to allow draining more time to complete):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach node drain 1 --host={address of any live node} --drain-wait=15m --certs-dir=certs
+    cockroach node drain --host={address of node to drain} --drain-wait=15m --certs-dir=certs
     ~~~
 
     You will see the draining status print to `stderr`:
@@ -577,16 +577,16 @@ This example assumes you will decommission node IDs `4` and `5` of a 5-node clus
 
 #### Step 2. Drain the nodes manually
 
-Run the [`cockroach node drain`](cockroach-node.html) command for each node to be removed, specifying the ID of the node to drain:
+Run the [`cockroach node drain`](cockroach-node.html) command for each node to be removed, specifying the address of the node to drain:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-cockroach node drain 4 --host={address of any live node} --certs-dir=certs
+cockroach node drain --host={address of node 4} --certs-dir=certs
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-cockroach node drain 5 --host={address of any live node} --certs-dir=certs
+cockroach node drain --host={address of node 5} --certs-dir=certs
 ~~~
 
 You will see the draining status of each node print to `stderr`:

--- a/v22.1/cockroach-node.md
+++ b/v22.1/cockroach-node.md
@@ -124,7 +124,7 @@ Flag | Description
 `--wait` | When to return to the client. Possible values: `all`, `none`.<br><br>If `all`, the command returns to the client only after all replicas on all specified nodes have been transferred to other nodes. If any specified nodes are offline, the command will not return to the client until those nodes are back online.<br><br>If `none`, the command does not wait for the decommissioning process to complete; it returns to the client after starting the decommissioning process on all specified nodes that are online. Any specified nodes that are offline will automatically be marked as decommissioning; if they come back online, the cluster will recognize this status and will not rebalance data to the nodes.<br><br>**Default:** `all`
 `--self` | **Deprecated.** Instead, specify a node ID explicitly in addition to the `--host` flag.
 
-The `node drain` subcommand also supports the following general flag:
+The `node drain` subcommand also supports the following general flags:
 
 Flag | Description
 -----|------------


### PR DESCRIPTION
Fixes [DOC-3623](https://cockroachlabs.atlassian.net/browse/DOC-3623).

The `--self` flag and node IDs cannot be passed with `cockroach node drain` in v21.2. This PR corrects the `cockroach node` doc and the example commands in the Node Shutdown doc, which use `cockroach node drain --host={address of node to drain}`.