### PR TITLE
DOC-5141 fix deploy systemd chown

### DIFF
--- a/_includes/v21.1/prod-deployment/secure-scale-cluster.md
+++ b/_includes/v21.1/prod-deployment/secure-scale-cluster.md
@@ -94,7 +94,7 @@ For each additional node you want to add to the cluster, complete the following 
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ chown -R cockroach.cockroach /var/lib/cockroach
+    $ chown -R cockroach:cockroach /var/lib/cockroach
     ~~~
 
 8.  Download the [sample configuration template](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/prod-deployment/securecockroachdb.service):

--- a/_includes/v21.1/prod-deployment/secure-start-nodes.md
+++ b/_includes/v21.1/prod-deployment/secure-start-nodes.md
@@ -154,7 +154,7 @@ After completing these steps, nodes will not yet be live. They will complete the
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ chown -R cockroach.cockroach /var/lib/cockroach
+    $ chown -R cockroach:cockroach /var/lib/cockroach
     ~~~
 
 9.  Download the [sample configuration template](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/prod-deployment/securecockroachdb.service) and save the file in the `/etc/systemd/system/` directory:

--- a/_includes/v21.2/prod-deployment/secure-scale-cluster.md
+++ b/_includes/v21.2/prod-deployment/secure-scale-cluster.md
@@ -94,7 +94,7 @@ For each additional node you want to add to the cluster, complete the following 
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ chown -R cockroach.cockroach /var/lib/cockroach
+    $ chown -R cockroach:cockroach /var/lib/cockroach
     ~~~
 
 8.  Download the [sample configuration template](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/prod-deployment/securecockroachdb.service):

--- a/_includes/v21.2/prod-deployment/secure-start-nodes.md
+++ b/_includes/v21.2/prod-deployment/secure-start-nodes.md
@@ -154,7 +154,7 @@ After completing these steps, nodes will not yet be live. They will complete the
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ chown -R cockroach.cockroach /var/lib/cockroach
+    $ chown -R cockroach:cockroach /var/lib/cockroach
     ~~~
 
 9.  Download the [sample configuration template](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/prod-deployment/securecockroachdb.service) and save the file in the `/etc/systemd/system/` directory:

--- a/_includes/v22.1/prod-deployment/secure-scale-cluster.md
+++ b/_includes/v22.1/prod-deployment/secure-scale-cluster.md
@@ -94,7 +94,7 @@ For each additional node you want to add to the cluster, complete the following 
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ chown -R cockroach.cockroach /var/lib/cockroach
+    $ chown -R cockroach:cockroach /var/lib/cockroach
     ~~~
 
 8.  Download the [sample configuration template](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/prod-deployment/securecockroachdb.service):

--- a/_includes/v22.1/prod-deployment/secure-start-nodes.md
+++ b/_includes/v22.1/prod-deployment/secure-start-nodes.md
@@ -154,7 +154,7 @@ After completing these steps, nodes will not yet be live. They will complete the
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ chown -R cockroach.cockroach /var/lib/cockroach
+    $ chown -R cockroach:cockroach /var/lib/cockroach
     ~~~
 
 9.  Download the [sample configuration template](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/prod-deployment/securecockroachdb.service) and save the file in the `/etc/systemd/system/` directory:


### PR DESCRIPTION
Addresses: DOC-5141

- (versions v22.1, v21.2, v21.1) Fixed `chown` step in deployment docs to use `cockroach:cockroach` to properly set ownership for both user and group.

[v22.1/deploy-cockroachdb-on-premises.md](https://deploy-preview-14607--cockroachdb-docs.netlify.app/docs/stable/deploy-cockroachdb-on-premises.html?filters=systemd#step-3-start-nodes) | [v21.2/deploy-cockroachdb-on-premises.md](https://deploy-preview-14607--cockroachdb-docs.netlify.app/docs/v21.2/deploy-cockroachdb-on-premises.html?filters=systemd#step-3-start-nodes) | [v21.1/deploy-cockroachdb-on-premises.md](https://deploy-preview-14607--cockroachdb-docs.netlify.app/docs/v21.1/deploy-cockroachdb-on-premises.html?filters=systemd#step-3-start-nodes)