### PR TITLE
DOC-5371 convert hardcoded versions

### DIFF
--- a/v22.1/manage-certs-vault.md
+++ b/v22.1/manage-certs-vault.md
@@ -570,14 +570,14 @@ Download the CockroachDB executable from `binaries.cockroachdb.com`.
 {% include_cached copy-clipboard.html %}
 ```shell
 function install_roach_on_node {
-    gcloud compute ssh $1 --command 'if [[ ! -e cockroach-v21.2.4.linux-amd64 ]];
+    gcloud compute ssh $1 --command 'if [[ ! -e cockroach-{{ page.release_info.version }}.linux-amd64 ]];
     then
         echo "roach not installed; installing roach"
-        sudo curl https://binaries.cockroachdb.com/cockroach-v22.1.0-beta.2.linux-amd64.tgz | tar -xz
-        sudo cp -i cockroach-v22.1.0-beta.2.linux-amd64/cockroach /usr/local/bin/
+        sudo curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz | tar -xz
+        sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
         sudo mkdir -p /usr/local/lib/cockroach
-        sudo cp -i cockroach-v22.1.0-beta.2.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-        sudo cp -i cockroach-v22.1.0-beta.2.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+        sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+        sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
     else
         echo "roach already installed"
     fi'

--- a/v22.2/manage-certs-vault.md
+++ b/v22.2/manage-certs-vault.md
@@ -570,14 +570,14 @@ Download the CockroachDB executable from `binaries.cockroachdb.com`.
 {% include_cached copy-clipboard.html %}
 ```shell
 function install_roach_on_node {
-    gcloud compute ssh $1 --command 'if [[ ! -e cockroach-v21.2.4.linux-amd64 ]];
+    gcloud compute ssh $1 --command 'if [[ ! -e cockroach-{{ page.release_info.version }}.linux-amd64 ]];
     then
         echo "roach not installed; installing roach"
-        sudo curl https://binaries.cockroachdb.com/cockroach-v22.1.0-beta.2.linux-amd64.tgz | tar -xz
-        sudo cp -i cockroach-v22.1.0-beta.2.linux-amd64/cockroach /usr/local/bin/
+        sudo curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz | tar -xz
+        sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
         sudo mkdir -p /usr/local/lib/cockroach
-        sudo cp -i cockroach-v22.1.0-beta.2.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-        sudo cp -i cockroach-v22.1.0-beta.2.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+        sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+        sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
     else
         echo "roach already installed"
     fi'


### PR DESCRIPTION
Addresses: DOC-5371

- Converts hardcoded CRDB versions to dynamic for v22.2 and v22.1:
	- Only appeared on one page in both versions: `manage-certs-vault.md`
	- Will need DOCs writer approval, as specific tag may be required for a reason I could not determine from copy on-page.
	- Please note that v22.2 binary naming omits specific minor, as v22.2 does not yet have a first alpha. This is in keeping with existing approach for dev docs, as seen also [here](https://deploy-preview-14862--cockroachdb-docs.netlify.app/docs/dev/deploy-cockroachdb-on-premises.html#step-3-start-nodes). This will auto-populate corrected with issuance of first alpha.

[v22.2/manage-certs-vault.md](https://deploy-preview-14862--cockroachdb-docs.netlify.app/docs/dev/manage-certs-vault.html#install-cockroachdb-on-each-node-and-client) | [v22.1/manage-certs-vault.md](https://deploy-preview-14862--cockroachdb-docs.netlify.app/docs/v22.1/manage-certs-vault.html#install-cockroachdb-on-each-node-and-client)