### PR TITLE
DOC-5577 preview range for row

### DIFF
--- a/v21.2/show-range-for-row.md
+++ b/v21.2/show-range-for-row.md
@@ -7,7 +7,7 @@ docs_area: reference.sql
 
 The `SHOW RANGE ... FOR ROW` [statement](sql-statements.html) shows information about a [range](architecture/overview.html#architecture-range) for a single row in a table or index. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for a range are located.
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {{site.data.alerts.callout_info}}
 To show information about the ranges for all data in a table, index, or database, use the [`SHOW RANGES`](show-ranges.html) statement.

--- a/v22.1/show-range-for-row.md
+++ b/v22.1/show-range-for-row.md
@@ -7,7 +7,7 @@ docs_area: reference.sql
 
 The `SHOW RANGE ... FOR ROW` [statement](sql-statements.html) shows information about a [range](architecture/overview.html#architecture-range) for a single row in a table or index. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for a range are located.
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {{site.data.alerts.callout_info}}
 To show information about the ranges for all data in a table, index, or database, use the [`SHOW RANGES`](show-ranges.html) statement.

--- a/v22.2/show-range-for-row.md
+++ b/v22.2/show-range-for-row.md
@@ -7,7 +7,7 @@ docs_area: reference.sql
 
 The `SHOW RANGE ... FOR ROW` [statement](sql-statements.html) shows information about a [range](architecture/overview.html#architecture-range) for a single row in a table or index. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for a range are located.
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {{site.data.alerts.callout_info}}
 To show information about the ranges for all data in a table, index, or database, use the [`SHOW RANGES`](show-ranges.html) statement.


### PR DESCRIPTION
Addresses: DOC-5577

- Updated `v21.2`, `v22.1`, and `v22.2` versions of `SHOW RANGE FOR ROW` reference page to use new `Preview` language include.

Staging:

[v22.2/show-range-for-row.md](https://deploy-preview-15610--cockroachdb-docs.netlify.app/docs/dev/show-range-for-row.html)