### PR TITLE
 Various 404 fixes to docs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,7 +35,7 @@
 <link rel="stylesheet" href="{{ 'css/fonts.css' | relative_url }}">
 {% include_cached corestyles.css.html %}
 <link rel="preload" href="{{ 'css/customstyles.css' | relative_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="css/customstyles.css"></noscript>
+<noscript><link rel="stylesheet" href="{{ 'css/customstyles.css' | relative_url }}"></noscript>
 
 <script>
 var pageConfig = {

--- a/_includes/releases/v22.2/v22.2.0-alpha.1.md
+++ b/_includes/releases/v22.2/v22.2.0-alpha.1.md
@@ -64,7 +64,7 @@ Release Date: August 30, 2022
 - The `to_regclass`, `to_regnamespace`, `to_regproc`, `to_regprocedure`, `to_regrole`, and `to_regtype` [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html) are now supported, improving compatibility with PostgreSQL. [#78652][#78652]
 - [Changefeed](../{{site.versions["dev"]}}/create-changefeed.html) statements now detect duplicate targets and throw an error. [#79465][#79465]
 - Previously, [`BACKUP`](../{{site.versions["dev"]}}/backup.html) allowed the user to specify a custom subdirectory name for their backups via `BACKUP .. INTO {subdir} IN {collectionURI}`. This is no longer supported. Users can only create a full backup via `BACKUP ... INTO {collectionURI}` or an incremental backup on the latest full backup in their collection via `BACKUP ... INTO LATEST IN {collectionURI}`. This deprecation also removes the need to address a bug in `SHOW BACKUPS IN`, which cannot display user-defined subdirectories. [#79447][#79447]
-- Added a [session variable](../{{site.versions["dev"]}}/set-vars.html), `enable_multiple_modifications_of_table`, which can be used instead of cluster variable `sql.multiple_modifications_of_table.enabled` to allow statements containing multiple `INSERT ON CONFLICT`, `UPSERT`, `UPDATE`, or `DELETE` subqueries to modify the same table. As with `sql.multiple_modifications_of_table.enabled`, with this session variable enabled there is nothing to prevent the table corruption seen in [issue #70731](../{{site.versions["dev"]}}/https://github.com/cockroachdb/cockroach/issues/70731) from occurring if the same row is modified multiple times by different subqueries of a single statement. We recommend rewriting these statements, but the session variable is provided as an aid if this is not possible. [#79677][#79677]
+- Added a [session variable](../{{site.versions["dev"]}}/set-vars.html), `enable_multiple_modifications_of_table`, which can be used instead of cluster variable `sql.multiple_modifications_of_table.enabled` to allow statements containing multiple `INSERT ON CONFLICT`, `UPSERT`, `UPDATE`, or `DELETE` subqueries to modify the same table. As with `sql.multiple_modifications_of_table.enabled`, with this session variable enabled there is nothing to prevent the table corruption seen in [issue #70731](https://github.com/cockroachdb/cockroach/issues/70731) from occurring if the same row is modified multiple times by different subqueries of a single statement. We recommend rewriting these statements, but the session variable is provided as an aid if this is not possible. [#79677][#79677]
 - Previously, if a column in a table has a comment, [`SHOW CREATE TABLE`](../{{site.versions["dev"]}}/show-create.html) would fail after the column type is changed. This is now fixed. [#79998][#79998]
 - Added the [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html): `uuid_nil`, `uuid_ns_dns`, `uuid_ns_url`, `uuid_ns_oid`, and `uuid_ns_x500` provided by the `uuid-ossp` extension in PostgresSQL. [#80204][#80204]
 - Added the [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html): `uuid_generate_v1`, `uuid_generate_v1mc`, `uuid_generate_v3`, and `uuid_generate_v5`. [#80204][#80204]
@@ -197,7 +197,7 @@ Release Date: August 30, 2022
 - The `CREATE EXTERNAL CONNECTION` statement can be used to represent an [Azure Storage URI](../{{site.versions["dev"]}}/use-cloud-storage-for-bulk-operations.html). [#86257][#86257]
 - Added the `SHOW CREATE EXTERNAL CONNECTION` and `SHOW CREATE ALL EXTERNAL CONNECTIONS` statements, which display the connection name and the unredacted query used to create the external connection. Currently, this can only be run by users of the `admin` role. [#86161][#86161]
 - Added index recommendations to `execution_insights`. [#86055][#86055]
-- Added support for the `verify_backup_table_data` option to the [`RESTORE`](../{{site.versions["dev"]}}/restore.html) statement. When using this option, along with the required `schema_only` option, a `schema_only` restore will run **and** all user data will be read from external storage, checksummed, and discarded before getting written to disk. This option provides two additional validation steps that a regular `schema_only` restore and [`SHOW BACKUP`](../{{site.versions["dev"]}}/show-backup.html) with `check_files` cannot provide: 
+- Added support for the `verify_backup_table_data` option to the [`RESTORE`](../{{site.versions["dev"]}}/restore.html) statement. When using this option, along with the required `schema_only` option, a `schema_only` restore will run **and** all user data will be read from external storage, checksummed, and discarded before getting written to disk. This option provides two additional validation steps that a regular `schema_only` restore and [`SHOW BACKUP`](../{{site.versions["dev"]}}/show-backup.html) with `check_files` cannot provide:
     - `RESTORE` will verify that all data can be read and rekeyed to the restoring cluster
     - `RESTORE` will verify that all data passes a checksum check [#86136][#86136]
 - The `CREATE EXTERNAL CONNECTION` statement can be used to represent an `aws-kms` scheme that represents an Amazon S3 KMS resource. [#86402][#86402]
@@ -208,19 +208,19 @@ Release Date: August 30, 2022
 
 <h3 id="v22-2-0-alpha-1-operational-changes">Operational changes</h3>
 
-- Introduced the `kv.allocator.l0_sublevels_threshold` and `kv.allocator.L0_sublevels_threshold_enforce` [cluster settings](../{{site.versions["dev"]}}/cluster-settings.html), which enable excluding stores as targets for allocation and rebalancing 
-of replicas when they have high-read amplification, indicated by the number of L0 sub-levels in level 0 of the store's LSM. By default, `kv.allocator.l0_sublevels_threshold` is set to `20` and `kv.allocator.l0_sublevels_threshold_enforce` is set to 
+- Introduced the `kv.allocator.l0_sublevels_threshold` and `kv.allocator.L0_sublevels_threshold_enforce` [cluster settings](../{{site.versions["dev"]}}/cluster-settings.html), which enable excluding stores as targets for allocation and rebalancing
+of replicas when they have high-read amplification, indicated by the number of L0 sub-levels in level 0 of the store's LSM. By default, `kv.allocator.l0_sublevels_threshold` is set to `20` and `kv.allocator.l0_sublevels_threshold_enforce` is set to
 `block_none_log`. When both `kv.allocator.l0_sublevels_threshold` and the cluster average is exceeded, the action corresponding to `kv.allocator.l0_sublevels_threshold_enforce` is taken, as follows: [#78608][#78608]
     - `block_none` will exclude no candidate stores
     - `block_none_log` will exclude no candidates but log an event
     - `block_rebalance_to` will exclude candidates stores from being targets of rebalance actions
     - `block_all` will exclude candidate stores from being targets of both allocation and rebalancing.
-- Added `requests-per-second`, exposed through the `rebalancing.requestspersecond` metric. `requests-per-second` tracks the average number of requests received per store, aggregated over the ranges it contains. Also added `reads-per-second`, exposed 
+- Added `requests-per-second`, exposed through the `rebalancing.requestspersecond` metric. `requests-per-second` tracks the average number of requests received per store, aggregated over the ranges it contains. Also added `reads-per-second`, exposed
 through the `rebalanacing.readspersecond` metric. `reads-per-second` tracks the count of keys read per second, on a replica basis. [#76609][#76609]
-- `HottestRanges` will now report additional range statistics for the reported ranges. These statistics are: 
-    - requests per second: the number of requests received by this range recently per second. 
-    - writes per second: the number of keys written to in this range recently per second. 
-    - reads per second: the number of keys read from this range recently, per second. 
+- `HottestRanges` will now report additional range statistics for the reported ranges. These statistics are:
+    - requests per second: the number of requests received by this range recently per second.
+    - writes per second: the number of keys written to in this range recently per second.
+    - reads per second: the number of keys read from this range recently, per second.
     - write bytes per second: the number of bytes written to this range recently, per second.
     - read bytes per second: the number of bytes read from this range recently, per second. [#76609][#76609]
 - Increased the default value of `kv.transaction.max_refresh_span_bytes` from 256KB to 4MB. [#80115][#80115]
@@ -232,20 +232,20 @@ through the `rebalanacing.readspersecond` metric. `reads-per-second` tracks the 
 - I/O [admission control](../{{site.versions["dev"]}}/admission-control.html) now reduces the likelihood of storage layer write stalls, which can be caused when memtable flushes become a bottleneck. This is done by limiting write tokens based on flush throughput, so as to reduce storage layer write stalls. Consequently, write tokens are now limited both by flush throughput, and by compaction throughput out of L0. This behavior is enabled by default. The `admission.min_flush_util_fraction` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html), defaulting to `0.5`, can be used to disable or tune flush throughput-based admission tokens. Setting it to a value greater than `1`, e.g., `10`, will disable flush-based tokens. Tuning the behavior, without disabling it, should be done only on the recommendation of a domain expert. [#82440][#82440]
 - The `admission.kv.pause_replication_io_threshold` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) can be set to a nonzero value to reduce I/O throughput on followers that are driven toward an inverted LSM by replication traffic. The functionality is disabled by default. A suggested value is `0.8`, meaning that replication traffic to non-essential followers is paused before these followers will begin throttling their foreground traffic. [#83851][#83851]
 - Adjusted the way memory is tracked against `kv.transaction.max_intents_bytes` and `kv.transaction.max_refresh_spans_bytes` to be more precise. As a result, the stability of CockroachDB has improved. However, this change effectively reduces the budgets determined by those cluster settings. In practice, this means that:
-    - the intents might be tracked more coarsely (due to span coalescing), which makes the intent resolution less efficient. 
+    - the intents might be tracked more coarsely (due to span coalescing), which makes the intent resolution less efficient.
     - the refresh spans become more coarse too, making it more likely that `ReadWithinUncertaintyIntervalError`s are returned to the user rather than retried transparently. [#84230][#84230]
 - Added the storage metrics `rangekeycount`, `rangekeybytes`, `rangevalcount`, and `rangevalbytes` for MVCC range keys (i.e., MVCC range tombstones). These are analogous to the corresponding point key metrics (e.g., `keycount`). [#85453][#85453]
 - Added new metrics `range.snapshots.(send|recv)-queue` and `range.snapshots.(send|recv)-in-progress` to track the number of queued and in-progress snapshots being sent or received on a store. [#84947][#84947]
 - The [cluster settings](../{{site.versions["dev"]}}/cluster-settings.html) `bulkio.restore_at_current_time.enabled` and `bulkio.import_at_current_time.enabled`, which were introduced in v22.1 and defaulted to `true`, have been retired. They are now always enabled. [#85757][#85757]
-- Added new metrics for tracking the successes/errors of a replica being processed by the replicate queue, using the allocator action as a method of categorizing these actions. 
-    - `queue.replicate.addreplica.(success|error)` 
-    - `queue.replicate.removereplica.(success|error)` 
-    - `queue.replicate.replacedeadreplica.(success|error)` 
-    - `queue.replicate.removedeadreplica.(success|error)` 
-    - `queue.replicate.replacedecommissioningreplica.(success|error)` 
-    - `queue.replicate.removedecommissioningreplica.(success|error)` 
+- Added new metrics for tracking the successes/errors of a replica being processed by the replicate queue, using the allocator action as a method of categorizing these actions.
+    - `queue.replicate.addreplica.(success|error)`
+    - `queue.replicate.removereplica.(success|error)`
+    - `queue.replicate.replacedeadreplica.(success|error)`
+    - `queue.replicate.removedeadreplica.(success|error)`
+    - `queue.replicate.replacedecommissioningreplica.(success|error)`
+    - `queue.replicate.removedecommissioningreplica.(success|error)`
 [#85844][#85844]
-- Clusters can now run nodes with different [`--max-offset`](../{{site.versions["dev"]}}/cockroach-start.html#flags-max-offset) settings at the same time. This enables operators to perform a rolling restart to change the value of each node's 
+- Clusters can now run nodes with different [`--max-offset`](../{{site.versions["dev"]}}/cockroach-start.html#flags-max-offset) settings at the same time. This enables operators to perform a rolling restart to change the value of each node's
 `--max-offset` flag. [#85983][#85983]
 - Introduced a new `server.secondary_tenants.redact_trace` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) that controls if traces should be redacted for operations run on behalf of secondary tenants. [#85853][#85853]
 - The `admission.kv.pause_replication_threshold` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) is now set to a default value of `0.8`. On a fully migrated v22.2+ deployment, this will allow the KV layer to pause replication streams to followers located on stores that are close to activating their I/O admission control subsystem (thereby protecting these followers from additional overload). This cluster setting can be disabled by setting it to `0`. [#86147][#86147]
@@ -253,7 +253,7 @@ through the `rebalanacing.readspersecond` metric. `reads-per-second` tracks the 
 - The new `sql.insights.high_retry_count.threshold` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) may be used to configure how many times a slow statement (as identified by the execution insights system) must have been retried to be marked as having a high retry count. [#86415][#86415]
 - Finalizing an upgrade to v22.2 requires that all in-flight schema changes enter a terminal state. This may mean that finalization takes as long as the longest-running schema change. [#76154][#76154]
 - The option `sql.mvcc_compliant_index_creation.enabled` has been removed. [#76154][#76154]
-- Added a new [time series metric](../{{site.versions["dev"]}}/monitoring-and-alerting.html) `storage.keys.range-key-set.count` for observing the count of internal range key set keys in the storage engine. In v22.2, these RangeKeySet keys are only 
+- Added a new [time series metric](../{{site.versions["dev"]}}/monitoring-and-alerting.html) `storage.keys.range-key-set.count` for observing the count of internal range key set keys in the storage engine. In v22.2, these RangeKeySet keys are only
 used during `DROP`/`TRUNCATE` table operations, or when canceling an [import](../{{site.versions["dev"]}}/import.html). [#86570][#86570]
 - The `sql.insights.anomaly_detection.enabled` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) now defaults to `true`, and the `sql.insights.anomaly_detection.latency_threshold` cluster setting now defaults to `50ms`, down from `100ms` to complement the fixed-threshold detector's default of `100ms`. [#86673][#86673]
 - The disk bandwidth constraint can now be used to control admission of elastic writes. This requires configuration for each store, via the `--store` flag, that now contains an optional provisioned-rate field. The provisioned-rate field, if specified, needs to provide a disk-name for the store and optionally a disk bandwidth. If the disk bandwidth is not provided the cluster setting `kv.store.admission.provisioned_bandwidth` will be used. The cluster setting defaults to `0` (which means that the disk bandwidth constraint is disabled). If the effective disk bandwidth is `0` (including if using the possibly overridden cluster setting), the disk bandwidth constraint is disabled. Additionally, the admission control cluster setting `admission.disk_bandwidth_tokens.elastic.enabled` (which defaults to `true`) can be used to turn off enforcement even if other settings enable it. Turning off enforcement will still output all the relevant information about disk bandwidth usage, so can be used to observe part of the mechanism in action. To summarize, to enable this for a cluster with homogeneous disk, provide a disk-name in the provisioned-rate field in the store-spec, and set the `kv.store.admission.provisioned_bandwidth` cluster setting to the bandwidth limit. To only get information about disk bandwidth usage by elastic traffic (currently via logs, not metrics), perform the above actions and also set `admission.disk_bandwidth_tokens.elastic.enabled` to `false`. [#86063][#86063]
@@ -263,13 +263,13 @@ used during `DROP`/`TRUNCATE` table operations, or when canceling an [import](..
 
 <h3 id="v22-2-0-alpha-1-command-line-changes">Command-line changes</h3>
 
-- Added support for the `\password` CLI command that enables secure alteration of the password for a user. The given password will always be pre-hashed with the password hash method obtained via the [session 
+- Added support for the `\password` CLI command that enables secure alteration of the password for a user. The given password will always be pre-hashed with the password hash method obtained via the [session
 variable](../{{site.versions["dev"]}}/set-vars.html) `password-encryption`, e.g., `scram-sha-256` as the default hashing algorithm. [#77975][#77975]
 - Changed the default `debug compact` maximum compaction concurrency to the number of processors, and added a `--max-concurrency` flag for overriding the new default. [#78987][#78987]
-- The standalone [`cockroach-sql`](../{{site.versions["dev"]}}/cockroach-sql-binary.html) executable now has more compatibility with [`cockroach sql`](../{{site.versions["dev"]}}/cockroach-sql.html), so it can be used as a drop-in replacement. For 
+- The standalone [`cockroach-sql`](../{{site.versions["dev"]}}/cockroach-sql-binary.html) executable now has more compatibility with [`cockroach sql`](../{{site.versions["dev"]}}/cockroach-sql.html), so it can be used as a drop-in replacement. For
 example, it supports running without a URL, using connection defaults. It also supports overriding `--certs-dir` and other client-side options also supported by `cockroach sql`. [#82020][#82020]
 - `BYTEA` values are now formatted according to the `bytea_output` [session setting](../{{site.versions["dev"]}}/set-vars.html). [#81943][#81943]
-- The statement tag displayed for `INSERT` statements now has the full information returned by the server: the string `"INSERT"`, followed by the `OID` of the row that was inserted (which is currently always `0` in CockroachDB), followed by the 
+- The statement tag displayed for `INSERT` statements now has the full information returned by the server: the string `"INSERT"`, followed by the `OID` of the row that was inserted (which is currently always `0` in CockroachDB), followed by the
 number of rows inserted. [#81943][#81943]
 - CLI commands that use a SQL connection (e.g., [`cockroach sql`](../{{site.versions["dev"]}}/cockroach-sql.html) and [`cockroach node status`](../{{site.versions["dev"]}}/cockroach-node.html)) now support connecting with `PGPASSFILE` and `PGSERVICEFILE`. The behavior is compatible with how `libpq` (the psql C library) behaves. The `PGPASSFILE` file defaults to the filepath `~/.pgpass`, and has the format `hostname:port:database:username:password`, where the password field from the first line that matches the current connection parameters will be used to connect to the database. The `PGSERVICEFILE` file defaults to the filepath `~/.pg_service.conf`, and has the format:
 
@@ -280,7 +280,7 @@ number of rows inserted. [#81943][#81943]
     user=someuser
     ~~~
 
-    - Any connection parameters (including `passfile` or `password`) can be specified in this file as well. Then, a connection string that specifies the `service=myservice` connection parameter will use the values in `PGSERVICEFILE` to connect. 
+    - Any connection parameters (including `passfile` or `password`) can be specified in this file as well. Then, a connection string that specifies the `service=myservice` connection parameter will use the values in `PGSERVICEFILE` to connect.
 [#82389][#82389]
 - CLI commands that use a SQL connection (e.g., [`cockroach sql`](../{{site.versions["dev"]}}/cockroach-sql.html), `cockroach node status`) now default to using the file in `~/.postgresql/root.crt` for the `sslrootcert` when connecting. The file can still be configured using the `PGSSLROOTCERT` environment variable or the `sslrootcert` URL parameter. [#82389][#82389]
 - Using [`COPY`](../{{site.versions["dev"]}}/copy-from.html) in the SQL shell is now supported while inside an explicit transaction. [#82101][#82101]
@@ -296,8 +296,8 @@ number of rows inserted. [#81943][#81943]
 - Added logic to support dropping unused [index](../{{site.versions["dev"]}}/indexes.html) recommendations. [#77642][#77642]
 - `ListSessions` now returns closed sessions in addition to open sessions. `ListSessionsRequest` now has a `exclude_closed_sessions` flag, which is a `BOOL` to exclude closed sessions. `serverpb.Session` now has `end` and `status` fields, which specify the time the session ended and the status (`opened`, `closed`) of the session, respectively. [#78650][#78650]
 - Updated the `api/v2/rules` endpoint to include additional rules for [events to alert on](../{{site.versions["dev"]}}/monitoring-and-alerting.html#events-to-alert-on). [#80274][#80274]
-- Added a new `last_auto_retry_reason` field under the `active_txn` field for a session to the `ListSessions` API. This field contains the string describing the retry reason or `nil` if none exists. This is also surfaced in the 
-[`crdb_internal.{cluster,node}_transactions`](../{{site.versions["dev"]}}/crdb-internal.html) tables and in the output of the [`SHOW TRANSACTIONS`](../{{site.versions["dev"]}}/show-transactions.html) statement under the `last_auto_retry_reason` 
+- Added a new `last_auto_retry_reason` field under the `active_txn` field for a session to the `ListSessions` API. This field contains the string describing the retry reason or `nil` if none exists. This is also surfaced in the
+[`crdb_internal.{cluster,node}_transactions`](../{{site.versions["dev"]}}/crdb-internal.html) tables and in the output of the [`SHOW TRANSACTIONS`](../{{site.versions["dev"]}}/show-transactions.html) statement under the `last_auto_retry_reason`
 column. [#81531][#81531]
 - `serverpb.Session` now has three new fields: number of transactions executed, transaction fingerprint IDs, and total active time. [#82352][#82352]
 - Added information about total bytes, live (non-MVCC) bytes and live (non-MVCC) percentage to the table details endpoint. [#83677][#83677]
@@ -314,7 +314,7 @@ column. [#81531][#81531]
 - The **Learn more** link on an empty transactions link now mentions transactions. [#81530][#81530]
 - The Circuit Breaker Tripped events chart now displays the rate of events per interval instead of accumulated number of events. [#81438][#81438]
 - The [Jobs page](../{{site.versions["dev"]}}/ui-jobs-page.html) now shows the oldest time (in UTC) that jobs are shown for. [#81148][#81148]
-- The [Cluster Overview page](../{{site.versions["dev"]}}/ui-cluster-overview-page.html) now displays a banner containing the previous versions of the cluster with a message `cluster_version - Mixed Versions` when a cluster runs nodes with different 
+- The [Cluster Overview page](../{{site.versions["dev"]}}/ui-cluster-overview-page.html) now displays a banner containing the previous versions of the cluster with a message `cluster_version - Mixed Versions` when a cluster runs nodes with different
 versions. [#82118][#82118]
 - Fixed grammar on the mixed-version banner alert. [#83150][#83150]
 - On the [SQL Activity page](../{{site.versions["dev"]}}/ui-overview.html#sql-activity), the selection to view historical or active executions will now persist between tabs. [#83903][#83903]
@@ -328,13 +328,13 @@ versions. [#82118][#82118]
 - A new section, Wait Time Insights has been added to the [Active Statement](../{{site.versions["dev"]}}/ui-overview.html#sql-activity) and [Transaction Details](../{{site.versions["dev"]}}/ui-transactions-page.html) pages. The section is included if the transaction being viewed is experiencing contention and includes information on the blocked schema, table, index name, time spent blocking, and the transactions blocking or waiting for the viewed transaction. Only users having `VIEWACTIVITY` or higher can view this feature. The column Time Spent Waiting has been added to the active executions tables that shows the total amount of time an execution has been waiting for a lock. [#85081][#85081]
 - The Explain Plans tab on [Statement Details](../{{site.versions["dev"]}}/ui-statements-page.html) page now displays insights of index recommendations. [#85863][#85863]
 - Added new Insights page to the DB Console. [#84612][#84612]
-- Added the following fields to the [Active Statement](../{{site.versions["dev"]}}/ui-overview.html#sql-activity) and [Transaction Details](../{{site.versions["dev"]}}/ui-transactions-page.html) pages: 
-    - Full Scan: indicates if the execution contains a full scan. 
+- Added the following fields to the [Active Statement](../{{site.versions["dev"]}}/ui-overview.html#sql-activity) and [Transaction Details](../{{site.versions["dev"]}}/ui-transactions-page.html) pages:
+    - Full Scan: indicates if the execution contains a full scan.
     - Last Retry Reason (Transactions page only): the last recorded reason the transaction was retried.
     - Priority (Transactions page only): the transaction priority. [#85974][#85974]
-- The following fields have been added to the [Sessions Overview](../{{site.versions["dev"]}}/ui-sessions-page.html) page: 
-    - Transaction Count: the number of transactions executed by the session. 
-    - Session Active Duration: the time a session spent executing transactions. 
+- The following fields have been added to the [Sessions Overview](../{{site.versions["dev"]}}/ui-sessions-page.html) page:
+    - Transaction Count: the number of transactions executed by the session.
+    - Session Active Duration: the time a session spent executing transactions.
     - Most recent Session fingerprint ids. [#85974][#85974]
 - Removed the **back to sessions** link on Session Details "not found" page. [#86050][#86050]
 - The statements and transaction fingerprint now refreshes data every 5 minutes for non-custom time ranges. [#85772][#85772]
@@ -362,7 +362,7 @@ versions. [#82118][#82118]
 - A [lookup join](../{{site.versions["dev"]}}/joins.html) on `pg_type.oid` no longer results in an error. Example: `SELECT pg_type.oid FROM (SELECT null::OID AS b) AS a INNER LOOKUP JOIN pg_type ON pg_type.oid=a.b`. [#78960][#78960]
 - Previously, queries reading from an index or primary key on `FLOAT` or `REAL` columns `DESC` would read `-0` for every `+0` value stored in the index. Fixed this to correctly read `+0` for `+0` and `-0` for `-0`. [#79473][#79473]
 - Previously, queries with many joins and projections of multi-column expressions, e.g., `col1 + col2`, either present in the query or within a virtual column definition, could experience very long optimization times or hangs, where the query is never sent for execution. This has now been fixed. [#80212][#80212]
-- Previously, queries which involve an [`ORDER BY`](../{{site.versions["dev"]}}/order-by.html) clause, a `DISTINCT ON` clause and a `GROUP BY` clause could sometimes error out depending on the columns referenced in those clauses. This is now fixed. 
+- Previously, queries which involve an [`ORDER BY`](../{{site.versions["dev"]}}/order-by.html) clause, a `DISTINCT ON` clause and a `GROUP BY` clause could sometimes error out depending on the columns referenced in those clauses. This is now fixed.
 [#80447][#80447]
 - Updated the type reported in the wire protocol for `STRING(n)` types to match `VARCHAR(n)`. [#80414][#80414]
 - Previously, creating a table with a locality of [`REGIONAL BY ROW`](../{{site.versions["dev"]}}/multiregion-overview.html#regional-by-row-tables) could intermittently fail with a missing type error. This is now fixed. [#80590][#80590]
@@ -392,7 +392,7 @@ versions. [#82118][#82118]
 - The [Active Transactions page](../{{site.versions["dev"]}}/ui-transactions-page.html) no longer shows transactions from closed sessions. [#83896][#83896]
 - Fixed a bug that could cause an [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) panic in rare cases when a query had a left join in the input of an inner join. [#83875][#83875]
 - `DROP SCHEMA ... CASCADE` in the legacy schema changer now correctly fails when a [backup](../{{site.versions["dev"]}}/backup.html), [restore](../{{site.versions["dev"]}}/restore.html), or an [import](../{{site.versions["dev"]}}/import.html) of an underlying table or type is concurrently underway. [#84189][#84189]
-- `DROP ... CASCADE` of a database or a schema in the [declarative schema changer](../{{site.versions["dev"]}}/online-schema-changes.html#declarative-schema-changer) now correctly fails when a when a 
+- `DROP ... CASCADE` of a database or a schema in the [declarative schema changer](../{{site.versions["dev"]}}/online-schema-changes.html#declarative-schema-changer) now correctly fails when a when a
 [backup](../{{site.versions["dev"]}}/backup.html), [restore](../{{site.versions["dev"]}}/restore.html), or an [import](../{{site.versions["dev"]}}/import.html) of an underlying table or type is concurrently underway. [#84189][#84189]
 - Fixed a bug that caused internal errors in rare cases when performing `DELETE`s on a table that had [foreign key](../{{site.versions["dev"]}}/foreign-key.html) references to it with the `ON DELETE CASCADE` option. For example, imagine tables `a` and `b` already exist, and `b` has a foreign key `ON DELETE CASCADE` column referencing `a`. If table `c` is added with a foreign key `ON DELETE CASCADE` column referencing table `b` and a `DELETE` statement is performed on table `a` in the same transaction, an internal error could occur. This bug has been present since v21.1.0. [#84219][#84219]
 - Fixed a bug that could corrupt [indexes](../{{site.versions["dev"]}}/indexes.html) and cause incorrect query results with `INTERVAL` values greater than about `290` years or less than about `-290` years. [#84045][#84045]
@@ -424,7 +424,7 @@ versions. [#82118][#82118]
 - Sequence integer bounds are now consistent with the [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) `default_int_size`. [#84555][#84555]
 - Users that create an external connection are now granted `ALL` privileges on the object. [#86336][#86336]
 - Fixed a vulnerability in the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) that could cause a panic in rare cases when planning complex queries with [`ORDER BY`](../{{site.versions["dev"]}}/order-by.html). [#86193][#86193]
-- Fixed a bug in [backup](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html) where spans for views were being backed up. Because ranges are not split at view boundaries, this can cause the backup to send [export 
+- Fixed a bug in [backup](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html) where spans for views were being backed up. Because ranges are not split at view boundaries, this can cause the backup to send [export
 requests](../{{site.versions["dev"]}}/backup-architecture.html) to ranges that do not belong to any backup target. [#85158][#85158]
 - Previously, [`SET SESSION AUTHORIZATION DEFAULT`](../{{site.versions["dev"]}}/set-vars.html) would have no effect. Now, it causes the current role to be reset to the original user who logged into the session. [#86485][#86485]
 - Fixed a bug with Search in the Active Execution Overview pages, where providing a search string did not properly filter out statements and transactions that do not contain the search string. [#86764][#86764]
@@ -440,9 +440,9 @@ requests](../{{site.versions["dev"]}}/backup-architecture.html) to ranges that d
 
 - Performance of inner, semi, or anti [joins](../{{site.versions["dev"]}}/joins.html) between two tables with `OR`ed equi-join predicates is improved by enabling the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) to select a join plan in which each equi-join predicate is evaluated by a separate join, with the results of the joins as a union or intersected together. [#74303][#74303]
 - Expressions using the overlaps (`&&`) operator for arrays now support index-acceleration for faster execution in some cases. [#77418][#77418]
-- Improved the ability of the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) to detect contradictions in filter conditions of the form `x IS NULL` when `x` can never be `NULL`. This enables the optimizer to simplify query plans. 
+- Improved the ability of the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) to detect contradictions in filter conditions of the form `x IS NULL` when `x` can never be `NULL`. This enables the optimizer to simplify query plans.
 [#80211][#80211]
-- Added per-span checkpointing to cases when the [high-water mark](../{{site.versions["dev"]}}/change-data-capture-overview.html#how-does-an-enterprise-changefeed-work) lags excessively behind the leading edge of the frontier in order to avoid 
+- Added per-span checkpointing to cases when the [high-water mark](../{{site.versions["dev"]}}/change-data-capture-overview.html#how-does-an-enterprise-changefeed-work) lags excessively behind the leading edge of the frontier in order to avoid
 re-emitting the majority of spans due to a small minority that is experiencing issues progressing. This helps to enable changefeeds to operate on very large tables when performing large catchup scan. [#77763][#77763]
 - The [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) cost model is now more aware of the cost of executing expensive functions (such as spatial functions) in filter conditions. This may lead to improved query plans. [#81924][#81924]
 - [Changefeed](../{{site.versions["dev"]}}/change-data-capture-overview.html) catchup scans now use time-bound iterators, which improves their performance by avoiding accessing data that is outside the catchup scan time interval. Previously, this was controlled by the `kv.rangefeed.catchup_scan_iterator_optimization.enabled` cluster setting, which defaulted to `off`. This change removes this cluster setting, as its functionality is in effect now always enabled. [#82450][#82450]

--- a/v1.1/known-limitations.md
+++ b/v1.1/known-limitations.md
@@ -19,7 +19,9 @@ As a workaround, any time you create, drop, or truncate a table, perform another
 
 ### Maximum cluster size
 
-{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.2.html#v1-2-alpha-20171026">v1.2-alpha.20171026</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/18970">#17016</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+Resolved as of <a href="../releases/v2.0.html#v1-2-alpha-20171026">v1.2-alpha.20171026</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/18970">#17016</a>.
+{{site.data.alerts.end}}
 
 The locations of all ranges in a cluster are stored in a two-level index at the beginning of the key-space, known as [meta ranges](architecture/distribution-layer.html#meta-ranges), where the first level (`meta1`) addresses the second, and the second level (`meta2`) addresses data in the cluster. A limitation in v1.1 prevents `meta2` from being split; thus, the max size of a single range, 64MiB by default, limits the overall size of a cluster to 64TB. Clusters beyond this size will experience problems.
 


### PR DESCRIPTION
During one of the most recent Lumar web crawls, we were given several errors related to a nested file called `css/css/.../css/customstyles.css`, which caused a sharp rise in 404s. This PR should fix that.

Additionally, this fixes 404s in v1.1/known-limitations and in the v22.2.0-alpha.1 release notes.