### PR TITLE
Disable using the API from the reference docs

### DIFF
--- a/api/cloud/v1.md
+++ b/api/cloud/v1.md
@@ -92,7 +92,8 @@ docs_area: reference.api
             allow-server-selection = "false"
             use-path-in-nav-bar = "false"
             schema-description-expanded = "true"
-            allow-spec-file-download = "true">
+            allow-spec-file-download = "true"
+            allow-try = "false">
     <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;"> 
       <img src = "https://d33wubrfki0l68.cloudfront.net/1c17b3053b29646cdddc53965186a02179b59842/69991/docs/images/cockroachlabs-logo-170.png" style="width:170px; margin-right: 20px" alt="Cockroach Labs logo"> <span style="color:#fff"> <b>nav-logo</b> slot </span>
     </div>


### PR DESCRIPTION
Until we work out the CORS issues between cockroachlabs.com and cockroaclabs.cloud, we need to disable using the API from the reference docs.