### PR TITLE
DOC-5670 proxy status vars

### DIFF
--- a/v22.1/ui-overview.md
+++ b/v22.1/ui-overview.md
@@ -72,7 +72,16 @@ If your CockroachDB cluster is behind a load balancer, you may wish to proxy you
 You can accomplish this using one of these methods:
 
 - Once connected to DB Console, use the **Web server** dropdown menu from the [**Advanced Debug**](ui-debug-pages.html#license-and-node-information) page to select a different node to proxy to.
-- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
+- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use the following to proxy directly to node `2`:
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    https://<host>:<http-port>/?remote_node_id=2
+    ~~~
+- Provide a `remote_node_id` cookie value to `curl` or `wget` when accessing the [Cluster API](cluster-api.html) or a specific metrics endpoint such as [`_status/vars`](monitoring-and-alerting.html#prometheus-endpoint). For example, use the following to proxy directly to node `2` and access the `_status/vars` endpoint:
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    curl -X GET --cookie "remote_node_id=2" https://<host>:<http-port>/_status/vars
+    ~~~
 
 ## DB Console security considerations
 

--- a/v22.2/ui-overview.md
+++ b/v22.2/ui-overview.md
@@ -72,7 +72,16 @@ If your CockroachDB cluster is behind a load balancer, you may wish to proxy you
 You can accomplish this using one of these methods:
 
 - Once connected to DB Console, use the **Web server** dropdown menu from the [**Advanced Debug**](ui-debug-pages.html#license-and-node-information) page to select a different node to proxy to.
-- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use `http://<host>:<http-port>/?remote_node_id=2` to proxy directly to node `2`. 
+- Use the `remote_node_id` parameter in your DB Console URL to proxy directly to a specific node. For example, use the following to proxy directly to node `2`:
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    https://<host>:<http-port>/?remote_node_id=2
+    ~~~
+- Provide a `remote_node_id` cookie value to `curl` or `wget` when accessing the [Cluster API](cluster-api.html) or a specific metrics endpoint such as [`_status/vars`](monitoring-and-alerting.html#prometheus-endpoint). For example, use the following to proxy directly to node `2` and access the `_status/vars` endpoint:
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    curl -X GET --cookie "remote_node_id=2" https://<host>:<http-port>/_status/vars
+    ~~~
 
 ## DB Console security considerations
 


### PR DESCRIPTION
Addresses: DOC-5670

- Added note to use `remote_node_id` cookie in `curl` to proxy an endpoint connection for versions v22.2 and v22.1.

Question: 

- Do we want to see this in versions previous to v22.1? Not sure when this functionality was introduced. Thanks!

NOTE:

- Existing mention of the URL argument approach, i.e. `https://<host>:<http-port>/?remote_node_id=2`, comes from #[12993](https://github.com/cockroachdb/docs/issues/12993) & DOC - 2567 (to type accurately would re-open it). So this new guidance is added alongside.

[v22.2/ui-overview.md](https://deploy-preview-15113--cockroachdb-docs.netlify.app/docs/stable/ui-overview.html#proxy-db-console) | [v22.1/ui-overview.md](https://deploy-preview-15113--cockroachdb-docs.netlify.app/docs/v22.1/ui-overview.html#proxy-db-console)