### PR TITLE
Zone config restoration followup.

### DIFF
--- a/_includes/v21.1/sql/movr-statements-geo-partitioned-replicas.md
+++ b/_includes/v21.1/sql/movr-statements-geo-partitioned-replicas.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--geo-partitioned-replicas` flag. This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](../v20.2/topology-geo-partitioned-replicas.html) applied to the `movr` database.
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--geo-partitioned-replicas` flag. This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](../v21.1/topology-geo-partitioned-replicas.html) applied to the `movr` database.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v21.2/sql/movr-statements-geo-partitioned-replicas.md
+++ b/_includes/v21.2/sql/movr-statements-geo-partitioned-replicas.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--geo-partitioned-replicas` flag. This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](../v20.2/topology-geo-partitioned-replicas.html) applied to the `movr` database.
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--geo-partitioned-replicas` flag. This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](../v21.2/topology-geo-partitioned-replicas.html) applied to the `movr` database.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v22.1/sql/movr-statements-geo-partitioned-replicas.md
+++ b/_includes/v22.1/sql/movr-statements-geo-partitioned-replicas.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--geo-partitioned-replicas` flag. This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](../v20.2/topology-geo-partitioned-replicas.html) applied to the `movr` database.
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--geo-partitioned-replicas` flag. This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](../v22.1/topology-geo-partitioned-replicas.html) applied to the `movr` database.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell

--- a/v21.1/topology-duplicate-indexes.md
+++ b/v21.1/topology-duplicate-indexes.md
@@ -44,7 +44,7 @@ Pinning secondary indexes requires an [Enterprise license](enterprise-licensing.
 
 Using this pattern, you tell CockroachDB to put the leaseholder for the table itself (also called the primary index) in one region, create 2 secondary indexes on the table, and tell CockroachDB to put the leaseholder for each secondary index in one of the other regions. This means that reads will access the local leaseholder (either for the table itself or for one of the secondary indexes). Writes, however, will still leave the region to get consensus for the table and its secondary indexes.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes1.png' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_duplicate_indexes1.png' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
 
 ### Steps
 
@@ -154,7 +154,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_reads.png' | relative_url }}" alt="Pinned secondary indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_duplicate_indexes_reads.png' | relative_url }}" alt="Pinned secondary indexes topology" style="max-width:100%" />
 
 #### Writes
 
@@ -170,17 +170,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_writes.gif' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_duplicate_indexes_writes.gif' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because this pattern balances the replicas for the table and its secondary indexes across regions, one entire region can fail without interrupting access to the table:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_resiliency.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_duplicate_indexes_resiliency.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" />
 
 <!-- However, if an additional machine holding a replica for the table or any of its secondary indexes fails at the same time as the region failure, the range to which the replica belongs becomes unavailable for reads and writes:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_pinned_index_leaseholders3.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" /> -->
+<img src="{{ 'images/v21.1/topology-patterns/topology_pinned_index_leaseholders3.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" /> -->
 
 ## Preferring the nearest index
 

--- a/v21.1/topology-geo-partitioned-leaseholders.md
+++ b/v21.1/topology-geo-partitioned-leaseholders.md
@@ -40,7 +40,7 @@ Geo-partitioning requires an [Enterprise license](https://www.cockroachlabs.com/
 
 Using this pattern, you design your table schema to allow for [partitioning](partitioning.html#table-creation), with a column identifying geography as the first column in the table's compound primary key (e.g., city/id). You tell CockroachDB to partition the table and all of its secondary indexes by that geography column, each partition becoming its own range of 3 replicas. You then tell CockroachDB to put the leaseholder for each partition in the relevant region (e.g., LA partitions in `us-west`, NY partitions in `us-east`). The other replicas of a partition remain balanced across the other regions. This means that reads in each region will access local leaseholders and, therefore, will have low, intra-region latencies. Writes, however, will leave the region to get consensus and, therefore, will have higher, cross-region latencies.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders1.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioned_leaseholders1.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 ### Steps
 
@@ -218,7 +218,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_reads.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioned_leaseholders_reads.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 #### Writes
 
@@ -234,17 +234,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_writes.gif' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioned_leaseholders_writes.gif' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because this pattern balances the replicas for each partition across regions, one entire region can fail without interrupting access to any partitions. In this case, if any range loses its leaseholder in the region-wide outage, CockroachDB makes one of the range's other replicas the leaseholder:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioned_leaseholders_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 <!-- However, if an additional machine fails at the same time as the region failure, the partitions that lose consensus become unavailable for reads and writes:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" /> -->
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioned_leaseholders_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" /> -->
 
 ## Alternatives
 

--- a/v21.1/topology-geo-partitioned-replicas.md
+++ b/v21.1/topology-geo-partitioned-replicas.md
@@ -39,7 +39,7 @@ Geo-partitioning requires an [Enterprise license](https://www.cockroachlabs.com/
 
 Using this pattern, you design your table schema to allow for [partitioning](partitioning.html#table-creation), with a column identifying geography as the first column in the table's compound primary key (e.g., city/id). You tell CockroachDB to partition the table and all of its secondary indexes by that geography column, each partition becoming its own range of 3 replicas. You then tell CockroachDB to pin each partition (all of its replicas) to the relevant region (e.g., LA partitions in `us-west`, NY partitions in `us-east`). This means that reads and writes in each region will always have access to the relevant replicas and, therefore, will have low, intra-region latencies.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioning1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ### Steps
 
@@ -192,7 +192,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_reads.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioning_reads.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 #### Writes
 
@@ -208,17 +208,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_writes.gif' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioning_writes.gif' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because each partition is constrained to the relevant region and balanced across the 3 AZs in the region, one AZ can fail per region without interrupting access to the partitions in that region:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioning_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 However, if an entire region fails, the partitions in that region become unavailable for reads and writes, even if your load balancer can redirect requests to a different region:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.1/topology-patterns/topology_geo-partitioning_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ## Tutorial
 

--- a/v21.2/topology-duplicate-indexes.md
+++ b/v21.2/topology-duplicate-indexes.md
@@ -44,7 +44,7 @@ Pinning secondary indexes requires an [Enterprise license](enterprise-licensing.
 
 Using this pattern, you tell CockroachDB to put the leaseholder for the table itself (also called the primary index) in one region, create 2 secondary indexes on the table, and tell CockroachDB to put the leaseholder for each secondary index in one of the other regions. This means that reads will access the local leaseholder (either for the table itself or for one of the secondary indexes). Writes, however, will still leave the region to get consensus for the table and its secondary indexes.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes1.png' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_duplicate_indexes1.png' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
 
 ### Steps
 
@@ -154,7 +154,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_reads.png' | relative_url }}" alt="Pinned secondary indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_duplicate_indexes_reads.png' | relative_url }}" alt="Pinned secondary indexes topology" style="max-width:100%" />
 
 #### Writes
 
@@ -170,17 +170,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_writes.gif' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_duplicate_indexes_writes.gif' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because this pattern balances the replicas for the table and its secondary indexes across regions, one entire region can fail without interrupting access to the table:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_resiliency.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_duplicate_indexes_resiliency.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" />
 
 <!-- However, if an additional machine holding a replica for the table or any of its secondary indexes fails at the same time as the region failure, the range to which the replica belongs becomes unavailable for reads and writes:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_pinned_index_leaseholders3.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" /> -->
+<img src="{{ 'images/v21.2/topology-patterns/topology_pinned_index_leaseholders3.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" /> -->
 
 
 ## Preferring the nearest index

--- a/v21.2/topology-geo-partitioned-leaseholders.md
+++ b/v21.2/topology-geo-partitioned-leaseholders.md
@@ -40,7 +40,7 @@ Geo-partitioning requires an [Enterprise license](https://www.cockroachlabs.com/
 
 Using this pattern, you design your table schema to allow for [partitioning](partitioning.html#table-creation), with a column identifying geography as the first column in the table's compound primary key (e.g., city/id). You tell CockroachDB to partition the table and all of its secondary indexes by that geography column, each partition becoming its own range of 3 replicas. You then tell CockroachDB to put the leaseholder for each partition in the relevant region (e.g., LA partitions in `us-west`, NY partitions in `us-east`). The other replicas of a partition remain balanced across the other regions. This means that reads in each region will access local leaseholders and, therefore, will have low, intra-region latencies. Writes, however, will leave the region to get consensus and, therefore, will have higher, cross-region latencies.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders1.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioned_leaseholders1.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 ### Steps
 
@@ -218,7 +218,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_reads.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioned_leaseholders_reads.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 #### Writes
 
@@ -234,17 +234,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_writes.gif' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioned_leaseholders_writes.gif' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because this pattern balances the replicas for each partition across regions, one entire region can fail without interrupting access to any partitions. In this case, if any range loses its leaseholder in the region-wide outage, CockroachDB makes one of the range's other replicas the leaseholder:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 <!-- However, if an additional machine fails at the same time as the region failure, the partitions that lose consensus become unavailable for reads and writes:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" /> -->
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" /> -->
 
 ## Alternatives
 

--- a/v21.2/topology-geo-partitioned-replicas.md
+++ b/v21.2/topology-geo-partitioned-replicas.md
@@ -39,7 +39,7 @@ Geo-partitioning requires an [Enterprise license](https://www.cockroachlabs.com/
 
 Using this pattern, you design your table schema to allow for [partitioning](partitioning.html#table-creation), with a column identifying geography as the first column in the table's compound primary key (e.g., city/id). You tell CockroachDB to partition the table and all of its secondary indexes by that geography column, each partition becoming its own range of 3 replicas. You then tell CockroachDB to pin each partition (all of its replicas) to the relevant region (e.g., LA partitions in `us-west`, NY partitions in `us-east`). This means that reads and writes in each region will always have access to the relevant replicas and, therefore, will have low, intra-region latencies.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioning1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ### Steps
 
@@ -192,7 +192,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_reads.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioning_reads.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 #### Writes
 
@@ -208,17 +208,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_writes.gif' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioning_writes.gif' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because each partition is constrained to the relevant region and balanced across the 3 AZs in the region, one AZ can fail per region without interrupting access to the partitions in that region:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioning_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 However, if an entire region fails, the partitions in that region become unavailable for reads and writes, even if your load balancer can redirect requests to a different region:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v21.2/topology-patterns/topology_geo-partitioning_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ## Tutorial
 

--- a/v22.1/topology-duplicate-indexes.md
+++ b/v22.1/topology-duplicate-indexes.md
@@ -44,7 +44,7 @@ Pinning secondary indexes requires an [Enterprise license](enterprise-licensing.
 
 Using this pattern, you tell CockroachDB to put the leaseholder for the table itself (also called the primary index) in one region, create 2 secondary indexes on the table, and tell CockroachDB to put the leaseholder for each secondary index in one of the other regions. This means that reads will access the local leaseholder (either for the table itself or for one of the secondary indexes). Writes, however, will still leave the region to get consensus for the table and its secondary indexes.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes1.png' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_duplicate_indexes1.png' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
 
 ### Steps
 
@@ -153,7 +153,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_reads.png' | relative_url }}" alt="Pinned secondary indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_duplicate_indexes_reads.png' | relative_url }}" alt="Pinned secondary indexes topology" style="max-width:100%" />
 
 #### Writes
 
@@ -169,17 +169,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_writes.gif' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_duplicate_indexes_writes.gif' | relative_url }}" alt="Duplicate Indexes topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because this pattern balances the replicas for the table and its secondary indexes across regions, one entire region can fail without interrupting access to the table:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_duplicate_indexes_resiliency.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_duplicate_indexes_resiliency.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" />
 
 <!-- However, if an additional machine holding a replica for the table or any of its secondary indexes fails at the same time as the region failure, the range to which the replica belongs becomes unavailable for reads and writes:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_pinned_index_leaseholders3.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" /> -->
+<img src="{{ 'images/v22.1/topology-patterns/topology_pinned_index_leaseholders3.png' | relative_url }}" alt="Pinned Secondary Indexes topology" style="max-width:100%" /> -->
 
 ## Preferring the nearest index
 

--- a/v22.1/topology-geo-partitioned-leaseholders.md
+++ b/v22.1/topology-geo-partitioned-leaseholders.md
@@ -40,7 +40,7 @@ Geo-partitioning requires an [Enterprise license](https://www.cockroachlabs.com/
 
 Using this pattern, you design your table schema to allow for [partitioning](partitioning.html#table-creation), with a column identifying geography as the first column in the table's compound primary key (e.g., city/id). You tell CockroachDB to partition the table and all of its secondary indexes by that geography column, each partition becoming its own range of 3 replicas. You then tell CockroachDB to put the leaseholder for each partition in the relevant region (e.g., LA partitions in `us-west`, NY partitions in `us-east`). The other replicas of a partition remain balanced across the other regions. This means that reads in each region will access local leaseholders and, therefore, will have low, intra-region latencies. Writes, however, will leave the region to get consensus and, therefore, will have higher, cross-region latencies.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders1.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioned_leaseholders1.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 ### Steps
 
@@ -217,7 +217,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_reads.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioned_leaseholders_reads.png' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 #### Writes
 
@@ -233,17 +233,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_writes.gif' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioned_leaseholders_writes.gif' | relative_url }}" alt="Geo-partitioned leaseholders topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because this pattern balances the replicas for each partition across regions, one entire region can fail without interrupting access to any partitions. In this case, if any range loses its leaseholder in the region-wide outage, CockroachDB makes one of the range's other replicas the leaseholder:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioned_leaseholders_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 <!-- However, if an additional machine fails at the same time as the region failure, the partitions that lose consensus become unavailable for reads and writes:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioned_leaseholders_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" /> -->
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioned_leaseholders_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" /> -->
 
 ## Alternatives
 

--- a/v22.1/topology-geo-partitioned-replicas.md
+++ b/v22.1/topology-geo-partitioned-replicas.md
@@ -39,7 +39,7 @@ Geo-partitioning requires an [Enterprise license](https://www.cockroachlabs.com/
 
 Using this pattern, you design your table schema to allow for [partitioning](partitioning.html#table-creation), with a column identifying geography as the first column in the table's compound primary key (e.g., city/id). You tell CockroachDB to partition the table and all of its secondary indexes by that geography column, each partition becoming its own range of 3 replicas. You then tell CockroachDB to pin each partition (all of its replicas) to the relevant region (e.g., LA partitions in `us-west`, NY partitions in `us-east`). This means that reads and writes in each region will always have access to the relevant replicas and, therefore, will have low, intra-region latencies.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioning1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ### Steps
 
@@ -191,7 +191,7 @@ For example, in the animation below:
 4. The leaseholder retrieves the results and returns to the gateway node.
 5. The gateway node returns the results to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_reads.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioning_reads.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 #### Writes
 
@@ -207,17 +207,17 @@ For example, in the animation below:
 6. The leaseholders then return acknowledgement of the commit to the gateway node.
 7. The gateway node returns the acknowledgement to the client.
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_writes.gif' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioning_writes.gif' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ### Resiliency
 
 Because each partition is constrained to the relevant region and balanced across the 3 AZs in the region, one AZ can fail per region without interrupting access to the partitions in that region:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioning_resiliency1.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 However, if an entire region fails, the partitions in that region become unavailable for reads and writes, even if your load balancer can redirect requests to a different region:
 
-<img src="{{ 'images/v20.2/topology-patterns/topology_geo-partitioning_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
+<img src="{{ 'images/v22.1/topology-patterns/topology_geo-partitioning_resiliency2.png' | relative_url }}" alt="Geo-partitioning topology" style="max-width:100%" />
 
 ## Tutorial
 


### PR DESCRIPTION
Followup to https://github.com/cockroachdb/docs/pull/13167.

Complete restoration by:

- Updating docs to point to current version instead of v20.2.
- Updating restored pages to point to correct image path.