### PR TITLE
DOC-436 auth-session reference

### DIFF
--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -1932,6 +1932,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach auth-session</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-auth-session.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach dump</code>",
                 "urls": [
                   "/${VERSION}/cockroach-dump.html"

--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -2541,6 +2541,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach auth-session</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-auth-session.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach dump</code>",
                 "urls": [
                   "/${VERSION}/cockroach-dump.html"

--- a/_includes/v21.1/sidebar-data-reference.json
+++ b/_includes/v21.1/sidebar-data-reference.json
@@ -1252,6 +1252,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach auth-session</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-auth-session.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach dump</code>",
                 "urls": [
                   "/${VERSION}/cockroach-dump.html"

--- a/_includes/v21.2/sidebar-data/reference.json
+++ b/_includes/v21.2/sidebar-data/reference.json
@@ -1440,6 +1440,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach auth-session</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-auth-session.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach demo</code>",
                 "urls": [
                   "/${VERSION}/cockroach-demo.html"

--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -1500,6 +1500,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach auth-session</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-auth-session.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach demo</code>",
                 "urls": [
                   "/${VERSION}/cockroach-demo.html"

--- a/v20.1/cockroach-auth-session.md
+++ b/v20.1/cockroach-auth-session.md
@@ -1,0 +1,210 @@
+---
+title: cockroach auth-session
+summary: To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the cockroach auth-session command.
+toc: true
+docs_area: reference.cli
+---
+
+To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the `cockroach auth-session` [command](cockroach-commands.html) with the appropriate subcommands and flags.
+
+## Subcommands
+
+Subcommand | Usage
+-----------|------
+`login` | Authenticate a user against a running cluster's HTTP interface, generating an HTTP authentication token (a "cookie") which can also be used by non-interactive HTTP-based database management tools. Must be used with a valid, existing user. May be used to generate a cookie for the `root` user.
+`logout` | Revokes all previously-issued HTTP authentication tokens for the given user.
+`list` | List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions.
+
+## Synopsis
+
+Log in to the HTTP interface, generating an HTTP authentication token for a given user:
+
+~~~ shell
+$ cockroach auth-session login {username} [flags]
+~~~
+
+Log out from the HTTP interface, revoking all active HTTP authentication tokens for a given user:
+
+~~~ shell
+$ cockroach auth-session logout {username} [flags]
+~~~
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+~~~ shell
+$ cockroach auth-session list [flags]
+~~~
+
+View help:
+
+~~~ shell
+$ cockroach auth-session --help
+~~~
+
+~~~ shell
+$ cockroach auth-session {subcommand} --help
+~~~
+
+## Flags
+
+All three `auth-session` subcommands accept the standard [SQL command-line flags](cockroach-start.html#flags).
+
+In addition, the `auth-session login` subcommand supports the following flags.
+
+Flag | Description
+-----|------------
+`--expire-after` | Duration of the newly-created HTTP authentication token, after which the token expires. Specify the duration in numeric values suffixed by one or more of `h`, `m`, and `s` to indicate hour, minute, and second duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).<br><br>**Default:** `1h0m0s` (1 hour)
+`--only-cookie` | Limits output to only the newly-created HTTP authentication token (the "cookie") in the response, appropriate for output to other commands. See the [example](#log-in-to-the-http-interface-with-limited-command-output).
+
+## Response
+
+The `cockroach auth-session` subcommands return the following fields.
+
+### `auth-session login`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`authentication cookie` | The cookie that may be used from the command line, or from other tools, to authenticate access to the HTTP interface for that user.
+
+### `auth-session logout`
+
+Field | Description
+------|------------
+`username` | The username of the user whose session was revoked.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`revoked` | The date and time of revocation for that user's authenticated session.
+
+### `auth-session list`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface established for that user.
+`created` | The date and time a session was created.
+`expired` | The date and time a session expired.
+`revoked` | The date and time of revocation for that user's authenticated session. If the session is still active, this will appear as `NULL`.
+`last used` | The date and time of the last access to the HTTP interface using this session token.
+
+## Required roles
+
+To run any of the `auth-session` subcommands, you must be a member of the [`admin` role](authorization.html#admin-role). The user being authenticated via `login` or `logout` does not require any special roles.
+
+## Considerations
+
+- The `login` subcommand allows users with the [`admin` role](authorization.html#admin-role) to create HTTP authentication tokens with an arbitrary duration. If operational policy requires stricter control of authentication sessions, you can:
+
+  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions.
+  - Revoke HTTP authentication tokens as needed with the `logout` subcommand. See the [example](#terminate-all-active-sessions-for-a-user).
+  - Set the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+- The `logout` subcommand logs out all sessions for the given user; you cannot target individual sessions for logout. If more granular control of sessions is desired, consider setting the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+## Examples
+
+### Log in to the HTTP interface
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with a custom expiry
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user and specifying a token expiry of 4 hours and 30 minutes:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --expire-after=4h30m
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with limited command output
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user, limiting command output to only the generated cookie:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --only-cookie
+~~~
+
+~~~
+session=CIGA6t2q0LrxChIQV8QCF3vuYSasR7h4LPSfmg==; Path=/; HttpOnly; Secure
+~~~
+
+This is useful if you intend to use the cookie with other command line tools. For example, you might output the generated cookie to a local file, and then pass that file to `curl` using its `--cookie` flag:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --certs-dir=certs --only-cookie > $HOME/.cockroachdb_api_key
+$ curl --cookie $HOME/.cockroachdb_api_key https://localhost:8080/_status/logfiles/local
+~~~
+
+Of course you can also provide the cookie directly:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --cookie 'session=CIGA8I7/irvxChIQDtZQsMtn3AqpgDko6bldSw==; Path=/; HttpOnly; Secure' https://localhost:8080/_status/logfiles/local
+~~~
+
+### Terminate all active sessions for a user
+
+Terminate all active sessions for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session logout web_user
+~~~
+
+~~~
+  username |     session ID     |          revoked
+-----------+--------------------+-----------------------------
+  web_user | 784445853689282561 | 2022-08-02 18:24:50.819614
+  web_user | 784447132063662081 | 2022-08-02 18:24:50.819614
+  web_user | 784449147579924481 | 2022-08-02 18:47:20.105254
+  web_user | 784449219848241153 | 2022-08-02 18:47:20.105254
+(4 rows)
+~~~
+
+Note that the output may include recently revoked sessions for this user as well.
+
+### List all sessions
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session list
+~~~
+
+~~~
+  username |     session ID     |          created           |          expires           |          revoked           |         last used
+-----------+--------------------+----------------------------+----------------------------+----------------------------+-----------------------------
+  root     | 784428093743988737 | 2022-08-02 16:47:36.342338 | 2022-08-02 17:47:36.341997 | NULL                       | 2022-08-02 16:47:36.342338
+  root     | 784428586862215169 | 2022-08-02 16:50:06.830294 | 2022-08-02 17:50:06.829974 | NULL                       | 2022-08-02 16:50:06.830294
+  web_user | 784447132063662081 | 2022-08-02 18:24:26.37664  | 2022-08-02 19:24:26.376299 | 2022-08-02 18:24:50.819614 | 2022-08-02 18:24:26.37664
+  web_user | 784449147579924481 | 2022-08-02 18:34:41.463345 | 2022-08-02 19:34:41.463006 | 2022-08-02 18:47:20.105254 | 2022-08-02 18:34:41.463345
+~~~
+
+A value of `NULL` in the `revoked` column indicates that the session is still active.
+
+## See also
+
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [Admin UI Overview](admin-ui-overview.html)

--- a/v20.1/cockroach-commands.md
+++ b/v20.1/cockroach-commands.md
@@ -21,6 +21,7 @@ Command | Usage
 [`cockroach sql`](cockroach-sql.html) | Use the built-in SQL client.
 [`cockroach sqlfmt`](cockroach-sqlfmt.html) | Reformat SQL queries for enhanced clarity.
 [`cockroach node`](cockroach-node.html) | List node IDs, show their status, decommission nodes for removal, or recommission nodes.
+[`cockroach auth-session`](cockroach-auth-session.html) | Create and manage web sessions and authentication tokens to the HTTP interface from the command line.
 [`cockroach dump`](cockroach-dump.html) | Back up a table by outputting the SQL statements required to recreate the table and all its rows.
 [`cockroach demo`](cockroach-demo.html) | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach gen`](cockroach-gen.html) | Generate manpages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.

--- a/v20.2/cockroach-auth-session.md
+++ b/v20.2/cockroach-auth-session.md
@@ -1,0 +1,210 @@
+---
+title: cockroach auth-session
+summary: To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the cockroach auth-session command.
+toc: true
+docs_area: reference.cli
+---
+
+To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the `cockroach auth-session` [command](cockroach-commands.html) with the appropriate subcommands and flags.
+
+## Subcommands
+
+Subcommand | Usage
+-----------|------
+`login` | Authenticate a user against a running cluster's HTTP interface, generating an HTTP authentication token (a "cookie") which can also be used by non-interactive HTTP-based database management tools. Must be used with a valid, existing user. May be used to generate a cookie for the `root` user.
+`logout` | Revokes all previously-issued HTTP authentication tokens for the given user.
+`list` | List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions.
+
+## Synopsis
+
+Log in to the HTTP interface, generating an HTTP authentication token for a given user:
+
+~~~ shell
+$ cockroach auth-session login {username} [flags]
+~~~
+
+Log out from the HTTP interface, revoking all active HTTP authentication tokens for a given user:
+
+~~~ shell
+$ cockroach auth-session logout {username} [flags]
+~~~
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+~~~ shell
+$ cockroach auth-session list [flags]
+~~~
+
+View help:
+
+~~~ shell
+$ cockroach auth-session --help
+~~~
+
+~~~ shell
+$ cockroach auth-session {subcommand} --help
+~~~
+
+## Flags
+
+All three `auth-session` subcommands accept the standard [SQL command-line flags](cockroach-start.html#flags).
+
+In addition, the `auth-session login` subcommand supports the following flags.
+
+Flag | Description
+-----|------------
+`--expire-after` | Duration of the newly-created HTTP authentication token, after which the token expires. Specify the duration in numeric values suffixed by one or more of `h`, `m`, and `s` to indicate hour, minute, and second duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).<br><br>**Default:** `1h0m0s` (1 hour)
+`--only-cookie` | Limits output to only the newly-created HTTP authentication token (the "cookie") in the response, appropriate for output to other commands. See the [example](#log-in-to-the-http-interface-with-limited-command-output).
+
+## Response
+
+The `cockroach auth-session` subcommands return the following fields.
+
+### `auth-session login`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`authentication cookie` | The cookie that may be used from the command line, or from other tools, to authenticate access to the HTTP interface for that user.
+
+### `auth-session logout`
+
+Field | Description
+------|------------
+`username` | The username of the user whose session was revoked.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`revoked` | The date and time of revocation for that user's authenticated session.
+
+### `auth-session list`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface established for that user.
+`created` | The date and time a session was created.
+`expired` | The date and time a session expired.
+`revoked` | The date and time of revocation for that user's authenticated session. If the session is still active, this will appear as `NULL`.
+`last used` | The date and time of the last access to the HTTP interface using this session token.
+
+## Required roles
+
+To run any of the `auth-session` subcommands, you must be a member of the [`admin` role](authorization.html#admin-role). The user being authenticated via `login` or `logout` does not require any special roles.
+
+## Considerations
+
+- The `login` subcommand allows users with the [`admin` role](authorization.html#admin-role) to create HTTP authentication tokens with an arbitrary duration. If operational policy requires stricter control of authentication sessions, you can:
+
+  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions.
+  - Revoke HTTP authentication tokens as needed with the `logout` subcommand. See the [example](#terminate-all-active-sessions-for-a-user).
+  - Set the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+- The `logout` subcommand logs out all sessions for the given user; you cannot target individual sessions for logout. If more granular control of sessions is desired, consider setting the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+## Examples
+
+### Log in to the HTTP interface
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with a custom expiry
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user and specifying a token expiry of 4 hours and 30 minutes:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --expire-after=4h30m
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with limited command output
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user, limiting command output to only the generated cookie:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --only-cookie
+~~~
+
+~~~
+session=CIGA6t2q0LrxChIQV8QCF3vuYSasR7h4LPSfmg==; Path=/; HttpOnly; Secure
+~~~
+
+This is useful if you intend to use the cookie with other command line tools. For example, you might output the generated cookie to a local file, and then pass that file to `curl` using its `--cookie` flag:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --certs-dir=certs --only-cookie > $HOME/.cockroachdb_api_key
+$ curl --cookie $HOME/.cockroachdb_api_key https://localhost:8080/_status/logfiles/local
+~~~
+
+Of course you can also provide the cookie directly:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --cookie 'session=CIGA8I7/irvxChIQDtZQsMtn3AqpgDko6bldSw==; Path=/; HttpOnly; Secure' https://localhost:8080/_status/logfiles/local
+~~~
+
+### Terminate all active sessions for a user
+
+Terminate all active sessions for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session logout web_user
+~~~
+
+~~~
+  username |     session ID     |          revoked
+-----------+--------------------+-----------------------------
+  web_user | 784445853689282561 | 2022-08-02 18:24:50.819614
+  web_user | 784447132063662081 | 2022-08-02 18:24:50.819614
+  web_user | 784449147579924481 | 2022-08-02 18:47:20.105254
+  web_user | 784449219848241153 | 2022-08-02 18:47:20.105254
+(4 rows)
+~~~
+
+Note that the output may include recently revoked sessions for this user as well.
+
+### List all sessions
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session list
+~~~
+
+~~~
+  username |     session ID     |          created           |          expires           |          revoked           |         last used
+-----------+--------------------+----------------------------+----------------------------+----------------------------+-----------------------------
+  root     | 784428093743988737 | 2022-08-02 16:47:36.342338 | 2022-08-02 17:47:36.341997 | NULL                       | 2022-08-02 16:47:36.342338
+  root     | 784428586862215169 | 2022-08-02 16:50:06.830294 | 2022-08-02 17:50:06.829974 | NULL                       | 2022-08-02 16:50:06.830294
+  web_user | 784447132063662081 | 2022-08-02 18:24:26.37664  | 2022-08-02 19:24:26.376299 | 2022-08-02 18:24:50.819614 | 2022-08-02 18:24:26.37664
+  web_user | 784449147579924481 | 2022-08-02 18:34:41.463345 | 2022-08-02 19:34:41.463006 | 2022-08-02 18:47:20.105254 | 2022-08-02 18:34:41.463345
+~~~
+
+A value of `NULL` in the `revoked` column indicates that the session is still active.
+
+## See also
+
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [DB Console Overview](ui-overview.html)

--- a/v20.2/cockroach-commands.md
+++ b/v20.2/cockroach-commands.md
@@ -21,6 +21,7 @@ Command | Usage
 [`cockroach sql`](cockroach-sql.html) | Use the built-in SQL client.
 [`cockroach sqlfmt`](cockroach-sqlfmt.html) | Reformat SQL queries for enhanced clarity.
 [`cockroach node`](cockroach-node.html) | List node IDs, show their status, decommission nodes for removal, or recommission nodes.
+[`cockroach auth-session`](cockroach-auth-session.html) | Create and manage web sessions and authentication tokens to the HTTP interface from the command line.
 [`cockroach dump`](cockroach-dump.html) | **Deprecated.** Use one of the following instead:<ul><li>To back up your data, take a [full backup](take-full-and-incremental-backups.html).</li><li>To export your data in plaintext format, use [`EXPORT`](export.html).</li><li>To view table schema in plaintext, use [`SHOW CREATE TABLE`](show-create.html).</li></ul>
 [`cockroach demo`](cockroach-demo.html) | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach gen`](cockroach-gen.html) | Generate manpages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.

--- a/v21.1/cockroach-auth-session.md
+++ b/v21.1/cockroach-auth-session.md
@@ -1,0 +1,210 @@
+---
+title: cockroach auth-session
+summary: To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the cockroach auth-session command.
+toc: true
+docs_area: reference.cli
+---
+
+To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the `cockroach auth-session` [command](cockroach-commands.html) with the appropriate subcommands and flags.
+
+## Subcommands
+
+Subcommand | Usage
+-----------|------
+`login` | Authenticate a user against a running cluster's HTTP interface, generating an HTTP authentication token (a "cookie") which can also be used by non-interactive HTTP-based database management tools. Must be used with a valid, existing user. May be used to generate a cookie for the `root` user.
+`logout` | Revokes all previously-issued HTTP authentication tokens for the given user.
+`list` | List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions.
+
+## Synopsis
+
+Log in to the HTTP interface, generating an HTTP authentication token for a given user:
+
+~~~ shell
+$ cockroach auth-session login {username} [flags]
+~~~
+
+Log out from the HTTP interface, revoking all active HTTP authentication tokens for a given user:
+
+~~~ shell
+$ cockroach auth-session logout {username} [flags]
+~~~
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+~~~ shell
+$ cockroach auth-session list [flags]
+~~~
+
+View help:
+
+~~~ shell
+$ cockroach auth-session --help
+~~~
+
+~~~ shell
+$ cockroach auth-session {subcommand} --help
+~~~
+
+## Flags
+
+All three `auth-session` subcommands accept the standard [SQL command-line flags](cockroach-start.html#flags).
+
+In addition, the `auth-session login` subcommand supports the following flags.
+
+Flag | Description
+-----|------------
+`--expire-after` | Duration of the newly-created HTTP authentication token, after which the token expires. Specify the duration in numeric values suffixed by one or more of `h`, `m`, and `s` to indicate hour, minute, and second duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).<br><br>**Default:** `1h0m0s` (1 hour)
+`--only-cookie` | Limits output to only the newly-created HTTP authentication token (the "cookie") in the response, appropriate for output to other commands. See the [example](#log-in-to-the-http-interface-with-limited-command-output).
+
+## Response
+
+The `cockroach auth-session` subcommands return the following fields.
+
+### `auth-session login`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`authentication cookie` | The cookie that may be used from the command line, or from other tools, to authenticate access to the HTTP interface for that user.
+
+### `auth-session logout`
+
+Field | Description
+------|------------
+`username` | The username of the user whose session was revoked.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`revoked` | The date and time of revocation for that user's authenticated session.
+
+### `auth-session list`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface established for that user.
+`created` | The date and time a session was created.
+`expired` | The date and time a session expired.
+`revoked` | The date and time of revocation for that user's authenticated session. If the session is still active, this will appear as `NULL`.
+`last used` | The date and time of the last access to the HTTP interface using this session token.
+
+## Required roles
+
+To run any of the `auth-session` subcommands, you must be a member of the [`admin` role](authorization.html#admin-role). The user being authenticated via `login` or `logout` does not require any special roles.
+
+## Considerations
+
+- The `login` subcommand allows users with the [`admin` role](authorization.html#admin-role) to create HTTP authentication tokens with an arbitrary duration. If operational policy requires stricter control of authentication sessions, you can:
+
+  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions.
+  - Revoke HTTP authentication tokens as needed with the `logout` subcommand. See the [example](#terminate-all-active-sessions-for-a-user).
+  - Set the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+- The `logout` subcommand logs out all sessions for the given user; you cannot target individual sessions for logout. If more granular control of sessions is desired, consider setting the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+## Examples
+
+### Log in to the HTTP interface
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with a custom expiry
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user and specifying a token expiry of 4 hours and 30 minutes:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --expire-after=4h30m
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with limited command output
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user, limiting command output to only the generated cookie:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --only-cookie
+~~~
+
+~~~
+session=CIGA6t2q0LrxChIQV8QCF3vuYSasR7h4LPSfmg==; Path=/; HttpOnly; Secure
+~~~
+
+This is useful if you intend to use the cookie with other command line tools. For example, you might output the generated cookie to a local file, and then pass that file to `curl` using its `--cookie` flag:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --certs-dir=certs --only-cookie > $HOME/.cockroachdb_api_key
+$ curl --cookie $HOME/.cockroachdb_api_key https://localhost:8080/_status/logfiles/local
+~~~
+
+Of course you can also provide the cookie directly:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --cookie 'session=CIGA8I7/irvxChIQDtZQsMtn3AqpgDko6bldSw==; Path=/; HttpOnly; Secure' https://localhost:8080/_status/logfiles/local
+~~~
+
+### Terminate all active sessions for a user
+
+Terminate all active sessions for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session logout web_user
+~~~
+
+~~~
+  username |     session ID     |          revoked
+-----------+--------------------+-----------------------------
+  web_user | 784445853689282561 | 2022-08-02 18:24:50.819614
+  web_user | 784447132063662081 | 2022-08-02 18:24:50.819614
+  web_user | 784449147579924481 | 2022-08-02 18:47:20.105254
+  web_user | 784449219848241153 | 2022-08-02 18:47:20.105254
+(4 rows)
+~~~
+
+Note that the output may include recently revoked sessions for this user as well.
+
+### List all sessions
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session list
+~~~
+
+~~~
+  username |     session ID     |          created           |          expires           |          revoked           |         last used
+-----------+--------------------+----------------------------+----------------------------+----------------------------+-----------------------------
+  root     | 784428093743988737 | 2022-08-02 16:47:36.342338 | 2022-08-02 17:47:36.341997 | NULL                       | 2022-08-02 16:47:36.342338
+  root     | 784428586862215169 | 2022-08-02 16:50:06.830294 | 2022-08-02 17:50:06.829974 | NULL                       | 2022-08-02 16:50:06.830294
+  web_user | 784447132063662081 | 2022-08-02 18:24:26.37664  | 2022-08-02 19:24:26.376299 | 2022-08-02 18:24:50.819614 | 2022-08-02 18:24:26.37664
+  web_user | 784449147579924481 | 2022-08-02 18:34:41.463345 | 2022-08-02 19:34:41.463006 | 2022-08-02 18:47:20.105254 | 2022-08-02 18:34:41.463345
+~~~
+
+A value of `NULL` in the `revoked` column indicates that the session is still active.
+
+## See also
+
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [DB Console Overview](ui-overview.html)

--- a/v21.1/cockroach-commands.md
+++ b/v21.1/cockroach-commands.md
@@ -21,6 +21,7 @@ Command | Usage
 [`cockroach sql`](cockroach-sql.html) | Use the built-in SQL client.
 [`cockroach sqlfmt`](cockroach-sqlfmt.html) | Reformat SQL queries for enhanced clarity.
 [`cockroach node`](cockroach-node.html) | List node IDs, show their status, decommission nodes for removal, or recommission nodes.
+[`cockroach auth-session`](cockroach-auth-session.html) | Create and manage web sessions and authentication tokens to the HTTP interface from the command line.
 [`cockroach dump`](cockroach-dump.html) | **Deprecated.** Use one of the following instead:<ul><li>To back up your data, take a [full backup](take-full-and-incremental-backups.html).</li><li>To export your data in plaintext format, use [`EXPORT`](export.html).</li><li>To view table schema in plaintext, use [`SHOW CREATE TABLE`](show-create.html).</li></ul>
 [`cockroach demo`](cockroach-demo.html) | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach gen`](cockroach-gen.html) | Generate manpages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.

--- a/v21.2/cockroach-auth-session.md
+++ b/v21.2/cockroach-auth-session.md
@@ -1,0 +1,210 @@
+---
+title: cockroach auth-session
+summary: To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the cockroach auth-session command.
+toc: true
+docs_area: reference.cli
+---
+
+To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the `cockroach auth-session` [command](cockroach-commands.html) with the appropriate subcommands and flags.
+
+## Subcommands
+
+Subcommand | Usage
+-----------|------
+`login` | Authenticate a user against a running cluster's HTTP interface, generating an HTTP authentication token (a "cookie") which can also be used by non-interactive HTTP-based database management tools. Must be used with a valid, existing user. May be used to generate a cookie for the `root` user.
+`logout` | Revokes all previously-issued HTTP authentication tokens for the given user.
+`list` | List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions.
+
+## Synopsis
+
+Log in to the HTTP interface, generating an HTTP authentication token for a given user:
+
+~~~ shell
+$ cockroach auth-session login {username} [flags]
+~~~
+
+Log out from the HTTP interface, revoking all active HTTP authentication tokens for a given user:
+
+~~~ shell
+$ cockroach auth-session logout {username} [flags]
+~~~
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+~~~ shell
+$ cockroach auth-session list [flags]
+~~~
+
+View help:
+
+~~~ shell
+$ cockroach auth-session --help
+~~~
+
+~~~ shell
+$ cockroach auth-session {subcommand} --help
+~~~
+
+## Flags
+
+All three `auth-session` subcommands accept the standard [SQL command-line flags](cockroach-start.html#flags).
+
+In addition, the `auth-session login` subcommand supports the following flags.
+
+Flag | Description
+-----|------------
+`--expire-after` | Duration of the newly-created HTTP authentication token, after which the token expires. Specify the duration in numeric values suffixed by one or more of `h`, `m`, and `s` to indicate hour, minute, and second duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).<br><br>**Default:** `1h0m0s` (1 hour)
+`--only-cookie` | Limits output to only the newly-created HTTP authentication token (the "cookie") in the response, appropriate for output to other commands. See the [example](#log-in-to-the-http-interface-with-limited-command-output).
+
+## Response
+
+The `cockroach auth-session` subcommands return the following fields.
+
+### `auth-session login`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`authentication cookie` | The cookie that may be used from the command line, or from other tools, to authenticate access to the HTTP interface for that user.
+
+### `auth-session logout`
+
+Field | Description
+------|------------
+`username` | The username of the user whose session was revoked.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`revoked` | The date and time of revocation for that user's authenticated session.
+
+### `auth-session list`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface established for that user.
+`created` | The date and time a session was created.
+`expired` | The date and time a session expired.
+`revoked` | The date and time of revocation for that user's authenticated session. If the session is still active, this will appear as `NULL`.
+`last used` | The date and time of the last access to the HTTP interface using this session token.
+
+## Required roles
+
+To run any of the `auth-session` subcommands, you must be a member of the [`admin` role](security-reference/authorization.html#admin-role). The user being authenticated via `login` or `logout` does not require any special roles.
+
+## Considerations
+
+- The `login` subcommand allows users with the [`admin` role](security-reference/authorization.html#admin-role) to create HTTP authentication tokens with an arbitrary duration. If operational policy requires stricter control of authentication sessions, you can:
+
+  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions.
+  - Revoke HTTP authentication tokens as needed with the `logout` subcommand. See the [example](#terminate-all-active-sessions-for-a-user).
+  - Set the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+- The `logout` subcommand logs out all sessions for the given user; you cannot target individual sessions for logout. If more granular control of sessions is desired, consider setting the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+## Examples
+
+### Log in to the HTTP interface
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with a custom expiry
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user and specifying a token expiry of 4 hours and 30 minutes:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --expire-after=4h30m
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with limited command output
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user, limiting command output to only the generated cookie:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --only-cookie
+~~~
+
+~~~
+session=CIGA6t2q0LrxChIQV8QCF3vuYSasR7h4LPSfmg==; Path=/; HttpOnly; Secure
+~~~
+
+This is useful if you intend to use the cookie with other command line tools. For example, you might output the generated cookie to a local file, and then pass that file to `curl` using its `--cookie` flag:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --certs-dir=certs --only-cookie > $HOME/.cockroachdb_api_key
+$ curl --cookie $HOME/.cockroachdb_api_key https://localhost:8080/_status/logfiles/local
+~~~
+
+Of course you can also provide the cookie directly:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --cookie 'session=CIGA8I7/irvxChIQDtZQsMtn3AqpgDko6bldSw==; Path=/; HttpOnly; Secure' https://localhost:8080/_status/logfiles/local
+~~~
+
+### Terminate all active sessions for a user
+
+Terminate all active sessions for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session logout web_user
+~~~
+
+~~~
+  username |     session ID     |          revoked
+-----------+--------------------+-----------------------------
+  web_user | 784445853689282561 | 2022-08-02 18:24:50.819614
+  web_user | 784447132063662081 | 2022-08-02 18:24:50.819614
+  web_user | 784449147579924481 | 2022-08-02 18:47:20.105254
+  web_user | 784449219848241153 | 2022-08-02 18:47:20.105254
+(4 rows)
+~~~
+
+Note that the output may include recently revoked sessions for this user as well.
+
+### List all sessions
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session list
+~~~
+
+~~~
+  username |     session ID     |          created           |          expires           |          revoked           |         last used
+-----------+--------------------+----------------------------+----------------------------+----------------------------+-----------------------------
+  root     | 784428093743988737 | 2022-08-02 16:47:36.342338 | 2022-08-02 17:47:36.341997 | NULL                       | 2022-08-02 16:47:36.342338
+  root     | 784428586862215169 | 2022-08-02 16:50:06.830294 | 2022-08-02 17:50:06.829974 | NULL                       | 2022-08-02 16:50:06.830294
+  web_user | 784447132063662081 | 2022-08-02 18:24:26.37664  | 2022-08-02 19:24:26.376299 | 2022-08-02 18:24:50.819614 | 2022-08-02 18:24:26.37664
+  web_user | 784449147579924481 | 2022-08-02 18:34:41.463345 | 2022-08-02 19:34:41.463006 | 2022-08-02 18:47:20.105254 | 2022-08-02 18:34:41.463345
+~~~
+
+A value of `NULL` in the `revoked` column indicates that the session is still active.
+
+## See also
+
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [DB Console Overview](ui-overview.html)

--- a/v21.2/cockroach-commands.md
+++ b/v21.2/cockroach-commands.md
@@ -22,6 +22,7 @@ Command | Usage
 [`cockroach sqlfmt`](cockroach-sqlfmt.html) | Reformat SQL queries for enhanced clarity.
 [`cockroach node`](cockroach-node.html) | List node IDs, show their status, decommission nodes for removal, or recommission nodes.
 [`cockroach demo`](cockroach-demo.html) | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
+[`cockroach auth-session`](cockroach-auth-session.html) | Create and manage web sessions and authentication tokens to the HTTP interface from the command line.
 [`cockroach gen`](cockroach-gen.html) | Generate manpages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.
 [`cockroach version`](cockroach-version.html) | Output CockroachDB version details.
 [`cockroach debug ballast`](cockroach-debug-ballast.html) | Create a large, unused file in a node's storage directory that you can delete if the node runs out of disk space.

--- a/v22.1/cockroach-auth-session.md
+++ b/v22.1/cockroach-auth-session.md
@@ -1,0 +1,210 @@
+---
+title: cockroach auth-session
+summary: To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the cockroach auth-session command.
+toc: true
+docs_area: reference.cli
+---
+
+To create and manage web sessions and authentication tokens to the HTTP interface from the command line, use the `cockroach auth-session` [command](cockroach-commands.html) with the appropriate subcommands and flags.
+
+## Subcommands
+
+Subcommand | Usage
+-----------|------
+`login` | Authenticate a user against a running cluster's HTTP interface, generating an HTTP authentication token (a "cookie") which can also be used by non-interactive HTTP-based database management tools. Must be used with a valid, existing user. May be used to generate a cookie for the `root` user.
+`logout` | Revokes all previously-issued HTTP authentication tokens for the given user.
+`list` | List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions.
+
+## Synopsis
+
+Log in to the HTTP interface, generating an HTTP authentication token for a given user:
+
+~~~ shell
+$ cockroach auth-session login {username} [flags]
+~~~
+
+Log out from the HTTP interface, revoking all active HTTP authentication tokens for a given user:
+
+~~~ shell
+$ cockroach auth-session logout {username} [flags]
+~~~
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+~~~ shell
+$ cockroach auth-session list [flags]
+~~~
+
+View help:
+
+~~~ shell
+$ cockroach auth-session --help
+~~~
+
+~~~ shell
+$ cockroach auth-session {subcommand} --help
+~~~
+
+## Flags
+
+All three `auth-session` subcommands accept the standard [SQL command-line flags](cockroach-start.html#flags).
+
+In addition, the `auth-session login` subcommand supports the following flags.
+
+Flag | Description
+-----|------------
+`--expire-after` | Duration of the newly-created HTTP authentication token, after which the token expires. Specify the duration in numeric values suffixed by one or more of `h`, `m`, and `s` to indicate hour, minute, and second duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).<br><br>**Default:** `1h0m0s` (1 hour)
+`--only-cookie` | Limits output to only the newly-created HTTP authentication token (the "cookie") in the response, appropriate for output to other commands. See the [example](#log-in-to-the-http-interface-with-limited-command-output).
+
+## Response
+
+The `cockroach auth-session` subcommands return the following fields.
+
+### `auth-session login`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`authentication cookie` | The cookie that may be used from the command line, or from other tools, to authenticate access to the HTTP interface for that user.
+
+### `auth-session logout`
+
+Field | Description
+------|------------
+`username` | The username of the user whose session was revoked.
+`session ID` | The session ID to the HTTP interface previously established for that user.
+`revoked` | The date and time of revocation for that user's authenticated session.
+
+### `auth-session list`
+
+Field | Description
+------|------------
+`username` | The username of the user authenticated.
+`session ID` | The session ID to the HTTP interface established for that user.
+`created` | The date and time a session was created.
+`expired` | The date and time a session expired.
+`revoked` | The date and time of revocation for that user's authenticated session. If the session is still active, this will appear as `NULL`.
+`last used` | The date and time of the last access to the HTTP interface using this session token.
+
+## Required roles
+
+To run any of the `auth-session` subcommands, you must be a member of the [`admin` role](security-reference/authorization.html#admin-role). The user being authenticated via `login` or `logout` does not require any special roles.
+
+## Considerations
+
+- The `login` subcommand allows users with the [`admin` role](security-reference/authorization.html#admin-role) to create HTTP authentication tokens with an arbitrary duration. If operational policy requires stricter control of authentication sessions, you can:
+
+  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions.
+  - Revoke HTTP authentication tokens as needed with the `logout` subcommand. See the [example](#terminate-all-active-sessions-for-a-user).
+  - Set the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+- The `logout` subcommand logs out all sessions for the given user; you cannot target individual sessions for logout. If more granular control of sessions is desired, consider setting the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
+
+## Examples
+
+### Log in to the HTTP interface
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with a custom expiry
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user and specifying a token expiry of 4 hours and 30 minutes:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --expire-after=4h30m
+~~~
+
+~~~
+  username |     session ID     |                       authentication cookie
+-----------+--------------------+---------------------------------------------------------------------
+  web_user | 784445853689282561 | session=CIGAtrWQq7rxChIQTXxYNNQxAYjyLAjHWxgUMQ==; Path=/; HttpOnly; Secure
+(1 row)
+~~~
+
+### Log in to the HTTP interface with limited command output
+
+Log in to the HTTP interface, by generating a new HTTP authentication token for the `web_user` user, limiting command output to only the generated cookie:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --only-cookie
+~~~
+
+~~~
+session=CIGA6t2q0LrxChIQV8QCF3vuYSasR7h4LPSfmg==; Path=/; HttpOnly; Secure
+~~~
+
+This is useful if you intend to use the cookie with other command line tools. For example, you might output the generated cookie to a local file, and then pass that file to `curl` using its `--cookie` flag:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session login web_user --certs-dir=certs --only-cookie > $HOME/.cockroachdb_api_key
+$ curl --cookie $HOME/.cockroachdb_api_key https://localhost:8080/_status/logfiles/local
+~~~
+
+Of course you can also provide the cookie directly:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --cookie 'session=CIGA8I7/irvxChIQDtZQsMtn3AqpgDko6bldSw==; Path=/; HttpOnly; Secure' https://localhost:8080/_status/logfiles/local
+~~~
+
+### Terminate all active sessions for a user
+
+Terminate all active sessions for the `web_user` user:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session logout web_user
+~~~
+
+~~~
+  username |     session ID     |          revoked
+-----------+--------------------+-----------------------------
+  web_user | 784445853689282561 | 2022-08-02 18:24:50.819614
+  web_user | 784447132063662081 | 2022-08-02 18:24:50.819614
+  web_user | 784449147579924481 | 2022-08-02 18:47:20.105254
+  web_user | 784449219848241153 | 2022-08-02 18:47:20.105254
+(4 rows)
+~~~
+
+Note that the output may include recently revoked sessions for this user as well.
+
+### List all sessions
+
+List all authenticated sessions to the HTTP interface, including currently active and recently expired sessions:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach auth-session list
+~~~
+
+~~~
+  username |     session ID     |          created           |          expires           |          revoked           |         last used
+-----------+--------------------+----------------------------+----------------------------+----------------------------+-----------------------------
+  root     | 784428093743988737 | 2022-08-02 16:47:36.342338 | 2022-08-02 17:47:36.341997 | NULL                       | 2022-08-02 16:47:36.342338
+  root     | 784428586862215169 | 2022-08-02 16:50:06.830294 | 2022-08-02 17:50:06.829974 | NULL                       | 2022-08-02 16:50:06.830294
+  web_user | 784447132063662081 | 2022-08-02 18:24:26.37664  | 2022-08-02 19:24:26.376299 | 2022-08-02 18:24:50.819614 | 2022-08-02 18:24:26.37664
+  web_user | 784449147579924481 | 2022-08-02 18:34:41.463345 | 2022-08-02 19:34:41.463006 | 2022-08-02 18:47:20.105254 | 2022-08-02 18:34:41.463345
+~~~
+
+A value of `NULL` in the `revoked` column indicates that the session is still active.
+
+## See also
+
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [DB Console Overview](ui-overview.html)

--- a/v22.1/cockroach-commands.md
+++ b/v22.1/cockroach-commands.md
@@ -21,6 +21,7 @@ Command | Usage
 [`cockroach sqlfmt`](cockroach-sqlfmt.html) | Reformat SQL queries for enhanced clarity.
 [`cockroach node`](cockroach-node.html) | List node IDs, show their status, decommission nodes for removal, or recommission nodes.
 [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) | Upload a file to the `externalIODir` on a node's local file system.
+[`cockroach auth-session`](cockroach-auth-session.html) | Create and manage web sessions and authentication tokens to the HTTP interface from the command line.
 [`cockroach demo`](cockroach-demo.html) | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach debug ballast`](cockroach-debug-ballast.html) | Create a large, unused file in a node's storage directory that you can delete if the node runs out of disk space.
 [`cockroach debug encryption-active-key`](cockroach-debug-encryption-active-key.html) | View the encryption algorithm and store key.


### PR DESCRIPTION
Addresses: DOC-436

- Adds reference documentation for the `cockroach auth-session` command, incl. its three subcommands `login`, `logout`, and `list`, as well as command-specific flags `--expire-after` and `--only-cookie`.
- Provides some general-use examples, including an example of using `--only-cookie` with `curl`.

Note:
- This effort goes back further than we usually go, given `auth-session` was introduced in `20.1` and has strong backwards compatibility (is client-change-only). Please verify that things like the `_status/logfiles/local` example I use is appropriate for, say, v20.1. Happy to replace with a version-appropriate example if needed (concerned about something like, say, api v1 vs. v2 for example). Alternately, if the example I use is not helpful, happy to replace with one of your choosing.
- For ease of reviewing: all versions are identical, save v20.1's `See also` referring to `Admin UI` instead of `DB Console`, and a slightly different `admin` role link structure for v21.2 and v22.1. If they are not: I messed up!

Question:
- `cockroach auth-session list --help` describes reporting only active HTTP sessions, but in practice I see terminated sessions also. I documented what I saw in practice, using the phrase "since the `cockroach` process began". Please correct if this an incorrect assumption. (EDIT: This has now been addressed in comments -- thanks!)

[v22.1/cockroach-auth-session.md](https://deploy-preview-14699--cockroachdb-docs.netlify.app/docs/stable/cockroach-auth-session.html) | [v21.2/cockroach-auth-session.md](https://deploy-preview-14699--cockroachdb-docs.netlify.app/docs/v21.2/cockroach-auth-session) | [v21.1/cockroach-auth-session.md](https://deploy-preview-14699--cockroachdb-docs.netlify.app/docs/v21.1/cockroach-auth-session) |  [v20.2/cockroach-auth-session.md](https://deploy-preview-14699--cockroachdb-docs.netlify.app/docs/v20.2/cockroach-auth-session) | [v20.1/cockroach-auth-session.md](https://deploy-preview-14699--cockroachdb-docs.netlify.app/docs/v20.1/cockroach-auth-session)