### PR TITLE
Add audit logs Private Preview spec, query param version

### DIFF
--- a/_data/cloud_api_releases.csv
+++ b/_data/cloud_api_releases.csv
@@ -1,3 +1,4 @@
-version,release_date,withdrawn,latest
-2022_09_20,2022-09-20,false,true
-2022_03_31,2022-03-31,false,false
+spec,version,release_date,withdrawn,private-preview,latest
+ccapi_spec_2022_09_20,2022-09-20,2022-09-20,false,false,true
+private-preview/audit_logs/openapi,audit-logs,2022-10-18,false,true,false
+ccapi_spec_2022_03_31,2022-03-31,2022-03-31,false,false,false

--- a/api/cloud/v1.md
+++ b/api/cloud/v1.md
@@ -74,21 +74,24 @@ docs_area: reference.api
   function changeVersion() {
     const doc = document.getElementById('rd');
     selectedVersion = document.getElementById("versionSelector").value;
-    doc.loadSpec('https://cockroachlabs.cloud/assets/docs/' + selectedVersion + '.json');
+    let specPath = "";
+    if (selectedVersion === "latest") {
+      specPath = "ccapi_spec_latest";
+    } else {
+      specPath = selectedVersion;
+    }
+    doc.loadSpec('https://cockroachlabs.cloud/assets/docs/' + specPath + '.json');
   }
 
   window.addEventListener('load', (event) => {
-    const params = new Proxy(new URLSearchParams(window.location.search), {
-      get: (searchParams, prop) => searchParams.get(prop),
-    });
-    // Get the value of the version query parameter
-    let version = params.version;
-    if (version != null) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const version = urlParams.get('version');
+    if (version !== null) {
       let select = document.getElementById("versionSelector");
       // find the version by the option text (not the label)
       for (var i = 0; i < select.length; i++){
-        var option = select.options[i];
-        if (version == option.text) {
+        const option = select.options[i];
+        if (version === option.text) {
           // refresh to the new spec
           select.value = option.value;
           select.dispatchEvent(new Event('change'));

--- a/api/cloud/v1.md
+++ b/api/cloud/v1.md
@@ -74,8 +74,28 @@ docs_area: reference.api
   function changeVersion() {
     const doc = document.getElementById('rd');
     selectedVersion = document.getElementById("versionSelector").value;
-    doc.loadSpec('https://cockroachlabs.cloud/assets/docs/ccapi_spec_' + selectedVersion + '.json');
+    doc.loadSpec('https://cockroachlabs.cloud/assets/docs/' + selectedVersion + '.json');
   }
+
+  window.addEventListener('load', (event) => {
+    const params = new Proxy(new URLSearchParams(window.location.search), {
+      get: (searchParams, prop) => searchParams.get(prop),
+    });
+    // Get the value of the version query parameter
+    let version = params.version;
+    if (version != null) {
+      let select = document.getElementById("versionSelector");
+      // find the version by the option text (not the label)
+      for (var i = 0; i < select.length; i++){
+        var option = select.options[i];
+        if (version == option.text) {
+          // refresh to the new spec
+          select.value = option.value;
+          select.dispatchEvent(new Event('change'));
+        }
+      }
+    }
+  });
 
 </script>
 <div class="apidocs">
@@ -102,18 +122,9 @@ docs_area: reference.api
       <select class="dropdown" id="versionSelector" onchange="changeVersion()">
         <option value="latest">Latest</option>
         {% for r in releases %}
-          <option value="{{ r.version }}">{{ r.version }}</option>
+          <option value="{{ r.spec }}" label="{{ r.version }}{% if r.private-preview == "true" %} (Private Preview){% endif %}">{{ r.version }}</option>
         {% endfor %}
       </select>
     </div>
-    <!--div slot="overview">
-      <select class="dropdown" id="versionSelector">
-        <option value="latest">Latest</option>
-        {% for r in releases %}
-          <option value="{{ r.version }}">{{ r.version }}</option>
-        {% endfor %}
-      </select>
-      <button onclick="changeVersion()" class="m-btn thin-border" part="btn btn-outline">Load version</button>
-    </div-->
   </rapi-doc>
 </div>


### PR DESCRIPTION
Fixes DOC-5986.

This PR adds the audit log Private Preview spec to the version selector. It also adds the ability to set the version as a query parameter by setting `version=<version>`. The version is the date for GA specs, and the subdirectory of `https://cockroachlabs.cloud/assets/docs/private-preview/` for Private Preview specs.

E.g. for audit logs, the URL is `/docs/api/cloud/v1.html?version=audit-logs`.