### PR TITLE
DOC-2388 verbose log lease transfer stall

### DIFF
--- a/v22.2/cockroach-node.md
+++ b/v22.2/cockroach-node.md
@@ -128,7 +128,7 @@ The `node drain` subcommand also supports the following general flags:
 
 Flag | Description
 -----|------------
-`--drain-wait` | Amount of time to wait for the node to drain before returning to the client. If draining fails to complete within this duration, you must re-initiate the command to continue the drain. A very long drain may indicate an anomaly, and you should manually inspect the server to determine what blocks the drain.<br><br>**Default:** `10m`
+`--drain-wait` | Amount of time to wait for the node to drain before returning to the client. If draining fails to complete within this duration, you must re-initiate the command to continue the drain. A very long drain may indicate an anomaly, and you should manually inspect the server to determine what blocks the drain.<br><br>**New in v22.2:** CockroachDB automatically increases the verbosity of logging when it detects a stall in the range lease transfer stage of `node drain`. Messages logged during such a stall include the time an attempt occurred, the total duration stalled waiting for the transfer attempt to complete, and the lease that is being transferred.<br><br>**Default:** `10m`
 `--self` | Applies the operation to the node against which the command was run (e.g., via `--host`).
 
 The `node recommission` subcommand also supports the following general flag:

--- a/v22.2/node-shutdown.md
+++ b/v22.2/node-shutdown.md
@@ -227,9 +227,9 @@ RESET CLUSTER SETTING server.time_until_store_dead;
 
 When [draining manually](#drain-a-node-manually) with `cockroach node drain`, all [drain phases](#draining) must be completed within the duration of `--drain-wait` (`10m` by default) or the drain will stop. This can be observed with an `ERROR: drain timeout` message in the terminal output. To continue the drain, re-initiate the command.
 
-{{site.data.alerts.callout_info}}
 A very long drain may indicate an anomaly, and you should manually inspect the server to determine what blocks the drain.
-{{site.data.alerts.end}}
+
+{% include_cached new-in.html version="v22.2" %} CockroachDB automatically increases the verbosity of logging when it detects a stall in the range lease transfer stage of `node drain`. Messages logged during such a stall include the time an attempt occurred, the total duration stalled waiting for the transfer attempt to complete, and the lease that is being transferred.
 
 `--drain-wait` sets the timeout for [all draining phases](#draining) and is **not** related to the `server.shutdown.drain_wait` cluster setting, which configures the "unready phase" of draining. The value of `--drain-wait` should be greater than the sum of [`server.shutdown.drain_wait`](#server-shutdown-drain_wait), [`server.shutdown.connection_wait`](#server-shutdown-connection_wait), [`server.shutdown.query_wait`](#server-shutdown-query_wait) times two, and [`server.shutdown.lease_transfer_wait`](#server-shutdown-lease_transfer_wait).
 


### PR DESCRIPTION
Addresses: DOC-2388

- Added notice to `cockroach node drain --drain-wait` reference entry on `cockroach-node.md`, and to the "Drain timeout" section on `node-shutdown.md` advising that CRDB v22.2 now increases log verbosity if a lease transfer stall is detected during a normal graceful drain. Let me know if you'd like this data elsewhere (instead | in addition).

Question:
- There were some references to internal variable tracking to toggle this feature in the code. Just confirming that this is not explicitly-toggle-able by the end user: only an automatic internal toggle. Thanks!

Staging:
- [node-shutdown.md](https://deploy-preview-15406--cockroachdb-docs.netlify.app/docs/dev/cockroach-node.html#general)
- [cockroach-node.md](https://deploy-preview-15406--cockroachdb-docs.netlify.app/docs/dev/node-shutdown.html#drain-timeout)