### PR TITLE
clarified testing page for local env

### DIFF
--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -371,7 +371,7 @@
             ]
           },
           {
-            "title": "Test Your Application",
+            "title": "Test Your Application Locally",
             "urls": [
               "/${VERSION}/local-testing.html"
             ]

--- a/_includes/v21.2/sidebar-data/develop.json
+++ b/_includes/v21.2/sidebar-data/develop.json
@@ -252,7 +252,7 @@
       ]
     },
     {
-      "title": "Test Your Application",
+      "title": "Test Your Application Locally",
       "urls": [
         "/${VERSION}/local-testing.html"
       ]

--- a/_includes/v22.1/sidebar-data/develop.json
+++ b/_includes/v22.1/sidebar-data/develop.json
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "title": "Test Your Application",
+      "title": "Test Your Application Locally",
       "urls": [
         "/${VERSION}/local-testing.html"
       ]

--- a/_includes/v22.2/sidebar-data/develop.json
+++ b/_includes/v22.2/sidebar-data/develop.json
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "title": "Test Your Application",
+      "title": "Test Your Application Locally",
       "urls": [
         "/${VERSION}/local-testing.html"
       ]

--- a/v21.1/local-testing.md
+++ b/v21.1/local-testing.md
@@ -1,10 +1,10 @@
 ---
-title: Test Your Application
+title: Test Your Application Locally
 summary: Best practices for locally testing an application built on CockroachDB
 toc: true
 ---
 
-This page documents best practices for unit testing applications built on CockroachDB.
+This page documents best practices for unit testing applications built on CockroachDB in a local environment.
 
 If you are deploying a self-hosted cluster, see the [Production Checklist](recommended-production-settings.html) for information about preparing your cluster for production.
 

--- a/v21.2/local-testing.md
+++ b/v21.2/local-testing.md
@@ -1,11 +1,11 @@
 ---
-title: Test Your Application
+title: Test Your Application Locally
 summary: Best practices for locally testing an application built on CockroachDB
 toc: true
 docs_area: develop
 ---
 
-This page documents best practices for unit testing applications built on CockroachDB.
+This page documents best practices for unit testing applications built on CockroachDB in a local environment.
 
 If you are deploying a self-hosted cluster, see the [Production Checklist](recommended-production-settings.html) for information about preparing your cluster for production.
 

--- a/v22.1/local-testing.md
+++ b/v22.1/local-testing.md
@@ -1,11 +1,11 @@
 ---
-title: Test Your Application
+title: Test Your Application Locally
 summary: Best practices for locally testing an application built on CockroachDB
 toc: true
 docs_area: develop
 ---
 
-This page documents best practices for unit testing applications built on CockroachDB.
+This page documents best practices for unit testing applications built on CockroachDB in a local environment.
 
 If you are deploying a self-hosted cluster, see the [Production Checklist](recommended-production-settings.html) for information about preparing your cluster for production.
 

--- a/v22.2/local-testing.md
+++ b/v22.2/local-testing.md
@@ -1,11 +1,11 @@
 ---
-title: Test Your Application
+title: Test Your Application Locally
 summary: Best practices for locally testing an application built on CockroachDB
 toc: true
 docs_area: develop
 ---
 
-This page documents best practices for unit testing applications built on CockroachDB.
+This page documents best practices for unit testing applications built on CockroachDB in a local environment.
 
 If you are deploying a self-hosted cluster, see the [Production Checklist](recommended-production-settings.html) for information about preparing your cluster for production.
 


### PR DESCRIPTION
Addresses DOC-2290

- Included 'local' in header, nav, first sentence
- Changed v22.2, 22.1, 21.2, 21.1 

[Staging](https://deploy-preview-15359--cockroachdb-docs.netlify.app/docs/stable/local-testing.html)