### PR TITLE
DOC-4604 v22.2.0-beta.2 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -30,7 +30,7 @@ jekyll-minifier:
   compress_json: 'true'
   exclude:
   - '**.html'
-  - 'js/rapidoc-min.js'
+  - js/rapidoc-min.js
   preserve_line_breaks: 'false'
   preserve_php: 'true'
   remove_comments: 'true'
@@ -128,12 +128,12 @@ release_info:
     start_time: 2022-09-23 16:26:45.490161 +0000 UTC
     version: v22.1.8
   v22.2:
-    build_time: 2022-09-26 00:00:00 (go1.17)
+    build_time: 2022-10-03 00:00:00 (go1.17)
     crdb_branch_name: release-22.2
     docker_image: cockroachdb/cockroach-unstable
-    name: v22.2.0-beta.1
-    start_time: 2022-09-26 11:18:25.079197 +0000 UTC
-    version: v22.2.0-beta.1
+    name: v22.2.0-beta.2
+    start_time: 2022-10-03 10:50:51.684827 +0000 UTC
+    version: v22.2.0-beta.2
 sass:
   sass_dir: css
   style: compressed

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -298,3 +298,4 @@ v22.2.0-alpha.4,v22.2,2022-09-22,false,False,Testing,False,go1.17,aac413cd4ca62f
 v22.2.0-beta.1,v22.2,2022-09-26,false,False,Testing,False,go1.17,a33d71dcd904c771d1297323d8d206b8b59d40bf,cockroachdb/cockroach-unstable,true,true
 v22.1.8,v22.1,2022-09-29,false,False,Production,False,go1.17,bdcab67f778617515597f1012f37f14f622b15a0,cockroachdb/cockroach,false,false
 v21.2.16,v21.2,2022-09-29,false,False,Production,False,go1.17,5c5501092e833d2a10d1351f8b4f4b2dc83e95a8,cockroachdb/cockroach,false,false
+v22.2.0-beta.2,v22.2,2022-10-03,false,False,Testing,False,go1.17,860584a59dee73d7a66ce882c668cef6eb2556f7,cockroachdb/cockroach-unstable,true,true

--- a/_includes/releases/v22.2/v22.2.0-beta.2.md
+++ b/_includes/releases/v22.2/v22.2.0-beta.2.md
@@ -1,0 +1,90 @@
+## v22.2.0-beta.2
+
+Release Date: October 3, 2022
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-2-0-beta-2-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
+
+- Introduced a new JWT-based authentication method as an option. [#88588][#88588]
+
+<h3 id="v22-2-0-beta-2-sql-language-changes">SQL language changes</h3>
+
+- Changed the default value of `sql.metrics.statement_details.plan_collection.enabled` to `false`, since we no longer use this information anywhere. [#88416][#88416]
+- The pgwire protocol implementation can now accept arguments of the JSON type (`oid=114`). Previously, it could only accept JSONB (`oid=3802`). Internally, JSON and JSONB values are still identical, so this change only affects how the values are received over the wire protocol. [#88576][#88576]
+- Added the `sql.metrics.statement_details.gateway_node.enabled` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html), which controls whether the gateway node ID should be persisted to the `system.statement_statistics` table as is or as a `0`, to decrease cardinality on the table. The node ID is still available on the statistics column. [#88616][#88616]
+- Added the `cloudstorage.gs.chunking.retry_timeout` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html), which can be used to configure the per-chunk retry timeout of files to Google Cloud Storage. The default value is 60 seconds. [#87720][#87720]
+- Previously [`SHOW GRANTS`](../{{site.versions["dev"]}}/show-grants.html) only supported `db`, `schema`, `table`, and `types`. This release adds supports for user-defined functions (UDFs), so that `SHOW GRANTS` returns a UDF's privilege info, and statements like `SHOW GRANTS ON FUNCTION <udf name/signatures>` are now supported. The full function signature must be provided if the function name is not unique. [#88866][#88866]
+
+<h3 id="v22-2-0-beta-2-operational-changes">Operational changes</h3>
+
+- Added two new sets of per-LSM-level time-series metrics, one for level size and another for level score. These metrics are of the form `storage.{level}-level-{size,score}`. [#88592][#88592]
+
+<h3 id="v22-2-0-beta-2-command-line-changes">Command-line changes</h3>
+
+- The `debug unsafe-remove-dead-replicas` CLI command has been deprecated, and will be removed in v23.1. Users should use the new `debug recover` set of commands instead. [#88765][#88765]
+
+<h3 id="v22-2-0-beta-2-db-console-changes">DB Console changes</h3>
+
+- Removed the **Full Scan** field from the **Active Transaction Details** page. [#88404][#88404]
+- Added support for multiple blocking transactions on the **Insights** > **Transaction Executions** page, merged displayed cards into the table, and fixed the reported total contention time. [#88522][#88522]
+- Renamed the **Insights Overview** table column **Execution ID** to **Latest Execution ID**. This will help avoid confusion since the UI only shows the latest ID per fingerprint. [#88591][#88591]
+- The {{ site.data.products.dedicated }} Cloud Console now displays information on which transactions are blocked or waiting on the **Active Execution** pages. This includes the `Time Spent Waiting` column in the **Overview** pages and the **Wait Time Insights** panel on the **Details** pages. This feature is currently unavailable for {{ site.data.products.serverless }}. [#88856][#88856]
+- The **Statements**, **Transactions**, and **Transaction Details** pages in the DB Console now properly show the Regions/Nodes columns, as well as filters for multi-region clusters. [#88572][#88572]
+
+<h3 id="v22-2-0-beta-2-bug-fixes">Bug fixes</h3>
+
+- CockroachDB no longer fetches unnecessary rows for queries that use the [`LIMIT`](../{{site.versions["dev"]}}/limit-offset.html) statement. The bug was introduced in v22.1.7. [#88417][#88417]
+- Active transactions with a non-zero executed statement count now always have populated statement text, even when no statement is being executed. [#88404][#88404]
+- Fixed a bug where offline tables were included in [full-cluster backups](../{{site.versions["dev"]}}/backup.html#backup-a-cluster), as reported in [#88043](https://github.com/cockroachdb/cockroach/issues/88043). [#88474][#88474]
+- Implemented a change to ensure that time elapsed for active transactions and statements is never negative. [#88467][#88467]
+- Fixed a rare internal error with message `estimated row count must be non-zero`, which could occur during planning when a predicate included values close to the maximum or minimum `int64` value. [#88529][#88529]
+- Upgraded `grpc` to v1.49.0 which fixed a few panics on nil pointers [#88630][#88630]
+- Fixed missing automatic statistics collection on system tables during cluster startup. This bug only affects the v22.2.0-alpha releases. [#88689][#88689]
+- Fixed a bug that could cause nodes to crash in rare cases when executing [apply joins](../{{site.versions["dev"]}}/joins.html#apply-joins) in query plans. [#88483][#88483]
+- Fixed a bug that caused errors in rare cases when executing queries with correlated [`WITH`](../{{site.versions["dev"]}}/common-table-expressions.html) expressions. This bug has been present since the introduction of correlated `WITH` expressions in v21.2.0. [#88483][#88483]
+- Fixed unintended recordings of index reads caused by internal executor/queries. [#88867][#88867]
+- Fixed a bug that caused incorrect evaluation of expressions in the form `col +/- const1 ? const2`, where `const1` and `const2` are constant values and `?` is any comparison operator. The bug was caused by operator overflow when the optimizer attempted to simplify these expressions to have a single constant value. [#88895][#88895]
+- Adjusted sending and receiving Raft queue sizes to match. Previously the receiver could unnecessarily drop messages in situations when the sending queue is bigger than the receiving one. [#88406][#88406]
+
+<h3 id="v22-2-0-beta-2-performance-improvements">Performance improvements</h3>
+
+- The [`SHOW BACKUP`](../{{site.versions["dev"]}}/show-backup.html) statement is now more performant when working with a backup containing several table descriptors. [#88711][#88711]
+
+<h3 id="v22-2-0-beta-2-contributors">Contributors</h3>
+
+This release includes 82 merged PRs by 43 authors.
+
+[#87720]: https://github.com/cockroachdb/cockroach/pull/87720
+[#88358]: https://github.com/cockroachdb/cockroach/pull/88358
+[#88404]: https://github.com/cockroachdb/cockroach/pull/88404
+[#88406]: https://github.com/cockroachdb/cockroach/pull/88406
+[#88416]: https://github.com/cockroachdb/cockroach/pull/88416
+[#88417]: https://github.com/cockroachdb/cockroach/pull/88417
+[#88424]: https://github.com/cockroachdb/cockroach/pull/88424
+[#88467]: https://github.com/cockroachdb/cockroach/pull/88467
+[#88474]: https://github.com/cockroachdb/cockroach/pull/88474
+[#88483]: https://github.com/cockroachdb/cockroach/pull/88483
+[#88522]: https://github.com/cockroachdb/cockroach/pull/88522
+[#88529]: https://github.com/cockroachdb/cockroach/pull/88529
+[#88572]: https://github.com/cockroachdb/cockroach/pull/88572
+[#88576]: https://github.com/cockroachdb/cockroach/pull/88576
+[#88588]: https://github.com/cockroachdb/cockroach/pull/88588
+[#88591]: https://github.com/cockroachdb/cockroach/pull/88591
+[#88592]: https://github.com/cockroachdb/cockroach/pull/88592
+[#88610]: https://github.com/cockroachdb/cockroach/pull/88610
+[#88616]: https://github.com/cockroachdb/cockroach/pull/88616
+[#88624]: https://github.com/cockroachdb/cockroach/pull/88624
+[#88630]: https://github.com/cockroachdb/cockroach/pull/88630
+[#88689]: https://github.com/cockroachdb/cockroach/pull/88689
+[#88701]: https://github.com/cockroachdb/cockroach/pull/88701
+[#88711]: https://github.com/cockroachdb/cockroach/pull/88711
+[#88765]: https://github.com/cockroachdb/cockroach/pull/88765
+[#88784]: https://github.com/cockroachdb/cockroach/pull/88784
+[#88856]: https://github.com/cockroachdb/cockroach/pull/88856
+[#88866]: https://github.com/cockroachdb/cockroach/pull/88866
+[#88867]: https://github.com/cockroachdb/cockroach/pull/88867
+[#88895]: https://github.com/cockroachdb/cockroach/pull/88895
+[32a45932b]: https://github.com/cockroachdb/cockroach/commit/32a45932b
+[d6c17165f]: https://github.com/cockroachdb/cockroach/commit/d6c17165f
+[f9ff657cf]: https://github.com/cockroachdb/cockroach/commit/f9ff657cf


### PR DESCRIPTION
Addresses: DOC-4604

- Release notes for v22.2.0-beta.2

[v22.2.md](https://deploy-preview-15270--cockroachdb-docs.netlify.app/docs/releases/v22.2.html#v22-2-0-beta-2)