### PR TITLE
DOC-4630 support downstream forks

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -1,7 +1,7 @@
 name: List files changed as GitHub comment
 
 on:
-  pull_request
+  pull_request_target
 
 jobs:
   list-files-changed:


### PR DESCRIPTION
Addresses: DOC-4630

- Extends `changed_files.yml`'s on-run logic to include PRs triggered from forks.

Note: since `changed_files,yml` only triggers on PR creation, and the test case is for a PR made from a fork, I can't think of a way to safely test this short of merging this and trying. If you can come up with a safer test, I'm all for it. Barring that, here's the change I think we need to make to support this, and we can test it live with a few mock PRs.