### PR TITLE
DOC-1901 v21.2.14 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -84,11 +84,11 @@ release_info:
     start_time: 2022-05-10 14:15:58.748869 +0000 UTC
     version: v21.1.19
   v21.2:
-    build_time: 2022-07-05 00:00:00 (go1.16)
+    build_time: 2022-08-01 00:00:00 (go1.16)
     docker_image: cockroachdb/cockroach
-    name: v21.2.13
-    start_time: 2022-06-29 11:07:02.191084 +0000 UTC
-    version: v21.2.13
+    name: v21.2.14
+    start_time: 2022-08-01 11:15:52.188207 +0000 UTC
+    version: v21.2.14
   v22.1:
     build_time: 2022-07-28 00:00:00 (go1.17)
     docker_image: cockroachdb/cockroach

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -286,3 +286,4 @@ v21.2.13,v21.2,2022-07-05,false,False,Production,False,go1.16,a3c796b1a49394d161
 v22.1.3,v22.1,2022-07-11,false,False,Production,False,go1.17,2ca74540cc1603ff810b43399846bb5b7caba651,cockroachdb/cockroach,true
 v22.1.4,v22.1,2022-07-19,false,False,Production,False,go1.17,3c6c8933f578a7fd140e24a603d6ec64c6b7a834,cockroachdb/cockroach,true
 v22.1.5,v22.1,2022-07-28,false,False,Production,False,go1.17,a30a663cbd9323d34d50f343dd038af64671e25f,cockroachdb/cockroach,true
+v21.2.14,v21.2,2022-08-01,false,False,Production,False,go1.16,8f4dc943d39780a07dff855151eb3ac217064bbe,cockroachdb/cockroach,false

--- a/_includes/releases/v21.2/v21.2.14.md
+++ b/_includes/releases/v21.2/v21.2.14.md
@@ -1,0 +1,87 @@
+## v21.2.14
+
+Release Date: August 1, 2022
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v21-2-14-security-updates">Security updates</h3>
+
+- Added access control checks to three [multi-region related built-in functions](../v21.2/functions-and-operators.html#multi-region-functions). [#83987][#83987]
+
+<h3 id="v21-2-14-sql-language-changes">SQL language changes</h3>
+
+- The error code reported when trying to use a system or virtual column in the [`STORING`](../v21.2/create-index.html#store-columns) clause of an index has been changed from `XXUUU (internal error)` to `0A000 (feature not supported)`. [#83649][#83649]
+- The error code reported when attempting to use a system column in an index as a key column has been changed from `XXUUU (internal error)` to `0A000 (feature not supported)`. [#83649][#83649]
+- [`AS OF SYSTEM TIME`](../v21.2/as-of-system-time.html) now takes the time zone into account when converting to UTC. For example: `2022-01-01 08:00:00-04:00` is treated the same as `2022-01-01 12:00:00` instead of `2022-01-01 08:00:00` [#84665][#84665]
+- Added additional logging for `COPY` statements to the [`SQL_EXEC` channel](../v21.2/logging.html#sql_exec) if the `sql.trace.log_statement_execute` cluster setting is set. [#84679][#84679]
+- An error message is now logged to the [`SQL_EXEC` channel](../v21.2/logging.html#sql_exec) when parsing fails. [#84679][#84679]
+
+<h3 id="v21-2-14-operational-changes">Operational changes</h3>
+
+- The application name that is part of a SQL session is no longer considered [`redactable`](../v21.2/configure-logs.html#redact-logs) information [#83558][#83558]
+- The [`cockroach debug zip`](../v21.2/cockroach-debug-zip.html) and [`cockroach debug merge-logs`](../v21.2/cockroach-debug-merge-logs.html) commands will now work with JSON formatted logs. [#83147][#83147]
+
+<h3 id="v21-2-14-db-console-changes">DB Console changes</h3>
+
+- Updated the message when there is no data on the selected time interval on the [**Statements**](../v21.2/ui-statements-page.html) and [**Transactions**](../v21.2/ui-transactions-page.html) pages. [#84624][#84624]
+
+<h3 id="v21-2-14-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug in transaction lifetime management where a lock could be held for a long period of time when adding a new column to a table (or altering a column type). This contention could make the [**Jobs**](../v21.2/ui-jobs-page.html) page non-responsive and job adoption slow. [#83475][#83475]
+- Fixed a bug that prevented [partial indexes](../v21.2/partial-indexes.html) from being used in some query plans. For example, a partial index with a predicate `WHERE a IS NOT NULL` was not previously used if `a` was a `NOT NULL` column. [#83240][#83240]
+- CockroachDB now treats `node unavailable` errors as retry-able [changefeed](../v21.2/change-data-capture-overview.html) errors. [#82876][#82876]
+- CockroachDB now ensures running [changefeeds](../v21.2/change-data-capture-overview.html) do not inhibit node shutdown. [#82876][#82876]
+- Index joins now consider functional dependencies from their input when determining equivalent columns instead of returning an internal error. [#83550][#83550]
+- Fixed a bug where using [`ADD COLUMN`](../v21.2/add-column.html) or [`DROP COLUMN`](../v21.2/drop-column.html) with the legacy schema changer could fail on tables with large rows due to exceeding the Raft command max size. [#83817][#83817]
+- Fixed a bug that may have caused a panic if a [Kafka](../v21.2/changefeed-sinks.html#kafka) server being written to by a [changefeed](../v21.2/change-data-capture-overview.html) failed at the wrong moment. [#83922][#83922]
+- The [`cockroach debug merge-logs`](../v21.2/cockroach-debug-merge-logs.html) command no longer returns an error when the log decoder attempts to parse older logs. [#83748][#83748]
+- A flush message sent during portal execution in the `pgwire` extended protocol no longer results in an error. [#83954][#83954]
+- Previously, [virtual computed columns](../v21.2/computed-columns.html) which were marked as `NOT NULL` could be added to new [secondary indexes](../v21.2/indexes.html). Now, attempts to add such columns to a secondary index will result in an error. Note that such invalid columns can still be added to tables. Work to resolve that bug is tracked in [#81675](https://github.com/cockroachdb/cockroach/issues/81675). [#83552][#83552]
+- Fixed a rare issue where the failure to apply a [Pebble](../v21.2/architecture/storage-layer.html#pebble) manifest change (typically due to block device failure or unavailability) could result in an incorrect [LSM](../v21.2/architecture/storage-layer.html#log-structured-merge-trees) state. Such a state would likely result in a panic soon after the failed application. This change alters the behavior of Pebble to panic immediately in the case of a failure to apply a change to the manifest. [#83734][#83734]
+- Moved connection OK log and metric to the same location after authentication completes for consistency. This resolves an inconsistency (see linked issue) in the [DB Console](../v21.2/ui-overview.html) where the log and metric did not match. [#84175][#84175]
+- Previously, CockroachDB would not normalize `timestamp/timestamptz - timestamp/timestamptz` like PostgreSQL does in some cases (depending on the query). This is now fixed. [#84002][#84002]
+- Fixed an internal error `node ... with MaxCost added to the memo` that could occur during planning when calculating the cardinality of an outer join when one of the inputs had 0 rows. [#84381][#84381]
+- Fixed a bug in transaction conflict resolution which could allow backups to wait on long-running transactions. [#83905][#83905]
+- Fixed a "fake" memory accounting leak that in rare cases could result in `memory budget exceeded` errors even if the actual RAM usage is within `--max-sql-memory` limit. [#84325][#84325]
+- Fixed the following [built-in functions](../v21.2/functions-and-operators.html) so that users can only run them if they have [`SELECT`](../v21.2/select-clause.html) privileges on the relevant tables: `crdb_internal.revalidate_unique_constraints_in_all_tables`, `crdb_internal.revalidate_unique_constraints_in_table`, and `crdb_internal.revalidate_unique_constraint`. [#84272][#84272]
+- Fixed a bug that could cause existing [secondary indexes](../v21.2/indexes.html) to be unexpectedly dropped after running an [`ALTER PRIMARY KEY`](../v21.2/alter-primary-key.html) statement, if the new [primary key](../v21.2/primary-key.html) column set is a subset of the old primary key column set. [#84578][#84578]
+- Fixed a bug that was introduced in release 21.2.0 that could cause increased memory usage when scanning a table with wide rows. [#84921][#84921]
+
+<h3 id="v21-2-14-contributors">Contributors</h3>
+
+This release includes 41 merged PRs by 26 authors.
+
+[#82876]: https://github.com/cockroachdb/cockroach/pull/82876
+[#83147]: https://github.com/cockroachdb/cockroach/pull/83147
+[#83240]: https://github.com/cockroachdb/cockroach/pull/83240
+[#83475]: https://github.com/cockroachdb/cockroach/pull/83475
+[#83550]: https://github.com/cockroachdb/cockroach/pull/83550
+[#83552]: https://github.com/cockroachdb/cockroach/pull/83552
+[#83558]: https://github.com/cockroachdb/cockroach/pull/83558
+[#83649]: https://github.com/cockroachdb/cockroach/pull/83649
+[#83734]: https://github.com/cockroachdb/cockroach/pull/83734
+[#83748]: https://github.com/cockroachdb/cockroach/pull/83748
+[#83817]: https://github.com/cockroachdb/cockroach/pull/83817
+[#83877]: https://github.com/cockroachdb/cockroach/pull/83877
+[#83905]: https://github.com/cockroachdb/cockroach/pull/83905
+[#83922]: https://github.com/cockroachdb/cockroach/pull/83922
+[#83954]: https://github.com/cockroachdb/cockroach/pull/83954
+[#83987]: https://github.com/cockroachdb/cockroach/pull/83987
+[#84002]: https://github.com/cockroachdb/cockroach/pull/84002
+[#84076]: https://github.com/cockroachdb/cockroach/pull/84076
+[#84096]: https://github.com/cockroachdb/cockroach/pull/84096
+[#84112]: https://github.com/cockroachdb/cockroach/pull/84112
+[#84175]: https://github.com/cockroachdb/cockroach/pull/84175
+[#84272]: https://github.com/cockroachdb/cockroach/pull/84272
+[#84325]: https://github.com/cockroachdb/cockroach/pull/84325
+[#84381]: https://github.com/cockroachdb/cockroach/pull/84381
+[#84578]: https://github.com/cockroachdb/cockroach/pull/84578
+[#84624]: https://github.com/cockroachdb/cockroach/pull/84624
+[#84665]: https://github.com/cockroachdb/cockroach/pull/84665
+[#84679]: https://github.com/cockroachdb/cockroach/pull/84679
+[#84848]: https://github.com/cockroachdb/cockroach/pull/84848
+[#84861]: https://github.com/cockroachdb/cockroach/pull/84861
+[#84864]: https://github.com/cockroachdb/cockroach/pull/84864
+[#84921]: https://github.com/cockroachdb/cockroach/pull/84921
+[2ea582b5c]: https://github.com/cockroachdb/cockroach/commit/2ea582b5c
+[6fec4f744]: https://github.com/cockroachdb/cockroach/commit/6fec4f744


### PR DESCRIPTION
Addresses: DOC-1901

- Release notes for v21.2.14

[v21.2.md](https://deploy-preview-14684--cockroachdb-docs.netlify.app/docs/releases/v21.2.html#v21-2-14)