### PR TITLE
JSONB example and reference improvements.

### DIFF
--- a/_includes/v22.1/sql/jsonb-comparison.md
+++ b/_includes/v22.1/sql/jsonb-comparison.md
@@ -1,13 +1,13 @@
-CockroachDB does not support using comparison operators (such as `<` or `>`) on [`JSONB`](jsonb.html) elements. For example, the following query does not work and returns an error:
+You cannot use comparison operators (such as `<` or `>`) on [`JSONB`](jsonb.html) elements. For example, the following query does not work and returns an error:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT '{"a": 1}'::JSONB -> 'a' < '{"b": 2}'::JSONB -> 'b';
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT '{"a": 1}'::JSONB -> 'a' < '{"b": 2}'::JSONB -> 'b';
+    ~~~
 
-~~~
-ERROR: unsupported comparison operator: <jsonb> < <jsonb>
-SQLSTATE: 22023
-~~~
+    ~~~
+    ERROR: unsupported comparison operator: <jsonb> < <jsonb>
+    SQLSTATE: 22023
+    ~~~
 
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/49144)
+    [Tracking issue](https://github.com/cockroachdb/cockroach/issues/49144)

--- a/v22.1/functions-and-operators.md
+++ b/v22.1/functions-and-operators.md
@@ -87,6 +87,7 @@ The following table lists all CockroachDB operators from highest to lowest prece
 |    |  `->` | Access a JSONB field, returning a JSONB value. | binary |
 |    |  `->>` | Access a JSONB field, returning a string. | binary |
 |    |  `@>` | Tests whether the left JSONB field contains the right JSONB field. | binary |
+|    |  `>@` | Tests whether the left JSONB field is contained by the right JSONB field. | binary |
 |    |  `#>` | Access a JSONB field at the specified path, returning a JSONB value. | binary |
 |    |  `#>>` | Access a JSONB field at the specified path, returning a string. | binary |
 | 12 | `[NOT] BETWEEN` | Value is [not] within the range specified | binary |

--- a/v22.1/functions-and-operators.md
+++ b/v22.1/functions-and-operators.md
@@ -90,6 +90,9 @@ The following table lists all CockroachDB operators from highest to lowest prece
 |    |  `>@` | Tests whether the left JSONB field is contained by the right JSONB field. | binary |
 |    |  `#>` | Access a JSONB field at the specified path, returning a JSONB value. | binary |
 |    |  `#>>` | Access a JSONB field at the specified path, returning a string. | binary |
+|    |  `?` | Does the key or element string exist within the JSONB value? | binary |
+|    |  `?&` | Do any of the key or element strings exist within the JSONB value? | binary |
+|    |  `?|` | Do all the key or element strings exist within the JSONB value?  | binary |
 | 12 | `[NOT] BETWEEN` | Value is [not] within the range specified | binary |
 |    | `[NOT] BETWEEN SYMMETRIC` | Like `[NOT] BETWEEN`, but in non-sorted order. For example, whereas `a BETWEEN b AND c` means `b <= a <= c`, `a BETWEEN SYMMETRIC b AND c` means `(b <= a <= c) OR (c <= a <= b)`. | binary |
 |    | `[NOT] IN` | Value is [not] in the set of values specified | binary |

--- a/v22.1/functions-and-operators.md
+++ b/v22.1/functions-and-operators.md
@@ -62,16 +62,16 @@ The following table lists all CockroachDB operators from highest to lowest prece
 | 1 | `.` | Member field access operator | binary |
 | 2 | `::` | [Type cast](scalar-expressions.html#explicit-type-coercions) | binary |
 | 3 | `-` | Unary minus | unary (prefix) |
-|  | `~` | Bitwise not | unary (prefix) |
+|   | `~` | Bitwise not | unary (prefix) |
 | 4 | `^` | Exponentiation | binary |
 | 5 | `*` | Multiplication | binary |
-|  | `/` | Division | binary |
-|  | `//` | Floor division | binary |
-|  | `%` | Modulo | binary |
+|   | `/` | Division | binary |
+|   | `//` | Floor division | binary |
+|   | `%` | Modulo | binary |
 | 6 | `+` | Addition | binary |
-|  | `-` | Subtraction | binary |
+|   | `-` | Subtraction | binary |
 | 7 | `<<` | Bitwise left-shift | binary |
-|  | `>>` | Bitwise right-shift | binary |
+|   | `>>` | Bitwise right-shift | binary |
 | 8 | `&` | Bitwise AND | binary |
 | 9 | `#` | Bitwise XOR | binary |
 | 10 | <code>&#124;</code> | Bitwise OR | binary |
@@ -84,27 +84,32 @@ The following table lists all CockroachDB operators from highest to lowest prece
 |    | `<> ANY` / `!= ANY`, `<> SOME` / `!= SOME`, `<> ALL` / `!= ALL` | [Multi-valued] "not equal" comparison | binary |
 |    | `[NOT] LIKE ANY`, `[NOT] LIKE SOME`, `[NOT] LIKE ALL` | [Multi-valued] `LIKE` comparison | binary |
 |    | `[NOT] ILIKE ANY`, `[NOT] ILIKE SOME`, `[NOT] ILIKE ALL` | [Multi-valued] `ILIKE` comparison | binary |
+|    |  `->` | Access a JSONB field, returning a JSONB value. | binary |
+|    |  `->>` | Access a JSONB field, returning a string. | binary |
+|    |  `@>` | Tests whether the left JSONB field contains the right JSONB field. | binary |
+|    |  `#>` | Access a JSONB field at the specified path, returning a JSONB value. | binary |
+|    |  `#>>` | Access a JSONB field at the specified path, returning a string. | binary |
 | 12 | `[NOT] BETWEEN` | Value is [not] within the range specified | binary |
-|  | `[NOT] BETWEEN SYMMETRIC` | Like `[NOT] BETWEEN`, but in non-sorted order. For example, whereas `a BETWEEN b AND c` means `b <= a <= c`, `a BETWEEN SYMMETRIC b AND c` means `(b <= a <= c) OR (c <= a <= b)`. | binary |
-|  | `[NOT] IN` | Value is [not] in the set of values specified | binary |
-|  | `[NOT] LIKE` | Matches [or not] LIKE expression, case sensitive  | binary |
-|  | `[NOT] ILIKE` | Matches [or not] LIKE expression, case insensitive | binary |
-|  | `[NOT] SIMILAR` | Matches [or not] SIMILAR TO regular expression | binary |
-|  | `~` | Matches regular expression, case sensitive | binary |
-|  | `!~` | Does not match regular expression, case sensitive | binary |
-|  | `~*` | Matches regular expression, case insensitive | binary |
-|  | `!~*` | Does not match regular expression, case insensitive | binary |
+|    | `[NOT] BETWEEN SYMMETRIC` | Like `[NOT] BETWEEN`, but in non-sorted order. For example, whereas `a BETWEEN b AND c` means `b <= a <= c`, `a BETWEEN SYMMETRIC b AND c` means `(b <= a <= c) OR (c <= a <= b)`. | binary |
+|    | `[NOT] IN` | Value is [not] in the set of values specified | binary |
+|    | `[NOT] LIKE` | Matches [or not] LIKE expression, case sensitive  | binary |
+|    | `[NOT] ILIKE` | Matches [or not] LIKE expression, case insensitive | binary |
+|    | `[NOT] SIMILAR` | Matches [or not] SIMILAR TO regular expression | binary |
+|    | `~` | Matches regular expression, case sensitive | binary |
+|    | `!~` | Does not match regular expression, case sensitive | binary |
+|    | `~*` | Matches regular expression, case insensitive | binary |
+|    | `!~*` | Does not match regular expression, case insensitive | binary |
 | 13 | `=` | Equal | binary |
-|  | `<` | Less than | binary |
-|  | `>` | Greater than | binary |
-|  | `<=` | Less than or equal to | binary |
-|  | `>=` | Greater than or equal to | binary |
-|  | `!=`, `<>` | Not equal | binary |
+|    | `<` | Less than | binary |
+|    | `>` | Greater than | binary |
+|    | `<=` | Less than or equal to | binary |
+|    | `>=` | Greater than or equal to | binary |
+|    | `!=`, `<>` | Not equal | binary |
 | 14 | `IS [DISTINCT FROM]` | Equal, considering `NULL` as value | binary |
-|  | `IS NOT [DISTINCT FROM]` | `a IS NOT b` equivalent to `NOT (a IS b)` | binary |
-|  | `ISNULL`, `IS UNKNOWN` , `NOTNULL`, `IS NOT UNKNOWN` | Equivalent to `IS NULL` / `IS NOT NULL` | unary (postfix) |
-|  | `IS NAN`, `IS NOT NAN` | [Comparison with the floating-point NaN value](scalar-expressions.html#comparison-with-nan) | unary (postfix) |
-|  | `IS OF(...)` | Type predicate | unary (postfix)
+|    | `IS NOT [DISTINCT FROM]` | `a IS NOT b` equivalent to `NOT (a IS b)` | binary |
+|    | `ISNULL`, `IS UNKNOWN` , `NOTNULL`, `IS NOT UNKNOWN` | Equivalent to `IS NULL` / `IS NOT NULL` | unary (postfix) |
+|    | `IS NAN`, `IS NOT NAN` | [Comparison with the floating-point NaN value](scalar-expressions.html#comparison-with-nan) | unary (postfix) |
+|    | `IS OF(...)` | Type predicate | unary (postfix)
 | 15 | `NOT` | [Logical NOT](scalar-expressions.html#logical-operators) | unary |
 | 16 | `AND` | [Logical AND](scalar-expressions.html#logical-operators) | binary |
 | 17 | `OR` | [Logical OR](scalar-expressions.html#logical-operators) | binary |

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -17,11 +17,7 @@ In CockroachDB, `JSON` is an alias for `JSONB`.
 {{site.data.alerts.callout_info}}In PostgreSQL, <code>JSONB</code> and <code>JSON</code> are two different data types. In CockroachDB, the <code>JSONB</code> / <code>JSON</code> data type is similar in behavior to the <a href="https://www.postgresql.org/docs/current/static/datatype-json.html"><code>JSONB</code> data type in PostgreSQL</a>.
 {{site.data.alerts.end}}
 
-## Index `JSONB` data
-
-To [index](indexes.html) a `JSONB` column you can use a [GIN index](inverted-indexes.html) or [index an expression on the column](expression-indexes.html#use-an-expression-to-index-a-field-in-a-jsonb-column).
-
-## Syntax
+### Syntax
 
 The syntax for the `JSONB` data type follows the format specified in [RFC8259](https://tools.ietf.org/html/rfc8259). You can express a constant value of type `JSONB` using an [interpreted literal](sql-constants.html#interpreted-literals) or a string literal [annotated with](scalar-expressions.html#explicitly-typed-expressions) type `JSONB`.
 
@@ -71,6 +67,10 @@ Function | Description
 `jsonb_set(val: jsonb, path: string[], to: jsonb)` | Returns the JSON value pointed to by the variadic arguments. See [Update an array element](#update-an-array-element).
 
 For the full list of supported `JSONB` functions, see [JSONB functions](functions-and-operators.html#jsonb-functions).
+
+# Index `JSONB` data
+
+To [index](indexes.html) a `JSONB` column you can use a [GIN index](inverted-indexes.html#examples) or [index an expression on the column](expression-indexes.html#use-an-expression-to-index-a-field-in-a-jsonb-column).
 
 ## Known limitations
 

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -17,11 +17,9 @@ In CockroachDB, `JSON` is an alias for `JSONB`.
 {{site.data.alerts.callout_info}}In PostgreSQL, <code>JSONB</code> and <code>JSON</code> are two different data types. In CockroachDB, the <code>JSONB</code> / <code>JSON</code> data type is similar in behavior to the <a href="https://www.postgresql.org/docs/current/static/datatype-json.html"><code>JSONB</code> data type in PostgreSQL</a>.
 {{site.data.alerts.end}}
 
-## Considerations
+## Index `JSONB` data
 
-- You cannot use [primary key](primary-key.html), [foreign key](foreign-key.html), and [unique](unique.html) [constraints](constraints.html) on `JSONB` values.
-- To [index](indexes.html) a `JSONB` column you can use a [GIN index](inverted-indexes.html) or [index an expression on the column](expression-indexes.html#use-an-expression-to-index-a-field-in-a-jsonb-column).
-- CockroachDB does not key-encode JSON values. As a result, tables cannot be [ordered by](order-by.html) `JSONB`/`JSON`-typed columns.
+To [index](indexes.html) a `JSONB` column you can use a [GIN index](inverted-indexes.html) or [index an expression on the column](expression-indexes.html#use-an-expression-to-index-a-field-in-a-jsonb-column).
 
 ## Syntax
 
@@ -38,8 +36,10 @@ There are six types of `JSONB` values:
 
 Examples:
 
+- `'[{"foo":"bar"}]'`
 - `'{"type": "account creation", "username": "harvestboy93"}'`
 - `'{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}'`
+- `'{"prices" : [ { "05/01/2022" : 100.5 } , { "06/01/2022" : 101.5 } ]}'`
 
 {{site.data.alerts.callout_info}}If duplicate keys are included in the input, only the last value is kept.{{site.data.alerts.end}}
 
@@ -47,37 +47,48 @@ Examples:
 
 The size of a `JSONB` value is variable, but we recommend that you keep values under 1 MB to ensure satisfactory performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
 
-## Functions
-
-Function | Description
----------|------------
-`jsonb_array_elements(<jsonb>)` | Expands a `JSONB` array to a set of `JSONB` values.
-`jsonb_build_object(<any_element>...)` | Builds a `JSONB` object out of a variadic argument list that alternates between keys and values.
-`jsonb_each(<jsonb>)` | Expands the outermost `JSONB` object into a set of key-value pairs.
-`jsonb_object_keys(<jsonb>)` | Returns sorted set of keys in the outermost `JSONB` object.
-`jsonb_pretty(<jsonb>)` | Returns the given `JSONB` value as a `STRING` indented and with newlines. See the [example](#retrieve-formatted-jsonb-data) below.
-
-For the full list of supported `JSONB` functions, see [Functions and Operators](functions-and-operators.html#jsonb-functions).
-
 ## Operators
 
 Operator | Description | Example |
 ---------|-------------|---------|
-`->` | Access a `JSONB` field, returning a `JSONB` value. | `SELECT '[{"foo":"bar"}]'::JSONB->0->'foo' = '"bar"'::JSONB;`
-`->>` | Access a `JSONB` field, returning a string. | `SELECT '{"foo":"bar"}'::JSONB->>'foo' = 'bar'::STRING;`
-`@>` | Tests whether the left `JSONB` field contains the right `JSONB` field. | `SELECT ('{"foo": {"baz": 3}, "bar": 2}'::JSONB @> '{"foo": {"baz":3}}'::JSONB ) = true;`
+`->` | Access a `JSONB` field, returning a `JSONB` value. | `SELECT '[{"foo":"bar"}]'::JSONB->0->'foo'; = "bar"::JSONB`
+`->>` | Access a `JSONB` field, returning a string. | `SELECT '{"foo":"bar"}'::JSONB->>'foo'; = bar::STRING;`
+`@>` | Tests whether the left `JSONB` field contains the right `JSONB` field. | `SELECT ('{"foo": {"baz": 3}, "bar": 2}'::JSONB@>'{"foo": {"baz":3}}'::JSONB ); = true;`
+`#> ` | Access a `JSONB` field at the specified path, returning a `JSONB` value.  | `SELECT '[{"foo":"bar"}]'::JSONB#>'{0,foo}'; = "bar"::JSONB`
+`#>>` | Access a `JSONB` field at the specified path, returning a string. | `SELECT '[{"foo":"bar"}]'::JSONB#>>'{0,foo}'; = bar::STRING`
 
-For the full list of supported `JSONB` operators, see [Functions and Operators](functions-and-operators.html).
+For the full list of supported `JSONB` operators, see [Operators](functions-and-operators.html#operators).
+
+## Functions
+
+Function | Description
+---------|------------
+`jsonb_array_elements(<jsonb>)` | Expands a `JSONB` array to a set of `JSONB` values. See [Map a `JSONB` array field into rows](#map-a-jsonb-array-field-into-rows).
+`jsonb_build_object(<any_element>...)` | Builds a `JSONB` object out of a variadic argument list that alternates between keys and values.
+`jsonb_each(<jsonb>)` | Expands the outermost `JSONB` object into a set of key-value pairs. See [Retrieve key-value pairs from a `JSONB` field](#retrieve-key-value-pairs-from-a-jsonb-field).
+`jsonb_object_keys(<jsonb>)` | Returns sorted set of keys in the outermost `JSONB` object. See [Retrieve the distinct keys from a `JSONB` field](#retrieve-the-distinct-keys-from-a-jsonb-field).
+`jsonb_pretty(<jsonb>)` | Returns the given `JSONB` value as a `STRING` indented and with newlines. See [Retrieve formatted `JSONB` data](#retrieve-formatted-jsonb-data).
+`jsonb_set(val: jsonb, path: string[], to: jsonb)` | Returns the JSON value pointed to by the variadic arguments. See [Update an array element](#update-an-array-element).
+
+For the full list of supported `JSONB` functions, see [JSONB functions](functions-and-operators.html#jsonb-functions).
 
 ## Known limitations
 
-If the execution of a [join](joins.html) query exceeds the limit set for [memory-buffering operations](vectorized-execution.html#disk-spilling-operations) (i.e., the value set for the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html)), CockroachDB will spill the intermediate results of computation to disk. If the join operation spills to disk, and at least one of the columns is of type `JSON`, CockroachDB returns the error `unable to encode table key: *tree.DJSON`. If the memory limit is not reached, then the query will be processed without error.
+- You cannot use [primary key](primary-key.html), [foreign key](foreign-key.html), and [unique](unique.html) [constraints](constraints.html) on `JSONB` values.
 
-For details, see [tracking issue](https://github.com/cockroachdb/cockroach/issues/35706).
+- {% include {{page.version.version}}/sql/jsonb-comparison.md %}
 
-{% include {{page.version.version}}/sql/jsonb-comparison.md %}
+- You cannot [order](order-by.html) queries using `JSONB` and `JSON`-typed columns.
+
+    [Tracking issue](https://github.com/cockroachdb/cockroach/issues/35706)
+
+- If the execution of a [join](joins.html) query exceeds the limit set for [memory-buffering operations](vectorized-execution.html#disk-spilling-operations) (i.e., the value set for the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html)), CockroachDB will spill the intermediate results of computation to disk. If the join operation spills to disk, and at least one of the columns is of type `JSON`, CockroachDB returns the error `unable to encode table key: *tree.DJSON`. If the memory limit is not reached, then the query will be processed without error.
+
+    [Tracking issue](https://github.com/cockroachdb/cockroach/issues/35706)
 
 ## Examples
+
+This section shows how to create tables with `JSONB` columns and use operators and functions to access and update `JSONB` data. For the full list of operators and functions, see [Operators](functions-and-operators.html#operators) and [JSONB functions](functions-and-operators.html#jsonb-functions).
 
 ### Create a table with a `JSONB` column
 
@@ -96,11 +107,11 @@ For details, see [tracking issue](https://github.com/cockroachdb/cockroach/issue
 ~~~
 
 ~~~
-  column_name  | data_type | is_nullable |  column_default   | generation_expression |  indices  | is_hidden
----------------+-----------+-------------+-------------------+-----------------------+-----------+------------
-  profile_id   | UUID      |    false    | gen_random_uuid() |                       | {primary} |   false
-  last_updated | TIMESTAMP |    true     | now():::TIMESTAMP |                       | {primary} |   false
-  user_profile | JSONB     |    true     | NULL              |                       | {primary} |   false
+  column_name  | data_type | is_nullable |  column_default   | generation_expression |  indices     | is_hidden
+---------------+-----------+-------------+-------------------+-----------------------+--------------+------------
+  profile_id   | UUID      |    false    | gen_random_uuid() |                       | {users_pkey} |   false
+  last_updated | TIMESTAMP |    true     | now():::TIMESTAMP |                       | {users_pkey} |   false
+  user_profile | JSONB     |    true     | NULL              |                       | {users_pkey} |   false
 (3 rows)
 ~~~
 
@@ -116,14 +127,12 @@ For details, see [tracking issue](https://github.com/cockroachdb/cockroach/issue
 > SELECT * FROM users;
 ~~~
 ~~~
-+--------------------------------------+----------------------------------+--------------------------------------------------------------------------+
-|              profile_id              |           last_updated           |                               user_profile                               |
-+--------------------------------------+----------------------------------+--------------------------------------------------------------------------+
-| 33c0a5d8-b93a-4161-a294-6121ee1ade93 | 2018-02-27 16:39:28.155024+00:00 | {"first_name": "Lola", "friends": 547, "last_name": "Dog", "location":   |
-|                                      |                                  | "NYC", "online": true}                                                   |
-| 6a7c15c9-462e-4551-9e93-f389cf63918a | 2018-02-27 16:39:28.155024+00:00 | {"first_name": "Ernie", "location": "Brooklyn", "status": "Looking for   |
-|                                      |                                  | treats"}                                                                 |
-+--------------------------------------+----------------------------------+--------------------------------------------------------------------------+
++--------------------------------------+----------------------------------+----------------------------------------------------------------------------------------------+
+|              profile_id              |           last_updated           |                               user_profile                                                   |
++--------------------------------------+----------------------------------+----------------------------------------------------------------------------------------------+
+| 33c0a5d8-b93a-4161-a294-6121ee1ade93 | 2022-02-27 16:39:28.155024+00:00 | {"first_name": "Lola", "friends": 547, "last_name": "Dog", "location":"NYC", "online": true} |
+| 6a7c15c9-462e-4551-9e93-f389cf63918a | 2022-02-27 16:39:28.155024+00:00 | {"first_name": "Ernie", "location": "Brooklyn", "status": "Looking for treats}               |
++--------------------------------------+----------------------------------+----------------------------------------------------------------------------------------------+
 ~~~
 
 ### Retrieve formatted `JSONB` data
@@ -138,14 +147,14 @@ To retrieve `JSONB` data with easier-to-read formatting, use the `jsonb_pretty()
 +--------------------------------------+----------------------------------+------------------------------------+
 |              profile_id              |           last_updated           |            jsonb_pretty            |
 +--------------------------------------+----------------------------------+------------------------------------+
-| 33c0a5d8-b93a-4161-a294-6121ee1ade93 | 2018-02-27 16:39:28.155024+00:00 | {                                  |
+| 33c0a5d8-b93a-4161-a294-6121ee1ade93 | 2022-02-27 16:39:28.155024+00:00 | {                                  |
 |                                      |                                  |     "first_name": "Lola",          |
 |                                      |                                  |     "friends": 547,                |
 |                                      |                                  |     "last_name": "Dog",            |
 |                                      |                                  |     "location": "NYC",             |
 |                                      |                                  |     "online": true                 |
 |                                      |                                  | }                                  |
-| 6a7c15c9-462e-4551-9e93-f389cf63918a | 2018-02-27 16:39:28.155024+00:00 | {                                  |
+| 6a7c15c9-462e-4551-9e93-f389cf63918a | 2022-02-27 16:39:28.155024+00:00 | {                                  |
 |                                      |                                  |     "first_name": "Ernie",         |
 |                                      |                                  |     "location": "Brooklyn",        |
 |                                      |                                  |     "status": "Looking for treats" |
@@ -153,14 +162,15 @@ To retrieve `JSONB` data with easier-to-read formatting, use the `jsonb_pretty()
 +--------------------------------------+----------------------------------+------------------------------------+
 ~~~
 
-### Retrieve specific fields from a `JSONB` value
+### Retrieve a specific field from `JSONB` data
 
-To retrieve a specific field from a `JSONB` value, use the `->` operator. For example, retrieve a field from the table you created in the [first example](#create-a-table-with-a-jsonb-column):
+To retrieve a specific field from `JSONB` data, use the `->` operator. For example, retrieve a field from the table you created in [Create a table with a `JSONB` column](#create-a-table-with-a-jsonb-column), run:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SELECT user_profile->'first_name',user_profile->'location' FROM users;
 ~~~
+
 ~~~
 +----------------------------+--------------------------+
 | user_profile->'first_name' | user_profile->'location' |
@@ -170,7 +180,7 @@ To retrieve a specific field from a `JSONB` value, use the `->` operator. For ex
 +----------------------------+--------------------------+
 ~~~
 
-You can also use the `->>` operator to return `JSONB` field values as `STRING` values:
+Use the `->>` operator to return `JSONB` fields as `STRING` values:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -185,7 +195,7 @@ You can also use the `->>` operator to return `JSONB` field values as `STRING` v
 +-----------------------------+---------------------------+
 ~~~
 
-You can use the `@>` operator to filter the values in key-value pairs to return `JSONB` field values:
+Use the `@>` operator to filter the values in a field in a `JSONB` column:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -199,8 +209,60 @@ You can use the `@>` operator to filter the values in key-value pairs to return 
 +-----------------------------+---------------------------+
 ~~~
 
-For the full list of functions and operators we support, see [Functions and Operators](functions-and-operators.html).
+Use the `#>>` operator with a path to return all first names:
 
+{% include_cached copy-clipboard.html %}
+~~~ sql
+select user_profile#>>'{first_name}' as "first name" from users;
+~~~
+
+~~~
+  first name
+--------------
+  Lola
+  Ernie
+(2 rows)
+~~~
+
+### Retrieve the distinct keys from a `JSONB` field
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT DISTINCT jsonb_object_keys(user_profile) AS keys FROM users;
+~~~
+
+~~~
+     keys
+--------------
+  first_name
+  friends
+  last_name
+  location
+  online
+  status
+(6 rows)
+~~~
+
+### Retrieve key-value pairs from a `JSONB` field
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT jsonb_each(user_profile) AS pairs FROM users;
+~~~
+
+~~~
+                pairs
+-------------------------------------
+  (first_name,"""Lola""")
+  (friends,547)
+  (last_name,"""Dog""")
+  (location,"""NYC""")
+  (online,true)
+  (first_name,"""Ernie""")
+  (location,"""Brooklyn""")
+  (status,"""Looking for treats""")
+(8 rows)
+~~~
 
 ### Group and order `JSONB` values
 
@@ -229,7 +291,7 @@ For this example, we will add a few more records to the existing table. This wil
   Lola       | Seoul
 ~~~
 
-Now let's group and order the data.
+Group and order the data.
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -244,9 +306,81 @@ Now let's group and order the data.
   Lola       | 2
 ~~~
 
-The `->>` operator returns `STRING` and uses string comparison rules to order the data. If you want numeric ordering, cast the resulting data to `FLOAT`.
+The `->>` operator returns `STRING` and uses string comparison rules to order the data. If you want numeric ordering, [cast the resulting data](supported-casting-and-conversion) to `FLOAT`.
 
-For the full list of functions and operators we support, see [Functions and Operators](functions-and-operators.html).
+### Map a `JSONB` array field into rows
+
+To map a `JSONB` array field into rows, use the `jsonb_array_elements` function:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE commodity (id varchar(10), data jsonb);
+INSERT INTO commodity (id, data) values ('silver', '{"prices" : [ { "05/01/2022" : 100.5 } , { "06/01/2022" : 101.5 } ]}');
+INSERT INTO commodity (id, data) values ('gold', '{"prices" : [ { "05/01/2022" : 200.5 } , { "06/01/2022" : 211.5 } ]}');
+SELECT * FROM commodity;
+~~~
+
+~~~
+    id   |                            data
+---------+-------------------------------------------------------------
+  silver | {"prices": [{"05/01/2022": 100.5}, {"06/01/2022": 101.5}]}
+  gold   | {"prices": [{"05/01/2022": 200.5}, {"06/01/2022": 211.5}]}
+(2 rows)
+
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT id, jsonb_array_elements(commodity.data->'prices') FROM commodity;
+~~~
+
+~~~
+    id   | jsonb_array_elements
+---------+------------------------
+  silver | {"05/01/2022": 100.5}
+  silver | {"06/01/2022": 101.5}
+  gold   | {"05/01/2022": 200.5}
+  gold   | {"06/01/2022": 211.5}
+(4 rows)
+~~~
+
+### Access nested `JSONB` fields
+
+To display the commodity prices for May, run:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT id AS commodity, data->'prices'->0->'05/01/2022' AS "May prices" from commodity;
+~~~
+~~~
+  commodity | May prices
+------------+-------------
+  silver    |      100.5
+  gold      |      200.5
+(2 rows)
+~~~
+
+### Update an array element
+
+To update a field value, use the `jsonb_set` function. For example, to update the price of `silver` on `06/01/2022` to `90.5`, run:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+UPDATE commodity SET data = jsonb_set(data, '{prices, 1, "06/01/2022"}', '90.5') where id = 'silver';
+UPDATE 1
+~~~
+
+~~~ sql
+SELECT * FROM commodity;
+~~~
+
+~~~
+    id   |                            data
+---------+-------------------------------------------------------------
+  silver | {"prices": [{"05/01/2022": 100.5}, {"06/01/2022": 90.5}]}
+  gold   | {"prices": [{"05/01/2022": 200.5}, {"06/01/2022": 211.5}]}
+(2 rows)
+~~~
 
 ### Create a table with a `JSONB` column and a computed column
 
@@ -274,7 +408,7 @@ For example:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT '100'::jsonb::int;
+> SELECT '100'::JSONB::INT;
 ~~~
 
 ~~~
@@ -286,7 +420,7 @@ For example:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT '100000'::jsonb::float;
+> SELECT '100000'::JSONB::FLOAT;
 ~~~
 
 ~~~
@@ -298,7 +432,7 @@ For example:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT '100.50'::jsonb::decimal;
+> SELECT '100.50'::JSONB::DECIMAL;
 ~~~
 
 ~~~
@@ -312,13 +446,13 @@ You use the [`parse_timestamp` function](functions-and-operators.html) to parse 
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-SELECT parse_timestamp ('2021-09-28T10:53:25.160Z');
+SELECT parse_timestamp ('2022-05-28T10:53:25.160Z');
 ~~~
 
 ~~~
       parse_timestamp
 --------------------------
-2021-09-28 10:53:25.16
+2022-05-28 10:53:25.16
 (1 row)
 ~~~
 
@@ -330,35 +464,26 @@ CREATE TABLE events (
   raw JSONB,
   event_created TIMESTAMP AS (parse_timestamp(raw->'event'->>'created')) VIRTUAL
 );
-INSERT INTO events (raw) VALUES ('{"event":{"created":"2021-09-28T10:53:25.160Z"}}');
+INSERT INTO events (raw) VALUES ('{"event":{"created":"2022-05-28T10:53:25.160Z"}}');
 SELECT event_created FROM events;
 ~~~
 
 ~~~
 CREATE TABLE
 
-
-Time: 6ms total (execution 6ms / network 0ms)
-
 INSERT 1
-
-
-Time: 9ms total (execution 9ms / network 0ms)
 
       event_created
 --------------------------
-  2021-09-28 10:53:25.16
+  2022-05-28 10:53:25.16
 (1 row)
-
-
-Time: 1ms total (execution 1ms / network 0ms)
 ~~~
 
 ## See also
 
 - [JSON tutorial](demo-json-support.html)
 - [GIN Indexes](inverted-indexes.html)
-- [Expression Indexes](expression-indexes.html)
+- [Use an expression to index a field in a JSONB column](expression-indexes.html#use-an-expression-to-index-a-field-in-a-jsonb-column)
 - [Computed Columns](computed-columns.html)
 - [Data Types](data-types.html)
 - [Functions and Operators](functions-and-operators.html)

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -306,7 +306,7 @@ Group and order the data.
   Lola       | 2
 ~~~
 
-The `->>` operator returns `STRING` and uses string comparison rules to order the data. If you want numeric ordering, [cast the resulting data](supported-casting-and-conversion) to `FLOAT`.
+The `->>` operator returns `STRING` and uses string comparison rules to order the data. If you want numeric ordering, [cast the resulting data](#supported-casting-and-conversion) to `FLOAT`.
 
 ### Map a `JSONB` array field into rows
 
@@ -352,6 +352,7 @@ To display the commodity prices for May, run:
 ~~~ sql
 SELECT id AS commodity, data->'prices'->0->'05/01/2022' AS "May prices" from commodity;
 ~~~
+
 ~~~
   commodity | May prices
 ------------+-------------

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -53,7 +53,9 @@ Operator | Description | Example |
 `>@` | Tests whether the left `JSONB` field is contained by the right `JSONB` field. | `SELECT('{"bar":2}'::JSONB<@'{"foo":1, "bar":2}'::JSONB); = true;`
 `#> ` | Access a `JSONB` field at the specified path, returning a `JSONB` value.  | `SELECT '[{"foo":"bar"}]'::JSONB#>'{0,foo}'; = "bar"::JSONB`
 `#>>` | Access a `JSONB` field at the specified path, returning a string. | `SELECT '[{"foo":"bar"}]'::JSONB#>>'{0,foo}'; = bar::STRING`
-
+`?` | Does the key or element string exist within the JSONB value? | `SELECT('{"foo":1, "bar":2}'::JSONB?'bar'); = true;`
+`?&` | Do any of the key or element strings exist within the JSONB value? | `SELECT('{"foo":1, "bar":2}'::JSONB?|array['bar']); = true;`
+`?|` | Do all the key or element strings exist within the JSONB value?  | `SELECT('{"foo":1, "bar":2}'::JSONB?&array['foo','bar']); = true;`
 For the full list of supported `JSONB` operators, see [Operators](functions-and-operators.html#operators).
 
 ## Functions

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -50,6 +50,7 @@ Operator | Description | Example |
 `->` | Access a `JSONB` field, returning a `JSONB` value. | `SELECT '[{"foo":"bar"}]'::JSONB->0->'foo'; = "bar"::JSONB`
 `->>` | Access a `JSONB` field, returning a string. | `SELECT '{"foo":"bar"}'::JSONB->>'foo'; = bar::STRING;`
 `@>` | Tests whether the left `JSONB` field contains the right `JSONB` field. | `SELECT ('{"foo": {"baz": 3}, "bar": 2}'::JSONB@>'{"foo": {"baz":3}}'::JSONB ); = true;`
+`>@` | Tests whether the left `JSONB` field is contained by the right `JSONB` field. | `SELECT('{"bar":2}'::JSONB<@'{"foo":1, "bar":2}'::JSONB); = true;`
 `#> ` | Access a `JSONB` field at the specified path, returning a `JSONB` value.  | `SELECT '[{"foo":"bar"}]'::JSONB#>'{0,foo}'; = "bar"::JSONB`
 `#>>` | Access a `JSONB` field at the specified path, returning a string. | `SELECT '[{"foo":"bar"}]'::JSONB#>>'{0,foo}'; = bar::STRING`
 

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -331,16 +331,16 @@ SELECT * FROM commodity;
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-SELECT id, jsonb_array_elements(commodity.data->'prices') FROM commodity;
+SELECT id as commodity, jsonb_array_elements(commodity.data->'prices') AS "price" FROM commodity;
 ~~~
 
 ~~~
-    id   | jsonb_array_elements
----------+------------------------
-  silver | {"05/01/2022": 100.5}
-  silver | {"06/01/2022": 101.5}
-  gold   | {"05/01/2022": 200.5}
-  gold   | {"06/01/2022": 211.5}
+  commodity |         price
+------------+------------------------
+  silver    | {"05/01/2022": 100.5}
+  silver    | {"06/01/2022": 101.5}
+  gold      | {"05/01/2022": 200.5}
+  gold      | {"06/01/2022": 211.5}
 (4 rows)
 ~~~
 


### PR DESCRIPTION
DOC-285, DOC-315, DOC-506, DOC-507.

- Added JSONB operators to Operator precedence table.
- Added example for each function in JSONB page.
- Added `#>`, `#>>`, `>@`, `?`, `?|`, `?&` operators and examples.
- Moved all limitations to Known limitations section.
