### PR TITLE
DOC-3591 add repl load metrics

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -147,6 +147,8 @@ Name | Help
 `rangevalbytes` | Number of bytes taken up by range key values (e.g. MVCC range tombstones)
 `rangevalcount` | Count of all range key values (e.g. MVCC range tombstones)
 `rebalancing.readbytespersecond` | Average number of bytes written recently per second
+`rebalancing.readspersecond` | Average number of keys read recently per second
+`rebalancing.requestspersecond` | Average number of requests received recently per second
 `rebalancing.writebytespersecond` | Average number of bytes read recently per second
 `rebalancing.writespersecond` | Number of keys written (i.e., applied by Raft) per second to the store, averaged over a large time period as used in rebalancing decisions
 `replicas.commandqueue.combinedqueuesize` | Number of commands in all CommandQueues combined


### PR DESCRIPTION
Addresses: DOC-3591

- Added two new metrics to `metric-names.md`.

Question:

- Is there somewhere else in the docs that you think I should be updating as well? The linked eng PR mentions several changes to the HotRanges graph, but I do not see them live at `http://localhost:8080/#/hotranges`  in the latest `v22.2.0-rc.1` binary (the column `QPS` remains, with no new columns visible), which matches what's [currently in the docs](https://www.cockroachlabs.com/docs/stable/ui-hot-ranges-page.html) for that page. I see that `RangeStatistics` is described as internal-only in the linked Eng commit (in file `docs/generated/http/full.md`) so perhaps, as far as end users are concerned, it's just the two new metrics that we need to surface (as I have done in this PR)? Please let me know!
- EDIT: Ah is it `http://localhost:8080/_status/hotranges`? I do see those new metrics here. If so, this is undocumented indeed.

Staging:

[metric-names.md](https://deploy-preview-15600--cockroachdb-docs.netlify.app/docs/stable/ui-custom-chart-debug-page.html#available-metrics)