### PR TITLE
Update search page to bring users to /dev and /stable instead of /vXX.Y

### DIFF
--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -423,8 +423,10 @@ $(function() {
       return
     }
 
+    Console.log(this)
+
     return this.hostname && this.hostname !== location.hostname;
-  }).addClass('external').attr("target","_blank").addClass('external').attr("rel","noopener");
+  }).addClass('external').attr("target","_blank").attr("rel","noopener");
 });
 
 

--- a/search.html
+++ b/search.html
@@ -137,7 +137,7 @@ docs_area: search
           hit =>
             `<div class="search-item">
           <div class="search-title">
-            <a href="${hit.url}">${hit.title}</a>
+            <a href="${hit.url.replace("/{{ site.versions["stable"] }}/", "/stable/").replace("/{{ site.versions["dev"] }}/", "/dev/")}">${hit.title}</a>
           </div>
           <div class="search-snippet">${showResult(hit._highlightResult)}</div>
           <div class="search-link">${hit.doc_type}</div>


### PR DESCRIPTION
This change now points users to go to `/dev` and `/stable` URLs instead of `/vXX.Y`.