### PR TITLE
DOC-6020 fix broken Grafana replication url

### DIFF
--- a/v21.2/monitor-cockroachdb-with-prometheus.md
+++ b/v21.2/monitor-cockroachdb-with-prometheus.md
@@ -175,7 +175,7 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replicas.json
+    $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replication.json
     # replicas dashboard: replica information and operations.
     ~~~
 

--- a/v22.1/monitor-cockroachdb-with-prometheus.md
+++ b/v22.1/monitor-cockroachdb-with-prometheus.md
@@ -176,7 +176,7 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replicas.json
+    $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replication.json
     # replicas dashboard: replica information and operations.
     ~~~
 

--- a/v22.2/monitor-cockroachdb-with-prometheus.md
+++ b/v22.2/monitor-cockroachdb-with-prometheus.md
@@ -176,7 +176,7 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replicas.json
+    $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replication.json
     # replicas dashboard: replica information and operations.
     ~~~
 


### PR DESCRIPTION
Addresses: DOC-6020

- Engineering changed the name of an upstream resource from `replicas.json` to `replication.json`. This docs PR to update the docs to use the new name.
	- Upstream rename was introduced for CRDB v21.2, so sending this change back that far.

Staging:
[monitor-cockroachdb-with-prometheus.md](https://deploy-preview-15460--cockroachdb-docs.netlify.app/docs/stable/monitor-cockroachdb-with-prometheus.html#step-5-visualize-metrics-in-grafana)