### PR TITLE
Added docs for the granular CHANGEFEED privilege model

### DIFF
--- a/_includes/v22.2/cdc/privilege-model.md
+++ b/_includes/v22.2/cdc/privilege-model.md
@@ -22,4 +22,6 @@ You can add `CHANGEFEED` to the user or role's [default privileges](security-ref
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
+{{site.data.alerts.callout_info}}
 Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.
+{{site.data.alerts.end}}

--- a/_includes/v22.2/cdc/privilege-model.md
+++ b/_includes/v22.2/cdc/privilege-model.md
@@ -1,0 +1,25 @@
+{{site.data.alerts.callout_info}}
+Starting in v22.2, CockroachDB introduces a new changefeed privilege model that provides finer control over a user's privilege to run changefeeds. 
+
+There is continued support for the [legacy privilege model](#legacy-privilege-model) in v22.2, however it **will be removed** in a future release. We recommend implementing the new privilege model that follows in this section for all changefeeds.
+{{site.data.alerts.end}}
+
+{% include_cached new-in.html version="v22.2" %} You can [grant](grant.html#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
+
+{% include_cached copy-clipboard.html %}
+~~~sql
+GRANT CHANGEFEED ON TABLE example_table TO user;
+~~~
+
+This privilege model provides a more granular way to grant users the ability to create a changefeed on a table. A user granted the `CHANGEFEED` privilege can create changefeeds on the target table even if the user does **not** have the [`CONTROLCHANGEFEED` role option](alter-role.html#role-options) or the `SELECT` privilege on the table. 
+
+Since you can grant the `CHANGEFEED` privilege to a user or role **without** them needing the `SELECT` privilege on a table, these users will be able to create changefeeds, but they will not be able to run a `SELECT` query on that data directly. {% if page.name == "create-changefeed.md" %} However, these users could still read this data indirectly if they have read access to the [sink](changefeed-sinks.html), or create a "sinkless" changefeed that emits messages to the SQL session.{% else %} However, these users will be able to read this data indirectly as `EXPERIMENTAL CHANGEFEED FOR` emits changefeed messages to the SQL session. {% endif %}
+
+You can add `CHANGEFEED` to the user or role's [default privileges](security-reference/authorization.html#default-privileges) with [`ALTER DEFAULT PRIVILEGES`](alter-default-privileges.html#grant-default-privileges-to-a-specific-role):
+
+{% include_cached copy-clipboard.html %}
+~~~sql
+ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
+~~~
+
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.

--- a/_includes/v22.2/sql/privileges.md
+++ b/_includes/v22.2/sql/privileges.md
@@ -15,3 +15,4 @@ Privilege | Levels
 `BACKUP` | System, Database, Table
 `RESTORE` | System, Database
 `EXTERNALIOIMPLICITACCESS` | System
+`CHANGEFEED` | Table

--- a/v22.2/changefeed-for.md
+++ b/v22.2/changefeed-for.md
@@ -19,6 +19,10 @@ For more information, see [Change Data Capture Overview](change-data-capture-ove
 
 ## Required privileges
 
+{% include {{ page.version.version }}/cdc/privilege-model.md %}
+
+### Legacy privilege model
+
 Changefeeds can only be created by superusers, i.e., [members of the `admin` role](security-reference/authorization.html#admin-role). The admin role exists by default with `root` as the member.
 
 ## Considerations

--- a/v22.2/changefeed-sinks.md
+++ b/v22.2/changefeed-sinks.md
@@ -159,7 +159,7 @@ Some considerations when using cloud storage sinks:
 - The supported cloud schemes are: `s3`, `gs`, `azure`, `http`, and `https`.
 - Both `http://` and `https://` are cloud storage sinks, **not** webhook sinks. It is necessary to prefix the scheme with `webhook-` for [webhook sinks](#webhook-sink).
 
-You can authenticate to cloud storage sinks using `specified` or `implicit` authentication. CockroachDB also supports assume role authentication, which allows you to limit the control specific users have over your storage buckets. For detail and instructions on authenticating to cloud storage sinks, see [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication). 
+You can authenticate to cloud storage sinks using `specified` or `implicit` authentication. CockroachDB also supports assume role authentication for Amazon S3 and Google Cloud Storage, which allows you to limit the control specific users have over your storage buckets. For detail and instructions on authenticating to cloud storage sinks, see [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication). 
 
 Examples of supported cloud storage sink URIs:
 

--- a/v22.2/create-changefeed.md
+++ b/v22.2/create-changefeed.md
@@ -21,6 +21,10 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 ## Required privileges
 
+{% include {{ page.version.version }}/cdc/privilege-model.md %}
+
+### Legacy privilege model
+
 To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`](create-user.html#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Synopsis


### PR DESCRIPTION
Fixes [DOC-4731](https://cockroachlabs.atlassian.net/browse/DOC-4731), [DOC-5658](https://cockroachlabs.atlassian.net/browse/DOC-5658)

Added docs for the newer changefeed privilege model. This includes both Enterprise and Core changefeeds. 