### PR TITLE
Add more Row-level TTL details

### DIFF
--- a/_includes/v22.1/known-limitations/row-level-ttl-limitations.md
+++ b/_includes/v22.1/known-limitations/row-level-ttl-limitations.md
@@ -1,6 +1,7 @@
 - You cannot use [foreign keys](foreign-key.html) to create references to or from a table that uses Row-Level TTL. [cockroachdb/cockroach#76407](https://github.com/cockroachdb/cockroach/issues/76407)
 - Any queries you run against tables with Row-Level TTL enabled do not filter out expired rows from the result set (this includes [`UPDATE`s](update.html) and [`DELETE`s](delete.html)). This feature may be added in a future release. For now, follow the instructions in [Filter out expired rows from a selection query](row-level-ttl.html#filter-out-expired-rows-from-a-selection-query).
-- The TTL cannot be customized based on the values of other columns in the row. [cockroachdb/cockroach#76916](https://github.com/cockroachdb/cockroach/issues/76916)
+- <a name="ttl-cannot-be-customized"></a> The TTL cannot be customized based on the values of other columns in the row. [cockroachdb/cockroach#76916](https://github.com/cockroachdb/cockroach/issues/76916)
+  - Because of the above limitation, adding TTL to large existing tables [can negatively affect performance](row-level-ttl.html#ttl-existing-table-performance-note), since a new column must be created and backfilled for every row. Creating a new table with a TTL is not affected by this limitation.
 - The queries executed by Row-Level TTL are not yet optimized for performance:
   - They do not use any indexes that may be available on the [`crdb_internal_expiration` column](row-level-ttl.html#crdb-internal-expiration).
   - They do not take into account [node localities](cockroach-start.html#locality).

--- a/v22.1/row-level-ttl.md
+++ b/v22.1/row-level-ttl.md
@@ -179,8 +179,17 @@ ALTER TABLE events SET (ttl_expire_after = '1 year');
 ALTER TABLE
 ~~~
 
+<a name="ttl-existing-table-performance-note"></a>
+
 {{site.data.alerts.callout_danger}}
-Adding or changing the Row-Level TTL settings for an existing table will result in a [schema change](online-schema-changes.html) that sets the [`crdb_internal_expiration` column](#crdb-internal-expiration) for all rows. Depending on table size, this could be an expensive operation.
+Adding or changing the Row-Level TTL settings for an existing table will result in a [schema change](online-schema-changes.html) that performs the following changes:
+
+- Creates a new [`crdb_internal_expiration`](#crdb-internal-expiration) column for all rows.
+- Backfills the value of the new [`crdb_internal_expiration`](#crdb-internal-expiration) column to `now()` + [`ttl_expire_after`](#param-ttl-expire-after).
+
+Depending on the table size, this can negatively affect performance.
+
+Creating a new table with a TTL is not affected by [this limitation](#ttl-cannot-be-customized).
 {{site.data.alerts.end}}
 
 ### View scheduled TTL jobs
@@ -465,9 +474,8 @@ Row-level TTL interacts with [backup and restore](backup-and-restore-overview.ht
 
 To add or update Row-Level TTL settings on a table, you must have one of the following:
 
-- Membership to the [`admin`](security-reference/authorization.html#roles) role for the cluster.
 - Membership to the [owner](security-reference/authorization.html#object-ownership) role for the database where the table is located.
-- The [`CREATE` privilege](security-reference/authorization.html#supported-privileges) on the database where the table is located.
+- The [`CREATE` or `ALTER` privilege](security-reference/authorization.html#supported-privileges) on the database where the table is located.
 
 ## Limitations
 


### PR DESCRIPTION
Fixes the last bits of DOC-3545

Followup to cockroachdb/docs#14481

Summary of changes:

- Update the required privileges to remove incorrect reference to
  `admin` role

- Add note that the schema change backfill of
  `crdb_internal_expiration` (and its performance impact) is necessary
  in part due to the limitation that the TTL cannot be customized based
  on the values of other columns in the row

  - Also note that adding TTL to new tables is not affected by this
    limitation