### PR TITLE
Developer vs sql admin clarification

### DIFF
--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -36,7 +36,7 @@ Every {{ site.data.products.db }} user is either a Developer or a Console Admin 
 
 ### Developer
 
-A Developer is a limited-access role. A Developer cannot invite Team Members to the Console or create new SQL users. Note that Developers can still create [SQL Users](#sql-users) with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role) on a cluster.
+A Developer is a limited-access role. A Developer cannot invite Team Members to the Console or create new SQL users. Note that Developers can still create [SQL Users](#sql-users) with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role) on a cluster and therefore privileges for all resources across the cluster.
 
 To access a cluster, you need to ask a Console Admin for the username and password of a SQL user. To find out who your Console Admin is, check the **Access** page.
 

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -36,7 +36,7 @@ Every {{ site.data.products.db }} user is either a Developer or a Console Admin 
 
 ### Developer
 
-A Developer is a limited-access role. A Developer cannot invite Team Members to the Console or create new SQL users.
+A Developer is a limited-access role. A Developer cannot invite Team Members to the Console or create new SQL users. Note that Developers can still create [SQL Users](#sql-users) with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role) on a cluster.
 
 To access a cluster, you need to ask a Console Admin for the username and password of a SQL user. To find out who your Console Admin is, check the **Access** page.
 

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -35,7 +35,7 @@ Learn more about [managing SQL users' privileges](../{{site.versions["stable"]}}
 Every {{ site.data.products.db }} user is either a Developer or a Console Admin for the organization. 
 
 {{site.data.alerts.callout_danger}}
-Both Console Admins and Developers have access to all the information on the **SQL Activity** and **Databases** pages in the {{ site.data.products.db }} Console because they can create SQL users with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role).
+Both Console Admins and Developers have access to all the information on the **SQL Activity** and **Databases** pages.
 {{site.data.alerts.end}}
 
 ### Developer

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -32,11 +32,15 @@ Learn more about [managing SQL users' privileges](../{{site.versions["stable"]}}
 
 ## Roles
 
-Every {{ site.data.products.db }} user is either a Developer or a Console Admin for the organization.
+Every {{ site.data.products.db }} user is either a Developer or a Console Admin for the organization. 
+
+{{site.data.alerts.callout_danger}}
+Both Console Admins and Developers have access to all the information on the **SQL Activity** and **Databases** pages in the {{ site.data.products.db }} Console because they can create SQL users with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role).
+{{site.data.alerts.end}}
 
 ### Developer
 
-A Developer is a limited-access role. A Developer cannot invite Team Members to the Console or create new SQL users. Note that Developers can still create [SQL Users](#sql-users) with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role) on a cluster and therefore privileges for all resources across the cluster.
+A Developer is a limited-access role. A Developer cannot invite Team Members to the Console or create new SQL users. Note that Developers can still create [SQL Users](#sql-users) with the [`admin` role](../{{site.versions["stable"]}}/security-reference/authorization.html#admin-role) on a cluster.
 
 To access a cluster, you need to ask a Console Admin for the username and password of a SQL user. To find out who your Console Admin is, check the **Access** page.
 


### PR DESCRIPTION
DOC-2884

Developers have sql admin privs on a cluster. Calling this out under both the SQL User and Developer sections as it can be a security issue.