### PR TITLE
DOC-5948 v21.2.17 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -114,12 +114,12 @@ release_info:
     start_time: 2022-09-14 12:48:52.570761 +0000 UTC
     version: v21.1.21
   v21.2:
-    build_time: 2022-09-29 00:00:00 (go1.17)
+    build_time: 2022-10-17 00:00:00 (go1.18)
     crdb_branch_name: release-21.2
     docker_image: cockroachdb/cockroach
-    name: v21.2.16
-    start_time: 2022-09-29 18:03:32.389265 +0000 UTC
-    version: v21.2.16
+    name: v21.2.17
+    start_time: 2022-10-13 17:45:03.909127 +0000 UTC
+    version: v21.2.17
   v22.1:
     build_time: 2022-09-29 00:00:00 (go1.17)
     crdb_branch_name: release-22.1

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -300,3 +300,4 @@ v22.1.8,v22.1,2022-09-29,false,False,Production,False,go1.17,bdcab67f77861751559
 v21.2.16,v21.2,2022-09-29,false,False,Production,False,go1.17,5c5501092e833d2a10d1351f8b4f4b2dc83e95a8,cockroachdb/cockroach,false,false
 v22.2.0-beta.2,v22.2,2022-10-03,false,False,Testing,False,go1.17,860584a59dee73d7a66ce882c668cef6eb2556f7,cockroachdb/cockroach-unstable,true,true
 v22.2.0-beta.3,v22.2,2022-10-10,false,False,Testing,False,go1.17,0937c6c2f6d727fe27d708bddec14daaa1ccfe94,cockroachdb/cockroach-unstable,true,true
+v21.2.17,v21.2,2022-10-17,false,False,Production,False,go1.18,6a8cfc30d1afea8b34a0c902aa5f5f625d2d21cc,cockroachdb/cockroach,false,false

--- a/_includes/releases/v21.2/v21.2.17.md
+++ b/_includes/releases/v21.2/v21.2.17.md
@@ -1,0 +1,36 @@
+## v21.2.17
+
+Release Date: October 17, 2022
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v21-2-17-bug-fixes">Bug fixes</h3>
+
+- Fixed a rare internal error that could occur during planning when a query predicate included values close to the maximum or minimum `int64` value. The error, `estimated row count must be non-zero`, has now been fixed. [#88955][#88955]
+- Fixed a longstanding bug that could cause the optimizer to produce an incorrect plan when aggregate functions `st_makeline` or `st_extent` were called with invalid-type and empty inputs respectively. [#88954][#88954]
+- Fixed a bug that caused high SQL tail latencies during background rebalancing in the cluster. [#88738][#88738]
+- Fixed a bug where draining or drained nodes could re-acquire leases during an import or an index backfill. [#88725][#88725]
+- Fixed a bug that caused incorrect evaluation of expressions in the form `col +/- const1 ? const2`, where `const1` and `const2` are constant values and `?` is any comparison operator. The bug was caused by operator overflow when the optimizer attempted to simplify these expressions to have a single constant value. [#88971][#88971]
+- Fixed a bug that has existed since v2.1.0 where queries containing a subquery with `EXCEPT` could produce incorrect results. This could happen if the optimizer could guarantee that the left side of the `EXCEPT` always returned more rows than the right side. In this case, the optimizer made a faulty assumption that the `EXCEPT` subquery always returned at least one row, which could cause the optimizer to perform an invalid transformation, possibly causing the full query to return incorrect results. [#89132][#89132]
+- CockroachDB will now flush the write-ahead log on consistency checker failures when writing storage checkpoints. [#89401][#89401]
+- Fixed a bug that could cause incorrect results from the floor division operator, `//`, when the numerator is non-constant and the denominator is the constant `1`. [#89264][#89264]
+- Fixed a source of internal connectivity problems that would resolve after restarting the affected node. [#89618][#89618]
+- Fixed errors that may occur in automatic statistics collection when the cluster setting `sql.stats.automatic_collection.min_stale_rows` is set to `0`. [#89706][#89706]
+- Fixed a bug that caused spurious failures when running a restore. [#89019][#89019]
+
+<h3 id="v21-2-17-contributors">Contributors</h3>
+
+This release includes 17 merged PRs by 13 authors.
+
+[#88725]: https://github.com/cockroachdb/cockroach/pull/88725
+[#88738]: https://github.com/cockroachdb/cockroach/pull/88738
+[#88954]: https://github.com/cockroachdb/cockroach/pull/88954
+[#88955]: https://github.com/cockroachdb/cockroach/pull/88955
+[#88971]: https://github.com/cockroachdb/cockroach/pull/88971
+[#89019]: https://github.com/cockroachdb/cockroach/pull/89019
+[#89132]: https://github.com/cockroachdb/cockroach/pull/89132
+[#89264]: https://github.com/cockroachdb/cockroach/pull/89264
+[#89401]: https://github.com/cockroachdb/cockroach/pull/89401
+[#89618]: https://github.com/cockroachdb/cockroach/pull/89618
+[#89667]: https://github.com/cockroachdb/cockroach/pull/89667
+[#89706]: https://github.com/cockroachdb/cockroach/pull/89706


### PR DESCRIPTION
Addresses: DOC-5948

- Release notes for v21.2.17, scheduled for Monday, October 17.

[v21.2.md](https://deploy-preview-15365--cockroachdb-docs.netlify.app/docs/releases/v21.2.html#v21-2-17)