### PR TITLE
Genericize cluster description

### DIFF
--- a/v21.2/build-a-python-app-with-cockroachdb.md
+++ b/v21.2/build-a-python-app-with-cockroachdb.md
@@ -53,7 +53,7 @@ For other ways to install psycopg2, see the [official documentation](http://init
 
 ## Step 4. Run the code
 
-1. Set the `DATABASE_URL` environment variable to the connection string to your {{ site.data.products.db }} cluster:
+1. Set the `DATABASE_URL` environment variable to the connection string to your cluster:
 
     <section class="filter-content" markdown="1" data-scope="local">
 


### PR DESCRIPTION
Tag `{{ site.data.products.db }}` expands as CockroachDB Cloud regardless of tab selected. This causes users who select the "Use a Local Cluster" tab to still see the direction: "connect to your CockroachDB Cloud cluster" in Step 4.

This commit truncates the directive to simply "connect to your cluster".

[v21.2/build-a-python-app-with-cockroachdb.md](https://deploy-preview-14553--cockroachdb-docs.netlify.app/docs/v21.2/build-a-python-app-with-cockroachdb.html)