### PR TITLE
add "invisible" and "not visible" as synonyms

### DIFF
--- a/jekyll-algolia-dev/lib/jekyll/algolia/indexer.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/indexer.rb
@@ -327,6 +327,12 @@ module Jekyll
           synonyms: ['postgresql', 'postgres']
         }, false)
 
+        index.save_synonym('not visible', {
+          objectID: 'not visible',
+          type: 'synonym',
+          synonyms: ['not visible', 'invisible']
+        }, false)        
+        
         return
       end
 


### PR DESCRIPTION
This should enable our docs on not visible indexes to surface when someone searches "invisible indexes".