### PR TITLE
Migrate Netlify build from Xenial to Focal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 # frozen_string_literal: true
 source "https://rubygems.org"
 


### PR DESCRIPTION
This PR supports the changes needed to get our site to build on Ubuntu Focal.