### PR TITLE
DOC-5661 log export externalid not supported

### DIFF
--- a/cockroachcloud/export-logs.md
+++ b/cockroachcloud/export-logs.md
@@ -295,6 +295,10 @@ Currently, the following CockroachDB [log channels](/docs/{{site.versions["stabl
 
 Yes, the [SQL Audit Log](/docs/{{site.versions["stable"]}}/sql-audit-logging.html) is exported via the `SENSITIVE_ACCESS` log channel by default, as long as you have previously enabled audit logging on desired tables using the [`ALTER TABLE ...EXPERIMENTAL_AUDIT`](/docs/{{site.versions["stable"]}}/experimental-audit.html) statement.
 
+### Can I use an AWS External ID with the log export feature?
+
+No, the {{ site.data.products.dedicated }} log export feature does not support use of an AWS External ID. You must configure a cross-account IAM Role as described in the [Enable log export](#enable-log-export) instructions.
+
 ## Troubleshooting
 
 ### AWS CloudWatch


### PR DESCRIPTION
Addresses: DOC-5661

- Adds a new FAQ entry advising that an AWS External ID is not supported for use with log export targeting AWS CloudWatch.

[export-logs.md](https://deploy-preview-15102--cockroachdb-docs.netlify.app/docs/cockroachcloud/export-logs#can-i-use-an-aws-external-id-with-the-log-export-feature)