### PR TITLE
DOC-5260 add auth-session to cluster api ref

### DIFF
--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -29,13 +29,17 @@ Endpoint | Name | Description
 
 All endpoints except `/health` and `/login` require authentication using a session token. To obtain a session token, you will need:
 
-* A [SQL role](create-role.html) that is a member of the [`admin` role](authorization.html#admin-role) and has login permissions and a password. You will use these credentials with the `/login` endpoint to retrieve the session token which you can then use with further API calls.
+* A [SQL role](create-role.html) that is a member of the [`admin` role](authorization.html#admin-role) and has login permissions and a password.
 
 To connect with the API on a secure cluster, you will need:
 
 * The CA cert used by the cluster or any intermediary proxy server, either in the client's cert store as a trusted certificate authority or as a file manually specified by the HTTP request (for example, using curl's [cacert](https://curl.se/docs/manpage.html#--cacert)).  
 
 ## Authentication
+
+To create and manage web sessions and authentication tokens to the Cluster API from the command line, use the [`cockroach auth-session`](cockroach-auth-session.html) CLI command.
+
+Alternatively, you may also request a token directly from the `/login` endpoint using the following instructions:
 
 1. Request a session token using the `/login` endpoint. For example:
 

--- a/v21.2/cluster-api.md
+++ b/v21.2/cluster-api.md
@@ -37,13 +37,17 @@ Endpoint | Name | Description
 
 All endpoints except `/health` and `/login` require authentication using a session token. To obtain a session token, you will need:
 
-* A [SQL role](create-role.html) that is a member of the [`admin` role](security-reference/authorization.html#admin-role) and has login permissions and a password. You will use these credentials with the `/login` endpoint to retrieve the session token which you can then use with further API calls.
+* A [SQL role](create-role.html) that is a member of the [`admin` role](security-reference/authorization.html#admin-role) and has login permissions and a password.
 
 To connect with the API on a secure cluster, you will need:
 
 * The CA cert used by the cluster or any intermediary proxy server, either in the client's cert store as a trusted certificate authority or as a file manually specified by the HTTP request (for example, using curl's [cacert](https://curl.se/docs/manpage.html#--cacert)).  
 
 ## Authentication
+
+To create and manage web sessions and authentication tokens to the Cluster API from the command line, use the [`cockroach auth-session`](cockroach-auth-session.html) CLI command.
+
+Alternatively, you may also request a token directly from the `/login` endpoint using the following instructions:
 
 1. Request a session token using the `/login` endpoint. For example:
 

--- a/v22.1/cluster-api.md
+++ b/v22.1/cluster-api.md
@@ -37,13 +37,17 @@ Endpoint | Name | Description | Support
 
 All endpoints except `/health` and `/login` require authentication using a session token. To obtain a session token, you will need:
 
-* A [SQL role](create-role.html) that is a member of the [`admin` role](security-reference/authorization.html#admin-role) and has login permissions and a password. You will use these credentials with the `/login` endpoint to retrieve the session token which you can then use with further API calls.
+* A [SQL role](create-role.html) that is a member of the [`admin` role](security-reference/authorization.html#admin-role) and has login permissions and a password.
 
 To connect with the API on a secure cluster, you will need:
 
 * The CA cert used by the cluster or any intermediary proxy server, either in the client's cert store as a trusted certificate authority or as a file manually specified by the HTTP request (for example, using curl's [cacert](https://curl.se/docs/manpage.html#--cacert)).  
 
 ## Authentication
+
+To create and manage web sessions and authentication tokens to the Cluster API from the command line, use the [`cockroach auth-session`](cockroach-auth-session.html) CLI command.
+
+Alternatively, you may also request a token directly from the `/login` endpoint using the following instructions:
 
 1. Request a session token using the `/login` endpoint. For example:
 

--- a/v22.2/cluster-api.md
+++ b/v22.2/cluster-api.md
@@ -37,13 +37,17 @@ Endpoint | Name | Description | Support
 
 All endpoints except `/health` and `/login` require authentication using a session token. To obtain a session token, you will need:
 
-* A [SQL role](create-role.html) that is a member of the [`admin` role](security-reference/authorization.html#admin-role) and has login permissions and a password. You will use these credentials with the `/login` endpoint to retrieve the session token which you can then use with further API calls.
+* A [SQL role](create-role.html) that is a member of the [`admin` role](security-reference/authorization.html#admin-role) and has login permissions and a password.
 
 To connect with the API on a secure cluster, you will need:
 
 * The CA cert used by the cluster or any intermediary proxy server, either in the client's cert store as a trusted certificate authority or as a file manually specified by the HTTP request (for example, using curl's [cacert](https://curl.se/docs/manpage.html#--cacert)).  
 
 ## Authentication
+
+To create and manage web sessions and authentication tokens to the Cluster API from the command line, use the [`cockroach auth-session`](cockroach-auth-session.html) CLI command.
+
+Alternatively, you may also request a token directly from the `/login` endpoint using the following instructions:
 
 1. Request a session token using the `/login` endpoint. For example:
 


### PR DESCRIPTION
Addresses: DOC-5260

- Added mention of newly-doc'd `auth-session` CLI to the Cluster API reference landing page for versions v21.1 - v22.2 incl.
  - Removed sentence that was `/login`-endpoint-specific, now that `auth-session` is also avail.

[v22.2/cluster-api.md](https://deploy-preview-14867--cockroachdb-docs.netlify.app/docs/dev/cluster-api.html#requirements) | [v22.1/cluster-api.md](https://deploy-preview-14867--cockroachdb-docs.netlify.app/docs/stable/cluster-api.html#requirements) | [v21.2/cluster-api.md](https://deploy-preview-14867--cockroachdb-docs.netlify.app/docs/v21.2/cluster-api.html#requirements) | [v21.1/cluster-api.md](https://deploy-preview-14867--cockroachdb-docs.netlify.app/docs/v21.1/cluster-api.html#requirements)