### PR TITLE
Tell git to make nicer diffs for Markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 css/customstyles.css.map binary
 css/customstyles.css -merge
+*.md diff=markdown


### PR DESCRIPTION
... by setting up the .gitattributes file to recognize Markdown
files (*.md).

This will result in diffs that are easier to read since the hunk context
will prefer to display nearby Markdown headings rather than random
nearby text.

Hopefully a small quality of life improvement.