### PR TITLE
analytics: persist Segment user and group ID & traits with non-standard names

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,7 +59,25 @@ var pageConfig = {
 {%- comment -%} Add the Brand Website segment source and fire a page impression. {%- endcomment -%}
 <script>
   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="Mz68FzJ2r4poMQ4bQTniyvZF9yF0ycET";;analytics.SNIPPET_VERSION="4.15.3";
-  analytics.load("Mz68FzJ2r4poMQ4bQTniyvZF9yF0ycET");
+  analytics.load("Mz68FzJ2r4poMQ4bQTniyvZF9yF0ycET", {
+    user: {
+      cookie: {
+        key: "crl_brand_ajs_user_id",
+        oldKey: "crl_brand_ajs_user",
+      },
+      localStorage: {
+        key: "crl_brand_ajs_user_traits",
+      },
+    },
+    group: {
+      cookie: {
+        key: "crl_brand_ajs_group_id",
+      },
+      localStorage: {
+        key: "crl_brand_ajs_group_properties",
+      }
+    }
+  });
   analytics.page();
   }}();
 </script>


### PR DESCRIPTION
The Segment JS client library locally persists the user’s ID and traits [1] and the user’s group ID and group properties [2] by default, using predefined names to store those values. Unfortunately, this means that any other Segment integration on the same domain that *doesn't* limit its persistence to a specific subdomain [3] (e.g. Open edX instance hosted on university.cockroachlabs.com) will overwrite any values persisted by any other Segment integration on that domain. In other words, the most recent analytics.identify() call sets the user ID for all other subdomains.

For example, loading cockroachlabs.cloud would correctly set the CC user ID for www.cockroachlabs.com, but loading university.cockroachlabs.com would overwrite the CC user ID until the user reloads cockroachlabs.cloud. All user interactions that happen in between will be attributed to the Open edX user ID, not the CC user ID. Set custom persistence names for user and group cookies and localStorage, so that anything persisted by the uncustomizable university.cockroachlabs.com integration doesn't overwrite this integration's user and group info.

[1] https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/persistence/#user-settings [2] https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/persistence/#group-settings [3] https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/persistence/#cookie-settings