### PR TITLE
DOC-5704 removed typo

### DIFF
--- a/v22.1/connection-parameters.md
+++ b/v22.1/connection-parameters.md
@@ -188,7 +188,7 @@ This specifies a connection for the `root` user to an insecure cluster listening
 
 ## Connect using discrete parameters
 
-Most [`cockroach` Commands Overview](cockroach-commands.html) accept connection
+Most [`cockroach` commands](cockroach-commands.html) accept connection
 parameters as separate, discrete command-line flags, in addition (or
 in replacement) to `--url` which [specifies all parameters as a
 URL](#connect-using-a-url).

--- a/v22.2/connection-parameters.md
+++ b/v22.2/connection-parameters.md
@@ -188,7 +188,7 @@ This specifies a connection for the `root` user to an insecure cluster listening
 
 ## Connect using discrete parameters
 
-Most [`cockroach` Commands Overview](cockroach-commands.html) accept connection
+Most [`cockroach` commands](cockroach-commands.html) accept connection
 parameters as separate, discrete command-line flags, in addition (or
 in replacement) to `--url` which [specifies all parameters as a
 URL](#connect-using-a-url).


### PR DESCRIPTION
Addresses DOC-5704

- removed typo from v22.2 and v22.1

Staging:
[v22.1 Connection Parameters](https://deploy-preview-15163--cockroachdb-docs.netlify.app/docs/stable/connection-parameters.html#connect-using-discrete-parameters)
[v22.2 Connection Parameters](https://deploy-preview-15163--cockroachdb-docs.netlify.app/docs/dev/connection-parameters.html#connect-using-discrete-parameters)