### PR TITLE
DOC-2567 DB Console proxy to any node

### DIFF
--- a/v21.2/ui-debug-pages.md
+++ b/v21.2/ui-debug-pages.md
@@ -18,7 +18,7 @@ These pages are experimental and undocumented. If you find an issue, let us know
 On the right-side of the page, the following information is displayed:
 
 - [**License type**](licensing-faqs.html): Determines if you have access to Enterprise features.
-- **Web server**: Indicates the current node to which DB Console access is being routed, and allows you to select a different node to route DB Console access to. To cancel routing to a different node, click **Reset**. You may also specify this directly in the URL with the `remote_node_id` parameter, e.g., `http://<host>:<http-port>/?remote_node_id=2` to select node `2`. The node selected here is also set as the target node for the **Profiling UI** section.
+- **Web server**: Indicates the node currently serving your DB Console web session, and allows you to select a different node if desired. To cancel your selection of a different node, click **Reset**. You may also specify this directly in the URL with the `remote_node_id` parameter. For example, use `http://<host>:<http-port>/?remote_node_id=2` to select node `2`. The node selected here is also set as the target node for the **Profiling UI** section.
 
 ## Reports
 

--- a/v21.2/ui-debug-pages.md
+++ b/v21.2/ui-debug-pages.md
@@ -18,7 +18,7 @@ These pages are experimental and undocumented. If you find an issue, let us know
 On the right-side of the page, the following information is displayed:
 
 - [**License type**](licensing-faqs.html): Determines if you have access to Enterprise features.
-- **Web server**: Identifies the current node when viewing the DB Console through a load balancer.
+- **Web server**: Indicates the current node to which DB Console access is being routed, and allows you to select a different node to route DB Console access to. To cancel routing to a different node, click **Reset**. You may also specify this directly in the URL with the `remote_node_id` parameter, e.g., `http://<host>:<http-port>/?remote_node_id=2` to select node `2`. The node selected here is also set as the target node for the **Profiling UI** section.
 
 ## Reports
 

--- a/v21.2/ui-overview.md
+++ b/v21.2/ui-overview.md
@@ -67,10 +67,12 @@ For guidance on accessing the DB Console in the context of cluster deployment, s
 
 ### Proxy DB Console
 
-If your CockroachDB cluster is behind a load balancer, you may wish to proxy your DB Console connection to a different node in the cluster from the node you first connect to. You can accomplish this using one of these methods:
+If your CockroachDB cluster is behind a load balancer, you may wish to proxy your DB Console connection to a different node in the cluster from the node you first connect to. This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
 
-- Once connected to DB Console, use the **Web server** dropdown menu from the [Advanced Debug page](ui-debug-pages.html#license-and-node-information) to select a different node to proxy to.
-- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node, e.g., use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
+You can accomplish this using one of these methods:
+
+- Once connected to DB Console, use the **Web server** dropdown menu from the [**Advanced Debug**](ui-debug-pages.html#license-and-node-information) page to select a different node to proxy to.
+- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
 
 This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
 

--- a/v21.2/ui-overview.md
+++ b/v21.2/ui-overview.md
@@ -74,8 +74,6 @@ You can accomplish this using one of these methods:
 - Once connected to DB Console, use the **Web server** dropdown menu from the [**Advanced Debug**](ui-debug-pages.html#license-and-node-information) page to select a different node to proxy to.
 - Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
 
-This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
-
 ## DB Console security considerations
 
 Access to DB Console is a function of cluster security and the role of the accessing user.

--- a/v21.2/ui-overview.md
+++ b/v21.2/ui-overview.md
@@ -65,6 +65,17 @@ You can access the DB Console from every node at `http://<host>:<http-port>`, or
 
 For guidance on accessing the DB Console in the context of cluster deployment, see [Start a Local Cluster](start-a-local-cluster.html) and [Manual Deployment](manual-deployment.html).
 
+### Proxy DB Console
+
+If your CockroachDB cluster is behind a load balancer, you may wish to proxy your DB Console connection to a different node in the cluster from the node you first connect to. You can accomplish this using one of these methods:
+
+- Once connected to DB Console, use the **Web server** dropdown menu from the [Advanced Debug page](ui-debug-pages.html#license-and-node-information) to select a different node to proxy to.
+- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node, e.g., use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
+
+This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
+
+## DB Console security considerations
+
 Access to DB Console is a function of cluster security and the role of the accessing user.
 
 ### Cluster security

--- a/v22.1/ui-debug-pages.md
+++ b/v22.1/ui-debug-pages.md
@@ -18,7 +18,7 @@ These pages are experimental and undocumented. If you find an issue, let us know
 On the right-side of the page, the following information is displayed:
 
 - [**License type**](licensing-faqs.html): Determines if you have access to Enterprise features.
-- **Web server**: Indicates the current node to which DB Console access is being routed, and allows you to select a different node to route DB Console access to. To cancel routing to a different node, click **Reset**. You may also specify this directly in the URL with the `remote_node_id` parameter, e.g., `http://<host>:<http-port>/?remote_node_id=2` to select node `2`. The node selected here is also set as the target node for the **Profiling UI** section.
+- **Web server**: Indicates the node currently serving your DB Console web session, and allows you to select a different node if desired. To cancel your selection of a different node, click **Reset**. You may also specify this directly in the URL with the `remote_node_id` parameter. For example, use `http://<host>:<http-port>/?remote_node_id=2` to select node `2`. The node selected here is also set as the target node for the **Profiling UI** section.
 
 ## Reports
 

--- a/v22.1/ui-debug-pages.md
+++ b/v22.1/ui-debug-pages.md
@@ -18,7 +18,7 @@ These pages are experimental and undocumented. If you find an issue, let us know
 On the right-side of the page, the following information is displayed:
 
 - [**License type**](licensing-faqs.html): Determines if you have access to Enterprise features.
-- **Web server**: Allows you to route DB Console access from the currently accessed node to a specific node on the cluster. Afterward, identifies the node to which DB Console access is being routed. To cancel this behavior, click **Reset**.
+- **Web server**: Indicates the current node to which DB Console access is being routed, and allows you to select a different node to route DB Console access to. To cancel routing to a different node, click **Reset**. You may also specify this directly in the URL with the `remote_node_id` parameter, e.g., `http://<host>:<http-port>/?remote_node_id=2` to select node `2`. The node selected here is also set as the target node for the **Profiling UI** section.
 
 ## Reports
 

--- a/v22.1/ui-overview.md
+++ b/v22.1/ui-overview.md
@@ -67,10 +67,12 @@ For guidance on accessing the DB Console in the context of cluster deployment, s
 
 ### Proxy DB Console
 
-If your CockroachDB cluster is behind a load balancer, you may wish to proxy your DB Console connection to a different node in the cluster from the node you first connect to. You can accomplish this using one of these methods:
+If your CockroachDB cluster is behind a load balancer, you may wish to proxy your DB Console connection to a different node in the cluster from the node you first connect to. This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
 
-- Once connected to DB Console, use the **Web server** dropdown menu from the [Advanced Debug page](ui-debug-pages.html#license-and-node-information) to select a different node to proxy to.
-- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node, e.g., use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
+You can accomplish this using one of these methods:
+
+- Once connected to DB Console, use the **Web server** dropdown menu from the [**Advanced Debug**](ui-debug-pages.html#license-and-node-information) page to select a different node to proxy to.
+- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
 
 This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
 

--- a/v22.1/ui-overview.md
+++ b/v22.1/ui-overview.md
@@ -74,8 +74,6 @@ You can accomplish this using one of these methods:
 - Once connected to DB Console, use the **Web server** dropdown menu from the [**Advanced Debug**](ui-debug-pages.html#license-and-node-information) page to select a different node to proxy to.
 - Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
 
-This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
-
 ## DB Console security considerations
 
 Access to DB Console is a function of cluster security and the role of the accessing user.

--- a/v22.1/ui-overview.md
+++ b/v22.1/ui-overview.md
@@ -72,7 +72,7 @@ If your CockroachDB cluster is behind a load balancer, you may wish to proxy you
 - Once connected to DB Console, use the **Web server** dropdown menu from the [Advanced Debug page](ui-debug-pages.html#license-and-node-information) to select a different node to proxy to.
 - Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node, e.g., use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
 
-This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
+This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster. 
 
 ## DB Console security considerations
 

--- a/v22.1/ui-overview.md
+++ b/v22.1/ui-overview.md
@@ -72,7 +72,7 @@ If your CockroachDB cluster is behind a load balancer, you may wish to proxy you
 - Once connected to DB Console, use the **Web server** dropdown menu from the [Advanced Debug page](ui-debug-pages.html#license-and-node-information) to select a different node to proxy to.
 - Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node, e.g., use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
 
-This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster. 
+This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
 
 ## DB Console security considerations
 

--- a/v22.1/ui-overview.md
+++ b/v22.1/ui-overview.md
@@ -65,6 +65,17 @@ You can access the DB Console from every node at `http://<host>:<http-port>`, or
 
 For guidance on accessing the DB Console in the context of cluster deployment, see [Start a Local Cluster](start-a-local-cluster.html) and [Manual Deployment](manual-deployment.html).
 
+### Proxy DB Console
+
+If your CockroachDB cluster is behind a load balancer, you may wish to proxy your DB Console connection to a different node in the cluster from the node you first connect to. You can accomplish this using one of these methods:
+
+- Once connected to DB Console, use the **Web server** dropdown menu from the [Advanced Debug page](ui-debug-pages.html#license-and-node-information) to select a different node to proxy to.
+- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node, e.g., use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
+
+This is useful in deployments where a third-party load balancer otherwise determines which CockroachDB node you connect to in DB Console, or where web management access is limited to a subset of CockroachDB instances in a cluster.
+
+## DB Console security considerations
+
 Access to DB Console is a function of cluster security and the role of the accessing user.
 
 ### Cluster security


### PR DESCRIPTION
Addresses: DOC-2567

- Expanded Ryan's DOC-2821 to also address `v21.2` (backported in #[76694](https://github.com/cockroachdb/cockroach/pull/76694)): re-used his copy as base.
	- Expanded above to also introduce `?remote_node_id=` and to mention that this setting is also reused for **Profiling UI** section.
- Added new _Proxy DB Console_ section to `ui_overview` for both `v22.1` and `v21.2` to detail two methods for proxying: Advanced Debug > Web server, and `?remote_node_id=`.
- To keep sensical ordering of subheadings, created new _Console security considerations_ heading to house two security subheadings and be able to retain `Access to DB Console is a function` statement.

Note: This PR omits the third proxy option of manually setting a cookie, as that is likely not useful to end users who have the above two methods in place already (i.e. likely no one will manually set a cookie when they can just use `http://localhost:8080/?remote_node_id=2` directly to do so). Please override if you feel otherwise!

Note to DOCS: I've created DOC-4697 to match "Access DB Console Access" to style guide separately.

[v22.1/ui-debug-pages.md](https://deploy-preview-14435--cockroachdb-docs.netlify.app/docs/v22.1/ui-debug-pages#license-and-node-information) | [v21.2/ui-debug-pages.md](https://deploy-preview-14435--cockroachdb-docs.netlify.app/docs/v21.2/ui-debug-pages#license-and-node-information) | [v22.1/ui-overview.md](https://deploy-preview-14435--cockroachdb-docs.netlify.app/docs/stable/ui-overview.html#proxy-db-console) | [v21.2/ui-overview.md](https://deploy-preview-14435--cockroachdb-docs.netlify.app/docs/v21.2/ui-overview.html#proxy-db-console)