### PR TITLE
DOC-3710 new range snapshot metrics

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -137,7 +137,13 @@ Name | Help
 `range.snapshots.normal-applied` | Number of applied snapshots
 `range.snapshots.preemptive-applied` | Number of applied preemptive snapshots
 `range.snapshots.rcvd-bytes` | Number of snapshot bytes received
+`range.snapshots.rebalancing.rcvd-bytes` | Number of rebalancing snapshot bytes received
+`range.snapshots.rebalancing.sent-bytes` | Number of rebalancing snapshot bytes sent
+`range.snapshots.recovery.rcvd-bytes` | Number of recovery snapshot bytes received
+`range.snapshots.recovery.sent-bytes` | Number of recovery snapshot bytes sent
 `range.snapshots.sent-bytes` | Number of snapshot bytes sent
+`range.snapshots.unknown.rcvd-bytes` | Number of unknown snapshot bytes received
+`range.snapshots.unknown.sent-bytes` | Number of unknown snapshot bytes sent
 `range.splits` | Number of range splits
 `ranges.unavailable` | Number of ranges with fewer live replicas than needed for quorum
 `ranges.underreplicated` | Number of ranges with fewer live replicas than the replication target


### PR DESCRIPTION
Addresses: DOC-3710

- Adds 6 new metrics:
	- `range.snapshots.rebalancing.rcvd-bytes`
	- `range.snapshots.rebalancing.sent-bytes`
	- `range.snapshots.recovery.rcvd-bytes`
	- `range.snapshots.recovery.sent-bytes`
	- `range.snapshots.unknown.rcvd-bytes`
	- `range.snapshots.unknown.sent-bytes`

Staging:
- [metric-names.md](https://deploy-preview-15438--cockroachdb-docs.netlify.app/docs/v22.2/ui-custom-chart-debug-page#available-metrics)