### PR TITLE
Add back contribute options to docs pages

### DIFF
--- a/_includes/contribute-options.html
+++ b/_includes/contribute-options.html
@@ -6,8 +6,7 @@
     </button>
     <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
       <li><a href="https://github.com/cockroachdb/docs/edit/master/{{ page.path }}" target="blank" id="edit-this-page" data-proofer-ignore>Edit This Page</a></li>
-      <li><a href="https://github.com/cockroachdb/docs/issues/new?title={{page.title}}%20Doc%20Update%20&amp;body=Re%3A%20%5B{{page.title}}%5D(https%3A%2F%2Fcockroachlabs.com/docs{{page.url}})%0A%0A%23%23%20Issue%20Description%0A%0A%23%23%20Suggested%20Resolution%20%0A&amp;labels=community" target="blank" id="report-doc-issue" data-proofer-ignore>Report Doc Issue</a></li>
-      <li><a href="https://github.com/cockroachdb/docs/issues/new?title=New%20Doc%20Proposal%20&amp;body=%23%23%20Title%0A%0A%0A%23%23%20Description%0A%0A%0A%23%23%20Outline%0A%0A%0A%23%23%20Expected%20Audience%0A&amp;labels=community" target="blank" id="suggest-new-content" data-proofer-ignore>Suggest New Content</a></li>
+      <li><a href="https://github.com/cockroachdb/docs/issues/new?title=Feedback:%20{{page.title}}&amp;body=Page%3A%20https%3A%2F%2Fcockroachlabs.com/docs{{page.url}}%0A%0A%23%23%20What is the reason for your feedback?%0A%0A&#91;%20&#93;%20Missing the information I need%0A%0A&#91;%20&#93;%20Too complicated%0A%0A&#91;%20&#93;%20Out of date%0A%0A&#91;%20&#93;%20Something is broken%0A%0A&#91;%20&#93;%20Other%0A%0A%23%23%20Additional details&amp;" target="blank" data-proofer-ignore>Report Doc Issue</a></li>
     </ul>
   </div>
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,7 +22,9 @@ layout: default
 {% endunless %}
 ">
   <h1 class="post-title-main">{{ page.title }}</h1>
-
+  {% unless page.contribute == false %}
+        {% include contribute-options.html %}
+  {% endunless %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
These options were accidentally removed as part of
experiments in https://github.com/cockroachdb/docs/pull/14436.

Adding these back with a few changes:
- The drop-down now offers 2 options: Edit This Page and Report Doc Issue.
  The previous third option, Suggest New Content, rarely got engagement
  and is probably covered by Report Doc Issue.
- The Report Doc Issue now uses the same GH issue template as the
  Was this page helpful? No vote.