### PR TITLE
Update simple CRUD examples with ccloud option

### DIFF
--- a/_includes/cockroachcloud/ccloud/quickstart.md
+++ b/_includes/cockroachcloud/ccloud/quickstart.md
@@ -5,7 +5,7 @@ The easiest way of getting started with CockroachDB Cloud is to use `ccloud quic
 ccloud quickstart
 ~~~
 
-The `ccloud quickstart` command will open a browser window to log you in to CockroachDB Cloud. If you are new to CockroachDB Cloud, you can register using one of the single sign-on(SSO) options, or create a new account using an email address.
+The `ccloud quickstart` command will open a browser window to log you in to CockroachDB Cloud. If you are new to CockroachDB Cloud, you can register using one of the single sign-on (SSO) options, or create a new account using an email address.
 
 The `ccloud quickstart` command will prompt you for the cluster name, cloud provider, and cloud provider region, then ask if you want to connect to the cluster. Each prompt has default values that you can select, or change if you want a different option.
 

--- a/_includes/v22.1/setup/init-bank-sample.md
+++ b/_includes/v22.1/setup/init-bank-sample.md
@@ -16,7 +16,7 @@
     export DATABASE_URL="{connection-string}"
     ~~~
 
-    Where `{connection-string}` is the connection string you obtained from the {{ site.data.products.db }} Console.
+    Where `{connection-string}` is the connection string you copied earlier.
 
     </section>
 

--- a/_includes/v22.1/setup/sample-setup-certs.md
+++ b/_includes/v22.1/setup/sample-setup-certs.md
@@ -9,7 +9,7 @@
 
 <h3>Choose your installation method</h3>
 
-You can install a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
+You can create a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
 
 <div class="filters clearfix">
     <button class="filter-button page-level" data-scope="console">Use the Cloud Console (GUI)<strong></strong></button>

--- a/_includes/v22.1/setup/sample-setup-certs.md
+++ b/_includes/v22.1/setup/sample-setup-certs.md
@@ -48,7 +48,7 @@ The connection string is pre-populated with your username, password, cluster nam
 Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
 
 {{site.data.alerts.callout_info}}
-The <code>ccloud</code> CLI tool is in beta.
+The <code>ccloud</code> CLI tool is in Preview.
 {{site.data.alerts.end}}
 
 <h3>Install <code>ccloud</code></h3>

--- a/_includes/v22.1/setup/sample-setup-jdbc.md
+++ b/_includes/v22.1/setup/sample-setup-jdbc.md
@@ -6,7 +6,6 @@
 
 <div class="filter-content" markdown="1" data-scope="cockroachcloud">
 
-
 <h3>Choose your installation method</h3>
 
 You can install a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
@@ -26,20 +25,17 @@ You can install a {{ site.data.products.serverless }} cluster using either the C
 
 {% include {{ page.version.version }}/setup/create-first-sql-user.md %}
 
-### Get the root certificate
+### Get the connection string
 
 The **Connect to cluster** dialog shows information about how to connect to your cluster.
 
-1. Select **General connection string** from the **Select option** dropdown.
-1. Open a new terminal on your local machine, and run the **CA Cert download command** provided in the **Download CA Cert** section. The client driver used in this tutorial requires this certificate to connect to {{ site.data.products.db }}.
+1. Select **Java** from the **Select option/language** dropdown.
+1. Select **JDBC** from the **Select tool** dropdown.
+1. Copy the command provided to set the `JDBC_DATABASE_URL` environment variable.
 
-### Get the connection string
-
-Open the **General connection string** section, then copy the connection string provided and save it in a secure location.
-
-{{site.data.alerts.callout_info}}
-The connection string is pre-populated with your username, password, cluster name, and other details. Your password, in particular, will be provided *only once*. Save it in a secure place (Cockroach Labs recommends a password manager) to connect to your cluster in the future. If you forget your password, you can reset it by going to the [**SQL Users** page](../cockroachcloud/user-authorization.html).
-{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}
+    The JDBC connection URL is pre-populated with your username, password, cluster name, and other details. Your password, in particular, will be provided *only once*. Save it in a secure place (Cockroach Labs recommends a password manager) to connect to your cluster in the future. If you forget your password, you can reset it by going to the [**SQL Users** page](../cockroachcloud/user-authorization.html).
+    {{site.data.alerts.end}}
 
 </div>
 

--- a/_includes/v22.1/setup/sample-setup-jdbc.md
+++ b/_includes/v22.1/setup/sample-setup-jdbc.md
@@ -44,7 +44,7 @@ The **Connect to cluster** dialog shows information about how to connect to your
 Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
 
 {{site.data.alerts.callout_info}}
-The <code>ccloud</code> CLI tool is in beta.
+The <code>ccloud</code> CLI tool is in Preview.
 {{site.data.alerts.end}}
 
 <h3>Install <code>ccloud</code></h3>

--- a/_includes/v22.1/setup/sample-setup-jdbc.md
+++ b/_includes/v22.1/setup/sample-setup-jdbc.md
@@ -8,7 +8,7 @@
 
 <h3>Choose your installation method</h3>
 
-You can install a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
+You can create a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
 
 <div class="filters clearfix">
     <button class="filter-button page-level" data-scope="console">Use the Cloud Console (GUI)<strong></strong></button>

--- a/_includes/v22.1/setup/sample-setup-parameters-certs.md
+++ b/_includes/v22.1/setup/sample-setup-parameters-certs.md
@@ -45,7 +45,7 @@ The **Connect to cluster** dialog shows information about how to connect to your
 Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
 
 {{site.data.alerts.callout_info}}
-The <code>ccloud</code> CLI tool is in beta.
+The <code>ccloud</code> CLI tool is in Preview.
 {{site.data.alerts.end}}
 
 <h3>Install <code>ccloud</code></h3>

--- a/_includes/v22.1/setup/sample-setup-parameters-certs.md
+++ b/_includes/v22.1/setup/sample-setup-parameters-certs.md
@@ -4,7 +4,19 @@
   <button class="filter-button page-level" data-scope="local">Use a Local Cluster</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="cockroachcloud">
+<div class="filter-content" markdown="1" data-scope="cockroachcloud">
+
+
+<h3>Choose your installation method</h3>
+
+You can install a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
+
+<div class="filters clearfix">
+    <button class="filter-button page-level" data-scope="console">Use the Cloud Console (GUI)<strong></strong></button>
+    <button class="filter-button page-level" data-scope="ccloud"><strong>Use <code>ccloud</code> (CLI)</strong></button>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="console">
 
 ### Create a free cluster
 
@@ -26,7 +38,46 @@ The **Connect to cluster** dialog shows information about how to connect to your
 1. Select **Parameters only** from the **Select option** dropdown.
 1. Copy the connection information for each parameter displayed and save it in a secure location.
 
-</section>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="ccloud">
+
+Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
+
+{{site.data.alerts.callout_info}}
+The <code>ccloud</code> CLI tool is in beta.
+{{site.data.alerts.end}}
+
+<h3>Install <code>ccloud</code></h3>
+
+{% include cockroachcloud/ccloud/install-ccloud.md %}
+
+### Run `ccloud quickstart` to create a new cluster, create a SQL user, and retrieve the connection string.
+
+{% include cockroachcloud/ccloud/quickstart.md %}
+
+Select **Parameters only** then copy the connection parameters displayed and save them in a secure location.
+
+~~~
+? How would you like to connect? Parameters only
+Looking up cluster ID: succeeded
+Creating SQL user: succeeded
+Success! Created SQL user
+ name: maxroach
+ cluster: 37174250-b944-461f-b1c1-3a99edb6af32
+Retrieving cluster info: succeeded
+Connection parameters
+ Database:  defaultdb
+ Host:      free-tier4.aws-us-west-2.cockroachlabs.cloud
+ Options:   --cluster=dim-dog-147
+ Password:  ThisIsNotAGoodPassword
+ Port:      26257
+ Username:  maxroach
+~~~
+
+</div>
+
+</div>
 
 <section class="filter-content" markdown="1" data-scope="local">
 

--- a/_includes/v22.1/setup/sample-setup-parameters.md
+++ b/_includes/v22.1/setup/sample-setup-parameters.md
@@ -4,7 +4,18 @@
   <button class="filter-button page-level" data-scope="local">Use a Local Cluster</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="cockroachcloud">
+<div class="filter-content" markdown="1" data-scope="cockroachcloud">
+
+<h3>Choose your installation method</h3>
+
+You can install a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
+
+<div class="filters clearfix">
+    <button class="filter-button page-level" data-scope="console">Use the Cloud Console (GUI)<strong></strong></button>
+    <button class="filter-button page-level" data-scope="ccloud"><strong>Use <code>ccloud</code> (CLI)</strong></button>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="console">
 
 ### Create a free cluster
 
@@ -21,7 +32,46 @@ The **Connect to cluster** dialog shows information about how to connect to your
 1. Select **Parameters only** from the **Select option** dropdown.
 1. Copy the connection information for each parameter displayed and save it in a secure location.
 
-</section>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="ccloud">
+
+Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
+
+{{site.data.alerts.callout_info}}
+The <code>ccloud</code> CLI tool is in beta.
+{{site.data.alerts.end}}
+
+<h3>Install <code>ccloud</code></h3>
+
+{% include cockroachcloud/ccloud/install-ccloud.md %}
+
+### Run `ccloud quickstart` to create a new cluster, create a SQL user, and retrieve the connection string.
+
+{% include cockroachcloud/ccloud/quickstart.md %}
+
+Select **Parameters only** then copy the connection parameters displayed and save them in a secure location.
+
+~~~
+? How would you like to connect? Parameters only
+Looking up cluster ID: succeeded
+Creating SQL user: succeeded
+Success! Created SQL user
+ name: maxroach
+ cluster: 37174250-b944-461f-b1c1-3a99edb6af32
+Retrieving cluster info: succeeded
+Connection parameters
+ Database:  defaultdb
+ Host:      free-tier4.aws-us-west-2.cockroachlabs.cloud
+ Options:   --cluster=dim-dog-147
+ Password:  ThisIsNotAGoodPassword
+ Port:      26257
+ Username:  maxroach
+~~~
+
+</div>
+
+</div>
 
 <section class="filter-content" markdown="1" data-scope="local">
 

--- a/_includes/v22.1/setup/sample-setup-parameters.md
+++ b/_includes/v22.1/setup/sample-setup-parameters.md
@@ -39,7 +39,7 @@ The **Connect to cluster** dialog shows information about how to connect to your
 Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
 
 {{site.data.alerts.callout_info}}
-The <code>ccloud</code> CLI tool is in beta.
+The <code>ccloud</code> CLI tool is in Preview.
 {{site.data.alerts.end}}
 
 <h3>Install <code>ccloud</code></h3>

--- a/_includes/v22.1/setup/sample-setup.md
+++ b/_includes/v22.1/setup/sample-setup.md
@@ -4,7 +4,18 @@
   <button class="filter-button page-level" data-scope="local">Use a Local Cluster</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="cockroachcloud">
+<div class="filter-content" markdown="1" data-scope="cockroachcloud">
+
+<h3>Choose your installation method</h3>
+
+You can install a {{ site.data.products.serverless }} cluster using either the CockroachDB Cloud Console, a web-based graphical user interface (GUI) tool, or <code>ccloud</code>, a command-line interface (CLI) tool.
+
+<div class="filters clearfix">
+    <button class="filter-button page-level" data-scope="console">Use the Cloud Console (GUI)<strong></strong></button>
+    <button class="filter-button page-level" data-scope="ccloud"><strong>Use <code>ccloud</code> (CLI)</strong></button>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="console">
 
 ### Create a free cluster
 
@@ -27,7 +38,35 @@ The **Connect to cluster** dialog shows information about how to connect to your
     The connection string is pre-populated with your username, password, cluster name, and other details. Your password, in particular, will be provided *only once*. Save it in a secure place (Cockroach Labs recommends a password manager) to connect to your cluster in the future. If you forget your password, you can reset it by going to the [**SQL Users** page](../cockroachcloud/user-authorization.html).
     {{site.data.alerts.end}}
 
-</section>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="ccloud">
+
+Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
+
+{{site.data.alerts.callout_info}}
+The <code>ccloud</code> CLI tool is in beta.
+{{site.data.alerts.end}}
+
+<h3>Install <code>ccloud</code></h3>
+
+{% include cockroachcloud/ccloud/install-ccloud.md %}
+
+### Run `ccloud quickstart` to create a new cluster, create a SQL user, and retrieve the connection string.
+
+{% include cockroachcloud/ccloud/quickstart.md %}
+
+Select **General connection string**, then copy the connection string displayed and save it in a secure location. The connection string is the line starting `postgresql://`.
+
+~~~
+? How would you like to connect? General connection string
+Retrieving cluster info: succeeded
+ Downloading cluster cert to /Users/maxroach/.postgresql/root.crt: succeeded
+postgresql://maxroach:ThisIsNotAGoodPassword@free-tier4.aws-us-west-2.cockroachlabs.cloud:26257/defaultdb?options=--cluster%3Ddim-dog-147&sslmode=verify-full&sslrootcert=%2FUsers%2Fmaxroach%2F.postgresql%2Froot.crt
+~~~
+</div>
+
+</div>
 
 <section class="filter-content" markdown="1" data-scope="local">
 

--- a/_includes/v22.1/setup/sample-setup.md
+++ b/_includes/v22.1/setup/sample-setup.md
@@ -45,7 +45,7 @@ The **Connect to cluster** dialog shows information about how to connect to your
 Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
 
 {{site.data.alerts.callout_info}}
-The <code>ccloud</code> CLI tool is in beta.
+The <code>ccloud</code> CLI tool is in Preview.
 {{site.data.alerts.end}}
 
 <h3>Install <code>ccloud</code></h3>

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -61,7 +61,7 @@ Follow these steps to create a {{ site.data.products.serverless }} cluster using
 Follow these steps to create a {{ site.data.products.serverless }} cluster using the <code>ccloud</code> CLI tool.
 
 {{site.data.alerts.callout_info}}
-The <code>ccloud</code> CLI tool is in beta.
+The <code>ccloud</code> CLI tool is in Preview.
 {{site.data.alerts.end}}
 
 <h2>Install <code>ccloud</code></h2>

--- a/v22.1/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v22.1/build-a-go-app-with-cockroachdb-gorm.md
@@ -49,7 +49,36 @@ The `main.go` file defines an `Account` struct that maps to a new `accounts` tab
 CockroachDB may require the [client to retry a transaction](transactions.html#transaction-retries) in the case of read/write contention. The [CockroachDB Go client](https://github.com/cockroachdb/cockroach-go) includes a generic **retry function** (`ExecuteTx()`) that runs inside a transaction and retries it as needed. The code sample shows how you can use this function to wrap SQL statements.
 {{site.data.alerts.end}}
 
-## Step 3. Run the code
+## Step 3. Initialize the database
+
+1. Navigate to the `example-app-go-gorm` directory:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ cd example-app-go-pgx
+    ~~~
+
+1. Set the `DATABASE_URL` environment variable to the connection string for your cluster:
+
+    <section class="filter-content" markdown="1" data-scope="local">
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    export DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
+    ~~~
+
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="cockroachcloud">
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    export DATABASE_URL="{connection-string}"
+    ~~~
+
+    Where `{connection-string}` is the connection string you copied earlier.
+
+## Step 4. Run the code
 
 1. Initialize the module:
 

--- a/v22.1/build-a-go-app-with-cockroachdb-pq.md
+++ b/v22.1/build-a-go-app-with-cockroachdb-pq.md
@@ -27,7 +27,36 @@ Clone the code's GitHub repo:
 $ git clone https://github.com/cockroachlabs/hello-world-go-pq
 ~~~
 
-## Step 3. Run the code
+## Step 3. Initialize the database
+
+1. Navigate to the `example-app-go-gorm` directory:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ cd hello-world-go-pq
+    ~~~
+
+1. Set the `DATABASE_URL` environment variable to the connection string for your cluster:
+
+    <section class="filter-content" markdown="1" data-scope="local">
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    export DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
+    ~~~
+
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="cockroachcloud">
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    export DATABASE_URL="{connection-string}"
+    ~~~
+
+    Where `{connection-string}` is the connection string you copied earlier.
+
+## Step 4. Run the code
 
 You can now run the code sample (`main.go`) provided in this tutorial to do the following:
 
@@ -39,11 +68,6 @@ You can now run the code sample (`main.go`) provided in this tutorial to do the 
     Note that CockroachDB may require the [client to retry a transaction](transactions.html#transaction-retries) in the case of read/write contention. The [CockroachDB Go client](https://github.com/cockroachdb/cockroach-go) includes a generic **retry function** (`ExecuteTx()`) that runs inside a transaction and retries it as needed. The code sample shows how you can use this function to wrap SQL statements.
 
 1. Initialize the module:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ cd hello-world-go-pq
-    ~~~
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell

--- a/v22.1/build-a-go-app-with-cockroachdb-pq.md
+++ b/v22.1/build-a-go-app-with-cockroachdb-pq.md
@@ -29,7 +29,7 @@ $ git clone https://github.com/cockroachlabs/hello-world-go-pq
 
 ## Step 3. Initialize the database
 
-1. Navigate to the `example-app-go-gorm` directory:
+1. Navigate to the `hello-world-go-pq` directory:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell

--- a/v22.1/build-a-java-app-with-cockroachdb.md
+++ b/v22.1/build-a-java-app-with-cockroachdb.md
@@ -22,7 +22,7 @@ For a sample app and tutorial that uses Spring Data JDBC and CockroachDB, see [B
 
 ## Step 1. Start CockroachDB
 
-{% include {{ page.version.version }}/setup/sample-setup.md %}
+{% include {{ page.version.version }}/setup/sample-setup-jdbc.md %}
 
 ## Step 2. Get the code
 
@@ -86,7 +86,7 @@ The `main` method of the app performs the following steps which roughly correspo
 
 It does all of the above using the practices we recommend for using JDBC with CockroachDB, which are listed in the [Recommended Practices](#recommended-practices) section below.
 
-## Step 3. Initialize the database
+## Step 3. Update the connection configuration
 
 1. Navigate to the `example-app-java-jdbc` directory:
 
@@ -95,87 +95,55 @@ It does all of the above using the practices we recommend for using JDBC with Co
     $ cd example-app-java-jdbc
     ~~~
 
-1. Set the `DATABASE_URL` environment variable to the connection string to your cluster:
+1. Set the `JDBC_DATABASE_URL` environment variable to a JDBC-compatible connection string:
 
     <section class="filter-content" markdown="1" data-scope="local">
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    export DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
+    export JDBC_DATABASE_URL=jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable&user=root
     ~~~
 
     </section>
 
-    <section class="filter-content" markdown="1" data-scope="cockroachcloud">
+    <section class="filter-content" markdown="1" data-scope="console">
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    export DATABASE_URL="{connection-string}"
-    ~~~
+    1. Paste in the command you copied earlier:
+    
+        {% include_cached copy-clipboard.html %}
+        ~~~ shell
+        export JDBC_DATABASE_URL="{connection-string}"
+        ~~~
 
-    Where `{connection-string}` is the connection string you obtained from the {{ site.data.products.db }} Console.
+        Where `{connection-string}` is the JDBC connection string from the command you copied earlier.
 
     </section>
+    
+    <section class="filter-content" markdown="1" data-scope="ccloud">
+    
+    1. Use the `cockroach convert-url` command to convert the connection string that you copied from the {{ site.data.products.cloud }} Console to a [valid connection string for JDBC connections](connect-to-the-database.html?filters=java):
 
-1. To initialize the example database, use the [`cockroach sql`](cockroach-sql.html) command to execute the SQL statements in the `dbinit.sql` file:
+        {% include_cached copy-clipboard.html %}
+        ~~~ shell
+        cockroach convert-url --url $DATABASE_URL
+        ~~~
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    cat app/src/main/resources/dbinit.sql | cockroach sql --url $DATABASE_URL
-    ~~~
+        ~~~
+        ...
 
-    The SQL statement in the initialization file should execute:
+        # Connection URL for JDBC (Java and JVM-based languages):
+        jdbc:postgresql://{host}:{port}/{database}?options=--cluster%3D{routing-id}&password={password}&sslmode=verify-full&user={username}
+        ~~~
 
-    ~~~
-    CREATE TABLE
+    1. Set the `JDBC_DATABASE_URL` environment variable to the JDBC-compatible connection string:
 
-
-    Time: 102ms
-    ~~~
+        {% include_cached copy-clipboard.html %}
+        ~~~ shell
+        export JDBC_DATABASE_URL="{jdbc-connection-string}"
+        ~~~
+    </section>
 
 ## Step 4. Run the code
-
-### Update the connection configuration
-
-<section class="filter-content" markdown="1" data-scope="local">
-
-Set the `JDBC_DATABASE_URL` environment variable to a JDBC-compatible connection string:
-
-{% include_cached copy-clipboard.html %}
-~~~ shell
-export JDBC_DATABASE_URL=jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable&user=root
-~~~
-
-</section>
-
-<section class="filter-content" markdown="1" data-scope="cockroachcloud">
-
-1. Use the `cockroach convert-url` command to convert the connection string that you copied from the {{ site.data.products.cloud }} Console to a [valid connection string for JDBC connections](connect-to-the-database.html?filters=java):
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    cockroach convert-url --url $DATABASE_URL
-    ~~~
-
-    ~~~
-    ...
-
-    # Connection URL for JDBC (Java and JVM-based languages):
-    jdbc:postgresql://{host}:{port}/{database}?options=--cluster%3D{routing-id}&password={password}&sslmode=verify-full&user={username}
-    ~~~
-
-1. Set the `JDBC_DATABASE_URL` environment variable to the JDBC-compatible connection string:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    export JDBC_DATABASE_URL="{jdbc-connection-string}"
-    ~~~
-
-</section>
-
-The code sample uses the connection string stored in the environment variable `JDBC_DATABASE_URL` to connect to your cluster.
-
-### Run the code
 
 Compile and run the code:
 
@@ -187,6 +155,9 @@ Compile and run the code:
 The output will look like the following:
 
 ~~~
+com.cockroachlabs.BasicExampleDAO.createAccountsTable:
+    'CREATE TABLE IF NOT EXISTS accounts (id UUID PRIMARY KEY, balance int8)'
+
 com.cockroachlabs.BasicExampleDAO.updateAccounts:
     'INSERT INTO accounts (id, balance) VALUES ('b5679853-b968-4206-91ec-68945fa3e716', 250)'
 

--- a/v22.1/build-a-nodejs-app-with-cockroachdb-knexjs.md
+++ b/v22.1/build-a-nodejs-app-with-cockroachdb-knexjs.md
@@ -47,7 +47,7 @@ $ git clone https://github.com/cockroachlabs/example-app-node-knex
     $ export DATABASE_URL="<connection-string>"
     ~~~
 
-    Where `<connection-string>` is the connection string you obtained from the {{ site.data.products.db }} Console.
+    Where `<connection-string>` is the connection string you copied earlier.
 
     </section>
 
@@ -64,7 +64,7 @@ $ git clone https://github.com/cockroachlabs/example-app-node-knex
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ npm run run
+    $ npm run
     ~~~
 
     The output should look like this:

--- a/v22.1/build-a-nodejs-app-with-cockroachdb-prisma.md
+++ b/v22.1/build-a-nodejs-app-with-cockroachdb-prisma.md
@@ -50,7 +50,7 @@ This tutorial shows you how build a simple Node.js application with CockroachDB 
     $ echo "DATABASE_URL=<connection-string>" >> .env
     ~~~
 
-    Where `<connection-string>` is the connection string you obtained earlier from the {{ site.data.products.db }} Console.
+    Where `<connection-string>` is the connection string you copied earlier.
 
     </div>
 

--- a/v22.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v22.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -51,7 +51,7 @@ To start the app:
     $ export DATABASE_URL="<connection-string>"
     ~~~
 
-    Where `<connection-string>` is the connection string you obtained from the {{ site.data.products.db }} Console.
+    Where `<connection-string>` is the connection string you copied earlier.
 
     </section>
 

--- a/v22.1/build-a-python-app-with-cockroachdb-django.md
+++ b/v22.1/build-a-python-app-with-cockroachdb-django.md
@@ -107,7 +107,7 @@ This tutorial uses [`virtualenv`](https://virtualenv.pypa.io) for dependency man
 
 ### Configure the database connection
 
-Open `cockroach_example/cockroach_example/settings.py`, and configure [the `DATABASES` dictionary](https://docs.djangoproject.com/en/3.2/ref/settings/#databases) to connect to your cluster using the connection information that you retrieved from the {{ site.data.products.db }} Console.
+Open `cockroach_example/cockroach_example/settings.py`, and configure [the `DATABASES` dictionary](https://docs.djangoproject.com/en/3.2/ref/settings/#databases) to connect to your cluster using the connection parameters that you copied earlier.
 
 {% include_cached copy-clipboard.html %}
 ~~~ python

--- a/v22.1/build-a-python-app-with-cockroachdb.md
+++ b/v22.1/build-a-python-app-with-cockroachdb.md
@@ -71,7 +71,7 @@ For other ways to install psycopg2, see the [official documentation](http://init
     $ export DATABASE_URL="{connection-string}"
     ~~~
 
-    Where `{connection-string}` is the connection string you obtained from the {{ site.data.products.db }} Console.
+    Where `{connection-string}` is the connection string you copied earlier.
 
     </section>
 

--- a/v22.1/build-a-ruby-app-with-cockroachdb-activerecord.md
+++ b/v22.1/build-a-ruby-app-with-cockroachdb-activerecord.md
@@ -80,7 +80,7 @@ git clone https://github.com/cockroachlabs/example-app-ruby-activerecord
     $ export DATABASE_URL="{connection-string}"
     ~~~
 
-    Where `{connection-string}` is the connection string you obtained from the {{ site.data.products.db }} Console.
+    Where `{connection-string}` is the connection string you copied earlier.
 
     </section>
 

--- a/v22.1/build-a-ruby-app-with-cockroachdb.md
+++ b/v22.1/build-a-ruby-app-with-cockroachdb.md
@@ -78,7 +78,7 @@ The code connects as the user you created and executes some basic SQL statements
     $ export DATABASE_URL="{connection-string}"
     ~~~
 
-    Where `{connection-string}` is the connection string you obtained from the {{ site.data.products.db }} Console.
+    Where `{connection-string}` is the connection string you copied earlier.
 
     </section>
 


### PR DESCRIPTION
This PR updates the simple CRUD tutorials with a `ccloud` option.

Fixes DOC-3635.