### PR TITLE
Remove references to private cluster setting

### DIFF
--- a/v21.2/architecture/replication-layer.md
+++ b/v21.2/architecture/replication-layer.md
@@ -151,7 +151,7 @@ When checking for leaseholder rebalancing opportunities, the current leaseholder
 
 ##### Controlling leaseholder rebalancing
 
-You can control leaseholder rebalancing through the `kv.allocator.load_based_lease_rebalancing.enabled` and `kv.allocator.lease_rebalancing_aggressiveness` [cluster settings](../cluster-settings.html). Note that depending on the needs of your deployment, you can exercise additional control over the location of leases and replicas by [configuring replication zones](../configure-replication-zones.html).
+You can control leaseholder rebalancing through the `kv.allocator.load_based_lease_rebalancing.enabled` [cluster setting](../cluster-settings.html). Note that depending on the needs of your deployment, you can exercise additional control over the location of leases and replicas by [configuring replication zones](../configure-replication-zones.html).
 
 ### Membership changes: rebalance/repair
 

--- a/v22.1/architecture/replication-layer.md
+++ b/v22.1/architecture/replication-layer.md
@@ -191,7 +191,7 @@ When checking for leaseholder rebalancing opportunities, the current leaseholder
 
 ##### Controlling leaseholder rebalancing
 
-You can control leaseholder rebalancing through the `kv.allocator.load_based_lease_rebalancing.enabled` and `kv.allocator.lease_rebalancing_aggressiveness` [cluster settings](../cluster-settings.html). Note that depending on the needs of your deployment, you can exercise additional control over the location of leases and replicas by [configuring replication zones](../configure-replication-zones.html).
+You can control leaseholder rebalancing through the `kv.allocator.load_based_lease_rebalancing.enabled` [cluster setting](../cluster-settings.html). Note that depending on the needs of your deployment, you can exercise additional control over the location of leases and replicas by [configuring replication zones](../configure-replication-zones.html).
 
 ### Membership changes: rebalance/repair
 


### PR DESCRIPTION
The referred-to setting no longer appears on the generated 'Cluster Settings' page.