### PR TITLE
Added note to performance section on pausing jobs after max retries

### DIFF
--- a/v22.1/backup.md
+++ b/v22.1/backup.md
@@ -134,7 +134,7 @@ This improves performance by decreasing the likelihood that the `BACKUP` will be
 
 `BACKUP` will initially ask individual ranges to backup but to skip if they encounter an intent. Any range that is skipped is placed at the end of the queue. When `BACKUP` has completed its initial pass and is revisiting ranges, it will ask any range that did not resolve within the given time limit (default 1 minute) to attempt to resolve any intents that it encounters and to **not** skip. Additionally, the backup's transaction priority is then set to `high`, which causes other transactions to abort until the intents are resolved and the backup is finished.
 
-{% include_cached new-in.html version="v22.1" %} A backup job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the backup has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
+{% include_cached new-in.html version="v22.1" %} A backup job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the backup has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
 
 {% include {{ page.version.version }}/backups/file-size-setting.md %}
 

--- a/v22.1/backup.md
+++ b/v22.1/backup.md
@@ -132,7 +132,9 @@ We recommend always starting backups with a specific [timestamp](timestamp.html)
 
 This improves performance by decreasing the likelihood that the `BACKUP` will be [retried because it contends with other statements/transactions](transactions.html#transaction-retries). However, because `AS OF SYSTEM TIME` returns historical data, your reads might be stale. Taking backups with `AS OF SYSTEM TIME '-10s'` is a good best practice to reduce the number of still-running transactions you may encounter, since the backup will take priority and will force still-running transactions to restart after the backup is finished.
 
-`BACKUP` will initially ask individual ranges to backup but to skip if they encounter an intent. Any range that is skipped is placed at the end of the queue. When `BACKUP` has completed its initial pass and is revisiting ranges, it will ask any range that did not resolve within the given time limit (default 1 minute) to attempt to resolve any intents that it encounters and to _not_ skip. Additionally, the backup's transaction priority is then set to `high`, which causes other transactions to abort until the intents are resolved and the backup is finished.
+`BACKUP` will initially ask individual ranges to backup but to skip if they encounter an intent. Any range that is skipped is placed at the end of the queue. When `BACKUP` has completed its initial pass and is revisiting ranges, it will ask any range that did not resolve within the given time limit (default 1 minute) to attempt to resolve any intents that it encounters and to **not** skip. Additionally, the backup's transaction priority is then set to `high`, which causes other transactions to abort until the intents are resolved and the backup is finished.
+
+{% include_cached new-in.html version="v22.1" %} A backup job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the backup has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
 
 {% include {{ page.version.version }}/backups/file-size-setting.md %}
 

--- a/v22.1/import-into.md
+++ b/v22.1/import-into.md
@@ -156,7 +156,11 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Performance
 
-All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
+- All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
+- To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
+- To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
+- {% include_cached new-in.html version="v22.1" %} An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
+- {% include_cached new-in.html version="v22.1" %} An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
 
 For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
 

--- a/v22.1/import-into.md
+++ b/v22.1/import-into.md
@@ -160,7 +160,7 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 - To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
 - To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
 - {% include_cached new-in.html version="v22.1" %} An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
-- {% include_cached new-in.html version="v22.1" %} An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
+- {% include_cached new-in.html version="v22.1" %} An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
 
 For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
 

--- a/v22.1/import.md
+++ b/v22.1/import.md
@@ -136,7 +136,7 @@ Imported tables are treated as new tables, so you must [`GRANT`](grant.html) pri
 - To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
 - To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
 - {% include_cached new-in.html version="v22.1" %} An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
-- {% include_cached new-in.html version="v22.1" %} An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
+- {% include_cached new-in.html version="v22.1" %} An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
 
 For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
 

--- a/v22.1/import.md
+++ b/v22.1/import.md
@@ -135,7 +135,8 @@ Imported tables are treated as new tables, so you must [`GRANT`](grant.html) pri
 - All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
 - To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
 - To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
-- An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
+- {% include_cached new-in.html version="v22.1" %} An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
+- {% include_cached new-in.html version="v22.1" %} An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
 
 For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
 

--- a/v22.1/restore.md
+++ b/v22.1/restore.md
@@ -185,8 +185,9 @@ CockroachDB does **not** support incremental-only restores.
 ## Performance
 
 - The `RESTORE` process minimizes its impact to the cluster's performance by distributing work to all nodes. Subsets of the restored data (known as ranges) are evenly distributed among randomly selected nodes, with each range initially restored to only one node. Once the range is restored, the node begins replicating it others.
-- A restore job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling restore jobs](#viewing-and-controlling-restore-jobs) for information on resuming and showing the progress of restore jobs. 
 - When a `RESTORE` fails or is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.
+- {% include_cached new-in.html version="v22.1" %} A restore job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling restore jobs](#viewing-and-controlling-restore-jobs) for information on resuming and showing the progress of restore jobs.
+- {% include_cached new-in.html version="v22.1" %} A restore job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the restore has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
 
 ## Restoring to multi-region databases
 

--- a/v22.1/restore.md
+++ b/v22.1/restore.md
@@ -187,7 +187,7 @@ CockroachDB does **not** support incremental-only restores.
 - The `RESTORE` process minimizes its impact to the cluster's performance by distributing work to all nodes. Subsets of the restored data (known as ranges) are evenly distributed among randomly selected nodes, with each range initially restored to only one node. Once the range is restored, the node begins replicating it others.
 - When a `RESTORE` fails or is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.
 - {% include_cached new-in.html version="v22.1" %} A restore job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling restore jobs](#viewing-and-controlling-restore-jobs) for information on resuming and showing the progress of restore jobs.
-- {% include_cached new-in.html version="v22.1" %} A restore job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the restore has paused, you can [resume](resume-job.html) or [cancel](cancel-job.html).
+- {% include_cached new-in.html version="v22.1" %} A restore job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the restore has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
 
 ## Restoring to multi-region databases
 


### PR DESCRIPTION
Fixes [DOC-3506](https://cockroachlabs.atlassian.net/browse/DOC-3506)

Added a note to the performance section of `RESTORE`, `IMPORT`, & `BACKUP` on pausing if reaching maximum retries. 

Also, opportunistic edit adding new version feature to a prior bullet that I missed in the original PR. 

Furthermore, added `IMPORT` performance bullets to `IMPORT INTO` as I believe these all belong there too and had been missing.