### PR TITLE
DOC-5336 12 new repl metrics

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -90,6 +90,8 @@ Name | Help
 `queue.replicagc.processingnanos` | Nanoseconds spent processing replicas in the replica GC queue
 `queue.replicagc.removereplica` | Number of replica removals attempted by the replica gc queue
 `queue.replicate.addreplica` | Number of replica additions attempted by the replicate queue
+`queue.replicate.addreplica.error` | Number of failed replica additions processed by the replicate queue
+`queue.replicate.addreplica.success` | Number of successful replica additions processed by the replicate queue
 `queue.replicate.pending` | Number of pending replicas in the replicate queue
 `queue.replicate.process.failure` | Number of replicas which failed processing in the replicate queue
 `queue.replicate.process.success` | Number of replicas successfully processed by the replicate queue
@@ -97,7 +99,17 @@ Name | Help
 `queue.replicate.purgatory` | Number of replicas in the replicate queue's purgatory, awaiting allocation options
 `queue.replicate.rebalancereplica` | Number of replica rebalancer-initiated additions attempted by the replicate queue
 `queue.replicate.removedeadreplica` | Number of dead replica removals attempted by the replicate queue (typically in response to a node outage)
+`queue.replicate.removedeadreplica.error` | Number of failed dead replica replica removals processed by the replicate queue
+`queue.replicate.removedeadreplica.success` | Number of successful dead replica replica removals processed by the replicate queue
+`queue.replicate.removedecommissioningreplica.error` | Number of failed decommissioning replica replica removals processed by the replicate queue
+`queue.replicate.removedecommissioningreplica.success` | Number of successful decommissioning replica replica removals processed by the replicate queue
 `queue.replicate.removereplica` | Number of replica removals attempted by the replicate queue (typically in response to a rebalancer-initiated addition)
+`queue.replicate.removereplica.error` | Number of failed replica removals processed by the replicate queue
+`queue.replicate.removereplica.success` | Number of successful replica removals processed by the replicate queue
+`queue.replicate.replacedeadreplica.error` | Number of failed dead replica replica replacements processed by the replicate queue
+`queue.replicate.replacedeadreplica.success` | Number of successful dead replica replica replacements processed by the replicate queue
+`queue.replicate.replacedecommissioningreplica.error` | Number of failed decommissioning replica replica replacements processed by the replicate queue
+`queue.replicate.replacedecommissioningreplica.success` | Number of successful decommissioning replica replica replacements processed by the replicate queue
 `queue.replicate.transferlease` | Number of range lease transfers attempted by the replicate queue
 `queue.split.pending` | Number of pending replicas in the split queue
 `queue.split.process.failure` | Number of replicas which failed processing in the split queue


### PR DESCRIPTION
Addresses: DOC-5336

- Added 12 new repl queue metrics to `metric-names.md`

QUESTION:
- Are these metrics also available for Serverless? If so I need to also add them to `metric-names-serverless.md`. Post v22.2 GA, DOCs has a method for automatically determining this, but it is not ready yet.

[metric-names.md](url)