### PR TITLE
Docs on single changefeed with many tables

### DIFF
--- a/v21.2/create-and-configure-changefeeds.md
+++ b/v21.2/create-and-configure-changefeeds.md
@@ -7,20 +7,23 @@ docs_area: stream_data
 
 Core and {{ site.data.products.enterprise }} changefeeds offer different levels of configurability. {{ site.data.products.enterprise }} changefeeds allow for active changefeed jobs to be [paused](#pause), [resumed](#resume), and [canceled](#cancel).
 
-## Create a changefeed (Core)
+When creating a changefeed, it's important to consider the number of changefeeds versus the number of tables to include in a single changefeed:
 
-A core changefeed streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+  - Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
+  - Creating a single changefeed that will watch hundreds of tables can affect the performance of a changefeed by introducing coupling. For example, any [schema change](use-changefeeds.html#schema-changes) on any of the tables will affect the entire changefeed's performance. 
 
-To create a core changefeed:
+We recommend monitoring your changefeeds. See [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) for more detail.
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> EXPERIMENTAL CHANGEFEED FOR name;
-~~~
+The following Enterprise and Core sections outline how to create and configure each type of changefeed:
 
-For more information, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="enterprise">Enterprise Changefeeds</button>
+  <button class="filter-button" data-scope="core">Core Changefeeds</button>
+</div>
 
-## Configure a changefeed ({{ site.data.products.enterprise }})
+<section class="filter-content" markdown="1" data-scope="enterprise">
+
+## Configure a changefeed
 
 An {{ site.data.products.enterprise }} changefeed streams row-level changes in a configurable format to a configurable sink (i.e., Kafka or a cloud storage sink). You can [create](#create), [pause](#pause), [resume](#resume), and [cancel](#cancel) an {{ site.data.products.enterprise }} changefeed.
 
@@ -73,6 +76,25 @@ For more information, see [`CANCEL JOB`](cancel-job.html).
 ### Configuring all changefeeds
 
 {% include {{ page.version.version }}/cdc/configure-all-changefeed.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="core">
+
+## Create a changefeed 
+
+A core changefeed streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+
+To create a core changefeed:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> EXPERIMENTAL CHANGEFEED FOR name;
+~~~
+
+For more information, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).
+
+</section>
 
 ## See also
 

--- a/v21.2/create-changefeed.md
+++ b/v21.2/create-changefeed.md
@@ -27,7 +27,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 
 Parameter | Description
 ----------|------------
-`table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
+`table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Before creating a changefeed, consider the number of changefeeds versus the number of tables to include in a single changefeed. Each scenario can have an impact on total memory usage or changefeed performance. See [Create and Configure Changefeeds](create-and-configure-changefeeds.html) for more detail. 
 `sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri) below.
 `option` / `value` | For a list of available options and their values, see [Options](#options) below.
 

--- a/v22.1/create-and-configure-changefeeds.md
+++ b/v22.1/create-and-configure-changefeeds.md
@@ -7,20 +7,23 @@ docs_area: stream_data
 
 Core and {{ site.data.products.enterprise }} changefeeds offer different levels of configurability. {{ site.data.products.enterprise }} changefeeds allow for active changefeed jobs to be [paused](#pause), [resumed](#resume), and [canceled](#cancel).
 
-## Create a changefeed (Core)
+When creating a changefeed, it's important to consider the number of changefeeds versus the number of tables to include in a single changefeed:
 
-A core changefeed streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+  - Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
+  - Creating a single changefeed that will watch hundreds of tables can affect the performance of a changefeed by introducing coupling. For example, any [schema change](use-changefeeds.html#schema-changes) on any of the tables will affect the entire changefeed's performance. 
 
-To create a core changefeed:
+We recommend monitoring your changefeeds. See [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) for more detail.
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> EXPERIMENTAL CHANGEFEED FOR table_name;
-~~~
+The following Enterprise and Core sections outline how to create and configure each type of changefeed:
 
-For more information, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="enterprise">Enterprise Changefeeds</button>
+  <button class="filter-button" data-scope="core">Core Changefeeds</button>
+</div>
 
-## Configure a changefeed ({{ site.data.products.enterprise }})
+<section class="filter-content" markdown="1" data-scope="enterprise">
+
+## Configure a changefeed
 
 An {{ site.data.products.enterprise }} changefeed streams row-level changes in a configurable format to a configurable sink (i.e., Kafka or a cloud storage sink). You can [create](#create), [pause](#pause), [resume](#resume), and [cancel](#cancel) an {{ site.data.products.enterprise }} changefeed.
 
@@ -77,6 +80,25 @@ For more information, see [`CANCEL JOB`](cancel-job.html).
 ### Configuring all changefeeds
 
 {% include {{ page.version.version }}/cdc/configure-all-changefeed.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="core">
+
+## Create a changefeed
+
+A core changefeed streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+
+To create a core changefeed:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> EXPERIMENTAL CHANGEFEED FOR table_name;
+~~~
+
+For more information, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).
+
+</section>
 
 ## See also
 

--- a/v22.1/create-changefeed.md
+++ b/v22.1/create-changefeed.md
@@ -27,7 +27,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 
 Parameter | Description
 ----------|------------
-`table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
+`table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Before creating a changefeed, consider the number of changefeeds versus the number of tables to include in a single changefeed. Each scenario can have an impact on total memory usage or changefeed performance. See [Create and Configure Changefeeds](create-and-configure-changefeeds.html) for more detail. 
 `sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri) below.
 `option` / `value` | For a list of available options and their values, see [Options](#options) below.
 


### PR DESCRIPTION
Fixes [DOC-2626](https://cockroachlabs.atlassian.net/browse/DOC-2626)

This adds information on why adding hundreds+ tables to a single changefeed could potentially cause problems. In this draft, currently have "hundreds" here to separate or set this off against the "too many changefeeds" on one cluster problem. Not sure if we want to reference a particular number here like "hundreds". It seemed like "many" was too vague.

Placement:
Added the considerations for a single changefeed with many tables and many changefeeds to the Create and Configure Changefeed page. Also linked out to these from the `CREATE CHANGEFEED` sql page where the many changefeed note was already in place.

Also made opportunistic filter edit to this page, which docs can review.