### PR TITLE
DOC-6142: Update to use the latest version of GitHub Actions

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -8,13 +8,13 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@main
         with:
           fetch-depth: 2
 
       - name: Get changed files
         id: changed_files
-        uses: tj-actions/changed-files@v32.1.0
+        uses: tj-actions/changed-files@v34.3.2
 
       - name: Format list of changed files
         id: format
@@ -96,7 +96,7 @@ jobs:
           echo "body=$body" >> $GITHUB_ENV
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2.0.0
+        uses: peter-evans/find-comment@v2.0.1
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -104,7 +104,7 @@ jobs:
           body-includes: Files changed
 
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2.0.0
+        uses: peter-evans/create-or-update-comment@v2.1.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@main
 
     - name: Get changed files
       id: changed_files
-      uses: tj-actions/changed-files@v32.1.0
+      uses: tj-actions/changed-files@v34.3.2
 
     - name: Calculate changed files to pass to Vale
       id: calc_changed_files


### PR DESCRIPTION
- Any actions from the `actions` organization now use main
- Update all other actions to the latest available version