### PR TITLE
Correction to CC FAQ page on backups

### DIFF
--- a/cockroachcloud/backups-page.md
+++ b/cockroachcloud/backups-page.md
@@ -19,8 +19,8 @@ The backups that Cockroach Labs runs for you can be viewed on the [Backups page]
 Cockroach Labs runs [full cluster backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#full-backups) hourly for every {{ site.data.products.serverless }} cluster. The full backups are retained for 30 days.
 </section>
 
-<section class="filter-content" markdown="1" data-scope="{{ site.data.products.dedicated }}">
-Cockroach Labs runs [full backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.db }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days.
+<section class="filter-content" markdown="1" data-scope="dedicated">
+Cockroach Labs runs [full cluster backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental cluster backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days. 
 
 {{site.data.alerts.callout_info}}
 Currently, you can only restore [databases](#restore-a-database) and [tables](#restore-a-table) to the same cluster that the backup was taken from.

--- a/cockroachcloud/frequently-asked-questions.md
+++ b/cockroachcloud/frequently-asked-questions.md
@@ -100,7 +100,7 @@ Today, we do not automatically scale nodes based on your capacity usage. To add 
 
 ### Who is responsible for backup?
 
-Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.db }} cluster. The full backups are retained for 30 days and incremental backups for 7 days. Only {{ site.data.products.dedicated }} cluster backups are available to users at this time.
+Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days and incremental backups for 7 days. Only {{ site.data.products.dedicated }} cluster backups are available to users at this time.
 
 The backups for AWS clusters are encrypted using [AWS S3’s server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) and the backups for GCP clusters are encrypted using [Google-managed server-side encryption keys](https://cloud.google.com/storage/docs/encryption/default-keys).
 

--- a/cockroachcloud/run-bulk-operations.md
+++ b/cockroachcloud/run-bulk-operations.md
@@ -49,7 +49,12 @@ Before you begin, connect to your cluster. For guidance on connecting to your {{
 
 <section class="filter-content" markdown="1" data-scope="cloud">
 
-Cockroach Labs runs [full backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.db }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days. For more information, read [Restore Data From a Backup](../cockroachcloud/backups-page.html).
+Cockroach Labs runs the following managed-service backups:
+
+- {{ site.data.products.dedicated }} clusters: [Full cluster backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental cluster backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#incremental-backups) hourly. The full backups are retained for 30 days, while incremental backups are retained for 7 days.
+- {{ site.data.products.serverless }} clusters: [Full cluster backups](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#full-backups) every hour that are retained for 30 days.
+
+For more information, read [Restore Data From a Backup](../cockroachcloud/backups-page.html). 
 
 The following examples show how to run manual backups and restores:
 


### PR DESCRIPTION
In the middle of reviewing Ashley's work on CC backup types, I noticed an error on the FAQ page around that implied full and incremental automated backups were available to both Serverless and Dedicated customers. This is not the case and this PR fixes that.