### PR TITLE
Generate the reference docs using Rapidoc.

### DIFF
--- a/api/cluster/v2.md
+++ b/api/cluster/v2.md
@@ -5,6 +5,9 @@ layout: api
 docs_area: reference.api
 ---
 
+{% assign versions = site.data.versions %}
+{% assign todays_date = "now" | date: '%s' %}
+
 <style>
   rapi-doc::part(section-operation-webhook-method) {
     padding 8px;
@@ -68,9 +71,34 @@ docs_area: reference.api
   }
 </style>
 
+<script type="text/javascript">
+  function changeVersion() {
+    const doc = document.getElementById('rd');
+    selectedVersion = document.getElementById("versionSelector").value;
+    doc.loadSpec('https://raw.githubusercontent.com/cockroachdb/cockroach/release-' + selectedVersion + '/docs/generated/swagger/spec.json');
+  }
+
+  window.addEventListener('load', (event) => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const version = urlParams.get('version');
+    if (version !== null) {
+      let select = document.getElementById("versionSelector");
+      // find the version by the option text (not the label)
+      for (var i = 0; i < select.length; i++){
+        const option = select.options[i];
+        if (version === option.text) {
+          // refresh to the new spec
+          select.value = option.value;
+          select.dispatchEvent(new Event('change'));
+        }
+      }
+    }
+  });
+
+</script>
 <div class="apidocs">
   <rapi-doc id="rd"
-            spec-url = "../spec_30_enriched.json"
+            spec-url = "https://raw.githubusercontent.com/cockroachdb/cockroach/release-{{ site.versions["stable"] | remove_first: 'v' }}/docs/generated/swagger/spec.json"
             theme = "light"
             text-color = "#242A35"
             primary-color = "#6933FF"
@@ -86,6 +114,17 @@ docs_area: reference.api
             allow-try = "false">
     <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;"> 
       <img src = "https://d33wubrfki0l68.cloudfront.net/1c17b3053b29646cdddc53965186a02179b59842/69991/docs/images/cockroachlabs-logo-170.png" style="width:170px; margin-right: 20px" alt="Cockroach Labs logo"> <span style="color:#fff"> <b>nav-logo</b> slot </span>
+    </div>
+    <div slot="nav-logo" style="align-items: left; margin-left: 8px">
+      Version: 
+      <select class="dropdown" id="versionSelector" onchange="changeVersion()">
+        {% for v in versions reversed %}
+          {% assign expired_date = v.asst_supp_exp_date | date: '%s' %}
+          {% if todays_date < expired_date and v.major_version != "v21.1" %}
+            <option value="{{ v.major_version | remove_first: 'v' }}" label="{{ v.major_version }}" {% if v.major_version == site.versions["stable"] %}selected="true"{% endif %}>{{ v.major_version }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
     </div>
     </rapi-doc>
 </div>

--- a/api/cluster/v2.md
+++ b/api/cluster/v2.md
@@ -5,8 +5,87 @@ layout: api
 docs_area: reference.api
 ---
 
-<div class="apidocs">
-  <redoc spec-url='../spec_30_enriched.json' expand-responses='200' disable-search hide-download-button hideSingleRequestSampleTab ></redoc>
-</div>
+<style>
+  rapi-doc::part(section-operation-webhook-method) {
+    padding 8px;
+    background-color: var(--bg3);
+  }
+  rapi-doc::part(section-operation-summary) {
+    font-size: xx-large;
+  }
+  rapi-doc {
+    --red: #dc3545;
+    --pink: #e83e8c;
+    --blue: #007bff;
+    --green: #28a745;
+    --orange: #fd7e14;
+    --yellow: #ffc107;
+    --purple: #6f42c1;
+    --nav-delete-color: var(--red);
+    --nav-post-color: var(--green);
+    --nav-get-color: var(--blue);
+    --nav-put-color: var(--orange);
+  }
 
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  .m-btn {
+    border: 1px solid var(--primary-color);
+    box-shadow: none;
+    border-radius: var(--border-radius);
+    font-weight: 600;
+    display: inline-block;
+    padding: 6px 16px;
+    font-size: var(--font-size-small);
+    outline: 0px;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    background-color: transparent;
+    transition: background-color 0.2s ease 0s;
+    user-select: none;
+    cursor: pointer;
+  }
+
+  .m-btn:hover {
+    background-color: var(--primary-color);
+    color: var(--primary-color-invert);
+  }
+
+  .thin-border {
+    border-width: 1px;
+  }
+
+  .dropdown {
+    color: var(--nav-hover-text-color);
+    border-color: var(--nav-accent-color);
+    background-color: var(--nav-hover-bg-color);
+    border-radius: var(--border-radius);
+    border-width: 1px;
+    font-family: var(--font-mono);
+    font-weight: 400;
+    font-size: var(--font-size-small);
+    transition: border 0.2s ease 0s;
+    padding: 4px 5px;
+  }
+</style>
+
+<div class="apidocs">
+  <rapi-doc id="rd"
+            spec-url = "../spec_30_enriched.json"
+            theme = "light"
+            text-color = "#242A35"
+            primary-color = "#6933FF"
+            nav-bg-color = "#fff"
+            show-header = "false"
+            regular-font = "'SourceSansPro-Regular', sans-serif"
+            mono-font = "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
+            show-method-in-nav-bar = "as-colored-text"
+            allow-server-selection = "false"
+            use-path-in-nav-bar = "false"
+            schema-description-expanded = "true"
+            allow-spec-file-download = "true"
+            allow-try = "false">
+    <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;"> 
+      <img src = "https://d33wubrfki0l68.cloudfront.net/1c17b3053b29646cdddc53965186a02179b59842/69991/docs/images/cockroachlabs-logo-170.png" style="width:170px; margin-right: 20px" alt="Cockroach Labs logo"> <span style="color:#fff"> <b>nav-logo</b> slot </span>
+    </div>
+    </rapi-doc>
+</div>


### PR DESCRIPTION
This PR changes the API reference doc genreation from Redoc to Rapidoc, to match the Cloud API. It adds a version switcher so users can browse other supported versions of the Cluster API. It loads the OpenAPI specs directly from the `cockroach` repo on GitHub.

Because we're directly loading the remote specs, we no longer have the `curl` examples, which were added through an enhancer as part of our Netlify builds. To get this functionality back, the `cockroach` repo should add the enhancer to the OpenAPI spec generation pipeline.