### PR TITLE
DOC-995 fix debug merge-logs time range example

### DIFF
--- a/v21.1/cockroach-debug-merge-logs.md
+++ b/v21.1/cockroach-debug-merge-logs.md
@@ -59,7 +59,7 @@ Alternatively, filter the merged logs for a specified time range:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-$ cockroach debug merge-logs debug/nodes/*/logs/* --from= "18:36:28.208553" --to= "18:36:29.232864"
+$ cockroach debug merge-logs debug/nodes/*/logs/* --from="220713 18:36:28.208553" --to="220713 18:36:29.232864"
 ~~~
 
 You can also filter the merged logs for a regular expression:

--- a/v21.2/cockroach-debug-merge-logs.md
+++ b/v21.2/cockroach-debug-merge-logs.md
@@ -60,7 +60,7 @@ Alternatively, filter the merged logs for a specified time range:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-$ cockroach debug merge-logs debug/nodes/*/logs/* --from= "18:36:28.208553" --to= "18:36:29.232864"
+$ cockroach debug merge-logs debug/nodes/*/logs/* --from="220713 18:36:28.208553" --to="220713 18:36:29.232864"
 ~~~
 
 You can also filter the merged logs for a regular expression:

--- a/v22.1/cockroach-debug-merge-logs.md
+++ b/v22.1/cockroach-debug-merge-logs.md
@@ -60,7 +60,7 @@ Alternatively, filter the merged logs for a specified time range:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-$ cockroach debug merge-logs debug/nodes/*/logs/* --from= "18:36:28.208553" --to= "18:36:29.232864"
+$ cockroach debug merge-logs debug/nodes/*/logs/* --from="220713 18:36:28.208553" --to="220713 18:36:29.232864"
 ~~~
 
 You can also filter the merged logs for a regular expression:


### PR DESCRIPTION
Addresses: DOC-995

- Fixes time range example for `cockroach debug merge-logs` for v22.1, v21.2, and v21.1.

Note: We don't normally go back any further in docs edits (not even supposed to do v21.1 in fact now!) but I see you filed the original issue against v20.1. If you like, I'll extend this fix back that far also, just let me know.

[v22.1/cockroach-debug-zip.md](https://deploy-preview-14534--cockroachdb-docs.netlify.app/docs/stable/cockroach-debug-merge-logs.html#example) | [v21.2/cockroach-debug-zip.md](https://deploy-preview-14534--cockroachdb-docs.netlify.app/docs/v21.2/cockroach-debug-merge-logs#example) | [v21.1/cockroach-debug-zip.md](https://deploy-preview-14534--cockroachdb-docs.netlify.app/docs/v21.1/cockroach-debug-merge-logs)