### PR TITLE
Update language about minimum supported k8s version

### DIFF
--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -846,11 +846,9 @@ To dynamically refer to the stable version of CockroachDB, as determined each ti
 {{site.versions["stable"]}}
 ~~~
 
-{{site.data.alerts.callout_danger}}
-If you use a `stable` link on a versioned page which is for a previous version, the link points to a different version  of CockroachDB than the version the page documents. Similarly, if you use a `stable` link on a page for the current version and then a new version is added, the link points to a different version than the version the page documents. If this is a problem, use one of the following methods instead.
-{{site.data.alerts.end}}
+**Warning**: If you use a `stable` link on a versioned page which is for a previous version, the link points to a different version  of CockroachDB than the version the page documents. Similarly, if you use a `stable` link on a page for the current version and then a new version is added, the link points to a different version than the version the page documents. If this is a problem, use one of the following methods instead.
 
-To refer to a page's minor version (for example, {{page.version.version}}) (as represented by its subdirectory within the docs repo):
+To refer to a page's minor version (for example, {{page.version.version}}), which matches its top-level subdirectory within the docs repo:
 
 ~~~
 {{page.version.version}}

--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -848,13 +848,13 @@ To dynamically refer to the stable version of CockroachDB, as determined each ti
 
 **Warning**: If you use a `stable` link on a versioned page which is for a previous version, the link points to a different version  of CockroachDB than the version the page documents. Similarly, if you use a `stable` link on a page for the current version and then a new version is added, the link points to a different version than the version the page documents. If this is a problem, use one of the following methods instead.
 
-To refer to a page's minor version (for example, {{page.version.version}}), which matches its top-level subdirectory within the docs repo:
+Pages that document CockroachDB itself exist within subdirectories that represent minor versions. To refer to a page's minor version (for example, v22.2), which matches its top-level subdirectory within the docs repo:
 
 ~~~
 {{page.version.version}}
 ~~~
 
-To refer to a page's patch version (for example, {{ page.release_info.name }}):
+A minor version of CockroachDB receives updates as patches. To refer to a page's current patch version (for example, v22.1.7):
 
 ~~~
 {{ page.release_info.name }}

--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -48,6 +48,7 @@ Included in this guide:
   - [Code](#code)
   - [Examples](#examples)
   - [Version tags](#version-tags)
+  - [Version references](#version-references)
   - [Tables](#tables)
   - [Lists](#lists)
   - [Images](#images)
@@ -830,6 +831,36 @@ If a feature is new in a GA release, use the major release number for the releas
 If a feature has been backported to a previous version in a patch release, use the minor release number for the release version tag (e.g., `{% include_cached new-in.html version="v21.2.10" %}`).
 
 Version tags should only refer to the version of the docset that contains them. For example, the version tag `{% include_cached new-in.html version="v21.1.9" %}` should only be on pages in `v21.1` directories.
+
+### Version references
+
+To refer to a static version of CockroachDB:
+
+~~~
+{{site.versions["v22.2"]}}
+~~~
+
+To dynamically refer to the stable version of CockroachDB, as determined each time the site is built:
+
+~~~
+{{site.versions["stable"]}}
+~~~
+
+{{site.data.alerts.callout_danger}}
+If you use a `stable` link on a versioned page which is for a previous version, the link points to a different version  of CockroachDB than the version the page documents. Similarly, if you use a `stable` link on a page for the current version and then a new version is added, the link points to a different version than the version the page documents. If this is a problem, use one of the following methods instead.
+{{site.data.alerts.end}}
+
+To refer to a page's minor version (for example, {{page.version.version}}) (as represented by its subdirectory within the docs repo):
+
+~~~
+{{page.version.version}}
+~~~
+
+To refer to a page's patch version (for example, {{ page.release_info.name }}):
+
+~~~
+{{ page.release_info.name }}
+~~~
 
 ### Tables
 

--- a/_includes/v20.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v20.1/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.18 or higher is required in order to use our current configuration files. If you need to run on an older version of Kubernetes, we keep configuration files in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is required. Cockroach Labs strongly recommends that you use a Kubernetes version that is [eligible for patch support by the Kubernetes project](https://kubernetes.io/releases/).
 
 #### Helm version
 

--- a/_includes/v20.2/orchestration/kubernetes-limitations.md
+++ b/_includes/v20.2/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.18 or higher is required in order to use our current configuration files. If you need to run on an older version of Kubernetes, we keep configuration files in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is required. Cockroach Labs strongly recommends that you use a Kubernetes version that is [eligible for patch support by the Kubernetes project](https://kubernetes.io/releases/).
 
 #### Helm version
 

--- a/_includes/v21.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v21.1/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.18 or higher is required in order to use our current configuration files. If you need to run on a previous version of Kubernetes, we keep configuration files in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is required. Cockroach Labs strongly recommends that you use a Kubernetes version that is [eligible for patch support by the Kubernetes project](https://kubernetes.io/releases/).
 
 #### Kubernetes Operator
 

--- a/_includes/v21.2/orchestration/kubernetes-limitations.md
+++ b/_includes/v21.2/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.18 or higher is required in order to use our current configuration files. If you need to run on a previous version of Kubernetes, we keep configuration files in the versioned subdirectories of the [CockroachDB Kubernetes repository](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is required. Cockroach Labs strongly recommends that you use a Kubernetes version that is [eligible for patch support by the Kubernetes project](https://kubernetes.io/releases/).
 
 #### Kubernetes Operator
 

--- a/_includes/v22.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v22.1/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.18 or higher is required in order to use our current configuration files. If you need to run on a previous version of Kubernetes, we keep configuration files in the versioned subdirectories of the [CockroachDB Kubernetes repository](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is required. Cockroach Labs strongly recommends that you use a Kubernetes version that is [eligible for patch support by the Kubernetes project](https://kubernetes.io/releases/).
 
 #### Kubernetes Operator
 

--- a/_includes/v22.2/orchestration/kubernetes-limitations.md
+++ b/_includes/v22.2/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.18 or higher is required in order to use our current configuration files. If you need to run on a previous version of Kubernetes, we keep configuration files in the versioned subdirectories of the [CockroachDB Kubernetes repository](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is required. Cockroach Labs strongly recommends that you use a Kubernetes version that is [eligible for patch support by the Kubernetes project](https://kubernetes.io/releases/).
 
 #### Kubernetes Operator
 


### PR DESCRIPTION
Also add a style guide entry about referring to CRDB versions.

## Tests
- [x] Local build
- [x] Local linkcheck 

## Reviewers
🙏 
- @meridional The k8s doc changes (only need to review the latest version)
- @nickvigilante The style guide update and the way I'm using the variables in the k8s content
- @stbof Overall content reviewer
