### PR TITLE
Replaced beta/experimental for preview in CDC & DR docs

### DIFF
--- a/v21.2/changefeed-examples.md
+++ b/v21.2/changefeed-examples.md
@@ -384,7 +384,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 [`CREATE CHANGEFEED`](create-changefeed.html) is an [enterprise-only](enterprise-licensing.html) feature. For the Core version, see [the `CHANGEFEED FOR` example above](#create-a-core-changefeed).
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/cdc/webhook-beta.md %}
+{% include feature-phases/preview.md %}
 
 {% include_cached new-in.html version="v21.2" %} In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
 

--- a/v21.2/changefeed-for.md
+++ b/v21.2/changefeed-for.md
@@ -11,11 +11,9 @@ docs_area: reference.sql
 
 The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
-{% include {{ page.version.version }}/cdc/core-url.md %}
-
 For more information, see [Stream Data Out of CockroachDB Using Changefeeds](change-data-capture-overview.html).
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 ## Required privileges
 

--- a/v21.2/changefeed-sinks.md
+++ b/v21.2/changefeed-sinks.md
@@ -143,9 +143,7 @@ URI Parameter      | Description
 
 ## Webhook sink
 
-{{site.data.alerts.callout_info}}
-The webhook sink is currently in **beta**. For more information, read about its usage considerations, available [parameters](create-changefeed.html#parameters), and [options](create-changefeed.html#options) below.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 {% include_cached new-in.html version="v21.2" %} Use a webhook sink to deliver changefeed messages to an arbitrary HTTP endpoint.
 

--- a/v21.2/create-schedule-for-backup.md
+++ b/v21.2/create-schedule-for-backup.md
@@ -60,11 +60,7 @@ For schedules that include both [full and incremental backups](take-full-and-inc
 
 ### Schedule options
 
-{{site.data.alerts.callout_danger}}
-**This is an experimental feature.**  Its interface, options, and outputs are subject to change, and there may be bugs.
-
-If you encounter a bug, please [file an issue](file-an-issue.html).
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
  Option                     | Value                                   | Description
 ----------------------------+-----------------------------------------+------------------------------

--- a/v21.2/monitor-and-debug-changefeeds.md
+++ b/v21.2/monitor-and-debug-changefeeds.md
@@ -38,7 +38,7 @@ You can use the high-water timestamp to [start a new changefeed where another en
 
 ### Using changefeed metrics labels
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {{site.data.alerts.callout_info}}
 An {{ site.data.products.enterprise }} license is required to use metrics labels in changefeeds.

--- a/v22.1/changefeed-examples.md
+++ b/v22.1/changefeed-examples.md
@@ -320,9 +320,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
 ## Create a changefeed connected to a Google Cloud Pub/Sub sink
 
-{{site.data.alerts.callout_info}}
-The Google Cloud Pub/Sub sink is currently in **beta**.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 {% include_cached new-in.html version="v22.1" %} In this example, you'll set up a changefeed for a single-node cluster that is connected to a [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/overview) sink. The changefeed will watch a table and send messages to the sink.
 
@@ -523,9 +521,9 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 [`CREATE CHANGEFEED`](create-changefeed.html) is an [{{ site.data.products.enterprise }}-only](enterprise-licensing.html) feature. For the Core version, see [the `CHANGEFEED FOR` example](#create-a-core-changefeed).
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/cdc/webhook-beta.md %}
+{% include feature-phases/preview.md %}
 
- In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
+In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
 
 1. If you do not already have one, [request a trial {{ site.data.products.enterprise }} license](enterprise-licensing.html).
 

--- a/v22.1/changefeed-for.md
+++ b/v22.1/changefeed-for.md
@@ -11,11 +11,9 @@ docs_area: reference.sql
 
 The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
-{% include {{ page.version.version }}/cdc/core-url.md %}
-
 For more information, see [Change Data Capture Overview](change-data-capture-overview.html).
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 ## Required privileges
 

--- a/v22.1/changefeed-sinks.md
+++ b/v22.1/changefeed-sinks.md
@@ -107,9 +107,7 @@ Field              | Type                | Description      | Default
 
 ## Google Cloud Pub/Sub
 
-{{site.data.alerts.callout_info}}
-The Google Cloud Pub/Sub sink is currently in **beta**. For more information, read about compatible changefeed [options](create-changefeed.html#options) and the [Create a changefeed connected to a Google Cloud Pub/Sub sink](changefeed-examples.html#create-a-changefeed-connected-to-a-google-cloud-pub-sub-sink) example.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 {% include_cached new-in.html version="v22.1" %} Changefeeds can deliver messages to a Google Cloud Pub/Sub sink, which is integrated with Google Cloud Platform.
 
@@ -137,6 +135,8 @@ When using Pub/Sub as your downstream sink, consider the following:
 - Your Google Service Account must have the [Pub/Sub Editor](https://cloud.google.com/iam/docs/understanding-roles#pub-sub-roles) role assigned at the [project level](https://cloud.google.com/resource-manager/docs/access-control-proj#using_predefined_roles).
 - You must specify the `region` parameter in the URI to maintain [ordering guarantees](changefeed-messages.html#ordering-guarantees). Unordered messages are not supported, see [Known Limitations](change-data-capture-overview.html#known-limitations) for more information.
 - Changefeeds connecting to a Pub/Sub sink do not support the `topic_prefix` option.
+
+For more information, read about compatible changefeed [options](create-changefeed.html#options) and the [Create a changefeed connected to a Google Cloud Pub/Sub sink](changefeed-examples.html#create-a-changefeed-connected-to-a-google-cloud-pub-sub-sink) example.
 
 ### Pub/Sub topic naming
 
@@ -194,9 +194,7 @@ URI Parameter      | Description
 
 ## Webhook sink
 
-{{site.data.alerts.callout_info}}
-The webhook sink is currently in **beta**. The following section provides usage considerations.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 Use a webhook sink to deliver changefeed messages to an arbitrary HTTP endpoint.
 

--- a/v22.1/create-schedule-for-backup.md
+++ b/v22.1/create-schedule-for-backup.md
@@ -60,11 +60,7 @@ For schedules that include both [full and incremental backups](take-full-and-inc
 
 ### Schedule options
 
-{{site.data.alerts.callout_danger}}
-**This is an experimental feature.**  Its interface, options, and outputs are subject to change, and there may be bugs.
-
-If you encounter a bug, please [file an issue](file-an-issue.html).
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
  Option                     | Value                                   | Description
 ----------------------------+-----------------------------------------+------------------------------

--- a/v22.1/monitor-and-debug-changefeeds.md
+++ b/v22.1/monitor-and-debug-changefeeds.md
@@ -38,7 +38,7 @@ You can use the high-water timestamp to [start a new changefeed where another en
 
 ### Using changefeed metrics labels
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {{site.data.alerts.callout_info}}
 An {{ site.data.products.enterprise }} license is required to use metrics labels in changefeeds.

--- a/v22.2/changefeed-examples.md
+++ b/v22.2/changefeed-examples.md
@@ -321,9 +321,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
 ## Create a changefeed connected to a Google Cloud Pub/Sub sink
 
-{{site.data.alerts.callout_info}}
-The Google Cloud Pub/Sub sink is currently in **beta**.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 In this example, you'll set up a changefeed for a single-node cluster that is connected to a [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/overview) sink. The changefeed will watch a table and send messages to the sink.
 
@@ -524,7 +522,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 [`CREATE CHANGEFEED`](create-changefeed.html) is an [{{ site.data.products.enterprise }}-only](enterprise-licensing.html) feature. For the Core version, see [the `CHANGEFEED FOR` example](#create-a-core-changefeed).
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/cdc/webhook-beta.md %}
+{% include feature-phases/preview.md %}
 
  In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
 

--- a/v22.2/changefeed-for.md
+++ b/v22.2/changefeed-for.md
@@ -11,11 +11,9 @@ docs_area: reference.sql
 
 The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
-{% include {{ page.version.version }}/cdc/core-url.md %}
-
 For more information, see [Change Data Capture Overview](change-data-capture-overview.html).
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 ## Required privileges
 

--- a/v22.2/changefeed-sinks.md
+++ b/v22.2/changefeed-sinks.md
@@ -109,9 +109,7 @@ Field              | Type                | Description      | Default
 
 ## Google Cloud Pub/Sub
 
-{{site.data.alerts.callout_info}}
-The Google Cloud Pub/Sub sink is currently in **beta**. For more information, read about compatible changefeed [options](create-changefeed.html#options) and the [Create a changefeed connected to a Google Cloud Pub/Sub sink](changefeed-examples.html#create-a-changefeed-connected-to-a-google-cloud-pub-sub-sink) example.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 Changefeeds can deliver messages to a Google Cloud Pub/Sub sink, which is integrated with Google Cloud Platform.
 
@@ -140,6 +138,8 @@ When using Pub/Sub as your downstream sink, consider the following:
 - Your Google Service Account must have the [Pub/Sub Editor](https://cloud.google.com/iam/docs/understanding-roles#pub-sub-roles) role assigned at the [project level](https://cloud.google.com/resource-manager/docs/access-control-proj#using_predefined_roles).
 - You must specify the `region` parameter in the URI to maintain [ordering guarantees](changefeed-messages.html#ordering-guarantees). Unordered messages are not supported, see [Known Limitations](change-data-capture-overview.html#known-limitations) for more information.
 - Changefeeds connecting to a Pub/Sub sink do not support the `topic_prefix` option.
+
+For more information, read about compatible changefeed [options](create-changefeed.html#options) and the [Create a changefeed connected to a Google Cloud Pub/Sub sink](changefeed-examples.html#create-a-changefeed-connected-to-a-google-cloud-pub-sub-sink) example.
 
 ### Pub/Sub topic naming
 
@@ -208,9 +208,7 @@ URI Parameter      | Storage | Description
 
 ## Webhook sink
 
-{{site.data.alerts.callout_info}}
-The webhook sink is currently in **beta**. The following section provides usage considerations.
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
 Use a webhook sink to deliver changefeed messages to an arbitrary HTTP endpoint.
 

--- a/v22.2/create-schedule-for-backup.md
+++ b/v22.2/create-schedule-for-backup.md
@@ -72,11 +72,7 @@ For schedules that include both [full and incremental backups](take-full-and-inc
 
 ### Schedule options
 
-{{site.data.alerts.callout_danger}}
-**This is an experimental feature.**  Its interface, options, and outputs are subject to change, and there may be bugs.
-
-If you encounter a bug, please [file an issue](file-an-issue.html).
-{{site.data.alerts.end}}
+{% include feature-phases/preview.md %}
 
  Option                     | Value                                   | Description
 ----------------------------+-----------------------------------------+------------------------------

--- a/v22.2/monitor-and-debug-changefeeds.md
+++ b/v22.2/monitor-and-debug-changefeeds.md
@@ -38,7 +38,7 @@ You can use the high-water timestamp to [start a new changefeed where another en
 
 ### Using changefeed metrics labels
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {{site.data.alerts.callout_info}}
 An {{ site.data.products.enterprise }} license is required to use metrics labels in changefeeds.


### PR DESCRIPTION
Fixes DOC-5403 

Replaced beta and experimental labels with preview for the new GTM phases. Changed all features in the DR & CDC docs that had references to the previous labels.