### PR TITLE
Added v22.1.1 anchor link target

### DIFF
--- a/advisories/a82309.md
+++ b/advisories/a82309.md
@@ -32,7 +32,7 @@ If the changefeeds run with the [`resolved` option](../{{site.versions["stable"]
 
 This is resolved in CockroachDB by PR [#82312](https://github.com/cockroachdb/cockroach/pull/82312).
 
-The fix will be applied to the upcoming maintenance version [v22.1.1](../releases/v22.1.html) of CockroachDB, currently scheduled for June 6, 2022.
+The fix will be applied to the upcoming maintenance version [v22.1.1](../releases/v22.1.html#v22-1-1) of CockroachDB, currently scheduled for June 6, 2022.
 
 This public issue is tracked by [#82309](https://github.com/cockroachdb/cockroach/issues/82309).
 


### PR DESCRIPTION
v22.1.1 is live today, adding direct anchor link to release notes.