### PR TITLE
DOC-5442 new range-key-set metric

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -213,6 +213,7 @@ Name | Help
 `sql.txn.commit.count` | Number of SQL transaction COMMIT statements
 `sql.txn.rollback.count` | Number of SQL transaction ROLLBACK statements
 `sql.update.count` | Number of SQL UPDATE statements
+`storage.keys.range-key-set.count` | Approximate count of RangeKeySet internal keys across the storage engine.
 `sys.cgo.allocbytes` | Current bytes of memory allocated by cgo
 `sys.cgo.totalbytes` | Total bytes of memory allocated by cgo, but not released
 `sys.cgocalls` | Total number of cgo call


### PR DESCRIPTION
Addresses: DOC-5442

- Added new `storage.keys.range-key-set.count` metric to `metric-names.md`

Note:

- Assuming this is not avail for Serverless given nature of metric. Pls correct if not the case (as I would need to also add to `metric-names-serverless.md`)

Staging:

- [metric-names.md](https://deploy-preview-15428--cockroachdb-docs.netlify.app/docs/v22.2/ui-custom-chart-debug-page#available-metrics)