### PR TITLE
[DOC-4826] Document Cloud organization audit log API

### DIFF
--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -84,6 +84,12 @@
       	      "urls": [
       		      "/cockroachcloud/sql-audit-logging.html"
       	      ]
+      	    },
+						{
+      	      "title": "Export Cloud Audit Logs",
+      	      "urls": [
+      		      "/cockroachcloud/cloud-audit-logs.html"
+      	      ]
       	    }
       	  ]
       	},

--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -86,9 +86,9 @@
       	      ]
       	    },
 						{
-      	      "title": "Export Cloud Audit Logs",
+      	      "title": "Export Cloud Organization Audit Logs",
       	      "urls": [
-      		      "/cockroachcloud/cloud-audit-logs.html"
+      		      "/cockroachcloud/cloud-org-audit-logs.html"
       	      ]
       	    }
       	  ]

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -413,7 +413,7 @@ Where:
 
 A request that includes no parameters exports roughly 200 entries in ascending order, starting from when your {{ site.data.products.db }} organization was created.
 
-If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and a `next_starting_from` field. If the results are returned in descending order (latest to earliest), then `next_starting_from` is not returned. If the results are returned in ascending order, `next_starting_from` is always returned.
+If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and a `next_starting_from` field. If the results are returned in descending order (latest to earliest), then `next_starting_from` is not returned when it reaches the time when the  {{ site.data.products.db }} organization was created. If the results are returned in ascending order, `next_starting_from` is always returned.
 
 {% include_cached copy-clipboard.html %}
 ~~~ json

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -401,19 +401,23 @@ To export audit logs for activities and events related to your Cloud organizatio
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom={timestamp},SortOrder={sort_order},limit={limit}' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom={timestamp},sortOrder={sort_order},limit={limit}' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 
 Where:
 
-  - `{timestamp}` is an [RFC3339 timestamp](https://www.ietf.org/rfc/rfc3339.txt) that indicates the first log entry to fetch. If unspecified, defaults to the time when the Cloud organization was created if `{sort_order}` is `ascending`, or the current time if `{sort_order}` is `descending`.
-  - `{sort_order}` is either `ascending` (the default) or `descending`.
+  - `{timestamp}` is an [RFC3339 timestamp](https://www.ietf.org/rfc/rfc3339.txt) that indicates the first log entry to fetch. If unspecified, defaults to the time when the Cloud organization was created if `{sort_order}` is `ASC`, or the current time if `{sort_order}` is `DESC`.
+  - `{sort_order}` is either `ASC` (the default) or `DESC`.
   - `{limit}` indicates roughly how many entries to return. If any entries would be returned for a timestamp, all entries for that timestamp are always returned. Defaults to `200`.
 
 A request that includes no parameters exports roughly 200 entries in ascending order, starting from when your {{ site.data.products.db }} organization was created.
 
-If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and a `next_starting_from` field. If the results are returned in descending order (latest to earliest), then `next_starting_from` is not returned when it reaches the time when the  {{ site.data.products.db }} organization was created. If the results are returned in ascending order, `next_starting_from` is always returned.
+If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and, depending on the circumstances, a `next_starting_from` field.
+
+- If `{sort_order}` is `ASC`, next_starting_from` is always returned.
+- If `{sort_order}` is `DESC`, then `next_starting_from` is returned as long as earlier audit logs are available. It is not returned when the earliest log entry is reached (when the {{ site.data.products.db }} organization was created).
+
 
 {% include_cached copy-clipboard.html %}
 ~~~ json
@@ -421,7 +425,7 @@ If the request was successful, the client will receive a JSON array consisting o
   "entries": [
     "{entry_array}"
   ],
-  "NextStartingFrom": "{timestamp}"
+  "next_starting_from": "{timestamp}"
 }
 ~~~
 

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -390,6 +390,46 @@ Where:
 
 If the `DELETE` request was successful the client will not receive a response payload.
 
+<a id="cloud-audit-logs"></a>
+
+## Export {{ site.data.products.db }} audit logs
+
+{% include feature-phases/preview-opt-in.md %}
+
+To export audit logs for activities and events related to your {{ site.data.products.db }} organization, send a `GET` request to the `/v1/auditlogevents` endpoint. The service account associated with the secret key must have `ADMIN` [permission](console-access-management.html#service-accounts).
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom={timestamp},SortOrder={sort_order},limit={limit}' \
+  --header 'Authorization: Bearer {secret_key}'
+~~~
+
+Where:
+
+  - `{timestamp}` indicates the first log entry to fetch. If unspecified, `{timestamp}` is set to the beginning of time if `{sort_order}` is `ascending`, or the current time if `{sort_order}` is `descending`.
+  - `{sort_order}` is either `ascending` (the default) or `descending`.
+  - `{limit}` indicates roughly how many entries to return. It is expected that slightly more results will be returned, because if any entries exist for a timestamp, all entries for that timestamp are always fetched. It defaults to `200`.
+
+A request that includes no parameters exports roughly 200 entries are returned in ascending order, starting from the first entry for your {{ site.data.products.db }} organization.
+
+If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and a `next_starting_from` field.
+
+{% include_cached copy-clipboard.html %}
+~~~ json
+{
+  "entries": [
+    "{entry_array}"
+  ],
+  "NextStartingFrom": "{timestamp}"
+}
+~~~
+
+Where:
+
+  - `{entry_array}` is a structured JSON array of audit log entries.
+  - `{timestamp}` indicates the timestamp to send to export the next batch of results.
+
 ## List all clusters in an organization
 
 To list all active clusters within an organization, send a `GET` request to the `/v1/clusters` endpoint. The service account associated with the secret key must have `ADMIN` or `READ` [permission](console-access-management.html#service-accounts) to list an organization's clusters.
@@ -514,7 +554,7 @@ Where:
   {{site.data.alerts.callout_info}}
   The cluster ID used in the Cloud API is different than the routing ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
   {{site.data.alerts.end}}
-  
+
 If the request was successful, the client will receive a list of SQL users.
 
 ~~~ json

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -392,7 +392,7 @@ If the `DELETE` request was successful the client will not receive a response pa
 
 <a id="cloud-audit-logs"></a>
 
-## Export {{ site.data.products.db }} Organization audit logs
+## Export Cloud Organization audit logs
 
 {% include feature-phases/preview-opt-in.md %}
 

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -392,11 +392,11 @@ If the `DELETE` request was successful the client will not receive a response pa
 
 <a id="cloud-audit-logs"></a>
 
-## Export {{ site.data.products.db }} audit logs
+## Export {{ site.data.products.db }} Organization audit logs
 
 {% include feature-phases/preview-opt-in.md %}
 
-To export audit logs for activities and events related to your {{ site.data.products.db }} organization, send a `GET` request to the `/v1/auditlogevents` endpoint. The service account associated with the secret key must have `ADMIN` [permission](console-access-management.html#service-accounts).
+To export audit logs for activities and events related to your Cloud organization, send a `GET` request to the `/v1/auditlogevents` endpoint. The service account associated with the secret key must have `ADMIN` [permission](console-access-management.html#service-accounts).
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -407,13 +407,13 @@ curl --request GET \
 
 Where:
 
-  - `{timestamp}` indicates the first log entry to fetch. If unspecified, `{timestamp}` is set to the beginning of time if `{sort_order}` is `ascending`, or the current time if `{sort_order}` is `descending`.
+  - `{timestamp}` is an [RFC3339 timestamp](https://www.ietf.org/rfc/rfc3339.txt) that indicates the first log entry to fetch. If unspecified, defaults to the time when the Cloud organization was created if `{sort_order}` is `ascending`, or the current time if `{sort_order}` is `descending`.
   - `{sort_order}` is either `ascending` (the default) or `descending`.
-  - `{limit}` indicates roughly how many entries to return. It is expected that slightly more results will be returned, because if any entries exist for a timestamp, all entries for that timestamp are always fetched. It defaults to `200`.
+  - `{limit}` indicates roughly how many entries to return. If any entries would be returned for a timestamp, all entries for that timestamp are always returned. Defaults to `200`.
 
-A request that includes no parameters exports roughly 200 entries are returned in ascending order, starting from the first entry for your {{ site.data.products.db }} organization.
+A request that includes no parameters exports roughly 200 entries in ascending order, starting from when your {{ site.data.products.db }} organization was created.
 
-If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and a `next_starting_from` field.
+If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and a `next_starting_from` field. If the results are returned in descending order (latest to earliest), then `next_starting_from` is not returned. If the results are returned in ascending order, `next_starting_from` is always returned.
 
 {% include_cached copy-clipboard.html %}
 ~~~ json

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -401,7 +401,7 @@ To export audit logs for activities and events related to your Cloud organizatio
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom={timestamp},sortOrder={sort_order},limit={limit}' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom={timestamp}&sortOrder={sort_order}&limit={limit}' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -402,7 +402,8 @@ To export audit logs for activities and events related to your Cloud organizatio
 ~~~ shell
 curl --request GET \
   --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom={timestamp}&sortOrder={sort_order}&limit={limit}' \
-  --header 'Authorization: Bearer {secret_key}'
+  --header 'Authorization: Bearer {secret_key}' \
+  --header 'Cc-Version: {api_version}'
 ~~~
 
 Where:
@@ -410,12 +411,13 @@ Where:
   - `{timestamp}` is an [RFC3339 timestamp](https://www.ietf.org/rfc/rfc3339.txt) that indicates the first log entry to fetch. If unspecified, defaults to the time when the Cloud organization was created if `{sort_order}` is `ASC`, or the current time if `{sort_order}` is `DESC`.
   - `{sort_order}` is either `ASC` (the default) or `DESC`.
   - `{limit}` indicates roughly how many entries to return. If any entries would be returned for a timestamp, all entries for that timestamp are always returned. Defaults to `200`.
+  - `{api_version}` is the [Cloud API version](#set-the-api-version).
 
 A request that includes no parameters exports roughly 200 entries in ascending order, starting from when your {{ site.data.products.db }} organization was created.
 
 If the request was successful, the client will receive a JSON array consisting of a list of log `entries` and, depending on the circumstances, a `next_starting_from` field.
 
-- If `{sort_order}` is `ASC`, next_starting_from` is always returned.
+- If `{sort_order}` is `ASC`, `next_starting_from` is always returned.
 - If `{sort_order}` is `DESC`, then `next_starting_from` is returned as long as earlier audit logs are available. It is not returned when the earliest log entry is reached (when the {{ site.data.products.db }} organization was created).
 
 

--- a/cockroachcloud/cloud-audit-logs.md
+++ b/cockroachcloud/cloud-audit-logs.md
@@ -1,0 +1,119 @@
+---
+title: Export CockroachDB Cloud audit logs
+summary: Learn about exporting Cockroach Cloud audit logs.
+toc: true
+docs_area: manage
+---
+
+{{ site.data.products.db }} captures audit logs when many types of events occur, such as when a cluster is created or when a user logs in to {{ site.data.products.db }}. Any user who is an admin of the organization can export these audit logs using the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs) of the [Cloud API](/docs/cockroachcloud/cloud-api.html).
+
+{% include feature-phases/preview-opt-in.md %}
+
+After your organization is enrolled in the preview, you can begin exporting {{ site.data.products.db }} audit logs.
+
+This page provides some examples of exporting {{ site.data.products.db }} audit logs. For details about each parameter and its defaults, refer to the API specification for the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs).
+
+## Export audit logs in ascending order
+
+This example requests audit logs without defining the starting timestamp, sort order, or limit. By default, the first 200 audit logs for your {{ site.data.products.db }} organization are returned in ascending order.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents' \
+  --header 'Authorization: Bearer {secret_key}'
+~~~
+
+The response is truncated for readability.
+
+~~~ json
+{
+  "entries": [
+    {
+      "id": "40b15ccd-6a87-4efc-ac7b-157ba172f957",
+      "trace_id": "cfa605927086bb630ab9eb69bfda5f5f",
+      "session_id": "5e24b61f9fc7459ab2fac703b926a2622a347bf8993d32ef84e836e2f11053d3",
+      "source": "AUDIT_LOG_SOURCE_INTERNAL",
+      "user_email": "",
+      "cluster_id": "dc6360d2-b21c-451f-aa9f-b20ad6906475",
+      "cluster_name": "example-cluster",
+      "action": "AUDIT_LOG_ACTION_CREATE_CLUSTER",
+      "payload": {
+        "request": {
+          "name": "example-cluster",
+          "provider": "GCP",
+          "spec": {
+            "dedicated": {
+              "cockroachVersion": "v21.2.4",
+              "hardware": {
+                "diskIops": 450,
+                "machineSpec": {
+                  "machineType": "n1-standard-2"
+                },
+                "storageGib": 15
+              },
+              "regionNodes": {
+                "europe-west4": 1
+              }
+            }
+          }
+        }
+      },
+      "metadata": null,
+      "error": "",
+      "created_at": "2022-10-09T02:40:00.262143Z"
+    }
+  ],
+  "next_starting_from": "2022-10-09T02:40:35.054818Z"
+}
+~~~
+
+To export the next batch of entries, send a second request and set `StartingFrom` to the value of `next_starting_from`, `2022-10-09T02:40:35.054818Z`.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom=2022-10-09T02:40:35.054818Z' \
+  --header 'Authorization: Bearer {secret_key}'
+~~~
+
+## Export audit logs in descending order
+
+This example requests the 300 most recent audit logs, starting from the current timestamp.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?SortOrder=descending,limit=300' \
+  --header 'Authorization: Bearer {secret_key}'
+~~~
+
+To request the next batch of entries in the same direction, send a second request with the same values for `SortOrder` and `limit` and set `StartingFrom` to the value of `next_starting_from`.
+
+## Events adjacent to a specific timestamp
+
+This example shows how to retrieve the 200 events on each side of a given timestamp by invoking the API multiple times with the same timestamp and a different sort order. The sort order determines whether the specified timestamp is at the beginning or end of the list. These examples use the default value for `limit`.
+
+First, retrieve roughly 200 entries for the specified timestamp and later.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom=2022-10-09T02:40:00.262143Z&SortOrder=ascending' \
+  --header 'Authorization: Bearer {secret_key}'
+~~~
+
+Next, retrieve roughly 200 less recent entries for the specified timestamp and earlier.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom=2022-10-09T02:40:00.262143Z&SortOrder=descending' \
+  --header 'Authorization: Bearer {secret_key}'
+~~~
+
+All entries for the timestamp itself are included in both sets of results. Duplicated entries have the same `id`.
+
+## What's next?
+
+- Learn more about the [Cloud API](cloud-api.html)

--- a/cockroachcloud/cloud-org-audit-logs.md
+++ b/cockroachcloud/cloud-org-audit-logs.md
@@ -1,21 +1,21 @@
 ---
-title: Export CockroachDB Cloud audit logs
-summary: Learn about exporting Cockroach Cloud audit logs.
+title: Export CockroachDB Cloud organization audit logs
+summary: Learn about exporting Cockroach Cloud organization audit logs.
 toc: true
 docs_area: manage
 ---
 
-{{ site.data.products.db }} captures audit logs when many types of events occur, such as when a cluster is created or when a user logs in to {{ site.data.products.db }}. Any user who is an admin of the organization can export these audit logs using the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs) of the [Cloud API](/docs/cockroachcloud/cloud-api.html).
+{{ site.data.products.db }} captures audit logs when many types of events occur, such as when a cluster is created or when a user is added to or removed from an organization. Any user who is an admin of the organization can export these audit logs using the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs) of the [Cloud API](/docs/cockroachcloud/cloud-api.html).
 
 {% include feature-phases/preview-opt-in.md %}
 
-After your organization is enrolled in the preview, you can begin exporting {{ site.data.products.db }} audit logs.
+After your organization is enrolled in the preview, you can begin exporting audit logs for {{ site.data.products.db }} organization.
 
-This page provides some examples of exporting {{ site.data.products.db }} audit logs. For details about each parameter and its defaults, refer to the API specification for the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs).
+This page provides some examples of exporting {{ site.data.products.db }} organization audit logs. For details about each parameter and its defaults, refer to the API specification for the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs).
 
 ## Export audit logs in ascending order
 
-This example requests audit logs without defining the starting timestamp, sort order, or limit. By default, the first 200 audit logs for your {{ site.data.products.db }} organization are returned in ascending order.
+This example requests audit logs without defining the starting timestamp, sort order, or limit. By default, the earliest 200 audit logs for your {{ site.data.products.db }} organization are returned in ascending order, starting from when the organization was created.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -68,6 +68,10 @@ The response is truncated for readability.
 }
 ~~~
 
+{{site.data.alerts.callout_info}}
+If you get an error, verify that the feature is enabled for your {{ site.data.products.db }} organization.
+{{site.data.alerts.end}}
+
 To export the next batch of entries, send a second request and set `StartingFrom` to the value of `next_starting_from`, `2022-10-09T02:40:35.054818Z`.
 
 {% include_cached copy-clipboard.html %}
@@ -88,11 +92,11 @@ curl --request GET \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 
-To request the next batch of entries in the same direction, send a second request with the same values for `SortOrder` and `limit` and set `StartingFrom` to the value of `next_starting_from`.
+To request the next batch of entries in the same direction, send a second request with the same values for `SortOrder` and `limit` and set `StartingFrom` to the value of `next_starting_from`. When there are no more results to fetch (because you have reached when your {{ site.data.products.db }} organization was created), no `next_starting_from` field is returned.
 
 ## Events adjacent to a specific timestamp
 
-This example shows how to retrieve the 200 events on each side of a given timestamp by invoking the API multiple times with the same timestamp and a different sort order. The sort order determines whether the specified timestamp is at the beginning or end of the list. These examples use the default value for `limit`.
+This example shows how to retrieve the 200 events on each side of a given timestamp by invoking the API twice, with the same timestamp and a different sort order for each request. The sort order determines whether the specified timestamp is at the beginning or end of the list. These examples use the default value for `limit`.
 
 First, retrieve roughly 200 entries for the specified timestamp and later.
 

--- a/cockroachcloud/cloud-org-audit-logs.md
+++ b/cockroachcloud/cloud-org-audit-logs.md
@@ -21,7 +21,8 @@ This example requests audit logs without defining the starting timestamp, sort o
 ~~~ shell
 curl --request GET \
   --url 'https://cockroachlabs.cloud/api/v1/auditlogevents' \
-  --header 'Authorization: Bearer {secret_key}'
+  --header 'Authorization: Bearer {secret_key}' \
+  --header 'Cc-Version: {api_version}'
 ~~~
 
 The response is truncated for readability.
@@ -78,7 +79,8 @@ To export the next batch of entries, send a second request and set `startingFrom
 ~~~ shell
 curl --request GET \
   --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom=2022-10-09T02:40:35.054818Z' \
-  --header 'Authorization: Bearer {secret_key}'
+  --header 'Authorization: Bearer {secret_key}' \
+  --header 'Cc-Version: {api_version}'
 ~~~
 
 ## Export audit logs in descending order
@@ -89,7 +91,8 @@ This example requests the 300 most recent audit logs, starting from the current 
 ~~~ shell
 curl --request GET \
   --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?sortOrder=DESC&limit=300' \
-  --header 'Authorization: Bearer {secret_key}'
+  --header 'Authorization: Bearer {secret_key}' \
+  --header 'Cc-Version: {api_version}'
 ~~~
 
 To request the next batch of entries in the same direction, send a second request with the same values for `sortOrder` and `limit` and set `startingFrom` to the value of `next_starting_from`. When there are no more results to fetch (because you have reached when your {{ site.data.products.db }} organization was created), no `next_starting_from` field is returned.
@@ -104,7 +107,8 @@ First, retrieve roughly 200 entries for the specified timestamp and later.
 ~~~ shell
 curl --request GET \
   --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom=2022-10-09T02:40:00.262143Z&sortOrder=ASC' \
-  --header 'Authorization: Bearer {secret_key}'
+  --header 'Authorization: Bearer {secret_key}' \
+  --header 'Cc-Version: {api_version}'
 ~~~
 
 Next, retrieve roughly 200 less recent entries for the specified timestamp and earlier.
@@ -113,7 +117,8 @@ Next, retrieve roughly 200 less recent entries for the specified timestamp and e
 ~~~ shell
 curl --request GET \
   --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom=2022-10-09T02:40:00.262143Z&sortOrder=DESC' \
-  --header 'Authorization: Bearer {secret_key}'
+  --header 'Authorization: Bearer {secret_key}' \
+  --header 'Cc-Version: {api_version}'
 ~~~
 
 All entries for the timestamp itself are included in both sets of results. Duplicated entries have the same `id`.

--- a/cockroachcloud/cloud-org-audit-logs.md
+++ b/cockroachcloud/cloud-org-audit-logs.md
@@ -1,11 +1,11 @@
 ---
 title: Export CockroachDB Cloud organization audit logs
-summary: Learn about exporting Cockroach Cloud organization audit logs.
+summary: Learn about exporting CockroachDB Cloud organization audit logs.
 toc: true
 docs_area: manage
 ---
 
-{{ site.data.products.db }} captures audit logs when many types of events occur, such as when a cluster is created or when a user is added to or removed from an organization. Any user who is an admin of the organization can export these audit logs using the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs) of the [Cloud API](/docs/cockroachcloud/cloud-api.html).
+{{ site.data.products.db }} captures audit logs when many types of events occur, such as when a cluster is created or when a user is added to or removed from an organization. Any user in an organization with an admin-level service account can export these audit logs using the [`auditlogevents` endpoint](cloud-api.html#cloud-audit-logs) of the [Cloud API](/docs/cockroachcloud/cloud-api.html).
 
 {% include feature-phases/preview-opt-in.md %}
 

--- a/cockroachcloud/cloud-org-audit-logs.md
+++ b/cockroachcloud/cloud-org-audit-logs.md
@@ -72,12 +72,12 @@ The response is truncated for readability.
 If you get an error, verify that the feature is enabled for your {{ site.data.products.db }} organization.
 {{site.data.alerts.end}}
 
-To export the next batch of entries, send a second request and set `StartingFrom` to the value of `next_starting_from`, `2022-10-09T02:40:35.054818Z`.
+To export the next batch of entries, send a second request and set `startingFrom` to the value of `next_starting_from`, `2022-10-09T02:40:35.054818Z`.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom=2022-10-09T02:40:35.054818Z' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom=2022-10-09T02:40:35.054818Z' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 
@@ -88,11 +88,11 @@ This example requests the 300 most recent audit logs, starting from the current 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?SortOrder=descending,limit=300' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?sortOrder=DESC,limit=300' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 
-To request the next batch of entries in the same direction, send a second request with the same values for `SortOrder` and `limit` and set `StartingFrom` to the value of `next_starting_from`. When there are no more results to fetch (because you have reached when your {{ site.data.products.db }} organization was created), no `next_starting_from` field is returned.
+To request the next batch of entries in the same direction, send a second request with the same values for `sortOrder` and `limit` and set `startingFrom` to the value of `next_starting_from`. When there are no more results to fetch (because you have reached when your {{ site.data.products.db }} organization was created), no `next_starting_from` field is returned.
 
 ## Events adjacent to a specific timestamp
 
@@ -103,7 +103,7 @@ First, retrieve roughly 200 entries for the specified timestamp and later.
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom=2022-10-09T02:40:00.262143Z&SortOrder=ascending' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom=2022-10-09T02:40:00.262143Z&sortOrder=ASC' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 
@@ -112,7 +112,7 @@ Next, retrieve roughly 200 less recent entries for the specified timestamp and e
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?StartingFrom=2022-10-09T02:40:00.262143Z&SortOrder=descending' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?startingFrom=2022-10-09T02:40:00.262143Z&sortOrder=DESC' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 

--- a/cockroachcloud/cloud-org-audit-logs.md
+++ b/cockroachcloud/cloud-org-audit-logs.md
@@ -88,7 +88,7 @@ This example requests the 300 most recent audit logs, starting from the current 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 curl --request GET \
-  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?sortOrder=DESC,limit=300' \
+  --url 'https://cockroachlabs.cloud/api/v1/auditlogevents?sortOrder=DESC&limit=300' \
   --header 'Authorization: Bearer {secret_key}'
 ~~~
 


### PR DESCRIPTION
[DOC-4826]

Reviewers:
- Please review directly in Github rather than ReviewBoard.

## Previews

[cockroachcloud/cloud-api.md](https://deploy-preview-15349--cockroachdb-docs.netlify.app/docs/cockroachcloud/cloud-api.html)
[cockroachcloud/cloud-org-audit-logs.md](https://deploy-preview-15349--cockroachdb-docs.netlify.app/docs/cockroachcloud/cloud-org-audit-logs.html)

## Tests
- [x] Local build
- [x] Linkcheck 