### PR TITLE
DOC-5379 add dbconsole metrics known issue

### DIFF
--- a/_includes/releases/v22.1/v22.1.4.md
+++ b/_includes/releases/v22.1/v22.1.4.md
@@ -38,6 +38,10 @@ Release Date: July 19, 2022
 - Fixed a bug in transaction conflict resolution which could allow backups to wait on long-running transactions. [#83900][#83900]
 - Fixed an internal error `node ... with MaxCost added to the memo` that could occur during planning when calculating the cardinality of an outer join when one of the inputs had 0 rows. [#84377][#84377]
 
+<h3 id="v22-1-4-known-limitations">Known limitations</h3>
+
+- A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in the upcoming v22.1.6 release. [#85636](https://github.com/cockroachdb/cockroach/issues/85636)
+
 <h3 id="v22-1-4-contributors">Contributors</h3>
 
 This release includes 42 merged PRs by 26 authors.

--- a/_includes/releases/v22.1/v22.1.4.md
+++ b/_includes/releases/v22.1/v22.1.4.md
@@ -40,7 +40,7 @@ Release Date: July 19, 2022
 
 <h3 id="v22-1-4-known-limitations">Known limitations</h3>
 
-- A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in the upcoming v22.1.6 release. [#85636](https://github.com/cockroachdb/cockroach/issues/85636)
+- A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in CockroachDB v22.1.6. [#85636](https://github.com/cockroachdb/cockroach/issues/85636)
 
 <h3 id="v22-1-4-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.5.md
+++ b/_includes/releases/v22.1/v22.1.5.md
@@ -33,7 +33,7 @@ Release Date: July 28, 2022
 
 <h3 id="v22-1-5-known-limitations">Known limitations</h3>
 
-- A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in the upcoming v22.1.6 release. [#85636](https://github.com/cockroachdb/cockroach/issues/85636)
+- A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in CockroachDB v22.1.6. [#85636](https://github.com/cockroachdb/cockroach/issues/85636)
 
 <h3 id="v22-1-5-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.5.md
+++ b/_includes/releases/v22.1/v22.1.5.md
@@ -31,6 +31,10 @@ Release Date: July 28, 2022
 - Fixed a bug in the `concat` projection operator on arrays that gave output of nulls when the projection operator can actually handle null arguments and may result in a non-null output. [#84615][#84615]
 - Reduced foreground latency impact when performing changefeed backfills by adjusting `changefeed.memory.per_changefeed_limit` [cluster setting](../v22.1/cluster-settings.html) to 128MiB (Enterprise only). [#84702][#84702]
 
+<h3 id="v22-1-5-known-limitations">Known limitations</h3>
+
+- A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in the upcoming v22.1.6 release. [#85636](https://github.com/cockroachdb/cockroach/issues/85636)
+
 <h3 id="v22-1-5-contributors">Contributors</h3>
 
 This release includes 30 merged PRs by 17 authors.

--- a/v22.1/known-limitations.md
+++ b/v22.1/known-limitations.md
@@ -10,6 +10,12 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 ## New limitations
 
+### DB Console Metrics page performance regression
+
+A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in the upcoming v22.1.6 release.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85636)
+
 ### A multi-region table cannot be restored into a non-multi-region table
 
 You cannot [restore](restore.html) a multi-region table into a non-multi-region table.

--- a/v22.1/known-limitations.md
+++ b/v22.1/known-limitations.md
@@ -10,12 +10,6 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 ## New limitations
 
-### DB Console Metrics page performance regression
-
-A performance regression exists for v22.1.4 and v22.1.5 that causes [DB Console Metrics pages](../v21.2/ui-overview-dashboard.html) to fail to load, or to load slower than expected, when attempting to display metrics graphs. This regression is fixed in the upcoming v22.1.6 release.
-
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85636)
-
 ### A multi-region table cannot be restored into a non-multi-region table
 
 You cannot [restore](restore.html) a multi-region table into a non-multi-region table.


### PR DESCRIPTION
Addresses: DOC-5379

- Added brief known limitation to v22.1.4 and v22.1.5 release notes advising of DB Console metrics page load failure / slowness.
- Added same mention to v22.1 standard `known-limitations` page.

NOTE: Indicating that v22.1.6 contains the fix. Confirming this is the case?

EDIT: v22.1.6 is now actually live, so amending text to accommodate.

[v22.1.md](https://deploy-preview-14854--cockroachdb-docs.netlify.app/docs/releases/v22.1.html#v22-1-5) | [known-limitations.md](https://deploy-preview-14854--cockroachdb-docs.netlify.app/docs/stable/known-limitations.html#new-limitations)