### PR TITLE
DOC-5378 Add includes for Preview/Private Preview callouts

### DIFF
--- a/_includes/cockroachcloud/private-preview.md
+++ b/_includes/cockroachcloud/private-preview.md
@@ -1,3 +1,0 @@
-{{site.data.alerts.callout_info}}
-This feature is in preview and can be enabled only on clusters in enrolled {{ site.data.products.db }} organizations. To enroll your organization in the preview, contact your Cockroach Labs account team.
-{{site.data.alerts.end}}

--- a/_includes/feature-phases/preview-opt-in.md
+++ b/_includes/feature-phases/preview-opt-in.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+**This feature is in preview** and is only available to enrolled organizations. To enroll your organization in the preview, contact your Cockroach Labs account team. This feature is subject to change.
+{{site.data.alerts.end}}

--- a/_includes/feature-phases/preview.md
+++ b/_includes/feature-phases/preview.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+**This feature is in preview.** This feature is subject to change. To share feedback and/or issues, contact [Support](https://support.cockroachlabs.com/hc/en-us).
+{{site.data.alerts.end}}

--- a/_includes/feature-phases/private-preview.md
+++ b/_includes/feature-phases/private-preview.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+**This feature is in private preview** and is only available to select users. This feature is subject to change. This feature is not intended for use in production.
+{{site.data.alerts.end}}

--- a/cockroachcloud/cloud-sso.md
+++ b/cockroachcloud/cloud-sso.md
@@ -7,7 +7,7 @@ docs_area: manage
 
 Users may authenticate to the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud) using Single Sign-On (SSO). GitHub, Google, and Microsoft are supported as identity providers (IdPs).
 
-{% include cockroachcloud/private-preview.md %}
+{% include feature-phases/preview-opt-in.md %}
 
 Authentication with a centralized identity managed by a dedicated IdP offers several security advantages:
 

--- a/cockroachcloud/cmek.md
+++ b/cockroachcloud/cmek.md
@@ -7,7 +7,7 @@ docs_area: manage.security
 
 Customer-Managed Encryption Keys (CMEK) allow you to protect data at rest in a {{ site.data.products.dedicated }} cluster using a cryptographic key that is entirely within your control, hosted in a supported key-management system (KMS) platform. This key is called the _CMEK key_.
 
-{% include cockroachcloud/private-preview.md %}
+{% include feature-phases/preview-opt-in.md %}
 
 You can manage your CMEK keys using one or more of the following services:
 

--- a/cockroachcloud/export-logs.md
+++ b/cockroachcloud/export-logs.md
@@ -7,7 +7,7 @@ docs_area: manage
 
 {{ site.data.products.dedicated }} users with clusters on the AWS platform can use the [Cloud API](cloud-api.html) to configure log export to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). Once the export is configured, logs will flow from all nodes in all regions of your {{ site.data.products.dedicated }} cluster to your CloudWatch log sink.
 
-{% include cockroachcloud/private-preview.md %}
+{% include feature-phases/preview-opt-in.md %}
 
 
 #### Availability 


### PR DESCRIPTION
This PR does the following:

- Creates a new `_includes/feature-phases` directory
- Updates the existing `private-preview` include to be in the new directory. Also changes this existing include to be called `preview-opt-in` instead of `private-preview`
- Creates a new `preview` include for features that are available to all users (not just those who opt-in)
- Creates a new `private-preview` include

Closes DOC-3758