### PR TITLE
DOC-4615 add preserve-downgrade metric

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -12,6 +12,7 @@ Name | Help
 `changefeed.running` | Number of currently running changefeeds, including sinkless
 `clock-offset.meannanos` | Mean clock offset with other nodes in nanoseconds
 `clock-offset.stddevnanos` | Std dev clock offset with other nodes in nanoseconds
+`cluster.preserve-downgrade-option.last-updated` | Unix timestamp of last updated time for cluster.preserve_downgrade_option
 `compactor.compactingnanos` | Number of nanoseconds spent compacting ranges
 `compactor.compactions.failure` | Number of failed compaction requests sent to the storage engine
 `compactor.compactions.success` | Number of successful compaction requests sent to the storage engine


### PR DESCRIPTION
Addresses: DOC-4615

- Added `cluster.preserve-downgrade-option.last-updated` metric to `metric-names.md`.

Notes:

- We don't presently doc the banner at top of Overview (i.e. for "setting set for over 48h" banner), but plans exist to expand this post-GA. For now, just documenting the new metric.
- Assuming this is not avail for Serverless given nature of metric. Pls correct if not the case (as I would need to also add to `metric-names-serverless.md`).

Staging:

- [metric-names.md](https://deploy-preview-15427--cockroachdb-docs.netlify.app/docs/v22.2/ui-custom-chart-debug-page#available-metrics)