### PR TITLE
Correct alpha order of SQL statements

### DIFF
--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -157,15 +157,15 @@
                 ]
               },
               {
-                "title": "<code>ALTER BACKUP</code> (Enterprise)",
-                "urls": [
-                  "/${VERSION}/alter-backup.html"
-                ]
-              },
-              {
                 "title": "<code>ADD SUPER REGION</code> (Enterprise)",
                 "urls": [
                   "/${VERSION}/add-super-region.html"
+                ]
+              },
+              {
+                "title": "<code>ALTER BACKUP</code> (Enterprise)",
+                "urls": [
+                  "/${VERSION}/alter-backup.html"
                 ]
               },
               {


### PR DESCRIPTION
This is a quick fix to the alphabetical order of the SQL statements. Seems like there was some sort of clash between PRs as the `ADD SUPER REGION` docs were added that changed the ordering on `ALTER BACKUP`.