### PR TITLE
DOC-5593: Add lastmod tag to sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group :jekyll_plugins do
     gem "jekyll-include-cache"
     gem 'jekyll-algolia', "~> 1.0", path: "./jekyll-algolia-dev"
     gem 'jekyll-remote-include', github: 'ianjevans/jekyll-remote-include', tag: 'v1.1.6'
+    gem "jekyll-last-modified-at"
   end

--- a/_config_base.yml
+++ b/_config_base.yml
@@ -54,6 +54,7 @@ keep_files:
 markdown: Redcarpet
 plugins:
 - jekyll-include-cache
+- jekyll-last-modified-at
 - jekyll-minifier
 release_info:
   v1.0:

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,6 +10,7 @@ layout: null
       {%- unless page.url contains '404' or page.sitemap == false or page.url contains site.versions["dev"] and stable_pages_names contains page.name %}
   <url>
     <loc>{{ page.canonical | absolute_url | replace: dev_path, "/dev/" }}</loc>
+    <lastmod>{{ page.last_modified_at | date: "%Y-%m-%dT%H:%M:%S%z" }}</lastmod>
   </url>
       {%- endunless -%}
     {%- endif -%}


### PR DESCRIPTION
Fixes DOC-5593

This helps pave the way for Google to effectively identify when content changes, with the exception of modifying any includes referenced in the file. After this is merged, we can then trigger a sitemap update during the Netlify build and have Google identify which pages need to change.