### PR TITLE
DOC-3085 add metric snapshot bytes 21.2

### DIFF
--- a/_includes/v21.2/metric-names.md
+++ b/_includes/v21.2/metric-names.md
@@ -136,6 +136,8 @@ Name | Help
 `range.snapshots.generated` | Number of generated snapshots
 `range.snapshots.normal-applied` | Number of applied snapshots
 `range.snapshots.preemptive-applied` | Number of applied pre-emptive snapshots
+`range.snapshots.rcvd-bytes` | Number of snapshot bytes received
+`range.snapshots.sent-bytes` | Number of snapshot bytes sent
 `range.splits` | Number of range splits
 `ranges.unavailable` | Number of ranges with fewer live replicas than needed for quorum
 `ranges.underreplicated` | Number of ranges with fewer live replicas than the replication target


### PR DESCRIPTION
Addresses: DOC-3085

- Simple docs update for v21.2 backport: https://github.com/cockroachdb/cockroach/pull/79056

[metric-names.md](https://deploy-preview-14869--cockroachdb-docs.netlify.app/docs/v21.2/ui-custom-chart-debug-page#available-metrics)