### PR TITLE
DOC-49 clarify livebytes metric

### DIFF
--- a/_includes/v21.2/metric-names.md
+++ b/_includes/v21.2/metric-names.md
@@ -47,7 +47,7 @@ Name | Help
 `leases.success` | Number of successful lease requests
 `leases.transfers.error` | Number of failed lease transfers
 `leases.transfers.success` | Number of successful lease transfers
-`livebytes` | Number of bytes of live data (keys plus values)
+`livebytes` | Number of bytes of live data (keys plus values), including unreplicated data
 `livecount` | Count of live keys
 `liveness.epochincrements` | Number of times this node has incremented its liveness epoch
 `liveness.heartbeatfailures` | Number of failed node liveness heartbeats from this node

--- a/_includes/v22.1/metric-names.md
+++ b/_includes/v22.1/metric-names.md
@@ -47,7 +47,7 @@ Name | Help
 `leases.success` | Number of successful lease requests
 `leases.transfers.error` | Number of failed lease transfers
 `leases.transfers.success` | Number of successful lease transfers
-`livebytes` | Number of bytes of live data (keys plus values)
+`livebytes` | Number of bytes of live data (keys plus values), including unreplicated data
 `livecount` | Count of live keys
 `liveness.epochincrements` | Number of times this node has incremented its liveness epoch
 `liveness.heartbeatfailures` | Number of failed node liveness heartbeats from this node


### PR DESCRIPTION
Addresses: DOC-49

- Clarified that `livebytes` metric also counts unreplicated data. This is the only mention of `livebytes` in the corpus.

[v22.1/metric-names.md](url) | [v21.2/metric-names.md](url) 