### PR TITLE
Kubernetes Operator 2.8.0 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -26,7 +26,6 @@ include:
 keep_files:
 - _internal
 markdown: Redcarpet
-operator_version: v2.6.0
 plugins:
 - jekyll-include-cache
 release_info:

--- a/_includes/latest_operator_version.md
+++ b/_includes/latest_operator_version.md
@@ -1,0 +1,1 @@
+{% remote_include  https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/version.txt %}

--- a/_includes/v20.2/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-stop-cluster.md
@@ -1,6 +1,9 @@
 To shut down the CockroachDB cluster:
 
 <section class="filter-content" markdown="1" data-scope="operator">
+
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Delete the previously created custom resource:
 
     {% include_cached copy-clipboard.html %}
@@ -12,7 +15,7 @@ To shut down the CockroachDB cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     This will delete the StatefulSet but will not delete the persistent volumes that were attached to the pods. 

--- a/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
@@ -4,11 +4,13 @@ The Operator is currently supported for GKE only.
 
 ### Install the Operator
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Apply the [CustomResourceDefinition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) for the Operator:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/crds.yaml
     ~~~
 
     ~~~
@@ -19,7 +21,7 @@ The Operator is currently supported for GKE only.
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     ~~~
@@ -49,7 +51,7 @@ On a production cluster, you will need to modify the StatefulSet configuration w
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/examples/example.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/example.yaml
     ~~~
 
     {% include copy-clipboard.html %}

--- a/_includes/v21.1/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v21.1/orchestration/kubernetes-stop-cluster.md
@@ -1,6 +1,8 @@
 To shut down the CockroachDB cluster:
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Delete the previously created custom resource:
 
     {% include_cached copy-clipboard.html %}
@@ -12,7 +14,7 @@ To shut down the CockroachDB cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     This will delete the CockroachDB cluster being run by the Operator. It will *not* delete the persistent volumes that were attached to the pods. 

--- a/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
@@ -1,10 +1,12 @@
 ### Install the Operator
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Apply the [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) for the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/crds.yaml
     ~~~
 
     ~~~
@@ -19,7 +21,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ shell
-        $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+        $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
         ~~~
 
     1. To use a custom namespace, edit all instances of `namespace: cockroach-operator-system` with your desired namespace.
@@ -37,7 +39,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     ~~~
@@ -75,7 +77,7 @@ By default, the Operator will generate and sign 1 client and 1 node certificate 
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/examples/example.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/example.yaml
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v21.1/orchestration/test-cluster-secure.md
+++ b/_includes/v21.1/orchestration/test-cluster-secure.md
@@ -1,10 +1,13 @@
 To use the CockroachDB SQL client, first launch a secure pod running the `cockroach` binary.
 
 <section class="filter-content" markdown="1" data-scope="operator">
+
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 $ kubectl create \
--f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/examples/client-secure-operator.yaml
+-f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/client-secure-operator.yaml
 ~~~
 
 1. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):

--- a/_includes/v21.2/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v21.2/orchestration/kubernetes-stop-cluster.md
@@ -1,6 +1,8 @@
 To shut down the CockroachDB cluster:
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Delete the previously created custom resource:
 
     {% include_cached copy-clipboard.html %}
@@ -12,7 +14,7 @@ To shut down the CockroachDB cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     This will delete the CockroachDB cluster being run by the Operator. It will *not* delete the persistent volumes that were attached to the pods. 

--- a/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
@@ -1,10 +1,12 @@
 ### Install the Operator
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Apply the [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) for the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/crds.yaml
     ~~~
 
     ~~~
@@ -19,7 +21,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ shell
-        $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+        $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
         ~~~
 
     1. To use a custom namespace, edit all instances of `namespace: cockroach-operator-system` with your desired namespace.
@@ -37,7 +39,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     ~~~
@@ -77,7 +79,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/examples/example.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/example.yaml
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v21.2/orchestration/test-cluster-secure.md
+++ b/_includes/v21.2/orchestration/test-cluster-secure.md
@@ -1,10 +1,13 @@
 To use the CockroachDB SQL client, first launch a secure pod running the `cockroach` binary.
 
 <section class="filter-content" markdown="1" data-scope="operator">
+
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 $ kubectl create \
--f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/examples/client-secure-operator.yaml
+-f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/client-secure-operator.yaml
 ~~~
 
 1. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):

--- a/_includes/v22.1/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v22.1/orchestration/kubernetes-stop-cluster.md
@@ -1,6 +1,8 @@
 To shut down the CockroachDB cluster:
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Delete the previously created custom resource:
 
     {% include_cached copy-clipboard.html %}
@@ -12,7 +14,7 @@ To shut down the CockroachDB cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     This will delete the CockroachDB cluster being run by the Operator. It will *not* delete the persistent volumes that were attached to the pods. 

--- a/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
@@ -1,10 +1,12 @@
 ### Install the Operator
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Apply the [custom resource definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) for the Operator:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/crds.yaml
     ~~~
 
     ~~~
@@ -19,7 +21,7 @@
 
         {% include_cached copy-clipboard.html %}
         ~~~ shell
-        $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+        $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
         ~~~
 
     1. To use a custom namespace, edit all instances of `namespace: cockroach-operator-system` with your desired namespace.
@@ -37,7 +39,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
     ~~~
@@ -77,7 +79,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/examples/example.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/example.yaml
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v22.1/orchestration/test-cluster-secure.md
+++ b/_includes/v22.1/orchestration/test-cluster-secure.md
@@ -1,10 +1,13 @@
 To use the CockroachDB SQL client, first launch a secure pod running the `cockroach` binary.
 
 <section class="filter-content" markdown="1" data-scope="operator">
+
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 $ kubectl create \
--f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/examples/client-secure-operator.yaml
+-f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/client-secure-operator.yaml
 ~~~
 
 1. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):

--- a/netlify/vale/vocab.txt
+++ b/netlify/vale/vocab.txt
@@ -263,6 +263,7 @@ kubectl
 kubemci
 kuwahara
 kv
+latest_operator_version
 Leakproof
 leakproof
 leiningen

--- a/releases/kubernetes-operator.md
+++ b/releases/kubernetes-operator.md
@@ -5,9 +5,11 @@ toc: true
 docs_area: releases
 ---
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 The CockroachDB [Kubernetes Operator](/docs/{{site.versions["stable"]}}/kubernetes-overview.html) is the recommended way to configure, deploy, and manage {{ site.data.products.core }} clusters on Kubernetes. The Kubernetes Operator is released on a separate schedule and is versioned independently from CockroachDB.
 
-This page briefly announces releases of the Kubernetes Operator and provides links to more information on GitHub. **Version {% include latest_operator_version.md %}** is the latest release.
+This page briefly announces releases of the Kubernetes Operator and provides links to more information on GitHub. **Version {{ latest_operator_version }} is the latest release**.
 
 In addition to monitoring this page, you can subscribe to be notified about releases to the Kubernetes Operator. Visit [CockroachDB Kubernetes Operator source code repository](https://github.com/cockroachdb/cockroach-operator) and click **Watch**.
 

--- a/releases/kubernetes-operator.md
+++ b/releases/kubernetes-operator.md
@@ -9,7 +9,7 @@ docs_area: releases
 
 The CockroachDB [Kubernetes Operator](/docs/{{site.versions["stable"]}}/kubernetes-overview.html) is the recommended way to configure, deploy, and manage {{ site.data.products.core }} clusters on Kubernetes. The Kubernetes Operator is released on a separate schedule and is versioned independently from CockroachDB.
 
-This page briefly announces releases of the Kubernetes Operator and provides links to more information on GitHub. **Version {{ latest_operator_version }} is the latest release**.
+This page announces releases of the Kubernetes Operator and provides links to more information on GitHub. **Version {{ latest_operator_version }} is the latest release**.
 
 In addition to monitoring this page, you can subscribe to be notified about releases to the Kubernetes Operator. Visit [CockroachDB Kubernetes Operator source code repository](https://github.com/cockroachdb/cockroach-operator) and click **Watch**.
 

--- a/releases/kubernetes-operator.md
+++ b/releases/kubernetes-operator.md
@@ -7,7 +7,7 @@ docs_area: releases
 
 The CockroachDB [Kubernetes Operator](/docs/{{site.versions["stable"]}}/kubernetes-overview.html) is the recommended way to configure, deploy, and manage {{ site.data.products.core }} clusters on Kubernetes. The Kubernetes Operator is released on a separate schedule and is versioned independently from CockroachDB.
 
-This page briefly announces releases of the Kubernetes Operator and provides links to more information on GitHub.
+This page briefly announces releases of the Kubernetes Operator and provides links to more information on GitHub. **Version {% include latest_operator_version.md %}** is the latest release.
 
 In addition to monitoring this page, you can subscribe to be notified about releases to the Kubernetes Operator. Visit [CockroachDB Kubernetes Operator source code repository](https://github.com/cockroachdb/cockroach-operator) and click **Watch**.
 
@@ -18,6 +18,14 @@ To be notified about updates to the Helm chart, visit the [CockroachDB Helm char
 {{site.data.alerts.end}}
 
 <!-- Copy the top section below and bump the variable -->
+
+## July 13, 2022
+
+{% assign operator_version = "2.8.0" %}
+CockroachDB Kubernetes Operator {{ operator_version }} is available.
+
+- [Changelog](https://github.com/cockroachdb/cockroach-operator/blob/master/CHANGELOG.md#v{{ operator_version }})
+- [Download](https://github.com/cockroachdb/cockroach-operator/releases/tag/v{{ operator_version }})
 
 ## May 26, 2022
 

--- a/v21.1/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v21.1/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -86,13 +86,15 @@ This article assumes you have already installed the OpenShift Container Platform
 
 ## Step 3. Start CockroachDB
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. When the Operator is ready, click **View Operator** to navigate to the **Installed Operators** page.
 
 1. In the **CockroachDB Operator** tile, click **Create instance**.
 
 	<img src="{{ 'images/v21.1/cockroachdb-operator-instance-openshift.png' | relative_url }}" alt="OpenShift OperatorHub" style="border:1px solid #eee;max-width:100%" />
 
-1. Make sure **CockroachDB Version** is set to a valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/{{site.operator_version}}/install/operator.yaml) on GitHub.
+1. Make sure **CockroachDB Version** is set to a valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml) on GitHub.
 
 1. This will open the **Create CrdbCluster** page. By default, this deploys a 3-node secure cluster. Leave the other fields unchanged and click **Create**.
 

--- a/v21.1/operate-cockroachdb-kubernetes.md
+++ b/v21.1/operate-cockroachdb-kubernetes.md
@@ -56,10 +56,10 @@ If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kuber
 <section class="filter-content" markdown="1" data-scope="operator">
 ## Apply settings
 
-Cluster parameters are configured in a `CrdbCluster` custom resource object. This tells the Operator how to configure the Kubernetes cluster. We provide a custom resource template called [`example.yaml`](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml):
+Cluster parameters are configured in a `CrdbCluster` custom resource object. This tells the Operator how to configure the Kubernetes cluster. We provide a custom resource template called [`example.yaml`](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/example.yaml):
 
 ~~~ yaml
-{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/examples/example.yaml||# Generated, do not edit. Please edit this file instead: config/templates/example.yaml.in\n#\n|| %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/examples/example.yaml %}
 ~~~
 
 It's simplest to download and customize a local copy of the custom resource manifest. After you modify its parameters, run this command to apply the new values to the cluster:
@@ -1105,11 +1105,13 @@ To enable the Operator to automatically remove persistent volumes when [scaling 
 This workflow is unsupported and should be enabled at your own risk.
 {{site.data.alerts.end}}
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Download the Operator manifest:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
 1. Uncomment the following lines in the Operator manifest:

--- a/v21.2/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v21.2/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -83,13 +83,15 @@ This article assumes you have already installed the OpenShift Container Platform
 
 ## Step 3. Start CockroachDB
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. When the Operator is ready, click **View Operator** to navigate to the **Installed Operators** page.
 
 1. In the **CockroachDB Operator** tile, click **Create instance**.
 
 	<img src="{{ 'images/v21.2/cockroachdb-operator-instance-openshift.png' | relative_url }}" alt="OpenShift OperatorHub" style="border:1px solid #eee;max-width:100%" />
 
-1. Make sure **CockroachDB Version** is set to a valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/{{site.operator_version}}/install/operator.yaml) on GitHub.
+1. Make sure **CockroachDB Version** is set to a valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml) on GitHub.
 
 1. This will open the **Create CrdbCluster** page. By default, this deploys a 3-node secure cluster. Leave the other fields unchanged and click **Create**.
 

--- a/v21.2/scale-cockroachdb-kubernetes.md
+++ b/v21.2/scale-cockroachdb-kubernetes.md
@@ -214,11 +214,13 @@ To enable the Operator to automatically remove persistent volumes when [scaling 
 This workflow is unsupported and should be enabled at your own risk.
 {{site.data.alerts.end}}
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Download the Operator manifest:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
 1. Uncomment the following lines in the Operator manifest:

--- a/v21.2/schedule-cockroachdb-kubernetes.md
+++ b/v21.2/schedule-cockroachdb-kubernetes.md
@@ -22,7 +22,9 @@ These settings control how CockroachDB pods can be identified or scheduled onto 
 
 ## Enable feature gates
 
-To enable the [affinity](#affinities-and-anti-affinities), [toleration](#taints-and-tolerations), and [topology spread constraint](#topology-spread-constraints) rules, [download the Operator manifest](https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml) and add the following line to the `spec.containers.args` field:
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
+To enable the [affinity](#affinities-and-anti-affinities), [toleration](#taints-and-tolerations), and [topology spread constraint](#topology-spread-constraints) rules, [download the Operator manifest](https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml) and add the following line to the `spec.containers.args` field:
 
 {% include_cached copy-clipboard.html %}
 ~~~ yaml
@@ -100,7 +102,7 @@ The `requiredDuringSchedulingIgnoredDuringExecution` node affinity rule, using t
 
 The `preferredDuringSchedulingIgnoredDuringExecution` node affinity rule, using the `NotIn` operator and specified `weight`, discourages (but does not disallow) CockroachDB pods from being scheduled onto nodes with the label `topology.kubernetes.io/zone=us-east4-b`. This achieves a similar effect as a `PreferNoSchedule` [taint](#taints-and-tolerations).
 
-For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ### Add a pod affinity or anti-affinity
 
@@ -138,7 +140,7 @@ The `preferredDuringSchedulingIgnoredDuringExecution` pod affinity rule, using t
 
 The `requiredDuringSchedulingIgnoredDuringExecution` pod anti-affinity rule, using the `In` operator, requires CockroachDB pods not to be co-located on a worker node, as specified with `topologyKey`.
 
-For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ### Example: Scheduling CockroachDB onto labeled nodes
 
@@ -280,7 +282,7 @@ spec:
 
 A `NoExecute` taint on a node prevents pods from being scheduled onto the node, and evicts pods from the node if they are already running on the node. The matching toleration allows a pod to be scheduled onto the node, and to continue running on the node if `tolerationSeconds` is not specified. If `tolerationSeconds` is specified, the pod is evicted after this number of seconds. 
 
-For more information on using taints and tolerations, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more information on using taints and tolerations, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [custom resource definition](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ### Example: Evicting CockroachDB from a running worker node
 
@@ -378,7 +380,7 @@ spec:
 
 The `DoNotSchedule` condition prevents labeled pods from being scheduled onto Kubernetes worker nodes when doing so would fail to meet the spread and topology constraints specified with `maxSkew` and `topologyKey`, respectively.
 
-For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The [custom resource definition](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ## Resource labels and annotations
 
@@ -392,7 +394,7 @@ spec:
   additionalLabels:
     app.kubernetes.io/version: {{page.release_info.version}}
   additionalAnnotations:
-    operator: https://github.com/cockroachdb/cockroach-operator/blob/master/install/operator.yaml
+    operator: https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
 ~~~
 
 To verify that the labels and annotations were applied to a pod, for example, run `kubectl describe pod {pod-name}`.

--- a/v22.1/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v22.1/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -83,13 +83,15 @@ This article assumes you have already installed the OpenShift Container Platform
 
 ## Step 3. Start CockroachDB
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. When the Operator is ready, click **View Operator** to navigate to the **Installed Operators** page.
 
 1. In the **CockroachDB Operator** tile, click **Create instance**.
 
 	<img src="{{ 'images/v22.1/cockroachdb-operator-instance-openshift.png' | relative_url }}" alt="OpenShift OperatorHub" style="border:1px solid #eee;max-width:100%" />
 
-1. Make sure **CockroachDB Version** is set to a valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/{{site.operator_version}}/install/operator.yaml) on GitHub.
+1. Make sure **CockroachDB Version** is set to a valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml) on GitHub.
 
 1. This will open the **Create CrdbCluster** page. By default, this deploys a 3-node secure cluster. Leave the other fields unchanged and click **Create**.
 

--- a/v22.1/kubernetes-overview.md
+++ b/v22.1/kubernetes-overview.md
@@ -8,6 +8,8 @@ redirect_from: orchestration.html
 docs_area: deploy
 ---
 
+Kubernetes is a portable, extensible, open source platform for managing containerized workloads and services. For a given workload, you provide Kubernetes with a configuration, and Kubernetes applies that configuration to all Kubernetes nodes that are running the application. , that facilitates both declarative configuration and automation.
+
 CockroachDB can be deployed and managed on Kubernetes using the following methods:
 
 - [CockroachDB Kubernetes Operator](https://github.com/cockroachdb/cockroach-operator)

--- a/v22.1/scale-cockroachdb-kubernetes.md
+++ b/v22.1/scale-cockroachdb-kubernetes.md
@@ -214,11 +214,13 @@ To enable the Operator to automatically remove persistent volumes when [scaling 
 This workflow is unsupported and should be enabled at your own risk.
 {{site.data.alerts.end}}
 
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
 1. Download the Operator manifest:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
+    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 
 1. Uncomment the following lines in the Operator manifest:

--- a/v22.1/schedule-cockroachdb-kubernetes.md
+++ b/v22.1/schedule-cockroachdb-kubernetes.md
@@ -22,7 +22,9 @@ These settings control how CockroachDB pods can be identified or scheduled onto 
 
 ## Enable feature gates
 
-To enable the [affinity](#affinities-and-anti-affinities), [toleration](#taints-and-tolerations), and [topology spread constraint](#topology-spread-constraints) rules, [download the Operator manifest](https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml) and add the following line to the `spec.containers.args` field:
+{% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
+
+To enable the [affinity](#affinities-and-anti-affinities), [toleration](#taints-and-tolerations), and [topology spread constraint](#topology-spread-constraints) rules, [download the Operator manifest](https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml) and add the following line to the `spec.containers.args` field:
 
 {% include_cached copy-clipboard.html %}
 ~~~ yaml
@@ -100,7 +102,7 @@ The `requiredDuringSchedulingIgnoredDuringExecution` node affinity rule, using t
 
 The `preferredDuringSchedulingIgnoredDuringExecution` node affinity rule, using the `NotIn` operator and specified `weight`, discourages (but does not disallow) CockroachDB pods from being scheduled onto nodes with the label `topology.kubernetes.io/zone=us-east4-b`. This achieves a similar effect as a `PreferNoSchedule` [taint](#taints-and-tolerations).
 
-For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ### Add a pod affinity or anti-affinity
 
@@ -138,7 +140,7 @@ The `preferredDuringSchedulingIgnoredDuringExecution` pod affinity rule, using t
 
 The `requiredDuringSchedulingIgnoredDuringExecution` pod anti-affinity rule, using the `In` operator, requires CockroachDB pods not to be co-located on a worker node, as specified with `topologyKey`.
 
-For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). The [custom resource definition](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ### Example: Scheduling CockroachDB onto labeled nodes
 
@@ -280,7 +282,7 @@ spec:
 
 A `NoExecute` taint on a node prevents pods from being scheduled onto the node, and evicts pods from the node if they are already running on the node. The matching toleration allows a pod to be scheduled onto the node, and to continue running on the node if `tolerationSeconds` is not specified. If `tolerationSeconds` is specified, the pod is evicted after this number of seconds. 
 
-For more information on using taints and tolerations, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more information on using taints and tolerations, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [custom resource definition](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ### Example: Evicting CockroachDB from a running worker node
 
@@ -378,7 +380,7 @@ spec:
 
 The `DoNotSchedule` condition prevents labeled pods from being scheduled onto Kubernetes worker nodes when doing so would fail to meet the spread and topology constraints specified with `maxSkew` and `topologyKey`, respectively.
 
-For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The [custom resource definition](https://github.com/cockroachdb/cockroach-operator/blob/master/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
+For more context on how these rules work, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The [custom resource definition](https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml) details the fields supported by the Operator.
 
 ## Resource labels and annotations
 
@@ -392,7 +394,7 @@ spec:
   additionalLabels:
     app.kubernetes.io/version: {{page.release_info.version}}
   additionalAnnotations:
-    operator: https://github.com/cockroachdb/cockroach-operator/blob/master/install/operator.yaml
+    operator: https://raw.github.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
 ~~~
 
 To verify that the labels and annotations were applied to a pod, for example, run `kubectl describe pod {pod-name}`.


### PR DESCRIPTION
Followup work from https://github.com/cockroachdb/cockroach-operator/pull/924

The second commit replaces a site-wide variable for the Operator version with a remote include that dynamically pulls the version from the upstream repo. That's the reason this PR touches so many old files.

**Non-docs reviewers: You need only check the 2.8.0 section of `kubernetes-operator.md` and the first preview link in this list:**

Sampling of previews, sorted by CRDB version:
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/releases/kubernetes-operator.html
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v22.1/schedule-cockroachdb-kubernetes.html
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v22.1/deploy-cockroachdb-with-kubernetes.html#step-5-stop-the-cluster
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v21.2/deploy-cockroachdb-with-kubernetes.html#install-the-operator
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v21.2/schedule-cockroachdb-kubernetes.html
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v21.2/deploy-cockroachdb-with-kubernetes.html#step-5-stop-the-cluster
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v21.2/scale-cockroachdb-kubernetes.html
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v21.1/deploy-cockroachdb-with-kubernetes.html#install-the-operator
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v21.1/deploy-cockroachdb-with-kubernetes#step-5-stop-the-cluster
- https://deploy-preview-14620--cockroachdb-docs.netlify.app/docs/v20.2/orchestrate-cockroachdb-with-kubernetes.html#step-2-start-cockroachdb






