### PR TITLE
[DOC-5572] Document CPU exhaustion scenario and workaround when SCRAM Authentication is enabled

### DIFF
--- a/_includes/v22.1/scram-authentication-recommendations.md
+++ b/_includes/v22.1/scram-authentication-recommendations.md
@@ -1,0 +1,4 @@
+- Test and adjust your workloads in batches when migrating to SCRAM authentication.
+- Start by enabling SCRAM authentication in a testing environment, and test the performance of your client application against the types of workloads you expect it to handle in production before rolling the changes out to production.
+- Limit the maximum number of connections in the client driver's connection pool.
+- Limit the maximum number of concurrent transactions the client application can issue.

--- a/_includes/v22.2/scram-authentication-recommendations.md
+++ b/_includes/v22.2/scram-authentication-recommendations.md
@@ -1,0 +1,4 @@
+- Test and adjust your workloads in batches when migrating to SCRAM authentication.
+- Start by enabling SCRAM authentication in a testing environment, and test the performance of your client application against types the of workloads you expect it to handle in production before rolling the changes out to production.
+- Limit the maximum number of connections in the client driver's connection pool.
+- Limit the maximum number of concurrent transactions the client application can issue.

--- a/_includes/v22.2/scram-authentication-recommendations.md
+++ b/_includes/v22.2/scram-authentication-recommendations.md
@@ -1,4 +1,4 @@
 - Test and adjust your workloads in batches when migrating to SCRAM authentication.
-- Start by enabling SCRAM authentication in a testing environment, and test the performance of your client application against types the of workloads you expect it to handle in production before rolling the changes out to production.
+- Start by enabling SCRAM authentication in a testing environment, and test the performance of your client application against the types of workloads you expect it to handle in production before rolling the changes out to production.
 - Limit the maximum number of connections in the client driver's connection pool.
 - Limit the maximum number of concurrent transactions the client application can issue.

--- a/v22.1/error-handling-and-troubleshooting.md
+++ b/v22.1/error-handling-and-troubleshooting.md
@@ -67,6 +67,23 @@ However, you may need to access the underlying cluster to troubleshoot issues wh
 
 For more information about how to troubleshoot cluster-level issues, see [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html).
 
+## Troubleshoot SQL client application problems
+
+### High client CPU load or connection pool exhaustion when SCRAM Password-based Authentication is enabled
+
+When [SASL/SCRAM-SHA-256 Secure Password-based Authentication](security-reference/scram-authentication.html) (SCRAM Authentication) is enabled on a cluster, some additional CPU load is incurred on client applications, which are responsible for handling SCRAM hashing. It's important to plan for this additional CPU load to avoid performance degradation, CPU starvation, and connection pool exhaustion on the client. For example, the following set of circumstances can exhaust the client application's resources:
+
+1. SCRAM Authentication is enabled on the cluster.
+1. The client driver's connection pool has no defined maximum number of connections.
+1. The client application issues transactions concurrently.
+
+In this situation, each new connection uses more CPU on the client application server than connecting to a cluster without SCRAM Authentication enabled. Because of this additional CPU load, each concurrent transaction is slower, and a larger quantity of concurrent transactions can accumulate, in conjunction with a larger number of concurrent connections. In this situation, it can be difficult for the client application server to recover.
+
+To mitigate against this situation, Cockroach Labs recommends that you:
+
+{% include_cached {{page.version.version}}/scram-authentication-recommendations.md %}
+
+
 ## See also
 
 ### Tasks

--- a/v22.1/security-reference/scram-authentication.md
+++ b/v22.1/security-reference/scram-authentication.md
@@ -7,15 +7,15 @@ docs_area: reference.security
 
 This page provides an overview of the security and implementation considerations for using SCRAM-SHA-256 [authentication](authentication.html) in CockroachDB.
 
-{% include_cached new-in.html version="v22.1" %} CockroachDB supports SCRAM-SHA-256 authentication for clients in both {{ site.data.products.db }} and {{ site.data.products.core }}.
+CockroachDB supports SCRAM-SHA-256 authentication for clients in both {{ site.data.products.db }} and {{ site.data.products.core }}.
 
 CockroachDB's support for SCRAM-SHA-256 is PostgreSQL-compatible. PostgreSQL client drivers that support SCRAM-SHA-256 remain compatible with CockroachDB when SCRAM authentication is enabled.
 
 **Contents:**
 
 - [Conceptual Overview of SASL and SCRAM](#sasl-scram-and-scram-sha-256)
-- [Guidance for implementing SCRAM-SHA-256 authentication in CockroachDB](#implementing-scram-authentication-in-your-cockroachdb-cluster)
-- [Guidance for implementing strict isolation of plaintext credentials (separation of concerns)](#implementing-strict-isolation-of-plaintext-credentials )
+- [Guidance for implementing SCRAM-SHA-256 authentication in CockroachDB](#implement-scram-authentication-in-your-cockroachdb-cluster)
+- [Guidance for implementing strict isolation of cleartext credentials (separation of concerns)](#implement-strict-isolation-of-cleartext-credentials )
 
 ## SASL, SCRAM and SCRAM-SHA-256
 
@@ -35,50 +35,54 @@ During password-based authentication, a hash of the password must be computed. T
 
 In SCRAM authentication, the client does the encryption work in order to produce the proof of identity. In other methods the hash is computed server-side after the password is transmitted across the network. SCRAM authentication therefore offloads the computation cost to its clients, which in most cases are application servers.
 
-Adopting SCRAM, in contrast to plaintext password authentication, therefore offers additional protection against distributed denial-of-service (DDoS) attacks against CockroachDB, by preventing a CPU overload of the server to compute password hashes.
+Adopting SCRAM, in contrast to cleartext password authentication, therefore offers additional protection against distributed denial-of-service (DDoS) attacks against CockroachDB, by preventing a CPU overload of the server to compute password hashes.
 
 {{site.data.alerts.callout_info}}
-Note that SCRAM authentication does impose an additional computational load on your application servers, which need to compute the client proof for each authentication. Therefore, we recommend migrating your user population in batches when migrating to SCRAM authentication. This process will allow you to evaluate the impact on performance and resource consumption, and make any necessary adjustments.
+SCRAM authentication imposes additional computational load on your application servers, which need to compute the client proof for each authentication. Additional changes may be required to your application, such as limiting the number of connections in your application's connection pool or limiting the number of concurrent transactions that your client allows. Cockroach Labs recommends that you:
+
+{% include_cached {{page.version.version}}/scram-authentication-recommendations.md %}
+
+For more details, refer to [Troubleshoot SQL client application problems](../error-handling-and-troubleshooting.html#troubleshoot-sql-client-application-problems)
 {{site.data.alerts.end}}
 
 #### Defense from replay attacks
 
-Without SCRAM, plaintext passwords can be TLS-encrypted when sent to the server, which offers some protection. However, if clients skip validation of the server's certificate (i.e., fail to use `sslmode=verify-full`), attackers may be able to intercept authentication messages (containing the password), and later reuse them to impersonate the user.
+Without SCRAM, cleartext passwords can be TLS-encrypted when sent to the server, which offers some protection. However, if clients skip validation of the server's certificate (i.e., fail to use `sslmode=verify-full`), attackers may be able to intercept authentication messages (containing the password), and later reuse them to impersonate the user.
 
 SCRAM offers strong protection against such [replay attacks](https://en.wikipedia.org/wiki/Replay_attack), wherein an attacker records and re-uses authentication messages.
 
 #### Separation of concerns
 
-A server that authenticates users with SCRAM does not need to store or handle plaintext passwords. Therefore, a system that employs SASL-compliant SCRAM authentication can consolidate responsibility for handling plaintext credentials to a dedicated secrets-management service. This helps to minimize exposure of the credentials to possible egress both at rest and in flight. In keeping with the principle of "separation of concerns", wherein each high-level functionality or "concern" should be handled by a dedicated component, enterprise IT infrastructures often enforce such a consolidation.
+A server that authenticates users with SCRAM does not need to store or handle cleartext passwords. Therefore, a system that employs SASL-compliant SCRAM authentication can consolidate responsibility for handling cleartext credentials to a dedicated secrets-management service. This helps to minimize exposure of the credentials to possible egress both at rest and in flight. In keeping with the principle of "separation of concerns", wherein each high-level functionality or "concern" should be handled by a dedicated component, enterprise IT infrastructures often enforce such a consolidation.
 
 Isolation of credential-handling offers many advantages to a delegated service (whether self-hosted or used as a cloud-based external service).
 Most importantly, it removes the possibility of any credential spill from your CockroachDB cluster's authentication database (i.e., the cluster's `system.users` table), since it no longer contains credentials.
 
 This not only reduces the impact of any compromises to the database, but also makes it a far less attractive target.
 
-Full separation of concerns requires more than just enabling SCRAM-SHA-256 authentication. The additional requirements are detailed [here](#implementing-strict-isolation-of-plaintext-credentials).
+Full separation of concerns requires more than just enabling SCRAM-SHA-256 authentication. The additional requirements are detailed [here](#implement-strict-isolation-of-cleartext-credentials).
 
-## Implementing SCRAM authentication in your CockroachDB Cluster
+## Implement SCRAM authentication in your CockroachDB Cluster
 
-This section details how to use SCRAM authentication rather than plaintext password authentication.
+This section details how to use SCRAM authentication rather than cleartext password authentication.
 
 **Requirements for implementing SCRAM-SHA-256**:
 
-1. [Enable SCRAM-SHA-256 password encryption](#enabling-scram-sha-256-authentication-for-new-users-roles)
-2. [Migrate pre-existing users](#migrating-existing-users-roles-to-scram-sha-256-authentication)
+1. [Enable SCRAM-SHA-256 password encryption](#enable-scram-sha-256-authentication-for-new-users-roles)
+2. [Migrate pre-existing users](#migrate-existing-users-roles-from-cleartext-passwords-to-scram-sha-256-authentication)
 
-{{site.data.alerts.callout_info}}
-SCRAM authentication can only be used after the upgrade to v22.1 has been finalized.
-{{site.data.alerts.end}}
+### Enable SCRAM-SHA-256 authentication for new users/roles
 
-### Enabling SCRAM-SHA-256 authentication for new users/roles
-
-To enable SCRAM-SHA-256 encoding of newly defined passwords, set the `server.user_login.password_encryption` [cluster setting](../cluster-settings.html) to `scram-sha-256`. When this setting is set to `scram-sha-256`, passwords created with the following SQL statements will be managed and authenticated according to SCRAM-SHA-256.
+In CockroachDB v22.1.x and below, the setting defaults to `bcrypt`. When this setting is set to `scram-sha-256`, passwords created with the following SQL statements will be managed and authenticated according to SCRAM-SHA-256.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
 SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';
 ~~~
+
+{{site.data.alerts.callout_info}}
+In CockroachDB v22.x and above, `user_login.password_encryption` defaults to `scram-sha-256`. In CockroachDB v22.1.x and below, the default is `bcrypt`. Automatic eventual migration of existing users and roles from cleartext passwords to SCRAM-SHA-256 authentication is disabled by default. Refer to [Migrate existing users/roles from cleartext passwords to SCRAM SHA-256 authentication](#migrate-existing-users-roles-from-cleartext-passwords-to-scram-sha-256-authentication).
+{{site.data.alerts.end}}
 
 Once a SQL user has a SCRAM password hash defined, CockroachDB will automatically select the SCRAM protocol to authenticate that user.
 
@@ -97,14 +101,14 @@ SELECT username, "hashedPassword" FROM system.users WHERE username='hypothetical
 ~~~
 
 {{site.data.alerts.callout_info}}
-The procedure documented here, creating a SCRAM-SHA-256-authenticated user by passing a *plaintext* password to the CockroachDB client, achieves the benefit of not requiring the plaintext password to be transmitted over the network; this offers good protection from replay attacks in case attackers bypass TLS. But it does not achieve full separation of concerns by isolating the plaintext password to a delegated service. The necessary additional steps to achieve this are documented in [Implementing strict isolation of plaintext credentials](#implementing-strict-isolation-of-plaintext-credentials).
+The procedure documented here, creating a SCRAM-SHA-256-authenticated user by passing a *cleartext* password to the CockroachDB client, achieves the benefit of not requiring the cleartext password to be transmitted over the network; this offers good protection from replay attacks in case attackers bypass TLS. But it does not achieve full separation of concerns by isolating the cleartext password to a delegated service. The necessary additional steps to achieve this are documented in [Implement strict isolation of cleartext credentials](#implement-strict-isolation-of-cleartext-credentials).
 {{site.data.alerts.end}}
 
-### Migrating existing users/roles to SCRAM-SHA-256 authentication
+### Migrate existing users/roles from cleartext passwords to SCRAM-SHA-256 authentication
 
 #### Eventual migration
 
-It is possible to automatically convert the records for previously created users from plaintext passwords to SCRAM-compatible hash encodings. This will cause CockroachDB to use SCRAM authentication when client apps connect to CockroachDB, provided that the cluster's authentication configuration has also been set to accept SCRAM-SHA-256.
+It is possible to automatically convert the records for previously created users from cleartext passwords to SCRAM-compatible hash encodings. This will cause CockroachDB to use SCRAM authentication when client apps connect to CockroachDB, provided that the cluster's authentication configuration has also been set to accept SCRAM-SHA-256.
 
 To convert existing users to SCRAM-SHA-256, enable the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` cluster setting. When this setting is enabled, the conversion occurs the first time a client app connects with the previously defined password. During that first connection, the previous mechanism will be used to establish the connection, and then CockroachDB will re-encode the password using the SCRAM algorithm. Subsequent connections will then use the SCRAM handshake for authentication.
 
@@ -119,43 +123,43 @@ SET CLUSTER SETTING server.user_login.upgrade_bcrypt_stored_passwords_to_scram.e
 
 It is not possible to automatically convert credentials to SCRAM in bulk, without client participation. To implement SCRAM for all SQL user accounts simultaneously, use [`ALTER USER <USERNAME> WITH PASSWORD`](../alter-user.html) statements instead.
 
-## Implementing strict isolation of plaintext credentials
+## Implement strict isolation of cleartext credentials
 
-Plaintext credentials are a valuable asset to malicious agents; known as ["credential stuffing,"](https://en.wikipedia.org/wiki/Credential_stuffing) re-use of stolen passwords is a persistent problem throughout the ecosystem of internet services. Hence, any system that handles plaintext credentials becomes a favorable target for malicious attackers with potentially weak points in the system.
+Cleartext credentials are a valuable asset to malicious agents; known as ["credential stuffing,"](https://en.wikipedia.org/wiki/Credential_stuffing) re-use of stolen passwords is a persistent problem throughout the ecosystem of internet services. Hence, any system that handles cleartext credentials becomes a favorable target for malicious attackers with potentially weak points in the system.
 
-While the measures [described previously](#implementing-scram-authentication-in-your-cockroachdb-cluster) allow CockroachDB to avoid transmitting plaintext passwords across the network, the  credentials still have a footprint within CockroachDB: they are transmitted in plaintext from the CockroachDB client to the server, and are hence vulnerable in transit. While the secrets are protected in transit by TLS, CA certificate server authentication is not infallible.
+While the measures [described previously](#implement-scram-authentication-in-your-cockroachdb-cluster) allow CockroachDB to avoid transmitting cleartext passwords across the network, the  credentials still have a footprint within CockroachDB: they are transmitted in cleartext from the CockroachDB client to the server, and are hence vulnerable in transit. While the secrets are protected in transit by TLS, CA certificate server authentication is not infallible.
 
-Moreover, the plaintext credentials must be handled in memory by CockroachDB in order to generate the hashes on the server, and this offers a potential opportunity for hypothetical attackers who have compromised your node's runtime environment. It is architecturally stronger to perform all handling of plaintext credentials for your system with a dedicated, hardened, specialized environment and process. This entails removing all handling of plaintext credentials from CockroachDB.
+Moreover, the cleartext credentials must be handled in memory by CockroachDB in order to generate the hashes on the server, and this offers a potential opportunity for hypothetical attackers who have compromised your node's runtime environment. It is architecturally stronger to perform all handling of cleartext credentials for your system with a dedicated, hardened, specialized environment and process. This entails removing all handling of cleartext credentials from CockroachDB.
 
-It is possible to operate a CockroachDB cluster in such a way that it never handles plaintext passwords. This prevents the malicious use of stolen credentials, even in case the CockroachDB node is compromised.
+It is possible to operate a CockroachDB cluster in such a way that it never handles cleartext passwords. This prevents the malicious use of stolen credentials, even in case the CockroachDB node is compromised.
 
 **Requirements for strict isolation**:
 
-- Handling plaintext credentials securely
-- Configuring your cluster settings
-- Managing users with pre-hashed passwords
+- Handle cleartext credentials securely
+- Configure your cluster settings
+- Manage users with pre-hashed passwords
 
-### Migrating from password to SCRAM
+### Migrate existing users/roles from cleartext passwords to SCRAM-SHA-256 authentication
 
-If a cluster had previously allowed plaintext password authentication (i.e., any cluster that began on a version prior to v22.1), you must carefully migrate to SCRAM-SHA-256 authentication in the following phases:
+If a cluster had previously allowed cleartext password authentication (i.e., any cluster that began on a version prior to v22.1), you must carefully migrate to SCRAM-SHA-256 authentication in the following phases:
 
-1. Instead of creating and rotating user passwords by passing plaintext passwords into SQL statements, as described [previously](#enabling-scram-sha-256-authentication-for-new-users-roles), you must instead generate CockroachDB/PostgreSQL-formatted SCRAM-SHA-256 hashes and enter those directly into the client, as described in the [following section](#managing-users-with-pre-hashed-passwords).
-2. You must block clients from sending plaintext passwords to CockroachDB during authentication by [customizing your cluster's authentication configuration](#configuring-your-cluster-settings-for-strict-credential-isolation) so that only the `scram-sha-256` and `cert-scram-sha-256` methods, and neither `password` nor `cert-password`, are allowed.
-3. After steps (1) and (2) are complete, you must update any previously created passwords with externally generated SCRAM-SHA-256 hashes, and continue to generate your own hashes for all user creation and password update operations.
+1. Instead of creating and rotating user passwords by passing cleartext passwords into SQL statements, as described [previously](#enable-scram-sha-256-authentication-for-new-users-roles), you must instead generate CockroachDB/PostgreSQL-formatted SCRAM-SHA-256 hashes and enter those directly into the client, as described in the [following section](#manage-users-with-pre-hashed-passwords).
+2. You must block clients from sending cleartext passwords to CockroachDB during authentication by [customizing your cluster's authentication configuration](#configure-your-cluster-settings-for-strict-credential-isolation) so that only the `scram-sha-256` and `cert-scram-sha-256` methods, and neither `password` nor `cert-password`, are allowed.
+3. After steps 1 and 2 are complete, you must update any previously-created passwords with externally-generated SCRAM-SHA-256 hashes, and you must continue to generate your own hashes for all user creation and password update operations.
 
-Note the importance of rotating passwords twice, both in steps (1) and again in (3), with different passwords.  Step (1) ensures that clients at step (2) can continue to connect after non-SCRAM logins are blocked. However, between step (1) and step (2) it is still possible for CockroachDB to receive plaintext passwords from clients, and so the passwords used at step (1) are not fully protected yet. After step (2), CockroachDB will not learn plaintext passwords from clients any more; then after step 3 it will not know plaintext passwords at all.
+Note the importance of rotating passwords twice, in both steps 1 and 3, with different passwords. Step 1 ensures that clients at step 2 can continue to connect after non-SCRAM logins are blocked. However, between step 1 and step 2 it is still possible for CockroachDB to receive cleartext passwords from clients, and so the passwords used at step 1 are not fully protected yet. After step 2, CockroachDB will no longer learn cleartext passwords from clients, and after step 3 it will not know cleartext passwords at all.
 
-### Configuring your cluster settings for strict credential isolation
+### Configure your cluster settings for strict credential isolation
 
 To enable strict credential isolation from CockroachDB, additional cluster settings are required beyond simply enabling SCRAM authentication, as detailed in [Enabling SCRAM-SHA-256 authentication for new users/roles
-](#enabling-scram-sha-256-authentication-for-new-users-roles).
+](#enable-scram-sha-256-authentication-for-new-users-roles).
 
 Required cluster settings:
 
 
 #### `server.user_login.password_encryption`
 
-Enable SCRAM for new passwords.
+Enable SCRAM for new passwords. In CockroachDB v22.1.x and below, this cluster setting defaults to `bcrypt`.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
@@ -164,7 +168,7 @@ SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';
 
 #### `server.user_login.store_client_pre_hashed_passwords.enabled`
 
-Enable the CockroachDB cluster to accept pre-computed SCRAM-SCHA-256 salted password hashes, rather than accepting a plaintext password and computing the hash itself.
+Enable the CockroachDB cluster to accept pre-computed SCRAM-SCHA-256 salted password hashes, rather than accepting a cleartext password and computing the hash itself. This cluster setting is disabled by default.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
@@ -176,9 +180,9 @@ SET CLUSTER SETTING setting server.user_login.store_client_pre_hashed_passwords.
 Allow *only* `scram-sha-256` (not the weaker `password`) in your [Authentication Configuration (HBA)](authentication.html#authentication-configuration).
 
 {{site.data.alerts.callout_danger}}
-After this change, users will not be able to sign in with plaintext passwords. All critical SQL users must be migrated to SCRAM-SHA-256 authentication before making this change:
+After this change, users will not be able to sign in with cleartext passwords. All critical SQL users must be migrated to SCRAM-SHA-256 authentication before making this change:
 1. All client drivers must be updated to a version that supports SCRAM handshakes.
-2. All stored credentials for client apps must be updated to use SCRAM encoded passwords. This procedure is detailed in [Migrating existing users/roles to SCRAM-SHA-256 authentication](#migrating-existing-users-roles-to-scram-sha-256-authentication).
+2. All stored credentials for client apps must be updated to use SCRAM encoded passwords. This procedure is detailed in [Migrating existing users/roles to SCRAM-SHA-256 authentication](#migrate-existing-users-roles-from-cleartext-passwords-to-scram-sha-256-authentication).
 {{site.data.alerts.end}}
 
 {% include_cached copy-clipboard.html %}
@@ -192,21 +196,21 @@ SET CLUSTER SETTING server.host_based_authentication.configuration TO '
 # any other lower-priority rules ...
 ~~~
 
-### Handling plaintext credentials securely
+### Handle cleartext credentials securely
 
-Using SCRAM authentication, a CockroachdDB cluster need not store or handle the plaintext passwords used by clients to authenticate. However, to achieve full separation of concerns, the plaintext credentials must be isolated so that they are exposed as little as possible in transit, storage, and during computation.
+Using SCRAM authentication, a CockroachdDB cluster need not store or handle the cleartext passwords used by clients to authenticate. However, to achieve full separation of concerns, the cleartext credentials must be isolated so that they are exposed as little as possible in transit, storage, and during computation.
 
-Generally, this can be best achieved by handling plaintext credentials only in a dedicated credential management environment, such as a secure compute instance or secure physical workstation.
+Generally, this can be best achieved by handling cleartext credentials only in a dedicated credential management environment, such as a secure compute instance or secure physical workstation.
 
 That environment must be provisioned with:
 
-- A tool for [creating PostgreSQL/CockroachDB-formatted SCRAM-SHA-256 hashes](#managing-users-with-pre-hashed-passwords), such as the example script provided in the [appendix](#appendix-python-scram-hashing-script).
+- A tool for [creating PostgreSQL/CockroachDB-formatted SCRAM-SHA-256 hashes](#manage-users-with-pre-hashed-passwords), such as the example script provided in the [appendix](#appendix-python-scram-hashing-script).
 - A CockroachDB client with ['USER CREATE/ALTER privileges'](../create-user.html#create-a-user-that-can-create-other-users-and-manage-authentication-methods-for-the-new-users).
-- Access, with write privileges, to a secrets store where the plaintext passwords will be persisted.
+- Access, with write privileges, to a secrets store where the cleartext passwords will be persisted.
 
-On that instance, [generate SCRAM salted password hashes](#managing-users-with-pre-hashed-passwords), manage the users via CockroachdDB client, as described in the following section, and persist the secrets in the secrets store.
+On that instance, [generate SCRAM salted password hashes](#manage-users-with-pre-hashed-passwords), manage the users via CockroachdDB client, as described in the following section, and persist the secrets in the secrets store.
 
-## Managing users with pre-hashed passwords
+## Manage users with pre-hashed passwords
 
 [Many database tools](https://passlib.readthedocs.io/en/stable/lib/passlib.hash.scram.html) support SCRAM-SHA-256 and can be used to calculate the hashes servers will need for authentication.
 
@@ -252,7 +256,7 @@ Time: 156ms total (execution 156ms / network 0ms)
 
 ### Inspect the user
 
-In this way, the server stores the information needed for SCRAM authentication, despite the plaintext password never having been conveyed to CockroachDB. The 'concern' with plaintext passwords has been cleanly 'separated' from CockroachDB.
+In this way, the server stores the information needed for SCRAM authentication, despite the cleartext password never having been conveyed to CockroachDB. The 'concern' with cleartext passwords has been cleanly 'separated' from CockroachDB.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql

--- a/v22.2/error-handling-and-troubleshooting.md
+++ b/v22.2/error-handling-and-troubleshooting.md
@@ -67,6 +67,23 @@ However, you may need to access the underlying cluster to troubleshoot issues wh
 
 For more information about how to troubleshoot cluster-level issues, see [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html).
 
+## Troubleshoot SQL client application problems
+
+### High client CPU load or connection pool exhaustion when SCRAM Password-based Authentication is enabled
+
+When [SASL/SCRAM-SHA-256 Secure Password-based Authentication](security-reference/scram-authentication.html) (SCRAM Authentication) is enabled on a cluster, some additional CPU load is incurred on client applications, which are responsible for handling SCRAM hashing. It's important to plan for this additional CPU load to avoid performance degradation, CPU starvation, and connection pool exhaustion on the client. For example, the following set of circumstances can exhaust the client application's resources:
+
+1. SCRAM Authentication is enabled on the cluster.
+1. The client driver's connection pool has no defined maximum number of connections.
+1. The client application issues transactions concurrently.
+
+In this situation, each new connection uses more CPU than connecting to a cluster without SCRAM Authentication enabled. Because of this additional CPU load, each concurrent transaction is slower, and a larger quantity of concurrent transactions can accumulate, in conjunction with a larger number of concurrent connections. In this situation, it can be difficult for the client application server to recover.
+
+To mitigate against this situation, Cockroach Labs recommends that you:
+
+{% include_cached {{page.version.version}}/scram-authentication-recommendations.md %}
+
+
 ## See also
 
 ### Tasks

--- a/v22.2/error-handling-and-troubleshooting.md
+++ b/v22.2/error-handling-and-troubleshooting.md
@@ -77,7 +77,7 @@ When [SASL/SCRAM-SHA-256 Secure Password-based Authentication](security-referenc
 1. The client driver's connection pool has no defined maximum number of connections.
 1. The client application issues transactions concurrently.
 
-In this situation, each new connection uses more CPU than connecting to a cluster without SCRAM Authentication enabled. Because of this additional CPU load, each concurrent transaction is slower, and a larger quantity of concurrent transactions can accumulate, in conjunction with a larger number of concurrent connections. In this situation, it can be difficult for the client application server to recover.
+In this situation, each new connection uses more CPU on the client application server than connecting to a cluster without SCRAM Authentication enabled. Because of this additional CPU load, each concurrent transaction is slower, and a larger quantity of concurrent transactions can accumulate, in conjunction with a larger number of concurrent connections. In this situation, it can be difficult for the client application server to recover.
 
 To mitigate against this situation, Cockroach Labs recommends that you:
 

--- a/v22.2/security-reference/scram-authentication.md
+++ b/v22.2/security-reference/scram-authentication.md
@@ -73,7 +73,7 @@ This section details how to use SCRAM authentication rather than cleartext passw
 
 ### Enable SCRAM-SHA-256 authentication for new users/roles
 
-In CockroachDB v22.2.x and above, passwords are encrypted using SCRAM-SHA-256 by default, and the `server.user_login.password_encryption` [cluster setting](../cluster-settings.html) defaults to `scram-sha-256`. In CockroachDB v22.1.x and below, the setting defaults to `bcrypt`. When this setting is set to `scram-sha-256`, passwords created with the following SQL statements will be managed and authenticated according to SCRAM-SHA-256.
+In CockroachDB v22.2.x and above, passwords are encrypted using SCRAM-SHA-256 by default, and the `server.user_login.password_encryption` [cluster setting](/docs/{{ page.version.version }}/cluster-settings.html) defaults to `scram-sha-256`. In CockroachDB v22.1.x and below, the setting defaults to `bcrypt`. When this setting is set to `scram-sha-256`, passwords created with the following SQL statements will be managed and authenticated according to SCRAM-SHA-256.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
@@ -113,7 +113,7 @@ It is possible to automatically convert the records for previously created users
 To convert existing users to SCRAM-SHA-256, enable the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` cluster setting. When this setting is enabled, the conversion occurs the first time a client app connects with the previously defined password. During that first connection, the previous mechanism will be used to establish the connection, and then CockroachDB will re-encode the password using the SCRAM algorithm. Subsequent connections will then use the SCRAM handshake for authentication.
 
 {{site.data.alerts.callout_info}}
-In CockroachDB v22.2.x and above, the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` [cluster setting](cluster-settings.html) is enabled by default. Because `user_login.password_encryption` also defaults to `scram-sha-256`, this means that by default, any user who still uses cleartext passwords will be migrated to SCRAM-SHA-256 authentication. To prevent this automatic migration, set `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` to `false` before upgrading to CockroachDB v22.2.x.
+In CockroachDB v22.2.x and above, the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` [cluster setting](/docs/{{ page.version.version }}/cluster-settings.html) is enabled by default. Because `user_login.password_encryption` also defaults to `scram-sha-256`, this means that by default, any user who still uses cleartext passwords will be migrated to SCRAM-SHA-256 authentication. To prevent this automatic migration, set `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` to `false` before upgrading to CockroachDB v22.2.x.
 {{site.data.alerts.end}}
 
 To enable the cluster setting:

--- a/v22.2/security-reference/scram-authentication.md
+++ b/v22.2/security-reference/scram-authentication.md
@@ -15,7 +15,7 @@ CockroachDB's support for SCRAM-SHA-256 is PostgreSQL-compatible. PostgreSQL cli
 
 - [Conceptual Overview of SASL and SCRAM](#sasl-scram-and-scram-sha-256)
 - [Guidance for implementing SCRAM-SHA-256 authentication in CockroachDB](#implement-scram-authentication-in-your-cockroachdb-cluster)
-- [Guidance for implementing strict isolation of plaintext credentials (separation of concerns)](#implement-strict-isolation-of-plaintext-credentials )
+- [Guidance for implementing strict isolation of cleartext credentials (separation of concerns)](#implement-strict-isolation-of-cleartext-credentials )
 
 ## SASL, SCRAM and SCRAM-SHA-256
 
@@ -35,7 +35,7 @@ During password-based authentication, a hash of the password must be computed. T
 
 In SCRAM authentication, the client does the encryption work in order to produce the proof of identity. In other methods the hash is computed server-side after the password is transmitted across the network. SCRAM authentication therefore offloads the computation cost to its clients, which in most cases are application servers.
 
-Adopting SCRAM, in contrast to plaintext password authentication, therefore offers additional protection against distributed denial-of-service (DDoS) attacks against CockroachDB, by preventing a CPU overload of the server to compute password hashes.
+Adopting SCRAM, in contrast to cleartext password authentication, therefore offers additional protection against distributed denial-of-service (DDoS) attacks against CockroachDB, by preventing a CPU overload of the server to compute password hashes.
 
 {{site.data.alerts.callout_info}}
 SCRAM authentication imposes additional computational load on your application servers, which need to compute the client proof for each authentication. Additional changes may be required to your application, such as limiting the number of connections in your application's connection pool or limiting the number of concurrent transactions that your client allows. Cockroach Labs recommends that you:
@@ -47,38 +47,42 @@ For more details, refer to [Troubleshoot SQL client application problems](../err
 
 #### Defense from replay attacks
 
-Without SCRAM, plaintext passwords can be TLS-encrypted when sent to the server, which offers some protection. However, if clients skip validation of the server's certificate (i.e., fail to use `sslmode=verify-full`), attackers may be able to intercept authentication messages (containing the password), and later reuse them to impersonate the user.
+Without SCRAM, cleartext passwords can be TLS-encrypted when sent to the server, which offers some protection. However, if clients skip validation of the server's certificate (i.e., fail to use `sslmode=verify-full`), attackers may be able to intercept authentication messages (containing the password), and later reuse them to impersonate the user.
 
 SCRAM offers strong protection against such [replay attacks](https://en.wikipedia.org/wiki/Replay_attack), wherein an attacker records and re-uses authentication messages.
 
 #### Separation of concerns
 
-A server that authenticates users with SCRAM does not need to store or handle plaintext passwords. Therefore, a system that employs SASL-compliant SCRAM authentication can consolidate responsibility for handling plaintext credentials to a dedicated secrets-management service. This helps to minimize exposure of the credentials to possible egress both at rest and in flight. In keeping with the principle of "separation of concerns", wherein each high-level functionality or "concern" should be handled by a dedicated component, enterprise IT infrastructures often enforce such a consolidation.
+A server that authenticates users with SCRAM does not need to store or handle cleartext passwords. Therefore, a system that employs SASL-compliant SCRAM authentication can consolidate responsibility for handling cleartext credentials to a dedicated secrets-management service. This helps to minimize exposure of the credentials to possible egress both at rest and in flight. In keeping with the principle of "separation of concerns", wherein each high-level functionality or "concern" should be handled by a dedicated component, enterprise IT infrastructures often enforce such a consolidation.
 
 Isolation of credential-handling offers many advantages to a delegated service (whether self-hosted or used as a cloud-based external service).
 Most importantly, it removes the possibility of any credential spill from your CockroachDB cluster's authentication database (i.e., the cluster's `system.users` table), since it no longer contains credentials.
 
 This not only reduces the impact of any compromises to the database, but also makes it a far less attractive target.
 
-Full separation of concerns requires more than just enabling SCRAM-SHA-256 authentication. The additional requirements are detailed [here](#implement-strict-isolation-of-plaintext-credentials).
+Full separation of concerns requires more than just enabling SCRAM-SHA-256 authentication. The additional requirements are detailed [here](#implement-strict-isolation-of-cleartext-credentials).
 
 ## Implement SCRAM authentication in your CockroachDB Cluster
 
-This section details how to use SCRAM authentication rather than plaintext password authentication.
+This section details how to use SCRAM authentication rather than cleartext password authentication.
 
 **Requirements for implementing SCRAM-SHA-256**:
 
 1. [Enable SCRAM-SHA-256 password encryption](#enable-scram-sha-256-authentication-for-new-users-roles)
-2. [Migrate pre-existing users](#migrate-existing-users-roles-to-scram-sha-256-authentication)
+2. [Migrate pre-existing users](#migrate-existing-users-roles-from-cleartext-passwords-to-scram-sha-256-authentication)
 
 ### Enable SCRAM-SHA-256 authentication for new users/roles
 
-To enable SCRAM-SHA-256 encoding of newly defined passwords, set the `server.user_login.password_encryption` [cluster setting](../cluster-settings.html) to `scram-sha-256`. When this setting is set to `scram-sha-256`, passwords created with the following SQL statements will be managed and authenticated according to SCRAM-SHA-256.
+In CockroachDB v22.2.x and above, passwords are encrypted using SCRAM-SHA-256 by default, and the `server.user_login.password_encryption` [cluster setting](../cluster-settings.html) defaults to `scram-sha-256`. In CockroachDB v22.1.x and below, the setting defaults to `bcrypt`. When this setting is set to `scram-sha-256`, passwords created with the following SQL statements will be managed and authenticated according to SCRAM-SHA-256.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
 SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';
 ~~~
+
+{{site.data.alerts.callout_info}}
+In CockroachDB v22.2x and above, `user_login.password_encryption` defaults to `scram-sha-256`. In CockroachDB v22.1.x and below, the default is `bcrypt`. Automatic eventual migration of existing users and roles from cleartext passwords to SCRAM-SHA-256 authentication is also enabled by default in CockroachDB v22.x and above. Refer to [Migrate existing users/roles from cleartext passwords to SCRAM SHA-256 authentication](#migrate-existing-users-roles-from-cleartext-passwords-to-scram-sha-256-authentication).
+{{site.data.alerts.end}}
 
 Once a SQL user has a SCRAM password hash defined, CockroachDB will automatically select the SCRAM protocol to authenticate that user.
 
@@ -97,16 +101,20 @@ SELECT username, "hashedPassword" FROM system.users WHERE username='hypothetical
 ~~~
 
 {{site.data.alerts.callout_info}}
-The procedure documented here, creating a SCRAM-SHA-256-authenticated user by passing a *plaintext* password to the CockroachDB client, achieves the benefit of not requiring the plaintext password to be transmitted over the network; this offers good protection from replay attacks in case attackers bypass TLS. But it does not achieve full separation of concerns by isolating the plaintext password to a delegated service. The necessary additional steps to achieve this are documented in [Implementing strict isolation of plaintext credentials](#implement-strict-isolation-of-plaintext-credentials).
+The procedure documented here, creating a SCRAM-SHA-256-authenticated user by passing a *cleartext* password to the CockroachDB client, achieves the benefit of not requiring the cleartext password to be transmitted over the network; this offers good protection from replay attacks in case attackers bypass TLS. But it does not achieve full separation of concerns by isolating the cleartext password to a delegated service. The necessary additional steps to achieve this are documented in [Implement strict isolation of cleartext credentials](#implement-strict-isolation-of-cleartext-credentials).
 {{site.data.alerts.end}}
 
-### Migrate existing users/roles to SCRAM-SHA-256 authentication
+### Migrate existing users/roles from cleartext passwords to SCRAM-SHA-256 authentication
 
 #### Eventual migration
 
-It is possible to automatically convert the records for previously created users from plaintext passwords to SCRAM-compatible hash encodings. This will cause CockroachDB to use SCRAM authentication when client apps connect to CockroachDB, provided that the cluster's authentication configuration has also been set to accept SCRAM-SHA-256.
+It is possible to automatically convert the records for previously created users from cleartext passwords to SCRAM-compatible hash encodings. This will cause CockroachDB to use SCRAM authentication when client apps connect to CockroachDB, provided that the cluster's authentication configuration has also been set to accept SCRAM-SHA-256.
 
 To convert existing users to SCRAM-SHA-256, enable the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` cluster setting. When this setting is enabled, the conversion occurs the first time a client app connects with the previously defined password. During that first connection, the previous mechanism will be used to establish the connection, and then CockroachDB will re-encode the password using the SCRAM algorithm. Subsequent connections will then use the SCRAM handshake for authentication.
+
+{{site.data.alerts.callout_info}}
+In CockroachDB v22.2.x and above, the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` [cluster setting](cluster-settings.html) is enabled by default. Because `user_login.password_encryption` also defaults to `scram-sha-256`, this means that by default, any user who still uses cleartext passwords will be migrated to SCRAM-SHA-256 authentication. To prevent this automatic migration, set `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` to `false` before upgrading to CockroachDB v22.2.x.
+{{site.data.alerts.end}}
 
 To enable the cluster setting:
 
@@ -119,31 +127,35 @@ SET CLUSTER SETTING server.user_login.upgrade_bcrypt_stored_passwords_to_scram.e
 
 It is not possible to automatically convert credentials to SCRAM in bulk, without client participation. To implement SCRAM for all SQL user accounts simultaneously, use [`ALTER USER <USERNAME> WITH PASSWORD`](../alter-user.html) statements instead.
 
-## Implement strict isolation of plaintext credentials
+## Implement strict isolation of cleartext credentials
 
-Plaintext credentials are a valuable asset to malicious agents; known as ["credential stuffing,"](https://en.wikipedia.org/wiki/Credential_stuffing) re-use of stolen passwords is a persistent problem throughout the ecosystem of internet services. Hence, any system that handles plaintext credentials becomes a favorable target for malicious attackers with potentially weak points in the system.
+Cleartext credentials are a valuable asset to malicious agents; known as ["credential stuffing,"](https://en.wikipedia.org/wiki/Credential_stuffing) re-use of stolen passwords is a persistent problem throughout the ecosystem of internet services. Hence, any system that handles cleartext credentials becomes a favorable target for malicious attackers with potentially weak points in the system.
 
-While the measures [described previously](#implement-scram-authentication-in-your-cockroachdb-cluster) allow CockroachDB to avoid transmitting plaintext passwords across the network, the  credentials still have a footprint within CockroachDB: they are transmitted in plaintext from the CockroachDB client to the server, and are hence vulnerable in transit. While the secrets are protected in transit by TLS, CA certificate server authentication is not infallible.
+While the measures [described previously](#implement-scram-authentication-in-your-cockroachdb-cluster) allow CockroachDB to avoid transmitting cleartext passwords across the network, the  credentials still have a footprint within CockroachDB: they are transmitted in cleartext from the CockroachDB client to the server, and are hence vulnerable in transit. While the secrets are protected in transit by TLS, CA certificate server authentication is not infallible.
 
-Moreover, the plaintext credentials must be handled in memory by CockroachDB in order to generate the hashes on the server, and this offers a potential opportunity for hypothetical attackers who have compromised your node's runtime environment. It is architecturally stronger to perform all handling of plaintext credentials for your system with a dedicated, hardened, specialized environment and process. This entails removing all handling of plaintext credentials from CockroachDB.
+Moreover, the cleartext credentials must be handled in memory by CockroachDB in order to generate the hashes on the server, and this offers a potential opportunity for hypothetical attackers who have compromised your node's runtime environment. It is architecturally stronger to perform all handling of cleartext credentials for your system with a dedicated, hardened, specialized environment and process. This entails removing all handling of cleartext credentials from CockroachDB.
 
-It is possible to operate a CockroachDB cluster in such a way that it never handles plaintext passwords. This prevents the malicious use of stolen credentials, even in case the CockroachDB node is compromised.
+It is possible to operate a CockroachDB cluster in such a way that it never handles cleartext passwords. This prevents the malicious use of stolen credentials, even in case the CockroachDB node is compromised.
 
 **Requirements for strict isolation**:
 
-- Handle plaintext credentials securely
+- Handle cleartext credentials securely
 - Configure your cluster settings
 - Manage users with pre-hashed passwords
 
-### Migrate from password to SCRAM
+### Migrate existing users/roles from cleartext passwords to SCRAM-SHA-256 authentication
 
-If a cluster had previously allowed plaintext password authentication (i.e., any cluster that began on a version prior to v22.1), you must carefully migrate to SCRAM-SHA-256 authentication in the following phases:
+If a cluster had previously allowed cleartext password authentication (i.e., any cluster that began on a version prior to v22.1), you must carefully migrate to SCRAM-SHA-256 authentication in the following phases:
 
-1. Instead of creating and rotating user passwords by passing plaintext passwords into SQL statements, as described [previously](#enable-scram-sha-256-authentication-for-new-users-roles), you must instead generate CockroachDB/PostgreSQL-formatted SCRAM-SHA-256 hashes and enter those directly into the client, as described in the [following section](#manage-users-with-pre-hashed-passwords).
-2. You must block clients from sending plaintext passwords to CockroachDB during authentication by [customizing your cluster's authentication configuration](#configure-your-cluster-settings-for-strict-credential-isolation) so that only the `scram-sha-256` and `cert-scram-sha-256` methods, and neither `password` nor `cert-password`, are allowed.
-3. After steps (1) and (2) are complete, you must update any previously created passwords with externally generated SCRAM-SHA-256 hashes, and continue to generate your own hashes for all user creation and password update operations.
+1. Instead of creating and rotating user passwords by passing cleartext passwords into SQL statements, as described [previously](#enable-scram-sha-256-authentication-for-new-users-roles), you must instead generate CockroachDB/PostgreSQL-formatted SCRAM-SHA-256 hashes and enter those directly into the client, as described in the [following section](#manage-users-with-pre-hashed-passwords).
+2. You must block clients from sending cleartext passwords to CockroachDB during authentication by [customizing your cluster's authentication configuration](#configure-your-cluster-settings-for-strict-credential-isolation) so that only the `scram-sha-256` and `cert-scram-sha-256` methods, and neither `password` nor `cert-password`, are allowed.
+3. After steps 1 and 2 are complete, you must update any previously-created passwords with externally-generated SCRAM-SHA-256 hashes, and you must continue to generate your own hashes for all user creation and password update operations.
 
-Note the importance of rotating passwords twice, both in steps (1) and again in (3), with different passwords.  Step (1) ensures that clients at step (2) can continue to connect after non-SCRAM logins are blocked. However, between step (1) and step (2) it is still possible for CockroachDB to receive plaintext passwords from clients, and so the passwords used at step (1) are not fully protected yet. After step (2), CockroachDB will not learn plaintext passwords from clients any more; then after step 3 it will not know plaintext passwords at all.
+{{site.data.alerts.callout_info}}
+In CockroachDB v22.2.x and above, the `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled` cluster setting is enabled by default. Because `user_login.password_encryption` also defaults to `scram-sha-256`, this means that by default, any user who still uses cleartext passwords will be migrated to SCRAM-SHA-256 authentication. Refer to [Eventual migration](#eventual-migration).
+{{site.data.alerts.end}}
+
+Note the importance of rotating passwords twice, in both steps 1 and 3, with different passwords. Step 1 ensures that clients at step 2 can continue to connect after non-SCRAM logins are blocked. However, between step 1 and step 2 it is still possible for CockroachDB to receive cleartext passwords from clients, and so the passwords used at step 1 are not fully protected yet. After step 2, CockroachDB will no longer learn cleartext passwords from clients, and after step 3 it will not know cleartext passwords at all.
 
 ### Configure your cluster settings for strict credential isolation
 
@@ -155,7 +167,7 @@ Required cluster settings:
 
 #### `server.user_login.password_encryption`
 
-Enable SCRAM for new passwords.
+Enable SCRAM for new passwords. In CockroachDB v22.2.x and above, this cluster setting defaults to `scram-sha-256`. In CockroachDB v22.1.x and below, it defaults to `bcrypt`.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
@@ -164,7 +176,7 @@ SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';
 
 #### `server.user_login.store_client_pre_hashed_passwords.enabled`
 
-Enable the CockroachDB cluster to accept pre-computed SCRAM-SCHA-256 salted password hashes, rather than accepting a plaintext password and computing the hash itself.
+Enable the CockroachDB cluster to accept pre-computed SCRAM-SCHA-256 salted password hashes, rather than accepting a cleartext password and computing the hash itself. In CockroachDB v22.2.x and above, this cluster setting is enabled by default.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
@@ -176,9 +188,9 @@ SET CLUSTER SETTING setting server.user_login.store_client_pre_hashed_passwords.
 Allow *only* `scram-sha-256` (not the weaker `password`) in your [Authentication Configuration (HBA)](authentication.html#authentication-configuration).
 
 {{site.data.alerts.callout_danger}}
-After this change, users will not be able to sign in with plaintext passwords. All critical SQL users must be migrated to SCRAM-SHA-256 authentication before making this change:
+After this change, users will not be able to sign in with cleartext passwords. All critical SQL users must be migrated to SCRAM-SHA-256 authentication before making this change:
 1. All client drivers must be updated to a version that supports SCRAM handshakes.
-2. All stored credentials for client apps must be updated to use SCRAM encoded passwords. This procedure is detailed in [Migrating existing users/roles to SCRAM-SHA-256 authentication](#migrate-existing-users-roles-to-scram-sha-256-authentication).
+2. All stored credentials for client apps must be updated to use SCRAM encoded passwords. This procedure is detailed in [Migrating existing users/roles to SCRAM-SHA-256 authentication](#migrate-existing-users-roles-from-cleartext-passwords-to-scram-sha-256-authentication).
 {{site.data.alerts.end}}
 
 {% include_cached copy-clipboard.html %}
@@ -202,7 +214,7 @@ That environment must be provisioned with:
 
 - A tool for [creating PostgreSQL/CockroachDB-formatted SCRAM-SHA-256 hashes](#manage-users-with-pre-hashed-passwords), such as the example script provided in the [appendix](#appendix-python-scram-hashing-script).
 - A CockroachDB client with ['USER CREATE/ALTER privileges'](../create-user.html#create-a-user-that-can-create-other-users-and-manage-authentication-methods-for-the-new-users).
-- Access, with write privileges, to a secrets store where the plaintext passwords will be persisted.
+- Access, with write privileges, to a secrets store where the cleartext passwords will be persisted.
 
 On that instance, [generate SCRAM salted password hashes](#manage-users-with-pre-hashed-passwords), manage the users via CockroachdDB client, as described in the following section, and persist the secrets in the secrets store.
 
@@ -252,7 +264,7 @@ Time: 156ms total (execution 156ms / network 0ms)
 
 ### Inspect the user
 
-In this way, the server stores the information needed for SCRAM authentication, despite the plaintext password never having been conveyed to CockroachDB. The 'concern' with plaintext passwords has been cleanly 'separated' from CockroachDB.
+In this way, the server stores the information needed for SCRAM authentication, despite the cleartext password never having been conveyed to CockroachDB. The 'concern' with cleartext passwords has been cleanly 'separated' from CockroachDB.
 
 {% include_cached copy-clipboard.html %}
 ~~~sql


### PR DESCRIPTION
- Also update some section headings to use non-gerund verbs, per the style guide
- Also change "plaintext" to "cleartext" when referring to passwords

## Preview
[v22.2/error-handling-and-troubleshooting.md](https://deploy-preview-15254--cockroachdb-docs.netlify.app/docs/v22.2/error-handling-and-troubleshooting.html)
[v22.2/security-reference/scram-authentication.md](https://deploy-preview-15254--cockroachdb-docs.netlify.app/docs/v22.2/security-reference/scram-authentication.html)
[v22.1/error-handling-and-troubleshooting.md](https://deploy-preview-15254--cockroachdb-docs.netlify.app/docs/v22.1/error-handling-and-troubleshooting.html)
[v22.1/security-reference/scram-authentication.md](https://deploy-preview-15254--cockroachdb-docs.netlify.app/docs/v22.1/security-reference/scram-authentication.html)

## Tests
- [x] Local linkcheck
- [x] Local build to verify that there are no build issues 