### PR TITLE
Provide a placeholder for the link to the Insights page in the Insights UI.

### DIFF
--- a/v22.1/ui-insights-page.md
+++ b/v22.1/ui-insights-page.md
@@ -1,6 +1,6 @@
 ---
 title: Insights Page
-summary: The Insights page exposes problems that CockroachDB has detected in your workloads and schemas and offers recommendations to improve the performance of your workloads.
+summary: The Insights page exposes problems that CockroachDB has detected in your workloads and schemas.
 toc: true
 docs_area: reference.db_console
 ---

--- a/v22.1/ui-insights-page.md
+++ b/v22.1/ui-insights-page.md
@@ -1,0 +1,15 @@
+---
+title: Insights Page
+summary: The Insights page exposes problems that CockroachDB has detected in your workloads and schemas and offers recommendations to improve the performance of your workloads.
+toc: true
+docs_area: reference.db_console
+---
+
+{% include {{ page.version.version }}/ui/admin-access.md %}
+
+The **Insights** page helps you:
+
+- Identify SQL statements with [high retry counts](transactions.html#automatic-retries), [slow execution](query-behavior-troubleshooting.html#identify-slow-queries), or [suboptimal plans](cost-based-optimizer.html).
+- Identify [indexes](indexes.html) that should be created, altered, replaced, or dropped to improve performance.
+
+This feature is under development.


### PR DESCRIPTION
The 22.2 Insights UI pages point to `/docs/stable/ui-insights-page.html` but that page won't exist until GA.  In fact, `/docs/dev/ui-insights-page.html` probably won't be published either when the beta is released because [the PR](https://github.com/cockroachdb/docs/pull/15074) is still under development.  This is a placeholder page in `/docs/v22.1/ui-insights-page.html` which maps to  `/docs/stable/ui-insights-page.html` that says the feature is under development so that the link from the UI doesn't return 404. 