### PR TITLE
DOC-5586 fix sql-only binary dl

### DIFF
--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -271,11 +271,11 @@ v21.2.8,v21.2,2022-04-04,false,False,Production,False,go1.16,cad00009ffee952065c
 v22.1.0-beta.2,v22.1,2022-04-12,false,False,Testing,False,go1.17,5d1063406d48c2713e0a7a8421f1946349b3db65,cockroachdb/cockroach-unstable,false
 v21.1.18,v21.1,2022-04-12,false,False,Production,False,go1.15,53cb1ed8f2f42376ad76d4888d582c88685b2820,cockroachdb/cockroach,false
 v21.2.9,v21.2,2022-04-13,false,False,Production,False,go1.16,eafda969629a6c883d645ffbcbbcb94a91adcb40,cockroachdb/cockroach,false
-v22.1.0-beta.3,v22.1,2022-04-18,false,False,Testing,False,go1.17,0509bc6c07ceed6d77d8cd088cb79d4a0e8f38ed,cockroachdb/cockroach-unstable,true
-v22.1.0-beta.4,v22.1,2022-04-26,false,False,Testing,False,go1.17,b89ce4cb855227c93e1fff6e7367e870fc9f2fef,cockroachdb/cockroach-unstable,true
+v22.1.0-beta.3,v22.1,2022-04-18,false,False,Testing,False,go1.17,0509bc6c07ceed6d77d8cd088cb79d4a0e8f38ed,cockroachdb/cockroach-unstable,false
+v22.1.0-beta.4,v22.1,2022-04-26,false,False,Testing,False,go1.17,b89ce4cb855227c93e1fff6e7367e870fc9f2fef,cockroachdb/cockroach-unstable,false
 v21.2.10,v21.2,2022-05-02,false,False,Production,False,go1.16,39511c6a4d0bbb580b7ff6f5c0e1e77664474efb,cockroachdb/cockroach,false
-v22.1.0-beta.5,v22.1,2022-05-03,false,False,Testing,False,go1.17,24ba4d7211aa9fb9cea18f856c693bc8f592c8f6,cockroachdb/cockroach-unstable,true
-v22.1.0-rc.1,v22.1,2022-05-09,false,False,Testing,False,go1.17,5b78463ed2e7106a8477b63fa837564ad02bb510,cockroachdb/cockroach-unstable,true
+v22.1.0-beta.5,v22.1,2022-05-03,false,False,Testing,False,go1.17,24ba4d7211aa9fb9cea18f856c693bc8f592c8f6,cockroachdb/cockroach-unstable,false
+v22.1.0-rc.1,v22.1,2022-05-09,false,False,Testing,False,go1.17,5b78463ed2e7106a8477b63fa837564ad02bb510,cockroachdb/cockroach-unstable,false
 v21.1.19,v21.1,2022-05-09,false,False,Production,False,go1.15,bf2bef135b5be9c73ccc445f2d996781ee59e94f,cockroachdb/cockroach,false
 v21.2.11,v21.2,2022-05-23,false,False,Production,False,go1.16,b05bab30da2ff789dc232da4fac771c01a72a87f,cockroachdb/cockroach,false
 v22.1.0,v22.1,2022-05-24,false,False,Production,False,go1.17,5b78463ed2e7106a8477b63fa837564ad02bb510,cockroachdb/cockroach,true

--- a/_includes/releases/release-downloads-docker-image.md
+++ b/_includes/releases/release-downloads-docker-image.md
@@ -32,9 +32,9 @@ This release was withdrawn, and we've removed the links to the downloads and Doc
 <h4>SQL-only command-line client executable</h4>
 
 <div><div id="os-tabs" class="filters clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.linux-amd64"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.darwin-10.9-amd64"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.windows-6.2-amd64.exe"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a target="_blank" rel="noopener" href="https://github.com/cockroachdb/cockroach/releases/tag/{{ release.version }}"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a
 </div></div>
 {% endif %}


### PR DESCRIPTION
Addresses: DOC-5586

- Fixed SQL-only binary DL path to include extension, affecting Linux, macOS, and Windows. Currently they 404. This is for v22.2 only.
- Removed sql-only download links for v22.1 non-prod releases, as they were also 404ing, and releases team approved.

[v22.2.md](https://deploy-preview-15017--cockroachdb-docs.netlify.app/docs/releases/v22.2.html) | [releases.md](https://deploy-preview-15017--cockroachdb-docs.netlify.app/docs/releases/index.html)