### PR TITLE
remove newline escape char on last line of example helm commands

### DIFF
--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -267,7 +267,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1
     ~~~
     </section>
 

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -516,7 +516,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1
     ~~~
 
 1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).

--- a/_includes/v21.1/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v21.1/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -176,7 +176,7 @@
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1
     ~~~
 
 1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).

--- a/_includes/v21.2/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v21.2/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -176,7 +176,7 @@
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1
     ~~~
 
 1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).

--- a/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
+++ b/_includes/v22.1/orchestration/kubernetes-upgrade-cluster-helm.md
@@ -180,7 +180,7 @@
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1
     ~~~
 
 1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).


### PR DESCRIPTION
Small PR to fix example bash commands where the last char is a `\`.