### PR TITLE
Added v22.1.1 anchor link target

### DIFF
--- a/advisories/a81315.md
+++ b/advisories/a81315.md
@@ -20,7 +20,7 @@ For example, executing a prepared statement of the form `SELECT ... FROM ... WHE
 
 This is resolved in CockroachDB by [PR 81331](https://github.com/cockroachdb/cockroach/pull/81331).
 
-The fix has been applied to maintenance versions [v21.2.11](../releases/v21.2.html#v21-2-11) and the upcoming [v22.1.1](../releases/v22.1.html) of CockroachDB.
+The fix has been applied to maintenance versions [v21.2.11](../releases/v21.2.html#v21-2-11) and the upcoming [v22.1.1](../releases/v22.1.html#v22-1-1) of CockroachDB.
 
 This public issue is tracked by [81315](https://github.com/cockroachdb/cockroach/issues/81315).
 


### PR DESCRIPTION
v22.1.1 is live today, adding direct anchor link to release notes.