### PR TITLE
Add docs on global MODIFYCLUSTERSETTING privilege

### DIFF
--- a/_includes/v22.2/sql/privileges.md
+++ b/_includes/v22.2/sql/privileges.md
@@ -16,3 +16,4 @@ Privilege | Levels
 `BACKUP` | System, Database, Table
 `RESTORE` | System, Database
 `EXTERNALIOIMPLICITACCESS` | System
+`MODIFYCLUSTERSETTING` | <a name="modifyclustersetting"></a> {% if page.name == "authorization.md" %} [Global privilege](../grant.html#grant-global-privileges-on-the-entire-cluster) that allows users to use the [`SET CLUSTER SETTING`](../set-cluster-setting.html) statement. {% else %} [Global privilege](grant.html#grant-global-privileges-on-the-entire-cluster) that allows users to use the [`SET CLUSTER SETTING`](set-cluster-setting.html) statement. {% endif %}

--- a/v22.2/grant.md
+++ b/v22.2/grant.md
@@ -166,6 +166,23 @@ SHOW GRANTS ON TABLE movr.public.*;
 (24 rows)
 ~~~
 
+### Grant global privileges on the entire cluster
+
+Global level [privileges](security-reference/authorization.html#supported-privileges) live above the database level and apply to the entire cluster.
+
+`root` and [`admin`](security-reference/authorization.html#admin-role) users have global privileges by default, and are capable of granting it to other users and roles using the `GRANT` statement.
+
+For example, the following statement allows the user `maxroach` to use [`SET CLUSTER SETTING`](set-cluster-setting.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;
+~~~
+
+{{site.data.alerts.callout_info}}
+Global privileges in this context mean "cluster-wide" privileges, and have no relation to the term "global" as used by [multi-region SQL statements](multiregion-overview.html).
+{{site.data.alerts.end}}
+
 ### Make a table readable to every user in the system
 
 {% include_cached copy-clipboard.html %}

--- a/v22.2/revoke.md
+++ b/v22.2/revoke.md
@@ -220,6 +220,23 @@ REVOKE DELETE ON movr.public.* FROM max;
 (22 rows)
 ~~~
 
+### Revoke global privileges on the entire cluster
+
+Global level [privileges](security-reference/authorization.html#supported-privileges) live above the database level and apply to the entire cluster.
+
+`root` and [`admin`](security-reference/authorization.html#admin-role) users have global privileges by default, and are capable of revoking it from other users and roles using the `REVOKE` statement.
+
+For example, the following statement removes the ability to use [`SET CLUSTER SETTING`](set-cluster-setting.html) from the user `maxroach`
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+REVOKE SYSTEM MODIFYCLUSTERSETTING FROM maxroach;
+~~~
+
+{{site.data.alerts.callout_info}}
+Global privileges in this context mean "cluster-wide" privileges, and have no relation to the term "global" as used by [multi-region SQL statements](multiregion-overview.html).
+{{site.data.alerts.end}}
+
 ### Revoke privileges on schemas
 
 {% include_cached copy-clipboard.html %}

--- a/v22.2/set-cluster-setting.md
+++ b/v22.2/set-cluster-setting.md
@@ -11,7 +11,14 @@ The `SET CLUSTER SETTING` [statement](sql-statements.html) modifies a [cluster-w
 
 ## Required privileges
 
-Only members of the `admin` role can modify cluster settings. By default, the `root` user belongs to the `admin` role.
+To use the `SET CLUSTER SETTING` statement, a user must have one of the following attributes:
+
+- Be a member of the `admin` role. (By default, the `root` user belongs to the `admin` role.)
+- Have the [`MODIFYCLUSTERSETTING` global privilege](security-reference/authorization.html#modifyclustersetting) granted. `root` and [`admin`](security-reference/authorization.html#admin-role) users have this global privilege by default and are capable of granting it to other users and roles using the [`GRANT`](grant.html) statement. For example to grant this privilege to user `maxroach`:
+
+    ~~~ sql
+    GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;
+    ~~~
 
 ## Synopsis
 

--- a/v22.2/show-default-privileges.md
+++ b/v22.2/show-default-privileges.md
@@ -113,5 +113,6 @@ To show default privileges, the user/role must have any [privilege](security-ref
 ## See also
 
 - [`ALTER DEFAULT PRIVILEGES`](alter-default-privileges.html)
+- [`SHOW ROLES`](show-roles.html)
 - [SQL Statements](sql-statements.html)
 - [Default Privileges](security-reference/authorization.html#default-privileges)


### PR DESCRIPTION
Fixes DOC-4749
Fixes DOC-4597

Summary of changes:

- Add new Global privilege to list of privileges

- Add 'Grant global privileges on the entire cluster' example to `GRANT` docs

- Add 'Revoke global privileges on the entire cluster' example to `REVOKE` docs

- Update the required privileges in the `SET CLUSTER SETTING` docs

- Drive-by add `SHOW ROLES` link to the `SHOW DEFAULT PRIVILEGES` doc