### PR TITLE
DOC-5759 clarify datadog cloud support

### DIFF
--- a/_includes/v21.2/sidebar-data/manage.json
+++ b/_includes/v21.2/sidebar-data/manage.json
@@ -358,7 +358,7 @@
               ]
             },
             {
-              "title": "Monitor with Datadog",
+              "title": "Monitor {{ site.data.products.core }} with Datadog",
               "urls": [
                 "/${VERSION}/datadog.html"
               ]

--- a/_includes/v22.1/sidebar-data/manage.json
+++ b/_includes/v22.1/sidebar-data/manage.json
@@ -440,7 +440,7 @@
               ]
             },
             {
-              "title": "Monitor with Datadog",
+              "title": "Monitor {{ site.data.products.core }} with Datadog",
               "urls": [
                 "/${VERSION}/datadog.html"
               ]

--- a/_includes/v22.2/sidebar-data/manage.json
+++ b/_includes/v22.2/sidebar-data/manage.json
@@ -452,7 +452,7 @@
               ]
             },
             {
-              "title": "Monitor with Datadog",
+              "title": "Monitor {{ site.data.products.core }} with Datadog",
               "urls": [
                 "/${VERSION}/datadog.html"
               ]

--- a/cockroachcloud/frequently-asked-questions.md
+++ b/cockroachcloud/frequently-asked-questions.md
@@ -179,6 +179,6 @@ To optimize schema design to achieve your performance goals, we recommend workin
 
 ### Can I monitor my cluster with third-party tools?
 
-Yes, {{ site.data.products.dedicated }} clusters support an integration with Datadog that enables data collection and alerting on a subset of CockroachDB metrics. Enabling the Datadog integration on your {{ site.data.products.dedicated }} cluster will apply additional charges to your **Datadog** bill. See [Monitor with Datadog](monitoring-page.html#monitor-with-datadog) for more information.
+Yes, {{ site.data.products.dedicated }} clusters support an integration with Datadog that enables data collection and alerting on a subset of CockroachDB metrics. Enabling the Datadog integration on your {{ site.data.products.dedicated }} cluster will apply additional charges to your **Datadog** bill. See [Monitor with Datadog](monitoring-page.html#monitor-cockroachdb-dedicated-with-datadog) for more information.
 
 If you need additional help, contact [Support](https://support.cockroachlabs.com/hc/en-us).

--- a/cockroachcloud/monitoring-page.md
+++ b/cockroachcloud/monitoring-page.md
@@ -7,12 +7,12 @@ docs_area: manage
 
 The **Monitoring** page is accessible on {{ site.data.products.dedicated }} clusters. This page allows you to:
 
-- Set up cluster [monitoring with Datadog](#monitor-with-datadog).
+- Set up cluster [monitoring with Datadog](#monitor-cockroachdb-dedicated-with-datadog).
 - Access the cluster's [built-in DB Console](#access-the-db-console) to view time-series data on SQL queries, troubleshoot query performance, view a list of jobs, and more.
 
 To view the **Monitoring** page, [log in](https://cockroachlabs.cloud/) and click **Monitoring** on the left-hand navigation.
 
-## Monitor with Datadog
+## Monitor {{ site.data.products.dedicated }} with Datadog
 
 The [{{ site.data.products.dedicated }} integration for Datadog](https://docs.datadoghq.com/integrations/cockroachdb_dedicated/) enables data collection and alerting on a [subset of CockroachDB metrics](#available-metrics) available at the [Prometheus endpoint](../{{site.versions["stable"]}}/monitoring-and-alerting.html#prometheus-endpoint), using the Datadog platform.
 

--- a/releases/cloud.md
+++ b/releases/cloud.md
@@ -94,7 +94,7 @@ As of August 29, 2022, {{ site.data.products.serverless }} clusters are running 
 
 <h3>General changes</h3>
 
-- [Datadog integration](../cockroachcloud/monitoring-page.html#monitor-with-datadog) is now available on the **Monitoring** page for all {{ site.data.products.dedicated }} users.
+- [Datadog integration](../cockroachcloud/monitoring-page.html#monitor-cockroachdb-dedicated-with-datadog) is now available on the **Monitoring** page for all {{ site.data.products.dedicated }} users.
 - [Single Sign-On (SSO)](../cockroachcloud/cloud-sso.html) for {{ site.data.products.db }} is now available with Google and Microsoft in addition to GitHub.
 
 <h3>Console changes</h3>

--- a/v21.2/datadog.md
+++ b/v21.2/datadog.md
@@ -1,29 +1,30 @@
 ---
-title: Monitor CockroachDB with Datadog
+title: Monitor CockroachDB Self-Hosted with Datadog
 summary: The CockroachDB integration with Datadog enables data visualization and alerting on CockroachDB metrics.
 toc: true
 docs_area: manage
 ---
 
-[Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The CockroachDB integration with Datadog enables data collection and alerting on [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
+[Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The {{ site.data.products.core }} integration with Datadog enables data collection and alerting on selected [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
+
+{{site.data.alerts.callout_success}}
+This tutorial explores the {{ site.data.products.core }} integration with Datadog. For the {{ site.data.products.dedicated }} integration with Datadog, see [Monitor CockroachDB Dedicated with Datadog](../cockroachcloud/monitoring-page.html#monitor-cockroachdb-dedicated-with-datadog)
+{{site.data.alerts.end}}
+
+The {{ site.data.products.core }} integration with Datadog is powered by the [Datadog Agent](https://app.datadoghq.com/account/settings#agent), and supported by Datadog directly:
+
+- For more information about the integration, see the [Datadog blog post](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/).
+- For more information about using Datadog, see the [Datadog documentation](https://docs.datadoghq.com/).
+- If you run into problems with this integration, please file an issue on the [Datadog Agent issue tracker](https://github.com/DataDog/datadog-agent).
 
 In this tutorial, you will enable the CockroachDB integration in Datadog, configure logging and alerting, and visualize data.
 
-For more information about the integration, see the [Datadog blog post](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/).
-
-{{site.data.alerts.callout_success}}
-For more information about using Datadog, see the [Datadog documentation](https://docs.datadoghq.com/).
-
-If you run into problems with this integration, please file an issue on the [Datadog Agent issue tracker](https://github.com/DataDog/datadog-agent).
-{{site.data.alerts.end}}
-
 ## Prerequisites
 
-- [Datadog Agent](https://app.datadoghq.com/account/settings#agent)
+Before you can follow the steps presented in this tutorial, you must have:
 
-{{site.data.alerts.callout_info}}
-This tutorial assumes that you have [started a secure CockroachDB cluster](secure-a-cluster.html). [{{ site.data.products.db }}](../cockroachcloud/index.html) does not expose a compatible monitoring endpoint.
-{{site.data.alerts.end}}
+- Downloaded and installed the [Datadog Agent](https://app.datadoghq.com/account/settings#agent).
+- Started a [secure CockroachDB Self-Hosted cluster](secure-a-cluster.html).
 
 ## Step 1. Enable CockroachDB integration
 
@@ -169,6 +170,10 @@ The example alert below will trigger when [a node has less than 15% of storage c
 The timeseries graph at the top of the page indicates the configured metric and threshold:
 
 <img src="{{ 'images/v21.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
+
+## Limitations
+
+- The {{ site.data.products.core }} integration with Datadog only supports displaying cluster-wide averages of reported metrics. Filtering by a specific node is unsupported.
 
 ## See also
 

--- a/v22.1/datadog.md
+++ b/v22.1/datadog.md
@@ -1,29 +1,30 @@
 ---
-title: Monitor CockroachDB with Datadog
+title: Monitor CockroachDB Self-Hosted with Datadog
 summary: The CockroachDB integration with Datadog enables data visualization and alerting on CockroachDB metrics.
 toc: true
 docs_area: manage
 ---
 
-[Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The CockroachDB integration with Datadog enables data collection and alerting on [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
+[Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The {{ site.data.products.core }} integration with Datadog enables data collection and alerting on selected [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
+
+{{site.data.alerts.callout_success}}
+This tutorial explores the {{ site.data.products.core }} integration with Datadog. For the {{ site.data.products.dedicated }} integration with Datadog, see [Monitor CockroachDB Dedicated with Datadog](../cockroachcloud/monitoring-page.html#monitor-cockroachdb-dedicated-with-datadog)
+{{site.data.alerts.end}}
+
+The {{ site.data.products.core }} integration with Datadog is powered by the [Datadog Agent](https://app.datadoghq.com/account/settings#agent), and supported by Datadog directly:
+
+- For more information about the integration, see the [Datadog blog post](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/).
+- For more information about using Datadog, see the [Datadog documentation](https://docs.datadoghq.com/).
+- If you run into problems with this integration, please file an issue on the [Datadog Agent issue tracker](https://github.com/DataDog/datadog-agent).
 
 In this tutorial, you will enable the CockroachDB integration in Datadog, configure logging and alerting, and visualize data.
 
-For more information about the integration, see the [Datadog blog post](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/).
-
-{{site.data.alerts.callout_success}}
-For more information about using Datadog, see the [Datadog documentation](https://docs.datadoghq.com/).
-
-If you run into problems with this integration, please file an issue on the [Datadog Agent issue tracker](https://github.com/DataDog/datadog-agent).
-{{site.data.alerts.end}}
-
 ## Prerequisites
 
-- [Datadog Agent](https://app.datadoghq.com/account/settings#agent)
+Before you can follow the steps presented in this tutorial, you must have:
 
-{{site.data.alerts.callout_info}}
-This tutorial assumes that you have [started a secure CockroachDB cluster](secure-a-cluster.html). [{{ site.data.products.db }}](../cockroachcloud/index.html) does not expose a compatible monitoring endpoint.
-{{site.data.alerts.end}}
+- Downloaded and installed the [Datadog Agent](https://app.datadoghq.com/account/settings#agent).
+- Started a [secure CockroachDB Self-Hosted cluster](secure-a-cluster.html).
 
 ## Step 1. Enable CockroachDB integration
 
@@ -169,6 +170,10 @@ The example alert below will trigger when [a node has less than 15% of storage c
 The timeseries graph at the top of the page indicates the configured metric and threshold:
 
 <img src="{{ 'images/v22.1/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
+
+## Limitations
+
+- The {{ site.data.products.core }} integration with Datadog only supports displaying cluster-wide averages of reported metrics. Filtering by a specific node is unsupported.
 
 ## See also
 

--- a/v22.2/datadog.md
+++ b/v22.2/datadog.md
@@ -1,29 +1,30 @@
 ---
-title: Monitor CockroachDB with Datadog
+title: Monitor CockroachDB Self-Hosted with Datadog
 summary: The CockroachDB integration with Datadog enables data visualization and alerting on CockroachDB metrics.
 toc: true
 docs_area: manage
 ---
 
-[Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The CockroachDB integration with Datadog enables data collection and alerting on [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
+[Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The {{ site.data.products.core }} integration with Datadog enables data collection and alerting on selected [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
+
+{{site.data.alerts.callout_success}}
+This tutorial explores the {{ site.data.products.core }} integration with Datadog. For the {{ site.data.products.dedicated }} integration with Datadog, see [Monitor CockroachDB Dedicated with Datadog](../cockroachcloud/monitoring-page.html#monitor-cockroachdb-dedicated-with-datadog)
+{{site.data.alerts.end}}
+
+The {{ site.data.products.core }} integration with Datadog is powered by the [Datadog Agent](https://app.datadoghq.com/account/settings#agent), and supported by Datadog directly:
+
+- For more information about the integration, see the [Datadog blog post](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/).
+- For more information about using Datadog, see the [Datadog documentation](https://docs.datadoghq.com/).
+- If you run into problems with this integration, please file an issue on the [Datadog Agent issue tracker](https://github.com/DataDog/datadog-agent).
 
 In this tutorial, you will enable the CockroachDB integration in Datadog, configure logging and alerting, and visualize data.
 
-For more information about the integration, see the [Datadog blog post](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/).
-
-{{site.data.alerts.callout_success}}
-For more information about using Datadog, see the [Datadog documentation](https://docs.datadoghq.com/).
-
-If you run into problems with this integration, please file an issue on the [Datadog Agent issue tracker](https://github.com/DataDog/datadog-agent).
-{{site.data.alerts.end}}
-
 ## Prerequisites
 
-- [Datadog Agent](https://app.datadoghq.com/account/settings#agent)
+Before you can follow the steps presented in this tutorial, you must have:
 
-{{site.data.alerts.callout_info}}
-This tutorial assumes that you have [started a secure CockroachDB cluster](secure-a-cluster.html). [{{ site.data.products.db }}](../cockroachcloud/index.html) does not expose a compatible monitoring endpoint.
-{{site.data.alerts.end}}
+- Downloaded and installed the [Datadog Agent](https://app.datadoghq.com/account/settings#agent).
+- Started a [secure CockroachDB Self-Hosted cluster](secure-a-cluster.html).
 
 ## Step 1. Enable CockroachDB integration
 
@@ -169,6 +170,10 @@ The example alert below will trigger when [a node has less than 15% of storage c
 The timeseries graph at the top of the page indicates the configured metric and threshold:
 
 <img src="{{ 'images/v22.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
+
+## Limitations
+
+- The {{ site.data.products.core }} integration with Datadog only supports displaying cluster-wide averages of reported metrics. Filtering by a specific node is unsupported.
 
 ## See also
 


### PR DESCRIPTION
Addresses: DOC-5759

- Added notice to Self-Hosted DD page advising of discrete Dedicated DD page, clarified that DD supports this integration directly, and reshuffled the intro to accommodate this additional info.
- Added Limitations section to Self-Hosted DD page, to advise that metrics are averaged over entire cluster, and granular filtering by node is not presently supported.
- Changed page name to "Monitor CockroachDB Self-Hosted with Datadog" on page and in left-nav sidebar to further clarify from Dedicated offering.
- Removed mention that there is no CC compatible monitoring endpoint -- there is now!

NOTES:

- Only made change to v22.2 for now. Once LGTM, will propagate these changes back through to v21.1 (version at which DD integration was first introduced).
- Opted not to link to DD [metrics.py](https://github.com/DataDog/integrations-core/blob/master/cockroachdb/datadog_checks/cockroachdb/metrics.py) file as metrics listing is already present, in easier-to-consume form, via first-sentence [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) link. Please LMK if you disagree!
- Omitted remainder of Dedicated-focused changes, which all seem TSE-focused, i.e. default dashboard difference is only a concern to those who bounce between Self-Hosted and Dedicated, which is TSEs only really, etc. LMK if you disagree!

EDIT: only sending back through to v21.2, as left-nav changes to v21.1 are more significant.

[v22.2/datadog](https://deploy-preview-15291--cockroachdb-docs.netlify.app/docs/v22.2/datadog)