### PR TITLE
Fix to filter issue on cloud storage bulk ops pages

### DIFF
--- a/v21.2/use-cloud-storage-for-bulk-operations.md
+++ b/v21.2/use-cloud-storage-for-bulk-operations.md
@@ -288,11 +288,11 @@ This table outlines the actions that each operation performs against the storage
 
 
 <div class="filters clearfix">
-  <button class="filter-button" data-scope="s3">Amazon S3</button>
-  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+  <button class="filter-button" data-scope="s3-perms">Amazon S3</button>
+  <button class="filter-button" data-scope="gcs-perms">Google Cloud Storage</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="s3">
+<section class="filter-content" markdown="1" data-scope="s3-perms">
 
 These [actions](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html) are the minimum access permissions to be set in an Amazon S3 bucket policy:
 
@@ -336,7 +336,7 @@ An example S3 bucket policy for a **backup**:
 
 </section>
 
-<section class="filter-content" markdown="1" data-scope="gcs">
+<section class="filter-content" markdown="1" data-scope="gcs-perms">
 
 In Google Cloud Storage, you can grant users roles that define their access level to the storage bucket. For the purposes of running CockroachDB operations to your bucket, the following table lists the permissions that represent the minimum level required for each operation. GCS provides different levels of granularity for defining the roles in which these permissions reside. You can assign roles that already have these [permissions](https://cloud.google.com/storage/docs/access-control/iam-permissions) configured, or make your own custom roles that include these permissions. 
 

--- a/v22.1/use-cloud-storage-for-bulk-operations.md
+++ b/v22.1/use-cloud-storage-for-bulk-operations.md
@@ -287,11 +287,11 @@ This table outlines the actions that each operation performs against the storage
 </table>
 
 <div class="filters clearfix">
-  <button class="filter-button" data-scope="s3">Amazon S3</button>
-  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+  <button class="filter-button" data-scope="s3-perms">Amazon S3</button>
+  <button class="filter-button" data-scope="gcs-perms">Google Cloud Storage</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="s3">
+<section class="filter-content" markdown="1" data-scope="s3-perms">
 
 These [actions](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html) are the minimum access permissions to be set in an Amazon S3 bucket policy:
 
@@ -334,7 +334,7 @@ An example S3 bucket policy for a **backup**:
 
 </section>
 
-<section class="filter-content" markdown="1" data-scope="gcs">
+<section class="filter-content" markdown="1" data-scope="gcs-perms">
 
 In Google Cloud Storage, you can grant users roles that define their access level to the storage bucket. For the purposes of running CockroachDB operations to your bucket, the following table lists the permissions that represent the minimum level required for each operation. GCS provides different levels of granularity for defining the roles in which these permissions reside. You can assign roles that already have these [permissions](https://cloud.google.com/storage/docs/access-control/iam-permissions) configured, or make your own custom roles that include these permissions. 
 

--- a/v22.2/use-cloud-storage-for-bulk-operations.md
+++ b/v22.2/use-cloud-storage-for-bulk-operations.md
@@ -287,11 +287,11 @@ This table outlines the actions that each operation performs against the storage
 </table>
 
 <div class="filters clearfix">
-  <button class="filter-button" data-scope="s3">Amazon S3</button>
-  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+  <button class="filter-button" data-scope="s3-perms">Amazon S3</button>
+  <button class="filter-button" data-scope="gcs-perms">Google Cloud Storage</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="s3">
+<section class="filter-content" markdown="1" data-scope="s3-perms">
 
 These [actions](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html) are the minimum access permissions to be set in an Amazon S3 bucket policy:
 
@@ -334,7 +334,7 @@ An example S3 bucket policy for a **backup**:
 
 </section>
 
-<section class="filter-content" markdown="1" data-scope="gcs">
+<section class="filter-content" markdown="1" data-scope="gcs-perms">
 
 In Google Cloud Storage, you can grant users roles that define their access level to the storage bucket. For the purposes of running CockroachDB operations to your bucket, the following table lists the permissions that represent the minimum level required for each operation. GCS provides different levels of granularity for defining the roles in which these permissions reside. You can assign roles that already have these [permissions](https://cloud.google.com/storage/docs/access-control/iam-permissions) configured, or make your own custom roles that include these permissions. 
 


### PR DESCRIPTION
To fix the filter issue on the Use Cloud Storage for Bulk Ops page, adjusted the name ID of the second filter. Although this means the filters won't adjust together between the two relevant sections, it seems a worthwhile trade-off to keep the filters in both sections that are distinct from one another. Also, this makes the most sense in the case that further _different_ storage options are added, or where storage options aren't applicable to the two sections in question. https://www.cockroachlabs.com/docs/v21.2/use-cloud-storage-for-bulk-operations