### PR TITLE
DOC-5662 v21.1.21 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -78,11 +78,12 @@ release_info:
     start_time: 2022-02-09 11:01:26.34274101 +0000 UTC
     version: v20.2.19
   v21.1:
-    build_time: 2022-09-12 00:00:00 (go1.15)
+    build_time: 2022-09-15 00:00:00 (go1.17)
+    crdb_branch_name: release-21.1
     docker_image: cockroachdb/cockroach
-    name: v21.1.20
-    start_time: 2022-09-08 16:40:49.784794 +0000 UTC
-    version: v21.1.20
+    name: v21.1.21
+    start_time: 2022-09-14 12:48:52.570761 +0000 UTC
+    version: v21.1.21
   v21.2:
     build_time: 2022-08-29 00:00:00 (go1.16)
     crdb_branch_name: release-21.2

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -293,3 +293,4 @@ v21.2.15,v21.2,2022-08-29,false,False,Production,False,go1.16,2326e63d4a9ad62b19
 v22.2.0-alpha.2,v22.2,2022-09-06,false,False,Testing,False,go1.17,d676dcb809083388a3a280a7f9d5c8230b1682e6,cockroachdb/cockroach-unstable,true
 v21.1.20,v21.1,2022-09-12,false,False,Production,False,go1.15,d03dba52dc78c98a680b53e82d7f8825c8ab1da5,cockroachdb/cockroach,false
 v22.2.0-alpha.3,v22.2,2022-09-12,false,False,Testing,False,go1.17,bcc1682b3a433f46cfb85bb38fe2d2f456019422,cockroachdb/cockroach-unstable,true
+v21.1.21,v21.1,2022-09-15,false,False,Production,False,go1.17,dd345173f3ef06b031cf470c67ae14dd0503a091,cockroachdb/cockroach,false,false

--- a/_includes/releases/v21.1/v21.1.21.md
+++ b/_includes/releases/v21.1/v21.1.21.md
@@ -1,0 +1,15 @@
+## v21.1.21
+
+Release Date: September 15, 2022
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v21-1-21-command-line-changes">Command-line changes</h3>
+
+- Added the `--log-config-vars` flag to the [`cockroach` CLI](../v21.1/cockroach-commands.html), which allows for environment variables to be specified for expansion within the logging configuration file. This change allows for a single logging configuration file to service an array of sinks without further manipulation of the configuration file. [#85173][#85173]
+
+<h3 id="v21-1-21-contributors">Contributors</h3>
+
+This release includes 1 merged PR by 2 authors.
+
+[#85173]: https://github.com/cockroachdb/cockroach/pull/85173


### PR DESCRIPTION
Addresses: DOC-5662

- v21.1.21 release notes.

[v21.1.md](https://deploy-preview-15095--cockroachdb-docs.netlify.app/docs/releases/v21.1.html#v21-1-21)