### PR TITLE
Update JDBC instructions

### DIFF
--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -117,9 +117,16 @@ The **Connect to cluster** dialog shows information about how to connect to your
 
 <section class="filter-content" markdown="1" data-scope="java">
 
-{% include cockroachcloud/quickstart/get-connection-string.md %}
+The **Connect to cluster** dialog shows information about how to connect to your cluster.
 
-1. If you haven't already, install the [`cockroach` binary](../{{site.versions["stable"]}}/install-cockroachdb.html) and add it to your OS's `PATH`.
+1. Select **Java** from the **Select option** dropdown.
+1. Copy the `JDBC_DATABASE_URL` environment variable command provided and save it in a secure location.
+    
+    This Quickstart uses default certificates, so you can skip the **Download CA Cert** instructions.
+
+    {{site.data.alerts.callout_info}}
+    The connection string is pre-populated with your username, password, cluster name, and other details. Your password, in particular, will be provided *only once*. Save it in a secure place (Cockroach Labs recommends a password manager) to connect to your cluster in the future. If you forget your password, you can reset it by going to the [**SQL Users** page](user-authorization.html).
+    {{site.data.alerts.end}}
 
 </section>
 
@@ -219,79 +226,41 @@ Use the [JDBC driver](https://jdbc.postgresql.org/) in a Java application.
 <section class="filter-content" markdown="1" data-scope="java">
 
 <section class="filter-content" markdown="1" data-scope="mac">
-1. Use the `cockroach convert-url` command to convert the connection string that you copied earlier to a [valid connection string for JDBC connections](../{{site.versions["stable"]}}/connect-to-the-database.html?filters=java):
+In a terminal set the `JDBC_DATABASE_URL` environment variable to the connection string by running the command that you copied earlier:
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    cockroach convert-url --url "<connection-string>"
-    ~~~
+{% include_cached copy-clipboard.html %}
+~~~ shell
+export JDBC_DATABASE_URL="<jdbc-connection-string>"
+~~~
 
-    ~~~
-    ...
-
-    # Connection URL for JDBC (Java and JVM-based languages):
-    jdbc:postgresql://{host}:{port}/{database}?options=--cluster%3D{routing-id}&password={password}&sslmode=verify-full&user={username}
-    ~~~
-
-1. Set the `JDBC_DATABASE_URL` environment variable to the JDBC-compatible connection string:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    export JDBC_DATABASE_URL="<jdbc-connection-string>"
-    ~~~
-
-    The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
+The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
 </section>
 
 <section class="filter-content" markdown="1" data-scope="linux">
-1. Use the `cockroach convert-url` command to convert the connection string that you copied earlier to a [valid connection string for JDBC connections](../{{site.versions["stable"]}}/connect-to-the-database.html?filters=java):
+In a terminal set the `JDBC_DATABASE_URL` environment variable to the connection string by running the command that you copied earlier:
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    cockroach convert-url --url "<connection-string>"
-    ~~~
+{% include_cached copy-clipboard.html %}
+~~~ shell
+export JDBC_DATABASE_URL="<jdbc-connection-string>"
+~~~
 
-    ~~~
-    ...
-
-    # Connection URL for JDBC (Java and JVM-based languages):
-    jdbc:postgresql://{host}:{port}/{database}?options=--cluster%3D{routing-id}&password={password}&sslmode=verify-full&user={username}
-    ~~~
-
-1. Set the `JDBC_DATABASE_URL` environment variable to the JDBC-compatible connection string:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    export JDBC_DATABASE_URL="<jdbc-connection-string>"
-    ~~~
-
-    The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
+The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
 </section>
 
 <section class="filter-content" markdown="1" data-scope="windows">
-1. Use the `cockroach convert-url` command to convert the connection string that you copied earlier to a [valid connection string for JDBC connections](../{{site.versions["stable"]}}/connect-to-the-database.html?filters=java):
+In a terminal set the `JDBC_DATABASE_URL` environment variable to the connection string by running the command that you copied earlier:
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    cockroach convert-url --url "<connection-string>"
-    ~~~
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$env:JDBC_DATABASE_URL = "<jdbc-connection-string>"
+~~~
 
-    ~~~
-    ...
-
-    # Connection URL for JDBC (Java and JVM-based languages):
-    jdbc:postgresql://{host}:{port}/{database}?options=--cluster%3D{routing-id}&password={password}&sslmode=verify-full&user={username}
-    ~~~
-
-1. Set the `JDBC_DATABASE_URL` environment variable to the JDBC-compatible connection string:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $env:JDBC_DATABASE_URL = "<jdbc-connection-string>"
-    ~~~
-
-    The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
+The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
 </section>
+
+{{site.data.alerts.callout_success}}
+For reference information about connecting to CockroachDB with supported client drivers, see [Connect to a CockroachDB Cluster](../../docs/stable/connect-to-the-database.html).
+{{site.data.alerts.end}}
 
 </section>
 

--- a/v21.2/connect-to-the-database.md
+++ b/v21.2/connect-to-the-database.md
@@ -938,10 +938,10 @@ For example:
 {% include_cached copy-clipboard.html %}
 ~~~ java
 PGSimpleDataSource ds = new PGSimpleDataSource();
-ds.setUrl(System.getenv("DATABASE_URL"));
+ds.setUrl(System.getenv("JDBC_DATABASE_URL"));
 ~~~
 
-Where `DATABASE_URL` is an environment variable set to a valid CockroachDB connection string.
+Where `JDBC_DATABASE_URL` is an environment variable set to a valid CockroachDB connection string.
 
 JDBC accepts the following format for CockroachDB connection strings:
 

--- a/v22.1/connect-to-the-database.md
+++ b/v22.1/connect-to-the-database.md
@@ -938,10 +938,10 @@ For example:
 {% include_cached copy-clipboard.html %}
 ~~~ java
 PGSimpleDataSource ds = new PGSimpleDataSource();
-ds.setUrl(System.getenv("DATABASE_URL"));
+ds.setUrl(System.getenv("JDBC_DATABASE_URL"));
 ~~~
 
-Where `DATABASE_URL` is an environment variable set to a valid CockroachDB connection string.
+Where `JDBC_DATABASE_URL` is an environment variable set to a valid JDBC-compatible CockroachDB connection string.
 
 JDBC accepts the following format for CockroachDB connection strings:
 


### PR DESCRIPTION
Remove references to downloading cockroach binary and running the "convert-url" since the cluster connect modal now provides a jdbc compatible connection url and these steps are no longer necessary.

The relevant changed pages are:
[/docs/cockroachcloud/quickstart.html?filters=java&](https://deploy-preview-14393--cockroachdb-docs.netlify.app/docs/cockroachcloud/quickstart.html?filters=java&) and  [/docs/stable/connect-to-the-database.html?filters=java](https://deploy-preview-14393--cockroachdb-docs.netlify.app/docs/stable/connect-to-the-database.html?filters=java)