### PR TITLE
Remove references to broken Instruqt tutorial pages

### DIFF
--- a/tutorials/demo-json-support-interactive.md
+++ b/tutorials/demo-json-support-interactive.md
@@ -4,5 +4,6 @@ summary: Use a local cluster to explore how CockroachDB can store and query unst
 layout: tutorial
 docs_area: deploy
 ---
-
-<iframe sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals" src="https://play.instruqt.com/embed/cockroachlabs/tracks/json-support?token=em_kLhgzYLoGsCAJBn_" style="overflow:hidden;height:100%;width:100%;border: 0;" height="100%" width="100%""></iframe>
+<!-->
+<iframe sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals" src="https://play.instruqt.com/embed/cockroachlabs/tracks/json-support?token=em_kLhgzYLoGsCAJBn_" style="overflow:hidden;height:100%;width:100%;border: 0;" height="100%" width="100%""></iframe>-->
+This content is currently unavailble.

--- a/tutorials/demo-spatial-tutorial-interactive.md
+++ b/tutorials/demo-spatial-tutorial-interactive.md
@@ -6,4 +6,4 @@ docs_area: deploy
 ---
 <!--
 <iframe sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals" src="https://play.instruqt.com/embed/cockroachlabs/tracks/spatial-data?token=em_8gXqjQ00Inft_mZn" style="overflow:hidden;height:100%;width:100%;border: 0;" height="100%" width="100%""></iframe>-->
-This content is currently unavailble.
+This content is currently unavailable.

--- a/tutorials/demo-spatial-tutorial-interactive.md
+++ b/tutorials/demo-spatial-tutorial-interactive.md
@@ -4,5 +4,6 @@ summary: Tutorial for working with spatial data in CockroachDB.
 layout: tutorial
 docs_area: deploy
 ---
-
-<iframe sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals" src="https://play.instruqt.com/embed/cockroachlabs/tracks/spatial-data?token=em_8gXqjQ00Inft_mZn" style="overflow:hidden;height:100%;width:100%;border: 0;" height="100%" width="100%""></iframe>
+<!--
+<iframe sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals" src="https://play.instruqt.com/embed/cockroachlabs/tracks/spatial-data?token=em_8gXqjQ00Inft_mZn" style="overflow:hidden;height:100%;width:100%;border: 0;" height="100%" width="100%""></iframe>-->
+This content is currently unavailble.

--- a/v22.1/demo-json-support.md
+++ b/v22.1/demo-json-support.md
@@ -7,10 +7,10 @@ docs_area: deploy
 ---
 
 This page guides you through a simple demonstration of how CockroachDB can store and query unstructured [`JSONB`](jsonb.html) data from a third-party API, as well as how a [GIN index](inverted-indexes.html) can optimize your queries.
-
+<!--
 <div class="clearfix">
   <a class="btn btn-outline-primary" href="../tutorials/demo-json-support-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
-</div>
+</div>-->
 
 ## Step 1. Install prerequisites
 

--- a/v22.1/spatial-tutorial.md
+++ b/v22.1/spatial-tutorial.md
@@ -14,10 +14,10 @@ In this tutorial, you will plan a vacation from New York City to the [Adirondack
 + Creating [indexes](spatial-indexes.html) on spatial data.
 + Performing [joins](joins.html) on spatial data, and using [`EXPLAIN`](explain.html) to make sure indexes are effective.
 + Visualizing the output of your queries using free tools like <https://geojson.io>
-
+<!--
 <div class="clearfix">
   <a class="btn btn-outline-primary" href="../tutorials/demo-spatial-tutorial-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
-</div>
+</div>-->
 
 ## Step 1. Review the scenario
 

--- a/v22.2/demo-json-support.md
+++ b/v22.2/demo-json-support.md
@@ -7,10 +7,10 @@ docs_area: deploy
 ---
 
 This page guides you through a simple demonstration of how CockroachDB can store and query unstructured [`JSONB`](jsonb.html) data from a third-party API, as well as how a [GIN index](inverted-indexes.html) can optimize your queries.
-
+<!--
 <div class="clearfix">
   <a class="btn btn-outline-primary" href="../tutorials/demo-json-support-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
-</div>
+</div>-->
 
 ## Step 1. Install prerequisites
 

--- a/v22.2/spatial-tutorial.md
+++ b/v22.2/spatial-tutorial.md
@@ -14,10 +14,10 @@ In this tutorial, you will plan a vacation from New York City to the [Adirondack
 + Creating [indexes](spatial-indexes.html) on spatial data.
 + Performing [joins](joins.html) on spatial data, and using [`EXPLAIN`](explain.html) to make sure indexes are effective.
 + Visualizing the output of your queries using free tools like <https://geojson.io>
-
+<!--
 <div class="clearfix">
   <a class="btn btn-outline-primary" href="../tutorials/demo-spatial-tutorial-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
-</div>
+</div>-->
 
 ## Step 1. Review the scenario
 


### PR DESCRIPTION
Partially addresses DOC-5571

* Updates the two non-working Instruqt demo pages to comment out iframe and add an 'unavailable' message.
* Comments out links on the applicable text-based tutorials to these Instruqt demo pages.