### PR TITLE
[DOC-4822] Docs for private clusters

### DIFF
--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -79,6 +79,12 @@
       		      "/cockroachcloud/network-authorization.html"
       	      ]
       	    },
+						{
+      	      "title": "Private clusters (Preview)",
+      	      "urls": [
+      		      "/cockroachcloud/private-clusters.html"
+      	      ]
+      	    },
       	    {
       	      "title": "SQL Audit Logging",
       	      "urls": [

--- a/cockroachcloud/network-authorization.md
+++ b/cockroachcloud/network-authorization.md
@@ -7,6 +7,10 @@ docs_area: manage
 
 To prevent denial-of-service and brute force password attacks, {{ site.data.products.dedicated }} requires you to authorize networks that can access your cluster by [allowlisting the public IP addresses](#ip-allowlisting) for your application. Optionally, you can [set up Virtual Private Cloud (VPC) peering](#vpc-peering) or [AWS PrivateLink](#aws-privatelink) for your cluster for enhanced network security and lower network latency.
 
+{{site.data.alerts.callout_success}}
+For additional cluster security, you can learn more about [Private Clusters (Preview)](private-clusters.html). A private cluster's nodes have no public IP addresses.
+{{site.data.alerts.end}}
+
 ## IP allowlisting
 
 Authorize your application server’s network and your local machine’s network by [adding their public IP addresses (in the CIDR format) to the {{ site.data.products.dedicated }} cluster's allowlist](connect-to-your-cluster.html#step-1-authorize-your-network). If you change your location, you will need to authorize the new location’s network, else the connection from that network will be rejected.
@@ -97,7 +101,7 @@ Use either the Amazon VPC Console or the [AWS Command Line Interface (CLI)](http
 1.  In the **Security group** section, select the security group you created in [Step 8](#step-8) and uncheck the box for **default** security group.
 1.  Click **Create Endpoint**.
 
-      The VPC Endpoint ID displays.  
+      The VPC Endpoint ID displays.
 
 1.  Copy the Endpoint ID to your clipboard and return to {{ site.data.products.db }}'s **Add PrivateLink** modal.
 

--- a/cockroachcloud/private-clusters.md
+++ b/cockroachcloud/private-clusters.md
@@ -1,0 +1,46 @@
+---
+title: Create private CockroachDB Dedicated clusters (Preview)
+summary: Learn how to create CockroachDB Dedicated clusters with no node-level public IP addresses.
+toc: true
+docs_area: manage.security
+---
+
+{% include feature-phases/preview-opt-in.md %}
+
+Limiting access to a CockroachDB cluster's nodes over the public internet is an important security practice and is also a compliance requirement for many organizations. {{ site.data.products.dedicated }} private clusters allow organizations to meet this objective.
+
+By default, {{ site.data.products.db }} has safeguards in place to protect cluster's data from the public internet. Ingress traffic to a cluster is routed through a load balancer, and it is possible to restrict inbound connections using a combination of [IP allowlisting](/docs/cockroachcloud/network-authorization.html#ip-allowlisting), and either of [AWS PrivateLink](/docs/cockroachcloud/network-authorization.html#aws-privatelink) or [GCP VPC peering](/docs/cockroachcloud/network-authorization.html#vpc-peering) depending on your cloud provider. However, data egress operations such as [exports](/docs/stable/export.html), [backups](/docs/stable/backup.html), and [Change Data Capture (CDC)](/docs/stable/change-data-capture-overview.html) use public subnets.
+
+On the other hand, a private {{ site.data.products.dedicated }} cluster's nodes have no public IP addresses, and egress traffic moves over private subnets and through a highly-available NAT gateway that is unique to the cluster. This page explains what happens when you create a private cluster.
+
+## Create a private cluster
+
+To be enrolled in the preview and deploy a new private cluster on AWS or GCP, contact your account team.
+
+After your organization is enrolled in the preview:
+
+- By default, newly-created {{ site.data.products.dedicated }} clusters deployed on GCP will be private clusters.
+- By default, newly-created {{ site.data.products.dedicated }} clusters deployed on AWS will **not** be private clusters. To create a private cluster on AWS, you can specify a special field using the [{{ site.data.products.db }} API](/docs/cockroachcloud/cloud-api.html). Contact your account team for details.
+- An existing cluster can't be migrated in-place to a private cluster.
+
+When you create a private cluster:
+
+1. One private subnet is created per requested region.
+1. Each node is connected to the regional private subnet.
+1. A highly-available NAT gateway is created with static egress public IP addresses. For private clusters deployed on AWS, the NAT gateways are created in three separate availability zones to mitigate against the risk of an availability zone outage.
+1. All egress traffic from the cluster nodes to non-cloud external resources is sent across the private subnet and through the NAT gateway to reach its destination.
+1. All egress traffic from the cluster nodes to S3 (for private clusters on AWS) or Google Cloud Storage (for private clusters on GCP) is sent across the private subnet and through the private network for the relevant cloud provider (S3 Gateway endpoints on AWS and Private Google Access on GCP).
+
+## Limit inbound connections from egress operations
+
+Egress traffic from a private cluster to non-cloud external resources will always appear to come from the static IP addresses that comprise the cluster's NAT gateway. To determine the NAT gateway's IP addresses, you can initiate an egress operation such as an [`EXPORT`](/docs/stable/export.html) or [`BACKUP`](/docs/stable/backup.html) operation on the cluster and observe the source addresses of the resulting connections to your non-cloud external resources. Cockroach Labs recommends that you allow connections to such resources only from those IP addresses.
+
+## What's next?
+- [Security Overview](security-overview.html)
+- [Network Authorization](network-authorization.html)
+{% comment %}- [Egress Perimeter Controls](egress-perimeter-controls.html){% endcomment %}
+
+## Limitations
+
+- An existing cluster can't be migrated in-place to a private cluster. Instead, migrate the existing cluster's data to a new private cluster. Refer to [Migrate Your Database to CockroachDB](/docs/stable/migration-overview.html).
+- Private clusters are not available with {{ site.data.products.serverless }}.

--- a/cockroachcloud/security-overview.md
+++ b/cockroachcloud/security-overview.md
@@ -73,10 +73,15 @@ The following table summarizes the {{ site.data.products.db }} security features
   <td>Role-based access control</td>
  </tr>
  <tr>
-   <td rowspan="2"><a href="network-authorization.html">Network Authorization</a></td>
+   <td rowspan="3"><a href="network-authorization.html">Network Authorization</a></td>
    <td>&nbsp;</td>
    <td>✓</td>
    <td>IP allowlisting</td>
+ </tr>
+ <tr>
+  <td>&nbsp;</td>
+  <td>✓</td>
+  <td><a href="private-clusters.html">Private Clusters (Preview)</a></a> whose clusters nodes have no public IP addresses </td>
  </tr>
  <tr>
   <td>&nbsp;</td>


### PR DESCRIPTION
[DOC-4822]
Describe private clusters for CockroachDB Dedicated

Reviewers: Please leave feedback using Github directly, rather than ReviewBoard.

## Previews
[cockroachcloud/private-clusters.md](https://deploy-preview-15342--cockroachdb-docs.netlify.app/docs/cockroachcloud/private-clusters.html)
[cockroachcloud/network-authorization.md](https://deploy-preview-15342--cockroachdb-docs.netlify.app/docs/cockroachcloud/network-authorization.html)
[cockroachcloud/security-overview.md](https://deploy-preview-15342--cockroachdb-docs.netlify.app/docs/cockroachcloud/security-overview.html)

## Tests
- [x] Local build
- [x] Linkcheck 