### PR TITLE
Steer users away from sql.defaults.* settings

### DIFF
--- a/_includes/v22.2/sql/sql-defaults-cluster-settings-deprecation-notice.md
+++ b/_includes/v22.2/sql/sql-defaults-cluster-settings-deprecation-notice.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v22.2:</span> Use [`ALTER ROLE ALL SET {sessionvar} = {val}`](alter-role.html#set-default-session-variable-values-for-all-users) instead of the `sql.defaults.*` [cluster settings](cluster-settings.html). This allows you to set a default value for all users for any [session variable](set-vars.html) that applies during login, making the `sql.defaults.*` cluster settings redundant.
+{{site.data.alerts.end}}

--- a/v22.2/alter-role.md
+++ b/v22.2/alter-role.md
@@ -234,6 +234,21 @@ root@:26257/movr> SHOW timezone;
 (1 row)
 ~~~
 
+### Set default session variable values for all users
+
+To set a default value for all users for any [session variable](set-vars.html) that applies during login, issue a statment like the following:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER ROLE ALL SET sql.spatial.experimental_box2d_comparison_operators.enabled = "on";
+~~~
+
+~~~
+ALTER ROLE
+~~~
+
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ## See also
 
 - [`DROP ROLE`](drop-role.html)

--- a/v22.2/cluster-settings.md
+++ b/v22.2/cluster-settings.md
@@ -19,6 +19,8 @@ In contrast to cluster-wide settings, node-level settings apply to a single node
 These cluster settings have a broad impact on CockroachDB internals and affect all applications, workloads, and users running on a CockroachDB cluster. For some settings, a [session setting](set-vars.html#supported-variables) could be a more appropriate scope.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 {% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/{{ page.release_info.crdb_branch_name }}/docs/generated/settings/settings.html %}
 
 ## View current cluster settings

--- a/v22.2/cost-based-optimizer.md
+++ b/v22.2/cost-based-optimizer.md
@@ -265,6 +265,8 @@ To avoid performance degradation, Cockroach Labs strongly recommends setting thi
 
 For more information about selecting an optimal join ordering, see our blog post [An Introduction to Join Ordering](https://www.cockroachlabs.com/blog/join-ordering-pt1/).
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Reduce planning time for queries with many joins
 
 The cost-based optimizer explores multiple join orderings to find the lowest-cost plan. If there are many joins or join subtrees in the query, this can increase the number of execution plans the optimizer explores, and therefore the exploration and planning time. If the planning phase of a query takes a long time (on the order of multiple seconds or minutes) to plan, or the query plan involves many joins, consider the following alternatives to reduce the planning time:

--- a/v22.2/data-domiciling.md
+++ b/v22.2/data-domiciling.md
@@ -183,6 +183,8 @@ The restricted replica placement settings should start to apply immediately.
 [`ALTER DATABASE ... PLACEMENT RESTRICTED`](placement-restricted.html) does not affect the replica placement for [global tables](global-tables.html), which are designed to provide fast, up-to-date reads from all [database regions](multiregion-overview.html#database-regions).
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Step 5. Verify updated replica placement
 
 Now that you have restricted the placement of non-voting replicas for all [regional tables](regional-tables.html), you can run another [replication report](query-replication-reports.html) to see the effects:

--- a/v22.2/date.md
+++ b/v22.2/date.md
@@ -19,6 +19,8 @@ CockroachDB also supports using uninterpreted [string literals](sql-constants.ht
 
 To change the input format of truncated dates (e.g., `12-16-06`) from `MM-DD-YY` to `YY-MM-DD` or `DD-MM-YY`, set the `datestyle` [session variable](set-vars.html) or the `sql.defaults.datestyle ` [cluster setting](cluster-settings.html).
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ## PostgreSQL compatibility
 
 `DATE` values in CockroachDB are fully [PostgreSQL-compatible](https://www.postgresql.org/docs/current/datatype-datetime.html), including support for special values (e.g., `+/- infinity`). Existing dates outside of the PostgreSQL date range (`4714-11-24 BC` to `5874897-12-31`) are converted to `+/- infinity` dates.

--- a/v22.2/hash-sharded-indexes.md
+++ b/v22.2/hash-sharded-indexes.md
@@ -37,6 +37,8 @@ A larger number of buckets allows for greater load-balancing and thus greater wr
 
 We recommend doing thorough performance testing of your workload with different `bucket_count`s if the default `bucket_count` does not satisfy your use case.
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Hash-sharded indexes on partitioned tables
 
 You can create hash-sharded indexes with implicit partitioning under the following scenarios:

--- a/v22.2/indexes.md
+++ b/v22.2/indexes.md
@@ -28,6 +28,8 @@ Each table automatically has a _primary index_ called `{tbl}_pkey`, which indexe
 
  To require an explicitly defined primary key for all tables created in your cluster, set the `sql.defaults.require_explicit_primary_keys.enabled` [cluster setting](cluster-settings.html) to `true`.
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 The primary index helps filter a table's primary key but doesn't help SQL find values in any other columns. However, you can use [secondary indexes](schema-design-indexes.html) to improve the performance of queries using columns not in a table's primary key. You can create them:
 
 <a name="unique-secondary-indexes"></a>

--- a/v22.2/int.md
+++ b/v22.2/int.md
@@ -51,6 +51,8 @@ If your application needs to use an integer size that is different than the Cock
 If your application requires arbitrary precision numbers, use the [`DECIMAL`](decimal.html) data type.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ## Examples
 
 {% include_cached copy-clipboard.html %}

--- a/v22.2/interval.md
+++ b/v22.2/interval.md
@@ -24,6 +24,8 @@ Abbreviated PostgreSQL | `INTERVAL '1 yr 2 mons 3 d 4 hrs 5 mins 6 secs'`
 
 The value of `intervalstyle` affects how CockroachDB parses certain `INTERVAL` values. Specifically, when `intervalstyle = 'sql_standard'`, and when the `INTERVAL` value begins with a negative symbol, CockroachDB parses all fields as negative values (e.g., `-3 years 1 day` is parsed as `-(3 years 1 day)`, or `-3 years, -1 day`). When `intervalstyle = 'postgres'` (the default format), and when the `INTERVAL` value begins with a negative symbol, CockroachDB only applies the negative symbol to the field that it directly precedes (e.g., `-3 years 1 day` is parsed as `-3 years, +1 day`).
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Details on SQL Standard input
 
 Without a [precision](#precision) or [duration field](#duration-fields) specified, expect the following behavior from SQL Standard input (`Y-M D H:M:S`):

--- a/v22.2/node-shutdown.md
+++ b/v22.2/node-shutdown.md
@@ -183,6 +183,8 @@ Ensure that `server.shutdown.query_wait` is greater than:
 If there are still open transactions on the draining node when the server closes its connections, you will encounter errors. Your application should handle these errors with a [connection retry loop](#connection-retry-loop).
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 #### `server.shutdown.lease_transfer_wait`
 
 In the ["lease transfer phase"](#draining) of node drain, the server attempts to transfer all range leases and Raft leaderships from the draining node. `server.shutdown.lease_transfer_wait` sets the maximum duration of each iteration of this attempt (`5s` by default). Because this phase does not exit until all transfers are completed, changing this value only affects the frequency at which drain progress messages are printed.

--- a/v22.2/online-schema-changes.md
+++ b/v22.2/online-schema-changes.md
@@ -77,6 +77,8 @@ Until all schema change statements are moved to use the declarative schema chang
 Declarative schema changer statements and legacy schema changer statements operating on the same objects cannot exist within the same transaction. Either split the transaction into multiple transactions, or disable the cluster setting or session variable.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ## Best practices for online schema changes
 
 ### Schema changes in multi-region clusters

--- a/v22.2/placement-restricted.md
+++ b/v22.2/placement-restricted.md
@@ -77,6 +77,8 @@ To follow along with the examples below:
         SET CLUSTER SETTING sql.defaults.multiregion_placement_policy.enabled = on;
         ~~~
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Create a database with the replica placement policy set to restricted
 
 If you know at database creation time that you'd like to set the database's replica placement policy to ["restricted"](#parameters-restricted), you can do so in a [`CREATE DATABASE`](create-database.html) statement as shown below:

--- a/v22.2/restore.md
+++ b/v22.2/restore.md
@@ -259,6 +259,8 @@ The ordering of regions and how region matching is determined is a known limitat
 
 For more on multi-region databases, see the [Multi-Region Capabilities Overview](multiregion-overview.html).
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ## Viewing and controlling restore jobs
 
 After CockroachDB successfully initiates a restore, it registers the restore as a job, which you can view with [`SHOW JOBS`](show-jobs.html).

--- a/v22.2/schema-design-table.md
+++ b/v22.2/schema-design-table.md
@@ -225,6 +225,8 @@ Here are some best practices to follow when selecting primary key columns:
 
     Randomly generating `UUID` values ensures that the primary key values will be unique and well-distributed across a cluster. For an example, see [below](#primary-key-examples).
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 #### Primary key examples
 
 To follow a [primary key best practice](#primary-key-best-practices), the `CREATE TABLE` statements in `max_init.sql` for the `users` and `vehicles` tables need to explicitly define a primary key.

--- a/v22.2/serial.md
+++ b/v22.2/serial.md
@@ -37,6 +37,8 @@ These modes can be configured with the [session variable](set-vars.html) `serial
 The particular choice of `DEFAULT` expression when clients use the `SERIAL` keyword is subject to change in future versions of CockroachDB. Applications that wish to use `unique_rowid()` specifically must use the full explicit syntax `INT DEFAULT unique_rowid()` and avoid `SERIAL` altogether.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Generated values for modes `rowid` and `virtual_sequence`
 
 In both modes `rowid` and `virtual_sequence`, a value is automatically generated using the `unique_rowid()` function. The difference between `rowid` and `virtual_sequence` is that the latter setting also creates a virtual (pseudo) sequence in the database. However, in both cases the `unique_rowid()` function is ultimately used to generate new values. This function produces a 64-bit integer (i.e., [`INT8`](int.html)) from the current timestamp and ID of the node executing the [`INSERT`](insert.html) or [`UPSERT`](upsert.html) operation. This behavior is statistically likely to be globally unique except in extreme cases (see [this FAQ entry](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb) for more details).

--- a/v22.2/set-cluster-setting.md
+++ b/v22.2/set-cluster-setting.md
@@ -47,6 +47,8 @@ To disable distributed execution for all new sessions:
 > SET CLUSTER SETTING sql.defaults.distsql = 0;
 ~~~
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ### Disable automatic diagnostic reporting
 
 To opt out of [automatic diagnostic reporting](diagnostics-reporting.html) of usage data to Cockroach Labs:

--- a/v22.2/timestamp.md
+++ b/v22.2/timestamp.md
@@ -54,6 +54,8 @@ To express a `TIMESTAMPTZ` value with time zone offset from UTC, use the followi
 
 By default, CockroachDB interprets truncated dates (e.g., `12-16-06`) as `MM-DD-YY`. To change the input string format of truncated dates, set the `datestyle` [session variable](set-vars.html) or the `sql.defaults.datestyle ` [cluster setting](cluster-settings.html).
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 ## Size
 
 A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.

--- a/v22.2/transactions.md
+++ b/v22.2/transactions.md
@@ -81,6 +81,8 @@ CockroachDB automatically retries individual statements (implicit transactions) 
 
 You can change the results buffer size for all new sessions using the `sql.defaults.results_buffer.size` [cluster setting](cluster-settings.html), or for a specific session using the `results_buffer_size` [session variable](set-vars.html). Decreasing the buffer size can increase the number of transaction retry errors a client receives, whereas increasing the buffer size can increase the delay until the client receives the first result row.
 
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
+
 #### Individual statements
 
 Individual statements are treated as implicit transactions, and so they fall
@@ -387,6 +389,8 @@ apply to `CREATE TABLE AS`, `SELECT`, `IMPORT`, `TRUNCATE`, `DROP`, `ALTER TABLE
 {{site.data.alerts.callout_info}}
 Enabling `transaction_rows_read_err` disables a performance optimization for mutation statements in implicit transactions where CockroachDB can auto-commit without additional network round trips.
 {{site.data.alerts.end}}
+
+{% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
 
 ## See also
 


### PR DESCRIPTION
Fixes DOC-4754

Summary of changes:

- Add a `sql.defaults.*` notice as an include

- Add that include to all the places in the docs where `sql.defaults.*`
  is mentioned

- NB. We did *not* change all uses of `SET CLUSTER SETTING
  sql.defaults.*` to use `ALTER ROLE ALL` for the following reasons:

  - Making a docs change of that scope and ensuring we don't break the
    pages in question would require a large amount of manual QA

  - The use of `ALTER ROLE` is merely encouraged (the old settings are
    not yet officially _deprecated_), and the SQL client prints a
    message to the user. So that amount of work is not strictly required
    yet.