### PR TITLE
Removed duplicate Serverless listing from Style Guide

### DIFF
--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -673,7 +673,6 @@ When the time comes to document known limitations, keep in mind that you are doc
 All product names except CockroachDB should be written as Liquid variables unless part of front-matter, file names, or non-Markdown files. Use the following code in place of product names:
 
 - **CockroachDB Serverless** : `{{ site.data.products.serverless }}`
-- **CockroachDB Serverless** : `{{ site.data.products.serverless }}`
 - **CockroachDB Dedicated** : `{{ site.data.products.dedicated }}`
 - **CockroachDB Self-Hosted** : `{{ site.data.products.core }}`
 - **Enterprise** : `{{ site.data.products.enterprise }}`


### PR DESCRIPTION
Quick update to Style Guide to remove the duplicate reference to Serverless under product naming.