### PR TITLE
Update the splash screen for new versions of docs

### DIFF
--- a/releases/v22.1.md
+++ b/releases/v22.1.md
@@ -30,5 +30,5 @@ To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.majo
 {% endfor %}
 
 {% else %}
-Currently, no releases are available for this version.
+No releases are available for this version. See the [Releases](https://www.cockroachlabs.com/docs/releases/index.html) page for all available releases.
 {% endif %}

--- a/releases/v22.1.md
+++ b/releases/v22.1.md
@@ -12,6 +12,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
 
+{% if rel and vers %}
 {% assign today = "today" | date: "%Y-%m-%d" %}
 
 {% include releases/testing-release-notice.md major_version=vers %}
@@ -27,3 +28,7 @@ To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.majo
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.version }}.md release=r.version %}
 {% endfor %}
+
+{% else %}
+Currently, no releases are available for this version.
+{% endif %}


### PR DESCRIPTION
When a new version of the docs is cut, this page will be prepared
to handle users who may try to manually access this URL in between
when the docs are cut and the first alpha becomes available.