### PR TITLE
fix: select2 loading issue

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,14 +36,14 @@ var pageConfig = {
 };
 </script>
 <script>
-  function whenAvailable(name, callback, isDeepFunction = false) {
+  function whenAvailable(name, callback, isJqueryFn = false) {
     var interval = 500; // ms
-    var evaluation = isDeepFunction ? name : window[name];
+    var evaluation = isJqueryFn ? $()[name] : window[name];
     window.setTimeout(function() {
         if (evaluation) {
             callback();
         } else {
-            whenAvailable(name, callback, isDeepFunction);
+            whenAvailable(name, callback, isJqueryFn);
         }
     }, interval);
   }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,7 +59,6 @@
 
     {% include sidebar.js.html %}
     <script src="//go.cockroachlabs.com/js/forms2/js/forms2.min.js" defer></script>
-    <script src="{{ 'js/jquery.min.js' | relative_url }}" defer></script>
     <script src="{{ 'js/jquery.cookie.min.js' | relative_url }}" defer></script>
     <script src="{{ 'js/jquery.navgoco.min.js' | relative_url }}" defer></script>
     <!-- bs 4.X -->

--- a/js/comparison-chart.js
+++ b/js/comparison-chart.js
@@ -1,4 +1,4 @@
-whenAvailable('select2', mainExecute);
+whenAvailable('select2', mainExecute, true);
 function mainExecute() {
   $(function() {
     function updateChart(db, column) {


### PR DESCRIPTION
Fix:
- select2 loading issue on comparison charts

Feat:
- remove extra jquery load

Next Task:
- Add a default behavior for comparison chart instead of loading everything (select2 does the job but we want to have something not switching while is loading)

Fixes DOC-5415