### PR TITLE
DOC-4530 tighten grep filename match

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -44,8 +44,8 @@ jobs:
               major_version=${path[0]}
             fi
             file_name=${path[-1]}
-            mainRefs=($(grep -irl ${file_name} ${major_version} | sed -e 's/^\.\///g'))
-            includeRefs=($(grep -irl ${file_name} _includes/${major_version} | sed -e 's/^\.\///g'))
+            mainRefs=($(grep -irl /${file_name} ${major_version} | sed -e 's/^\.\///g'))
+            includeRefs=($(grep -irl /${file_name} _includes/${major_version} | sed -e 's/^\.\///g'))
             if [[ ${#mainRefs[@]} > 0 ]]
             then
               for ref in ${mainRefs[@]}; do

--- a/_includes/v22.1/known-limitations/cdc.md
+++ b/_includes/v22.1/known-limitations/cdc.md
@@ -1,5 +1,5 @@
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html). [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73434)
-- Changefeed target options are limited to tables. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73435)
+- Changefeed target options are limited to tables and [column families](use-changefeeds.html#changefeeds-on-tables-with-column-families). [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73435)
 - Using a [cloud storage sink](changefeed-sinks.html#cloud-storage-sink) only works with `JSON` and emits [newline-delimited json](http://ndjson.org) files. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73432)
 - Webhook sinks only support HTTPS. Use the [`insecure_tls_skip_verify`](create-changefeed.html#tls-skip-verify) parameter when testing to disable certificate verification; however, this still requires HTTPS and certificates. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73431)
 - [Webhook sinks](changefeed-sinks.html#webhook-sink) and [Google Cloud Pub/Sub sinks](changefeed-sinks.html#google-cloud-pub-sub) only have support for emitting `JSON`. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73432)

--- a/_includes/v22.1/known-limitations/cdc.md
+++ b/_includes/v22.1/known-limitations/cdc.md
@@ -1,5 +1,5 @@
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html). [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73434)
-- Changefeed target options are limited to tables and [column families](use-changefeeds.html#changefeeds-on-tables-with-column-families). [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73435)
+- Changefeed target options are limited to tables. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73435)
 - Using a [cloud storage sink](changefeed-sinks.html#cloud-storage-sink) only works with `JSON` and emits [newline-delimited json](http://ndjson.org) files. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73432)
 - Webhook sinks only support HTTPS. Use the [`insecure_tls_skip_verify`](create-changefeed.html#tls-skip-verify) parameter when testing to disable certificate verification; however, this still requires HTTPS and certificates. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73431)
 - [Webhook sinks](changefeed-sinks.html#webhook-sink) and [Google Cloud Pub/Sub sinks](changefeed-sinks.html#google-cloud-pub-sub) only have support for emitting `JSON`. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/73432)


### PR DESCRIPTION
Addresses: DOC-4530

- Tightens `grep` match on `$filename` on our `changed_files.yaml` GH action to capture cases where `filename.md` is actually `more-to-filename.md`; current `grep` syntax matches both.
- `cdc.md` file in here to test that this works, will pull for final merge ofc.