### PR TITLE
Added docs for GCP assume role authentication

### DIFF
--- a/v22.2/changefeed-sinks.md
+++ b/v22.2/changefeed-sinks.md
@@ -188,7 +188,9 @@ The following table lists the available parameters for cloud storage sink URIs:
 
 URI Parameter      | Storage | Description
 -------------------+------------------------+---------------------------
-`ASSUME_ROLE`      | AWS S3, GCS | The ARN (AWS) or service account (GCS) of the role to assume. Use in combination with `AUTH=implicit` or `specified`.
+`AWS_ACCESS_KEY_ID` | AWS | The access key to your AWS account.
+`AWS_SECRET_ACCESS_KEY` | AWS | The secret access key to your AWS account.
+`ASSUME_ROLE`      | AWS S3, GCS | The [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) (AWS) or [service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) (GCS) of the role to assume. Use in combination with `AUTH=implicit` or `specified`.
 `AUTH`             | AWS S3, GCS | The authentication parameter can define either `specified` (default) or `implicit` authentication. To use `specified` authentication, pass your account credentials with the URI. To use `implicit` authentication, configure these credentials via an environment variable. See [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#authentication) for examples of each of these. 
 `AZURE_ACCOUNT_NAME` | Azure | The name of your Azure account.
 `AZURE_ACCOUNT_KEY` | Azure | The URL-encoded account key for your Azure account.

--- a/v22.2/changefeed-sinks.md
+++ b/v22.2/changefeed-sinks.md
@@ -128,6 +128,7 @@ URI Parameter      | Description
 `topic_name`       | (Optional) The topic name to which messages will be sent. See the following section on [Topic Naming](#topic-naming) for detail on how topics are created.
 `AUTH`             | The authentication parameter can define either `specified` (default) or `implicit` authentication. To use `specified` authentication, pass your [Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts) credentials with the URI. To use `implicit` authentication, configure these credentials via an environment variable. See [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#authentication) for examples of each of these.
 `CREDENTIALS`      | (Required with `AUTH=specified`) The base64-encoded credentials of your Google [Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts) credentials.
+`ASSUME_ROLE` | The service account of the role to assume. Use in combination with `AUTH=implicit` or `specified`.
 
 {% include {{ page.version.version }}/cdc/options-table-note.md %}
 
@@ -185,12 +186,17 @@ Examples of supported cloud storage sink URIs:
 
 The following table lists the available parameters for cloud storage sink URIs:
 
-URI Parameter      | Description
--------------------+------------------------------------------------------------------
-`file_size`        | The file will be flushed (i.e., written to the sink) when it exceeds the specified file size. This can be used with the [`WITH resolved` option](create-changefeed.html#options), which flushes on a specified cadence. <br><br>**Default:** `16MB`
-<a name ="partition-format"></a>`partition_format` | Specify how changefeed [file paths](create-changefeed.html#general-file-format) are partitioned in cloud storage sinks. Use `partition_format` with the following values: <br><br><ul><li>`daily` is the default behavior that organizes directories by dates (`2022-05-18/`, `2022-05-19/`, etc.).</li><li>`hourly` will further organize directories by hour within each date directory (`2022-05-18/06`, `2022-05-18/07`, etc.).</li><li>`flat` will not partition the files at all.</ul><br>For example: `CREATE CHANGEFEED FOR TABLE users INTO 'gs://...?AUTH...&partition_format=hourly'` <br><br> **Default:** `daily`
-`S3_storage_class` | Specify the **Amazon S3** storage class for files created by the changefeed. See [Create a changefeed with an S3 storage class](create-changefeed.html#create-a-changefeed-with-an-s3-storage-class) for the available classes and an example. <br><br>**Default:** `STANDARD`
-`topic_prefix`     | Adds a prefix to all topic names.<br><br>For example, `CREATE CHANGEFEED FOR TABLE foo INTO 's3://...?topic_prefix=bar_'` would emit rows under the topic `bar_foo` instead of `foo`.
+URI Parameter      | Storage | Description
+-------------------+------------------------+---------------------------
+`ASSUME_ROLE`      | AWS S3, GCS | The ARN (AWS) or service account (GCS) of the role to assume. Use in combination with `AUTH=implicit` or `specified`.
+`AUTH`             | AWS S3, GCS | The authentication parameter can define either `specified` (default) or `implicit` authentication. To use `specified` authentication, pass your account credentials with the URI. To use `implicit` authentication, configure these credentials via an environment variable. See [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#authentication) for examples of each of these. 
+`AZURE_ACCOUNT_NAME` | Azure | The name of your Azure account.
+`AZURE_ACCOUNT_KEY` | Azure | The URL-encoded account key for your Azure account.
+`CREDENTIALS`      | GCS | (Required with `AUTH=specified`) The base64-encoded credentials of your Google [Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts) credentials.
+`file_size`        | All | The file will be flushed (i.e., written to the sink) when it exceeds the specified file size. This can be used with the [`WITH resolved` option](create-changefeed.html#options), which flushes on a specified cadence. <br><br>**Default:** `16MB`
+<a name ="partition-format"></a>`partition_format` | All | Specify how changefeed [file paths](create-changefeed.html#general-file-format) are partitioned in cloud storage sinks. Use `partition_format` with the following values: <br><br><ul><li>`daily` is the default behavior that organizes directories by dates (`2022-05-18/`, `2022-05-19/`, etc.).</li><li>`hourly` will further organize directories by hour within each date directory (`2022-05-18/06`, `2022-05-18/07`, etc.).</li><li>`flat` will not partition the files at all.</ul><br>For example: `CREATE CHANGEFEED FOR TABLE users INTO 'gs://...?AUTH...&partition_format=hourly'` <br><br> **Default:** `daily`
+`S3_storage_class` | AWS S3 | Specify the S3 storage class for files created by the changefeed. See [Create a changefeed with an S3 storage class](create-changefeed.html#create-a-changefeed-with-an-s3-storage-class) for the available classes and an example. <br><br>**Default:** `STANDARD`
+`topic_prefix`     | All | Adds a prefix to all topic names.<br><br>For example, `CREATE CHANGEFEED FOR TABLE foo INTO 's3://...?topic_prefix=bar_'` would emit rows under the topic `bar_foo` instead of `foo`.
 
 {% include {{ page.version.version }}/cdc/options-table-note.md %}
 

--- a/v22.2/use-cloud-storage-for-bulk-operations.md
+++ b/v22.2/use-cloud-storage-for-bulk-operations.md
@@ -323,7 +323,7 @@ CockroachDB supports assume role authentication on clusters running v22.2. Authe
 
 {% include_cached new-in.html version="v22.2" %} To limit the control access to your Google Cloud Storage buckets, you can create service accounts for users to assume. Service accounts do not necessarily have an association to a particular user. The service account contains permissions that define the operations a user can complete. A service account can then assume another service account to undertake a CockroachDB backup, restore, import, etc. As a result, a service account with limited privileges only has access to the roles of the assumed service account, rather than having unlimited access to a GCS bucket (for example).
 
-The access is also limited by short-lived credentials that are generated per call. The service account that is being assumed will issue the request for the credentials.
+The access is also limited by the generated [short-lived credentials](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct). The service account/role that is assuming another role, will issue the request for the short-lived credentials. If there are multiple roles in the [chain](#role-chaining), then each role defined in the chain will issue the request for credentials for the next role in the chain. 
 
 The [following section](#set-up-assume-role-authentication) demonstrates setting up assume role authentication between two service accounts A and B. You can also chain an arbitrary number of roles, see the [Role chaining](#role-chaining) section for additional detail.
 

--- a/v22.2/use-cloud-storage-for-bulk-operations.md
+++ b/v22.2/use-cloud-storage-for-bulk-operations.md
@@ -154,9 +154,9 @@ CockroachDB supports assume role authentication on clusters running v22.2. Authe
 Role assumption applies the principle of least privilege rather than directly providing privilege to a user. Creating IAM roles to manage access to AWS resources is Amazon's recommended approach compared to giving access straight to IAM users.
 {{site.data.alerts.end}}
 
-The [following section](#set-up-assume-role-authentication) demonstrates setting up assume role authentication between two users. Since you can chain an arbitrary number of roles, see the [Role chaining](#role-chaining) section for additional detail. 
+The [following section](#set-up-aws-assume-role-authentication) demonstrates setting up assume role authentication between two users. Since you can chain an arbitrary number of roles, see the [Role chaining](#aws-role-chaining) section for additional detail. 
 
-#### Set up assume role authentication
+#### Set up AWS assume role authentication
 
 For example, to configure a user to assume an IAM role that allows a bulk operation to an Amazon S3 bucket, take the following steps:
 
@@ -217,9 +217,9 @@ For example, to configure a user to assume an IAM role that allows a bulk operat
 
     For more information on AWS KMS URI formats, see [Take and Restore Encrypted Backups](take-and-restore-encrypted-backups.html).
 
-#### Role chaining
+#### AWS role chaining
 
-Beyond a user assuming a role, it is also possible to "chain" roles to create a path for users to assume roles to particular operations. Role chaining allows a user to assume a role through an intermediate role(s) instead of the user directly assuming a role. In this way, the role chain passes the request for access to the final role in the chain. Role chaining could be useful when a third-party organization needs access to your Amazon S3 bucket to complete a bulk operation. Or, your organization could grant roles based on limited-privilege levels.
+Role chaining allows a user to assume a role through an intermediate role(s) instead of the user directly assuming a role. In this way, the role chain passes the request for access to the final role in the chain. Role chaining could be useful when a third-party organization needs access to your Amazon S3 bucket to complete a bulk operation. Or, your organization could grant roles based on limited-privilege levels.
 
 Assuming the role follows the same approach outlined in the previous section. The additional required step to chain roles is to ensure that the ARN of role A, which is assuming role B, is present in role B's trust policy with the `sts:AssumeRole` action. 
 
@@ -253,7 +253,7 @@ When passing a chained role into `BACKUP`, it will follow this pattern:
 BACKUP DATABASE movr INTO "s3://{bucket name}?AWS_ACCESS_KEY_ID={user's key}&AWS_SECRET_ACCESS_KEY={user's secret key}&ASSUME_ROLE={role A ARN},{role B ARN},{role C ARN}" AS OF SYSTEM TIME '-10s';
 ~~~
 
-Each chained role is listed separated by a `,`. You can copy the ARN of the role from its summary page.
+Each chained role is listed separated by a `,` character. You can copy the ARN of the role from its summary page.
 
 </section>
 
@@ -321,27 +321,27 @@ If the use of implicit credentials is disabled with [`--external-io-disable-impl
 CockroachDB supports assume role authentication on clusters running v22.2. Authenticating to cloud storage with `ASSUME_ROLE` on clusters running versions v22.1 and earlier, or mixed versions, is not supported and will result in failed bulk operations.
 {{site.data.alerts.end}}
 
-{% include_cached new-in.html version="v22.2" %} To limit the control access to your Google Cloud Storage buckets, you can create service accounts for users to assume. Service accounts do not necessarily have an association to a particular user. The service account contains permissions that define the operations a user can complete. A service account can then assume another service account to undertake a CockroachDB backup, restore, import, etc. As a result, a service account with limited privileges only has access to the roles of the assumed service account, rather than having unlimited access to a GCS bucket (for example).
+{% include_cached new-in.html version="v22.2" %} To limit the control access to your Google Cloud Storage buckets, you can create [service accounts](https://cloud.google.com/iam/docs/understanding-service-accounts) for another service account to assume. Service accounts do not necessarily have an association to a particular user. The service account contains permissions that define the operations a user, who has access to the service account, can complete. A service account can then assume another service account to undertake a CockroachDB backup, restore, import, etc. As a result, a service account with limited privileges only has access to the roles of the assumed service account, rather than having unlimited access to a GCS bucket.
 
-The access is also limited by the generated [short-lived credentials](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct). The service account/role that is assuming another role, will issue the request for the short-lived credentials. If there are multiple roles in the [chain](#role-chaining), then each role defined in the chain will issue the request for credentials for the next role in the chain. 
+The access is also limited by the generated [short-lived credentials](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct). The service account/role that is assuming another role, will issue the request for the short-lived credentials. If there are multiple roles in the [chain](#google-cloud-role-chaining), then each role defined in the chain will issue the request for credentials for the next role in the chain. 
 
-The [following section](#set-up-assume-role-authentication) demonstrates setting up assume role authentication between two service accounts A and B. You can also chain an arbitrary number of roles, see the [Role chaining](#role-chaining) section for additional detail.
+The [following section](#set-up-google-cloud-assume-role-authentication) demonstrates setting up assume role authentication between two service accounts A and B. You can also chain an arbitrary number of roles, see the [Role chaining](#google-cloud-role-chaining) section for additional detail.
 
-#### Set up assume role authentication
+#### Set up Google Cloud assume role authentication
 
 In the following example, we will configure service account A to assume service account B. In this way, service account A will be able to assume the role of service account B to complete a bulk operation to a GCS bucket.
 
-Both service accounts are already existing in this example, to create a service account, see Google Cloud's [Creating and managing service accounts](https://cloud.google.com/iam/docs/creating-managing-service-accounts) page. 
+For this example, both service accounts have already been created. If you need to create your own service accounts, see Google Cloud's [Creating and managing service accounts](https://cloud.google.com/iam/docs/creating-managing-service-accounts) page.
 
 1. First, you'll create a role that contains a policy to interact with the Google Cloud Storage bucket depending on the bulk operation your user needs to complete. This role will be attached to service account B in order that service account A can assume it.
     - In [Google's Cloud console](https://console.cloud.google.com/getting-started), click **IAM & Admin**, **Roles**, and then **Create Role**.
-    - Add a title for the role and then click **Add Permissions**. Filter for the permissions required for the bulk operation. For example, For example, if you want to enable service account B to run a changefeed your role will include the `storage.objects.create` permission. See the [Storage permissions](#storage-permissions) section on this page for details on the minimum permissions each CockroachDB bulk operation requires.
+    - Add a title for the role and then click **Add Permissions**. Filter for the permissions required for the bulk operation. For example, if you want to enable service account B to run a changefeed, your role will include the `storage.objects.create` permission. See the [Storage permissions](#storage-permissions) section on this page for details on the minimum permissions each CockroachDB bulk operation requires.
 
     {{site.data.alerts.callout_success}}
     Alternately, you can use the [gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/iam/roles/create) to create roles. 
     {{site.data.alerts.end}}
 
-1. The service account that will be assumed (B in this case), must be granted access to the Storage bucket with the role assigned from step 1. 
+1. The service account that will be assumed (B in this case) must be granted access to the storage bucket with the role assigned from step 1. 
     - Go to the **Cloud Storage** menu and select the bucket. In the bucket's menu, click **Grant Access**. 
     - Add the service account to the **Add principals** box and select the name of the role you created in step 1 under **Assign roles**.
 
@@ -359,9 +359,9 @@ Both service accounts are already existing in this example, to create a service 
 
     CockroachDB also supports authentication for assuming roles when taking encrypted backups. To use with an encrypted backup, pass the `ASSUME_ROLE` parameter to the KMS URI as well as the bucket's: 
 
+    {% include_cached copy-clipboard.html %}
     ~~~sql
-    BACKUP DATABASE <database> INTO 'gs://{bucket name}/{path}?AUTH=implicit&ASSUME_ROLE={service account name}iam.gserviceaccount.com'
-    WITH kms = 'gs:///projects/{project name}/locations/us-east1/keyRings/{key ring name}/cryptoKeys/{key name}?AUTH=IMPLICIT&ASSUME_ROLE={service account name}iam.gserviceaccount.com';
+    BACKUP DATABASE <database> INTO 'gs://{bucket name}/{path}?AUTH=implicit&ASSUME_ROLE={service account name}iam.gserviceaccount.com' WITH kms = 'gs:///projects/{project name}/locations/us-east1/keyRings/{key ring name}/cryptoKeys/{key name}?AUTH=IMPLICIT&ASSUME_ROLE={service account name}iam.gserviceaccount.com';
     ~~~
 
     For more information on Google Cloud Storage KMS URI formats, see [Take and Restore Encrypted Backups](take-and-restore-encrypted-backups.html).
@@ -370,9 +370,9 @@ Both service accounts are already existing in this example, to create a service 
     CockroachDB supports assume role authentication for changefeeds emitting to Google Cloud Pub/Sub sinks. The process to set up assume role for Pub/Sub works in a similar way, except that you will provide the final service account with the "Pub/Sub Editor" role at the project level. See the [Changefeed Sinks](changefeed-sinks.html#google-cloud-pub-sub) page for more detail on the Pub/Sub sink.
     {{site.data.alerts.end}}
 
-#### Role Chaining
+#### Google Cloud role chaining
 
-Beyond a user assuming a role, it is also possible to "chain" roles to create a path for users to assume roles to particular operations. Role chaining allows a user to assume a role through an intermediate role(s) instead of the user directly assuming a role. In this way, the role chain passes the request for access to the final role in the chain. Role chaining could be useful when a third-party organization needs access to your Google Cloud Storage bucket to complete a bulk operation. Or, your organization could grant roles based on limited-privilege levels.
+Role chaining allows a service account to assume a role through an intermediate service account(s) instead of the service account directly assuming a role. In this way, the role chain passes the request for access to the final role in the chain. Role chaining could be useful when a third-party organization needs access to your Google Cloud Storage bucket to complete a bulk operation. Or, your organization could grant roles based on limited-privilege levels.
 
 Following from the previous setup section, if you want to add an intermediate account to the chain of roles, it is necessary to ensure each service account has granted the "Service Account Token Creator" role to the previous account in the chain. See [step 3](#service-account-token-granting) in the previous section to add this role on a service account.
 
@@ -382,11 +382,13 @@ Service Account A | &larr; Service Account B (intermediate accounts) | &larr; Se
 -----------------+----------------+---------
 Credentials included in `AUTH=implicit` or `specified` | Grants access to **A** with the Service Account Token Creator role | Grants access to **B** with the Service Account Token Creator role<br>Access to the resource e.g., storage bucket
 
-- The intermediate account will delegate the request to account C.
-- The final service account will request the credentials that account A requires.
+- The initial account (A) requests permissions from account B.
+- The intermediate account (B) will delegate the request to account C.
+- The final service account (C) will request the credentials that account A requires.
 
-When passing a chained role into `BACKUP`, it will follow this pattern with each chained role separated by a `,`: 
+When passing a chained role into `BACKUP`, it will follow this pattern with each chained role separated by a `,` character: 
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
 BACKUP DATABASE <database> INTO 'gs://{bucket name}/{path}?AUTH=implicit&ASSUME_ROLE={intermediate service account name}iam.gserviceaccount.com,{final service account name}iam.gserviceaccount.com'; AS OF SYSTEM TIME '-10s';
 ~~~


### PR DESCRIPTION
Fixes [DOC-4829](https://cockroachlabs.atlassian.net/browse/DOC-4829), [DOC-4791](https://cockroachlabs.atlassian.net/browse/DOC-4791), [DOC-5156](https://cockroachlabs.atlassian.net/browse/DOC-5156), [DOC-4802](https://cockroachlabs.atlassian.net/browse/DOC-4802), [DOC-5102](https://cockroachlabs.atlassian.net/browse/DOC-5102), [DOC-3690](https://cockroachlabs.atlassian.net/browse/DOC-3690), [DOC-4555](https://cockroachlabs.atlassian.net/browse/DOC-4555)

Added docs for assume role auth to GCP resources that includes cloud storage bulk & changefeeds and Pub/Sub for changefeeds.

This follows a similar pattern to the AWS version. Procedural steps through the setup for the service accounts with the nuances of GCP covered.

Docs PRs to follow include assume role work relating to workload identity.