### PR TITLE
Restore advisories and releases redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -6,6 +6,8 @@ layout: null
 / /docs/ 301!
 /docs/v2.2/* /docs/v19.1/:splat 301!
 /docs/managed/* /docs/cockroachcloud/:splat 301!
+/docs/releases/ /docs/releases/index.html 301
+/docs/advisories/ /docs/advisories/index.html 301
 /docs/advisories/advisories.html /docs/advisories/index.html 301
 
 # Pages undergoing maintenance

--- a/_redirects
+++ b/_redirects
@@ -6,8 +6,8 @@ layout: null
 / /docs/ 301!
 /docs/v2.2/* /docs/v19.1/:splat 301!
 /docs/managed/* /docs/cockroachcloud/:splat 301!
-/docs/releases/ /docs/releases/index.html 301
-/docs/advisories/ /docs/advisories/index.html 301
+/docs/releases/ /docs/releases/index.html 301!
+/docs/advisories/ /docs/advisories/index.html 301!
 /docs/advisories/advisories.html /docs/advisories/index.html 301
 
 # Pages undergoing maintenance


### PR DESCRIPTION
Navigating directly to https://www.cockroachlabs.com/docs/advisories/ and https://www.cockroachlabs.com/docs/releases/ doesn't expand the sidebar properly. This should resolve that.