### PR TITLE
DOC-4573 v22.1.5 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -91,10 +91,10 @@ release_info:
     start_time: 2022-06-29 11:07:02.191084 +0000 UTC
     version: v21.2.13
   v22.1:
-    build_time: 2022-07-19 00:00:00 (go1.17)
+    build_time: 2022-07-28 00:00:00 (go1.17)
     docker_image: cockroachdb/cockroach
-    name: v22.1.4
-    start_time: 2022-07-18 12:08:36.898533 +0000 UTC
-    version: v22.1.4
+    name: v22.1.5
+    start_time: 2022-07-27 13:34:27.897839 +0000 UTC
+    version: v22.1.5
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -285,3 +285,4 @@ v22.1.2,v22.1,2022-06-22,false,False,Production,False,go1.17,fc456a26830067b6dfb
 v21.2.13,v21.2,2022-07-05,false,False,Production,False,go1.16,a3c796b1a49394d161ccc50fe4c05766d4d5b626,cockroachdb/cockroach,false
 v22.1.3,v22.1,2022-07-11,false,False,Production,False,go1.17,2ca74540cc1603ff810b43399846bb5b7caba651,cockroachdb/cockroach,true
 v22.1.4,v22.1,2022-07-19,false,False,Production,False,go1.17,3c6c8933f578a7fd140e24a603d6ec64c6b7a834,cockroachdb/cockroach,true
+v22.1.5,v22.1,2022-07-28,false,False,Production,False,go1.17,a30a663cbd9323d34d50f343dd038af64671e25f,cockroachdb/cockroach,true

--- a/_includes/releases/v22.1/v22.1.5.md
+++ b/_includes/releases/v22.1/v22.1.5.md
@@ -1,0 +1,62 @@
+## v22.1.5
+
+Release Date: July 28, 2022
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-1-5-sql-language-changes">SQL language changes</h3>
+
+- [`AS OF SYSTEM TIME`](../v22.1/as-of-system-time.html) now takes the time zone into account when converting to UTC. For example: `2022-01-01 08:00:00-04:00` is now treated the same as `2022-01-01 12:00:00` instead of being interpreted as `2022-01-01 08:00:00` [#84663][#84663]
+- The [sampled query telemetry log](../v22.1/logging-overview.html#logging-destinations) includes a new database ID field. [#84354][#84354]
+- The sampled query telemetry log now includes the statement's fingerprint ID. [#84857][#84857]
+- Introduced a new `troubleshooting_mode_enabled` [session variable](../v22.1/set-vars.html) to avoid doing additional work on queries when possible (i.e., collecting telemetry data). By default, this session variable is disabled. [#84858][#84858]
+
+<h3 id="v22-1-5-db-console-changes">DB Console changes</h3>
+
+- Updated labels from "date range" to "time interval" on time picker (custom option, preset title, previous and next arrows) [#84517][#84517]
+- Removed `View Statement Details` link inside the [**Session Details**](../v22.1/ui-sessions-page.html) page. [#84502][#84502]
+- Updated the message when there is no data on the selected time interval on the [**Statements**](../v22.1/ui-statements-page.html) and [**Transactions**](../v22.1/ui-transactions-page.html) pages. [#84623][#84623]
+
+<h3 id="v22-1-5-bug-fixes">Bug fixes</h3>
+
+- Fixed a conversion on the jobs endpoint, so that the [**Jobs**](../v22.1/ui-jobs-page.html) page won't return a `500` error when a job contained an error with quotes. [#84464][#84464]
+- The 'Parse', 'Bind', and 'Execute' `pgwire` commands now return an error if they are used during an aborted transaction. [`COMMIT`](../v22.1/commit-transaction.html) and [`ROLLBACK`](../v22.1/rollback-transaction.html) statements are still allowed during an aborted transaction. [#84329][#84329]
+- Sorting on the plans table inside the [**Statement Details**](../v22.1/ui-statements-page.html#statement-details-page) page is now properly working. [#84627][#84627]
+- Fixed a bug that could cause [unique indexes](../v22.1/unique.html) to be unexpectedly dropped after running an [`ALTER PRIMARY KEY`](../v22.1/alter-primary-key.html) statement, if the new PK column set is a subset of the old PK column set.[#84570][#84570]
+- In case client-provided session parameters fail to parse, CRDB no longer leaks accounted for memory. [#84472][#84472]
+- Fixed a bug where some statements in a batch would not get executed if the following conditions were met:
+  - A batch of statements is sent in a single string.
+  - A [`BEGIN`](../v22.1/begin-transaction.html) statement appears in the middle of the batch.
+  - The `enable_implicit_transaction_for_batch_statements` [session variable](../v22.1/set-vars.html) is set to `true`. (This defaults to false in v22.1)
+  This bug was introduced in v22.1.2. [#84593][#84593]
+- Previously, CockroachDB could deadlock when evaluating analytical queries if multiple queries had to [spill to disk](../v22.1/vectorized-execution.html#disk-spilling-operations) at the same time. This is now fixed by making some of the queries error out instead. If you know that there is no deadlock and that some analytical queries that have spilled are just taking too long, blocking other queries from spilling, you can adjust newly introduced `sql.distsql.acquire_vec_fds.max_retries` [cluster setting](../v22.1/cluster-settings.html) (use `0` to enable the previous behavior of indefinite waiting until spilling resources open up). [#84657][#84657]
+- Fixes a bug where cluster restores of older backups would silently clobber system tables or fail to complete. [#84904][#84904]
+- Fixed a bug that was introduced in v21.2 that could cause increased memory usage when scanning a table with wide rows. [#83966][#83966]
+- Fixed a bug in the `concat` projection operator on arrays that gave output of nulls when the projection operator can actually handle null arguments and may result in a non-null output. [#84615][#84615]
+- Reduced foreground latency impact when performing changefeed backfills by adjusting `changefeed.memory.per_changefeed_limit` [cluster setting](../v22.1/cluster-settings.html) to 128MiB (Enterprise only). [#84702][#84702]
+
+<h3 id="v22-1-5-contributors">Contributors</h3>
+
+This release includes 30 merged PRs by 17 authors.
+
+[#83966]: https://github.com/cockroachdb/cockroach/pull/83966
+[#84269]: https://github.com/cockroachdb/cockroach/pull/84269
+[#84329]: https://github.com/cockroachdb/cockroach/pull/84329
+[#84354]: https://github.com/cockroachdb/cockroach/pull/84354
+[#84464]: https://github.com/cockroachdb/cockroach/pull/84464
+[#84472]: https://github.com/cockroachdb/cockroach/pull/84472
+[#84502]: https://github.com/cockroachdb/cockroach/pull/84502
+[#84517]: https://github.com/cockroachdb/cockroach/pull/84517
+[#84570]: https://github.com/cockroachdb/cockroach/pull/84570
+[#84593]: https://github.com/cockroachdb/cockroach/pull/84593
+[#84615]: https://github.com/cockroachdb/cockroach/pull/84615
+[#84623]: https://github.com/cockroachdb/cockroach/pull/84623
+[#84627]: https://github.com/cockroachdb/cockroach/pull/84627
+[#84657]: https://github.com/cockroachdb/cockroach/pull/84657
+[#84663]: https://github.com/cockroachdb/cockroach/pull/84663
+[#84702]: https://github.com/cockroachdb/cockroach/pull/84702
+[#84726]: https://github.com/cockroachdb/cockroach/pull/84726
+[#84857]: https://github.com/cockroachdb/cockroach/pull/84857
+[#84858]: https://github.com/cockroachdb/cockroach/pull/84858
+[#84904]: https://github.com/cockroachdb/cockroach/pull/84904
+[0ac3ee0ca]: https://github.com/cockroachdb/cockroach/commit/0ac3ee0ca


### PR DESCRIPTION
Addresses: DOC-4573

- Release notes for v22.1.5

Guess: the following selected changelog entries might not be intended for end users:

```
- Fixed the following builtins so that users can only run them if they have [`SELECT`](../v22.1/selection-queries.html) privileges on the relevant tables: `crdb_internal.revalidate_unique_constraints_in_all_tables`, `crdb_internal.revalidate_unique_constraints_in_table`, and `crdb_internal.revalidate_unique_constraint`. [#84269][#84269]
- `crdb_internal.decode_plan_gist` will no longer produce an internal error when it is used to decode a plan gist for which no schema information is available. [#84726][#84726]
- The [sampled query telemetry log] ... (x2) (as Telemetry channel is described as "Telemetry events for internal usage")
- Introduced a new `troubleshooting_mode_enabled` ... (telemetry data also)
- In case client-provided session parameters fail to parse ... (engineer changelog clearly not intended for non-engineer consumption)
```

Should I remove some or all of these?

[v22.1.5.md](https://deploy-preview-14641--cockroachdb-docs.netlify.app/docs/releases/v22.1.html#v22-1-5)