### PR TITLE
Added replacement `show backup` diagram as local

### DIFF
--- a/_includes/v22.1/backups/show-backup-replace-diagram.html
+++ b/_includes/v22.1/backups/show-backup-replace-diagram.html
@@ -1,0 +1,50 @@
+<div style="overflow-x:auto;"><svg width="1171" height="223">
+    <polygon points="11 17 3 13 3 21"/>
+    <polygon points="19 17 11 13 11 21"/>
+    <rect x="33" y="3" width="64" height="32" rx="10"/>
+    <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="41" y="21">SHOW</text>
+    <rect x="45" y="69" width="84" height="32" rx="10"/>
+    <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="53" y="87">BACKUPS</text>
+    <rect x="149" y="69" width="36" height="32" rx="10"/>
+    <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="157" y="87">IN</text>
+    <rect x="205" y="69" width="102" height="32"/>
+    <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="213" y="87">collectionURI</text>
+    <rect x="45" y="113" width="74" height="32" rx="10"/>
+    <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="53" y="131">BACKUP</text>
+    <rect x="159" y="145" width="86" height="32" rx="10"/>
+    <rect x="157" y="143" width="86" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="167" y="163">SCHEMAS</text>
+    <rect x="285" y="113" width="60" height="32" rx="10"/>
+    <rect x="283" y="111" width="60" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="293" y="131">FROM</text>
+    <rect x="365" y="113" width="98" height="32"/>
+    <rect x="363" y="111" width="98" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="373" y="131">subdirectory</text><rect x="483" y="113" width="36" height="32" rx="10"/>
+    <rect x="481" y="111" width="36" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="491" y="131">IN</text>
+    <rect x="539" y="113" width="102" height="32"/>
+    <rect x="537" y="111" width="102" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="547" y="131">collectionURI</text><rect x="681" y="145" width="58" height="32" rx="10"/>
+    <rect x="679" y="143" width="58" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="689" y="163">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+    <rect x="779" y="145" width="108" height="32"/>
+    <rect x="777" y="143" width="108" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="787" y="163">kv_option_list</text></a><rect x="779" y="189" width="84" height="32" rx="10"/>
+    <rect x="777" y="187" width="84" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="787" y="207">OPTIONS</text>
+    <rect x="883" y="189" width="26" height="32" rx="10"/>
+    <rect x="881" y="187" width="26" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="891" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+    <rect x="929" y="189" width="108" height="32"/>
+    <rect x="927" y="187" width="108" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="937" y="207">kv_option_list</text></a><rect x="1057" y="189" width="26" height="32" rx="10"/>
+    <rect x="1055" y="187" width="26" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="1065" y="207">)</text>
+    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h816 m-1118 0 h20 m1098 0 h20 m-1138 0 q10 0 10 10 m1118 0 q0 -10 10 -10 m-1128 10 v24 m1118 0 v-24 m-1118 24 q0 10 10 10 m1098 0 q10 0 10 -10 m-1108 10 h10 m74 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m63 -120 h-3"/>
+    <polygon points="1161 83 1169 79 1169 87"/>
+    <polygon points="1161 83 1153 79 1153 87"/></svg></div>

--- a/_includes/v22.2/backups/show-backup-replace-diagram.html
+++ b/_includes/v22.2/backups/show-backup-replace-diagram.html
@@ -1,0 +1,50 @@
+<div style="overflow-x:auto;"><svg width="1171" height="223">
+    <polygon points="11 17 3 13 3 21"/>
+    <polygon points="19 17 11 13 11 21"/>
+    <rect x="33" y="3" width="64" height="32" rx="10"/>
+    <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="41" y="21">SHOW</text>
+    <rect x="45" y="69" width="84" height="32" rx="10"/>
+    <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="53" y="87">BACKUPS</text>
+    <rect x="149" y="69" width="36" height="32" rx="10"/>
+    <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="157" y="87">IN</text>
+    <rect x="205" y="69" width="102" height="32"/>
+    <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="213" y="87">collectionURI</text>
+    <rect x="45" y="113" width="74" height="32" rx="10"/>
+    <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="53" y="131">BACKUP</text>
+    <rect x="159" y="145" width="86" height="32" rx="10"/>
+    <rect x="157" y="143" width="86" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="167" y="163">SCHEMAS</text>
+    <rect x="285" y="113" width="60" height="32" rx="10"/>
+    <rect x="283" y="111" width="60" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="293" y="131">FROM</text>
+    <rect x="365" y="113" width="98" height="32"/>
+    <rect x="363" y="111" width="98" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="373" y="131">subdirectory</text><rect x="483" y="113" width="36" height="32" rx="10"/>
+    <rect x="481" y="111" width="36" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="491" y="131">IN</text>
+    <rect x="539" y="113" width="102" height="32"/>
+    <rect x="537" y="111" width="102" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="547" y="131">collectionURI</text><rect x="681" y="145" width="58" height="32" rx="10"/>
+    <rect x="679" y="143" width="58" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="689" y="163">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+    <rect x="779" y="145" width="108" height="32"/>
+    <rect x="777" y="143" width="108" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="787" y="163">kv_option_list</text></a><rect x="779" y="189" width="84" height="32" rx="10"/>
+    <rect x="777" y="187" width="84" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="787" y="207">OPTIONS</text>
+    <rect x="883" y="189" width="26" height="32" rx="10"/>
+    <rect x="881" y="187" width="26" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="891" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+    <rect x="929" y="189" width="108" height="32"/>
+    <rect x="927" y="187" width="108" height="32" class="nonterminal"/>
+    <text class="nonterminal" x="937" y="207">kv_option_list</text></a><rect x="1057" y="189" width="26" height="32" rx="10"/>
+    <rect x="1055" y="187" width="26" height="32" class="terminal" rx="10"/>
+    <text class="terminal" x="1065" y="207">)</text>
+    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h816 m-1118 0 h20 m1098 0 h20 m-1138 0 q10 0 10 10 m1118 0 q0 -10 10 -10 m-1128 10 v24 m1118 0 v-24 m-1118 24 q0 10 10 10 m1098 0 q10 0 10 -10 m-1108 10 h10 m74 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m63 -120 h-3"/>
+    <polygon points="1161 83 1169 79 1169 87"/>
+    <polygon points="1161 83 1153 79 1153 87"/></svg></div>

--- a/v22.1/show-backup.md
+++ b/v22.1/show-backup.md
@@ -24,7 +24,7 @@ For guidance on the syntax for `SHOW BACKUP FROM`, see the [examples](#examples)
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/show_backup.html %}
+{% include {{ page.version.version }}/backups/show-backup-replace-diagram.html %}
 </div>
 
 ## Parameters

--- a/v22.2/show-backup.md
+++ b/v22.2/show-backup.md
@@ -37,7 +37,7 @@ We recommend using [cloud storage for bulk operations](use-cloud-storage-for-bul
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_backup.html %}
+{% include {{ page.version.version }}/backups/show-backup-replace-diagram.html %}
 </div>
 
 ## Parameters


### PR DESCRIPTION
Fixes DOC-3010

Replaced the remote include for the show backup SQL diagrams for 22.1 & 22.2 since the diagram pulling from the `cockroach` repo exposes some parts of the show backup SQL that are not intended for users. Added a local include instead with the intention of figuring out how to resolve the misalignment between what's in the `cockroach` SQL.y file and what should be user facing.