### PR TITLE
DOC-3670 update prometheus operator

### DIFF
--- a/v21.1/monitor-cockroachdb-kubernetes.md
+++ b/v21.1/monitor-cockroachdb-kubernetes.md
@@ -68,31 +68,32 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     This ensures that there is a Prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
     </section>
 
-1. Install [CoreOS's Prometheus Operator](https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/bundle.yaml):
+1. Determine the latest version of [CoreOS's Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) and run the following to download and apply the latest `bundle.yaml` definition file:
 
     {{site.data.alerts.callout_info}}
-    We recommend checking for the latest Prometheus Operator [release version](https://github.com/prometheus-operator/prometheus-operator/blob/master/RELEASE.md) and specifying this version in the following command.
+    Be sure to specify the latest [CoreOS Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) version in the following command, in place of this example's use of version `v0.58.0`.
     {{site.data.alerts.end}}
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl apply \
-    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.47.1/bundle.yaml
+    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/bundle.yaml \
+    --server-side
     ~~~
 
     ~~~
-    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
-    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator configured
-    clusterrole.rbac.authorization.k8s.io/prometheus-operator configured
-    deployment.apps/prometheus-operator created
-    serviceaccount/prometheus-operator configured
-    service/prometheus-operator created
+    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
+    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    clusterrole.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    deployment.apps/prometheus-operator serverside-applied
+    serviceaccount/prometheus-operator serverside-applied
+    service/prometheus-operator serverside-applied
     ~~~
 
 1. Confirm that the `prometheus-operator` has started:

--- a/v21.2/monitor-cockroachdb-kubernetes.md
+++ b/v21.2/monitor-cockroachdb-kubernetes.md
@@ -77,31 +77,32 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     This ensures that there is a Prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
     </section>
 
-1. Install [CoreOS's Prometheus Operator](https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/bundle.yaml):
+1. Determine the latest version of [CoreOS's Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) and run the following to download and apply the latest `bundle.yaml` definition file:
 
     {{site.data.alerts.callout_info}}
-    We recommend checking for the latest Prometheus Operator [release version](https://github.com/prometheus-operator/prometheus-operator/blob/master/RELEASE.md) and specifying this version in the following command.
+    Be sure to specify the latest [CoreOS Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) version in the following command, in place of this example's use of version `v0.58.0`.
     {{site.data.alerts.end}}
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl apply \
-    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.47.1/bundle.yaml
+    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/bundle.yaml \
+    --server-side
     ~~~
 
     ~~~
-    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
-    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator configured
-    clusterrole.rbac.authorization.k8s.io/prometheus-operator configured
-    deployment.apps/prometheus-operator created
-    serviceaccount/prometheus-operator configured
-    service/prometheus-operator created
+    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
+    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    clusterrole.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    deployment.apps/prometheus-operator serverside-applied
+    serviceaccount/prometheus-operator serverside-applied
+    service/prometheus-operator serverside-applied
     ~~~
 
 1. Confirm that the `prometheus-operator` has started:

--- a/v22.1/monitor-cockroachdb-kubernetes.md
+++ b/v22.1/monitor-cockroachdb-kubernetes.md
@@ -77,31 +77,32 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     This ensures that there is a Prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
     </section>
 
-1. Install [CoreOS's Prometheus Operator](https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/bundle.yaml):
+1. Determine the latest version of [CoreOS's Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) and run the following to download and apply the latest `bundle.yaml` definition file:
 
     {{site.data.alerts.callout_info}}
-    We recommend checking for the latest Prometheus Operator [release version](https://github.com/prometheus-operator/prometheus-operator/blob/master/RELEASE.md) and specifying this version in the following command.
+    Be sure to specify the latest [CoreOS Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) version in the following command, in place of this example's use of version `v0.58.0`.
     {{site.data.alerts.end}}
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl apply \
-    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.47.1/bundle.yaml
+    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/bundle.yaml \
+    --server-side
     ~~~
 
     ~~~
-    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
-    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator configured
-    clusterrole.rbac.authorization.k8s.io/prometheus-operator configured
-    deployment.apps/prometheus-operator created
-    serviceaccount/prometheus-operator configured
-    service/prometheus-operator created
+    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
+    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    clusterrole.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    deployment.apps/prometheus-operator serverside-applied
+    serviceaccount/prometheus-operator serverside-applied
+    service/prometheus-operator serverside-applied
     ~~~
 
 1. Confirm that the `prometheus-operator` has started:

--- a/v22.2/monitor-cockroachdb-kubernetes.md
+++ b/v22.2/monitor-cockroachdb-kubernetes.md
@@ -77,31 +77,32 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     This ensures that there is a Prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
     </section>
 
-1. Install [CoreOS's Prometheus Operator](https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/bundle.yaml):
+1. Determine the latest version of [CoreOS's Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) and run the following to download and apply the latest `bundle.yaml` definition file:
 
     {{site.data.alerts.callout_info}}
-    We recommend checking for the latest Prometheus Operator [release version](https://github.com/prometheus-operator/prometheus-operator/blob/master/RELEASE.md) and specifying this version in the following command.
+    Be sure to specify the latest [CoreOS Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator/releases/) version in the following command, in place of this example's use of version `v0.58.0`.
     {{site.data.alerts.end}}
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl apply \
-    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.47.1/bundle.yaml
+    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/bundle.yaml \
+    --server-side
     ~~~
 
     ~~~
-    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
-    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
-    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator configured
-    clusterrole.rbac.authorization.k8s.io/prometheus-operator configured
-    deployment.apps/prometheus-operator created
-    serviceaccount/prometheus-operator configured
-    service/prometheus-operator created
+    customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
+    customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
+    clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    clusterrole.rbac.authorization.k8s.io/prometheus-operator serverside-applied
+    deployment.apps/prometheus-operator serverside-applied
+    serviceaccount/prometheus-operator serverside-applied
+    service/prometheus-operator serverside-applied
     ~~~
 
 1. Confirm that the `prometheus-operator` has started:


### PR DESCRIPTION
Addresses: DOC-3670

- Updates hardlink to CoreOS Prometheus Operator to `v0.58.0` from `v0.47.1`
- Doubles up on notice to replace example hardcoded version with latest version
- Adds `--server-side` to `apply` step
- Updates command output to match use of `--server-side`

Question:

- Your ZD ticket has the end user split the yaml payload into two files, and only suggests using `--server-side` with one of them. Is that because your client already had an extant config, and new users -- i.e. those following this docs page -- would not need to split as you have?

Alternatives:

- If approach: "look up latest, then replace hardcoded with your findings" is too cumbersome, we can instead just direct users to download latest `bundle.yaml` from [here](https://github.com/prometheus-operator/prometheus-operator/releases/) directly, then run `kubectl apply -f /local/path/to/bundle.yaml --server-side` instead. What do you think?

[v22.2/monitor-cockroachdb-kubernetes.md](https://deploy-preview-14882--cockroachdb-docs.netlify.app/docs/dev/monitor-cockroachdb-kubernetes.html#configure-prometheus) | [v22.1/monitor-cockroachdb-kubernetes.md](https://deploy-preview-14882--cockroachdb-docs.netlify.app/docs/stable/monitor-cockroachdb-kubernetes.html#configure-prometheus) | [v21.2/monitor-cockroachdb-kubernetes.md](https://deploy-preview-14882--cockroachdb-docs.netlify.app/docs/v21.2/monitor-cockroachdb-kubernetes.html#configure-prometheus) | [v21.1/monitor-cockroachdb-kubernetes.md](https://deploy-preview-14882--cockroachdb-docs.netlify.app/docs/v21.1/monitor-cockroachdb-kubernetes.html#configure-prometheus)