### PR TITLE
DOC-937 add server.eventlog.enabled troubleshooting

### DIFF
--- a/v21.1/cluster-setup-troubleshooting.md
+++ b/v21.1/cluster-setup-troubleshooting.md
@@ -467,12 +467,6 @@ The [DB Console][db_console] provides several ways to check for node liveness is
 For more information about how node liveness works, see [the architecture documentation on the replication layer](architecture/replication-layer.html#epoch-based-leases-table-data).
 {{site.data.alerts.end}}
 
-## Partial availability issues
-
-If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of notable events (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
-
-Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as normal.
-
 ### Check node heartbeat latency
 
 To check node heartbeat latency:
@@ -510,6 +504,12 @@ To view command commit latency:
 3. Scroll down the metrics page to find the **Command Commit Latency: 90th percentile** and **Command Commit Latency: 99th percentile** graphs.
 
 **Expected values for a healthy cluster**: On SSDs, this should be between 1 and 100 milliseconds.  On HDDs, this should be no more than 1 second.  Note that we [strongly recommend running CockroachDB on SSDs](recommended-production-settings.html#storage).
+
+## Partial availability issues
+
+If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of [notable events](eventlog.html) (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
+
+Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as usual.
 
 ## Check for under-replicated or unavailable data
 

--- a/v21.1/cluster-setup-troubleshooting.md
+++ b/v21.1/cluster-setup-troubleshooting.md
@@ -467,6 +467,12 @@ The [DB Console][db_console] provides several ways to check for node liveness is
 For more information about how node liveness works, see [the architecture documentation on the replication layer](architecture/replication-layer.html#epoch-based-leases-table-data).
 {{site.data.alerts.end}}
 
+## Partial availability issues
+
+If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of notable events (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
+
+Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as normal.
+
 ### Check node heartbeat latency
 
 To check node heartbeat latency:

--- a/v21.2/cluster-setup-troubleshooting.md
+++ b/v21.2/cluster-setup-troubleshooting.md
@@ -524,9 +524,9 @@ For more information about how node liveness works, see [Replication Layer](arch
 
 ## Partial availability issues
 
-If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of notable events (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
+If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of [notable events](eventlog.html) (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
 
-Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as normal.
+Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as usual.
 
 ## Check for under-replicated or unavailable data
 

--- a/v21.2/cluster-setup-troubleshooting.md
+++ b/v21.2/cluster-setup-troubleshooting.md
@@ -522,6 +522,12 @@ The [DB Console][db_console] provides several ways to check for node liveness is
 For more information about how node liveness works, see [Replication Layer](architecture/replication-layer.html#epoch-based-leases-table-data).
 {{site.data.alerts.end}}
 
+## Partial availability issues
+
+If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of notable events (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
+
+Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as normal.
+
 ## Check for under-replicated or unavailable data
 
 To see if any data is under-replicated or unavailable in your cluster, use the `system.replication_stats` report as described in [Replication Reports](query-replication-reports.html).

--- a/v22.1/cluster-setup-troubleshooting.md
+++ b/v22.1/cluster-setup-troubleshooting.md
@@ -535,9 +535,9 @@ For more information about how node liveness works, see [Replication Layer](arch
 
 ## Partial availability issues
 
-If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of notable events (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
+If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of [notable events](eventlog.html) (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
 
-Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as normal.
+Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as usual.
 
 ## Check for under-replicated or unavailable data
 

--- a/v22.1/cluster-setup-troubleshooting.md
+++ b/v22.1/cluster-setup-troubleshooting.md
@@ -533,6 +533,12 @@ The [DB Console][db_console] provides several ways to check for node liveness is
 For more information about how node liveness works, see [Replication Layer](architecture/replication-layer.html#epoch-based-leases-table-data).
 {{site.data.alerts.end}}
 
+## Partial availability issues
+
+If your cluster is in a partially-available state due to a recent node or network failure, the internal logging table `system.eventlog` might be unavailable. This can cause the logging of notable events (e.g., the execution of SQL statements) to the `system.eventlog` table to fail to complete, contributing to cluster unavailability. If this occurs, you can set the [cluster setting](cluster-settings.html) `server.eventlog.enabled` to `false` to disable writing notable log events to this table, which may help to recover your cluster.
+
+Even with `server.eventlog.enabled` set to `false`, notable log events are still sent to configured [log sinks](configure-logs.html#configure-log-sinks) as normal.
+
 ## Check for under-replicated or unavailable data
 
 To see if any data is under-replicated or unavailable in your cluster, use the `system.replication_stats` report as described in [Replication Reports](query-replication-reports.html).


### PR DESCRIPTION
Addresses: DOC-937

- Adds brief mention to _Troubleshoot Cluster Setup_ guide that covers partial availability scenario where `server.eventlog` table might not be available: set `sever.eventlog.enabled` to `false` to try to recover.
- Since this setting was first introduced in 21.1, I have propagated this docs change back to include it.

Note: this setting is not covered anywhere else in the corpus (excluding the generated [cluster-settings list](https://deploy-preview-14294--cockroachdb-docs.netlify.app/docs/v22.1/cluster-settings)). If this troubleshooting-focused inclusion is deemed unnecessary, I would suggest that this ticket is instead a no-op.

[v22.1/cluster-setup-troubleshooting.md](https://deploy-preview-14294--cockroachdb-docs.netlify.app/docs/stable/cluster-setup-troubleshooting.html#partial-availability-issues) | [v21.2/cluster-setup-troubleshooting.md](https://deploy-preview-14294--cockroachdb-docs.netlify.app/docs/v21.2/cluster-setup-troubleshooting.html#partial-availability-issues) | [v21.1/cluster-setup-troubleshooting.md](https://deploy-preview-14294--cockroachdb-docs.netlify.app/docs/v21.1/cluster-setup-troubleshooting.html#partial-availability-issues)