### PR TITLE
Force any /dev/ canonical pages to redirect to /dev/

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,8 @@
 <meta name="google-site-verification" content="xIjIKHNh-szz0m5JilyA4IriUmVD5DxeYBE18xSqvZY" /> {% comment %} Joe Nickdow {% endcomment %}
 {% endif %}
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="canonical" href="{{ page.canonical | absolute_url }}">
+{%- assign dev_path = "/" | append: site.versions["dev"] | append: "/" -%}
+<link rel="canonical" href="{{ page.canonical | absolute_url | replace: dev_path, "/dev/" }}">
 <link rel="shortcut icon" href="{{ 'images/favicon.png' | relative_url }}" type="image/png">
 
 {% if page.comparison == true %}<link rel="stylesheet" type="text/css" href="{{ 'css/select2.min.css' | relative_url }}">{% endif %}


### PR DESCRIPTION
Currently, we have some new pages, such as `ALTER FUNCTION` to support UDFs. We want these pages to be part of our search index, but Google can't index them because the canonical of these pages is set to v22.2/ instead of dev/. This PR fixes that.