### PR TITLE
Add links from multi-region migration docs

### DIFF
--- a/v22.2/migrate-to-multiregion-sql.md
+++ b/v22.2/migrate-to-multiregion-sql.md
@@ -5,13 +5,13 @@ toc: true
 docs_area: deploy
 ---
 
-This page describes how to migrate a multi-region cluster from using replication zones to using multi-region SQL abstractions.
+This page describes how to migrate a multi-region cluster from using [replication zones](configure-replication-zones.html) to using [multi-region SQL abstractions](multiregion-overview.html).
+
+{{site.data.alerts.callout_success}}
+If you are already using [multi-region SQL statements](multiregion-overview.html) to control your multi-region cluster, see [Scale to Multiple Regions](multiregion-scale-application.html) for instructions showing how to go from one region to multiple regions.
+{{site.data.alerts.end}}
 
 ## Overview
-
-{{site.data.alerts.callout_info}}
-If you are already using [multi-region SQL statements](multiregion-overview.html) to control your multi-region cluster, you can ignore this page.
-{{site.data.alerts.end}}
 
 CockroachDB v21.1 added support for [improved multi-region capabilities that make it easier to run global applications](multiregion-overview.html). Using high-level SQL statements, you can control where your data is stored and how it is accessed to provide good performance and tunable latency for your application's users.
 
@@ -300,6 +300,7 @@ SHOW ZONE CONFIGURATION FROM TABLE promo_codes;
 
 ## See also
 
+- [Scale to Multiple Regions](multiregion-scale-application.html)
 - [Multi-Region Capabilities Overview](multiregion-overview.html)
 - [When to Use `REGIONAL` vs. `GLOBAL` Tables](when-to-use-regional-vs-global-tables.html)
 - [When to Use `ZONE` vs. `REGION` Survival Goals](when-to-use-zone-vs-region-survival-goals.html)


### PR DESCRIPTION
Summary of changes:

- Update note at top of 'Migrate to Multi-Region SQL' to direct users who are already using Multiregion SQL to the page 'Scale to multiple regions', where they can learn how to go from 1 to n regions.

  - This PR was prompted by an internal user report that searching for "cockroachdb migrate from single region to multi-region" in Google was giving them the 'Migrate to Multi-region SQL' page