### PR TITLE
DOC-6000 rename ttl metrics

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -38,6 +38,8 @@ Name | Help
 `intentage` | Cumulative age of intents in seconds
 `intentbytes` | Number of bytes in intent KV pairs
 `intentcount` | Count of intent keys
+`jobs.row_level_ttl.num_active_spans` | Number of active spans the TTL job is deleting from
+`jobs.row_level_ttl.span_total_duration` | Duration for processing a span during row level TTL
 `keybytes` | Number of bytes taken up by keys
 `keycount` | Count of all keys
 `lastupdatenanos` | Time in nanoseconds since Unix epoch at which bytes/keys/intents metrics were last updated


### PR DESCRIPTION
Addresses: DOC-6000

- Renames two metrics (actually, DOCS didn't know these existed, so we're actually just adding them!)

Note:

- The renamed metrics also appear on the DB Console  > Metrics > TTL dashboard, but we don't currently document this dashboard. Plans exist!

Staging:

[metric-names.md](https://deploy-preview-15599--cockroachdb-docs.netlify.app/docs/stable/ui-custom-chart-debug-page.html#available-metrics)