### PR TITLE
DOC-5726: Force absolute URLs in sidebar

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -138,4 +138,3 @@ sass:
   sass_dir: css
   style: compressed
 site_title: CockroachDB Docs
-url: https://www.cockroachlabs.com

--- a/_includes/sidebar.js.html
+++ b/_includes/sidebar.js.html
@@ -97,13 +97,22 @@
             // This condition makes it possible to use external
             // urls in the sidebar.
             if (!/^https?:/.test(url)) {
-              url = sidebar.baseUrl + url;
+              url = '{{ site.url }}' + sidebar.baseUrl + url;
             }
             return url;
           });
 
           // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
-          const activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
+          var activePathname
+          if (!/^https?:/.test(location.pathname)) {
+            activePathname = '{{ site.url }}' + location.pathname
+          }
+          else {
+            activePathname = location.pathname
+          }
+          if (location.pathname.slice(-5) !== '.html') {
+            activePathname += '.html'
+          }
 
           const active = (urls.indexOf(activePathname) !== -1);
           if (active) {

--- a/netlify/build
+++ b/netlify/build
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Populate the site_url to be used by jekyll for generating sidebar and search links
+site_url="${DEPLOY_PRIME_URL}"
+JEKYLL_ENV="preview"
+if [[ "$CONTEXT" = "production" ]]; then
+	site_url="https://www.cockroachlabs.com"
+	JEKYLL_ENV="production"
+fi;
+
+echo "url: ${site_url}" > _config_url.yml
+
 function build {
 	bundle exec jekyll build --trace --config _config_base.yml,$1
 	if [[ $? != 0 ]]; then
@@ -16,7 +26,7 @@ popd
 
 gem install bundler --silent
 bundle install --quiet
-build _config_cockroachdb.yml
+build _config_cockroachdb.yml,_config_url.yml
 
 cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
@@ -43,7 +53,7 @@ fi;
 # Run Algolia if building master
 if [[ "$CONTEXT" = "production" ]]; then
 	echo "Building Algolia index..."
-	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml --builds-config _config_cockroachdb.yml
+	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml,_config_url.yml --builds-config _config_cockroachdb.yml
 fi;
 
 # Run htmltest, but skip checking external links to speed things up

--- a/search.html
+++ b/search.html
@@ -137,7 +137,7 @@ docs_area: search
           hit =>
             `<div class="search-item">
           <div class="search-title">
-            <a href="${hit.url.replace("/{{ site.versions["stable"] }}/", "/stable/").replace("/{{ site.versions["dev"] }}/", "/dev/")}">${hit.title}</a>
+            <a href="${hit.url.replace("/{{ site.versions["stable"] }}/", "/stable/").replace("/{{ site.versions["dev"] }}/", "/dev/").replace("https://www.cockroachlabs.com", "{{ site.url }}")}">${hit.title}</a>
           </div>
           <div class="search-snippet">${showResult(hit._highlightResult)}</div>
           <div class="search-link">${hit.doc_type}</div>


### PR DESCRIPTION
This will help remove some of the burden Google has to navigate multiple URLs while crawling our site. The hope is that this will increase our crawl budget. This should not have any end-user impact.

Additionally, this now allows search to search the local instance running Jekyll, whether that be the Netlify build or the local `make standard` target.