### PR TITLE
DOC-5579 preview experimental audit

### DIFF
--- a/v21.2/experimental-audit.md
+++ b/v21.2/experimental-audit.md
@@ -24,7 +24,7 @@ For descriptions of all SQL audit event types and their fields, see [Notable Eve
 
 CockroachDB stores audit log information in a way that ensures durability, but negatively impacts performance. As a result, we recommend using SQL audit logs for security purposes only. For more information, see [Performance considerations](#performance-considerations).
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
 

--- a/v21.2/logging-use-cases.md
+++ b/v21.2/logging-use-cases.md
@@ -228,7 +228,7 @@ The [`SENSITIVE_ACCESS`](logging.html#sensitive_access) channel logs SQL audit e
 Enabling these logs can negatively impact performance. We recommend using `SENSITIVE_ACCESS` for security purposes only.
 {{site.data.alerts.end}}
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 To log all queries against a specific table, enable auditing on the table with [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html).
 

--- a/v21.2/sql-audit-logging.md
+++ b/v21.2/sql-audit-logging.md
@@ -21,7 +21,7 @@ Note that enabling SQL audit logs can negatively impact performance. As a result
 For the best visibility into security-related events on your cluster, we recommend configuring `SENSITIVE_ACCESS` together with the `USER_ADMIN`, `PRIVILEGES`, and `SESSIONS` logging channels. To learn more, see [Logging Use Cases](logging-use-cases.html#security-and-audit-monitoring).
 {{site.data.alerts.end}}
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 ## Step 1. Create sample tables
 

--- a/v22.1/experimental-audit.md
+++ b/v22.1/experimental-audit.md
@@ -24,7 +24,7 @@ For descriptions of all SQL audit event types and their fields, see [Notable Eve
 
 CockroachDB stores audit log information in a way that ensures durability, but negatively impacts performance. As a result, we recommend using SQL audit logs for security purposes only. For more information, see [Performance considerations](#performance-considerations).
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
 

--- a/v22.1/logging-use-cases.md
+++ b/v22.1/logging-use-cases.md
@@ -228,7 +228,7 @@ The [`SENSITIVE_ACCESS`](logging.html#sensitive_access) channel logs SQL audit e
 Enabling these logs can negatively impact performance. We recommend using `SENSITIVE_ACCESS` for security purposes only.
 {{site.data.alerts.end}}
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 To log all queries against a specific table, enable auditing on the table with [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html).
 

--- a/v22.1/sql-audit-logging.md
+++ b/v22.1/sql-audit-logging.md
@@ -21,7 +21,7 @@ Note that enabling SQL audit logs can negatively impact performance. As a result
 For the best visibility into security-related events on your cluster, we recommend configuring `SENSITIVE_ACCESS` together with the `USER_ADMIN`, `PRIVILEGES`, and `SESSIONS` logging channels. To learn more, see [Logging Use Cases](logging-use-cases.html#security-and-audit-monitoring).
 {{site.data.alerts.end}}
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 ## Step 1. Create sample tables
 

--- a/v22.2/experimental-audit.md
+++ b/v22.2/experimental-audit.md
@@ -24,7 +24,7 @@ For descriptions of all SQL audit event types and their fields, see [Notable Eve
 
 CockroachDB stores audit log information in a way that ensures durability, but negatively impacts performance. As a result, we recommend using SQL audit logs for security purposes only. For more information, see [Performance considerations](#performance-considerations).
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
 

--- a/v22.2/logging-use-cases.md
+++ b/v22.2/logging-use-cases.md
@@ -228,7 +228,7 @@ The [`SENSITIVE_ACCESS`](logging.html#sensitive_access) channel logs SQL audit e
 Enabling these logs can negatively impact performance. We recommend using `SENSITIVE_ACCESS` for security purposes only.
 {{site.data.alerts.end}}
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 To log all queries against a specific table, enable auditing on the table with [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html).
 

--- a/v22.2/sql-audit-logging.md
+++ b/v22.2/sql-audit-logging.md
@@ -21,7 +21,7 @@ Note that enabling SQL audit logs can negatively impact performance. As a result
 For the best visibility into security-related events on your cluster, we recommend configuring `SENSITIVE_ACCESS` together with the `USER_ADMIN`, `PRIVILEGES`, and `SESSIONS` logging channels. To learn more, see [Logging Use Cases](logging-use-cases.html#security-and-audit-monitoring).
 {{site.data.alerts.end}}
 
-{% include common/experimental-warning.md %}
+{% include feature-phases/preview.md %}
 
 ## Step 1. Create sample tables
 


### PR DESCRIPTION
Addresses: DOC-5579

- Updated `v21.2`, `v22.1`, and `v22.2` versions of EXPERIMENTAL_AUDIT reference page to use new `Preview` language include.

Note:

- Assuming that closely-related `SENSITIVE_ACCESS` log channel is also [in need of this change](https://www.cockroachlabs.com/docs/stable/logging-use-cases.html#sensitive_access), so making it here (no explicit ticket for this log channel to D O C - 3 7 5 8, so using this ticket to accomplish.)

Staging:

- [experimental-audit.md](https://deploy-preview-15611--cockroachdb-docs.netlify.app/docs/dev/experimental-audit.html)
- [logging-use-cases.md](https://deploy-preview-15611--cockroachdb-docs.netlify.app/docs/dev/logging-use-cases.html#sensitive_access)
- [sql-audit-logging.md](https://deploy-preview-15611--cockroachdb-docs.netlify.app/docs/dev/sql-audit-logging.html)