### PR TITLE
Add advisories and releases url targets to sidebar

### DIFF
--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -12,7 +12,9 @@
     {
       "title": "All Releases",
       "urls": [
-        "/releases/index.html"
+        "/releases/index.html",
+        "/releases/",
+        "/releases"
       ]
     },
     {% for x in v_prod %} {% comment %} iterate through all supported versions {% endcomment %}
@@ -48,6 +50,8 @@
       "title": "Technical Advisories",
       "urls": [
         "/advisories/index.html",
+        "/advisories/",
+        "/advisories",
         {% for x in site.data.advisories %}
           "/advisories/{{ x.advisory }}.html",
         {% endfor %}

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -13,8 +13,7 @@
       "title": "All Releases",
       "urls": [
         "/releases/index.html",
-        "/releases/",
-        "/releases"
+        "/releases/"
       ]
     },
     {% for x in v_prod %} {% comment %} iterate through all supported versions {% endcomment %}
@@ -50,8 +49,7 @@
       "title": "Technical Advisories",
       "urls": [
         "/advisories/index.html",
-        "/advisories/",
-        "/advisories",
+        "/advisories/"
         {% for x in site.data.advisories %}
           "/advisories/{{ x.advisory }}.html",
         {% endfor %}

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -49,11 +49,10 @@
       "title": "Technical Advisories",
       "urls": [
         "/advisories/index.html",
-        "/advisories/"
         {% for x in site.data.advisories %}
           "/advisories/{{ x.advisory }}.html",
         {% endfor %}
-        "/advisories/index.html"
+        "/advisories/"
       ]
     }
   ]


### PR DESCRIPTION
Now that navigating to /docs/advisories and /docs/releases is supported, the sidebar wasn't updating properly. This should resolve that.