### PR TITLE
Updates to Serverless feature gap doc.

### DIFF
--- a/cockroachcloud/serverless-faqs.md
+++ b/cockroachcloud/serverless-faqs.md
@@ -138,6 +138,10 @@ No, {{ site.data.products.serverless }} clusters are upgraded automatically for 
 
 Yes, you can view and your clusters in the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/). However, some [DB Console](../{{site.versions["stable"]}}/ui-overview.html) pages are not currently available for {{ site.data.products.serverless }} clusters.
 
+### Are all CockroachDB features available in {{ site.data.products.serverless }} clusters?
+
+There are some features of CockroachDB that are unsupported or partially supported in {{ site.data.products.serverless }} clusters. Cockroach Labs intends to eliminate these feature gaps in future releases of {{ site.data.products.serverless }}. See [Unsupported Features in CockroachDB Serverless](serverless-unsupported-features.html) for more details.
+
 ### Can I run bulk operations such as `IMPORT` and `EXPORT` from my cluster?
 
 Yes, you can [run bulk operations on Serverless clusters](run-bulk-operations.html). If you [add billing information to your organization](billing-management.html), even if you don't set a spend limit, you can run bulk operations using cloud storage providers. If you don't have billing set up for your organization, you can set up a [`userfile`](../{{site.versions["stable"]}}/use-userfile-for-bulk-operations.html) location for bulk operations.

--- a/cockroachcloud/serverless-unsupported-features.md
+++ b/cockroachcloud/serverless-unsupported-features.md
@@ -35,6 +35,14 @@ Both {{ site.data.products.serverless }} and {{ site.data.products.dedicated }} 
 
 [Follower reads](../{{site.versions["stable"]}}/follower-reads.html) are not supported in {{ site.data.products.serverless }} clusters.
 
+## Range management
+
+The [`ALTER TABLE ... SPLIT AT`](../{{site.versions["stable"]}}/split-at.html) and [`ALTER RANGE ... RELOCATE`](../{{site.versions["stable"]}}/alter-range-relocate.html) statements are not supported in {{ site.data.products.serverless }}.
+
+## Query cancellation using pgwire
+
+[Canceling queries from client drivers/ORMs using the PostgreSQL wire protocol (pgwire)](../{{site.versions["stable"]}}/cancel-query.html#considerations) is not supported in {{ site.data.products.serverless }}.
+
 ## Self service upgrades
 
 {{ site.data.products.serverless }} is a fully managed multi-tenant deployment of CockroachDB. Major and minor upgrades of CockroachDB are handled by Cockroach Labs, and [can't be initiated by users](serverless-faqs.html#can-i-upgrade-the-version-of-cockroachdb-my-cockroachdb-serverless-beta-cluster-is-running-on).

--- a/releases/cloud.md
+++ b/releases/cloud.md
@@ -8,6 +8,8 @@ docs_area: releases
 
 CockroachDB Cloud supports the latest major version of CockroachDB and the version immediately preceding it. All clusters are subject to automatic upgrades to the latest supported minor version. [{{ site.data.products.serverless }}](../cockroachcloud/quickstart.html) clusters are subject to automatic upgrades for both minor and major releases while Serverless is in beta. For more information, see the [{{ site.data.products.db }} Upgrade Policy](../cockroachcloud/upgrade-policy.html).
 
+For details on features that are not supported in {{ site.data.products.serverless }}, see [Unsupported Features in CockroachDB Serverless](../cockroachcloud/serverless-unsupported-features.html).
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}


### PR DESCRIPTION
This PR adds a section on managing ranges to the unsupported Serverless features topic, and adds additional cross links to the topic from the Serverless FAQ and main Cloud release notes page.