### PR TITLE
Removed pages with redirects from the sitemap

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -6,8 +6,6 @@ layout: null
 / /docs/ 301!
 /docs/v2.2/* /docs/v19.1/:splat 301!
 /docs/managed/* /docs/cockroachcloud/:splat 301!
-/docs/releases/ /docs/releases/index.html 301!
-/docs/advisories/ /docs/advisories/index.html 301!
 /docs/advisories/advisories.html /docs/advisories/index.html 301
 
 # Pages undergoing maintenance
@@ -544,4 +542,3 @@ layout: null
 {% endfor -%}
 
 /docs/frequently-asked-questions.html /docs/stable/frequently-asked-questions.html  301
-

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,7 +3,7 @@ layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {%- assign stable_pages_names = site.pages | where_exp: "stable_pages", "stable_pages.url contains site.versions['stable']" | map: "name" -%}
+  {%- assign stable_pages_names = site.pages | where_exp: "stable_pages", "stable_pages.url contains site.versions['stable']" | where_exp: "stable_pages", "stable_pages.name != 'index.md'" | map: "name" -%}
   {%- assign dev_path = "/" | append: site.versions["dev"] | append: "/" -%}
   {%- for page in site.pages -%}
     {%- if page.url contains site.versions["stable"] or page.url contains site.versions["dev"] or page.url contains 'cockroachcloud/' or page.url contains 'releases/' or page.url contains 'advisories/' -%}

--- a/v22.1/build-a-python-app-with-cockroachdb-peewee.md
+++ b/v22.1/build-a-python-app-with-cockroachdb-peewee.md
@@ -2,6 +2,7 @@
 title: Build a Python App with CockroachDB and peewee
 summary: Learn how to use CockroachDB from a simple Python application with the peewee driver.
 toc: false
+sitemap: false
 twitter: false
 docs_area: get_started
 ---

--- a/v22.1/install-cockroachdb.md
+++ b/v22.1/install-cockroachdb.md
@@ -2,6 +2,7 @@
 title: Install CockroachDB
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 toc: false
+sitemap: false
 feedback: false
 docs_area: deploy
 ---

--- a/v22.1/topology-duplicate-indexes.md
+++ b/v22.1/topology-duplicate-indexes.md
@@ -2,6 +2,7 @@
 title: Duplicate Indexes Topology
 summary: Guidance on using the duplicate indexes topology in a multi-region deployment.
 toc: true
+sitemap: false
 docs_area: deploy
 ---
 

--- a/v22.1/topology-geo-partitioned-leaseholders.md
+++ b/v22.1/topology-geo-partitioned-leaseholders.md
@@ -2,6 +2,7 @@
 title: Geo-Partitioned Leaseholders Topology
 summary: Common cluster topology patterns with setup examples and performance considerations.
 toc: true
+sitemap: false
 docs_area: deploy
 ---
 

--- a/v22.1/topology-geo-partitioned-replicas.md
+++ b/v22.1/topology-geo-partitioned-replicas.md
@@ -2,6 +2,7 @@
 title: Geo-Partitioned Replicas Topology
 summary: Guidance on using the geo-partitioned replicas topology in a multi-region deployment.
 toc: true
+sitemap: false
 docs_area: deploy
 ---
 

--- a/v22.2/build-a-python-app-with-cockroachdb-peewee.md
+++ b/v22.2/build-a-python-app-with-cockroachdb-peewee.md
@@ -2,6 +2,7 @@
 title: Build a Python App with CockroachDB and peewee
 summary: Learn how to use CockroachDB from a simple Python application with the peewee driver.
 toc: false
+sitemap: false
 twitter: false
 docs_area: get_started
 ---

--- a/v22.2/install-cockroachdb.md
+++ b/v22.2/install-cockroachdb.md
@@ -2,6 +2,7 @@
 title: Install CockroachDB
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 toc: false
+sitemap: false
 feedback: false
 docs_area: deploy
 ---

--- a/v22.2/topology-duplicate-indexes.md
+++ b/v22.2/topology-duplicate-indexes.md
@@ -2,6 +2,7 @@
 title: Duplicate Indexes Topology
 summary: Guidance on using the duplicate indexes topology in a multi-region deployment.
 toc: true
+sitemap: false
 docs_area: deploy
 ---
 

--- a/v22.2/topology-geo-partitioned-leaseholders.md
+++ b/v22.2/topology-geo-partitioned-leaseholders.md
@@ -2,6 +2,7 @@
 title: Geo-Partitioned Leaseholders Topology
 summary: Common cluster topology patterns with setup examples and performance considerations.
 toc: true
+sitemap: false
 docs_area: deploy
 ---
 

--- a/v22.2/topology-geo-partitioned-replicas.md
+++ b/v22.2/topology-geo-partitioned-replicas.md
@@ -2,6 +2,7 @@
 title: Geo-Partitioned Replicas Topology
 summary: Guidance on using the geo-partitioned replicas topology in a multi-region deployment.
 toc: true
+sitemap: false
 docs_area: deploy
 ---
 


### PR DESCRIPTION
- Some pages like `install-cockroachdb.md` and the Python Peewee wrapper serve as in-page redirects and are hurting our SEO. I'm excluding those from the sitemap.
- Other pages that are redirected inside of the `_redirects` file should also be excluded because they are also hurting our SEO.
- We also have issues not being able to index the releases and advisories indexes properly, so Google can't actually process those pages. I've removed the redirects that are causing this.