### PR TITLE
Remove docs for deprecated `EXPERIMENTAL_RELOCATE`

### DIFF
--- a/_includes/releases/v22.1/v22.1.0-alpha.1.md
+++ b/_includes/releases/v22.1/v22.1.0-alpha.1.md
@@ -131,7 +131,7 @@ Release Date: January 24, 2022
 - Previously, the output from [`SHOW CREATE VIEW`](../v22.1/show-create.html#show-the-create-view-statement-for-a-view) returned on a single line. The format has now been improved to be more readable. [#73642][#73642]
 - The output of the [`EXPLAIN`](../v22.1/explain.html) SQL statement has changed. Below the plan, index recommendations are now outputted for the SQL statement in question, if there are any. These index recommendations are indexes the user could add or indexes they could replace to make the given query faster. [#73302][#73302]
 - The [`VOID` type](../v22.1/data-types.html) is now recognized. [#73488][#73488]
-- In the experimental [`RELOCATE`](../v22.1/experimental-features.html#relocate-leases-and-replicas) syntax forms, the positional keyword that indicates that the statement should move non-voter replicas is now spelled `NONVOTERS`, instead of `NON_VOTERS`. [#73803][#73803]
+- In the experimental [`RELOCATE`](../v22.1/experimental-features.html) syntax forms, the positional keyword that indicates that the statement should move non-voter replicas is now spelled `NONVOTERS`, instead of `NON_VOTERS`. [#73803][#73803]
 - The inline help for the `ALTER` statements now mentions the `RELOCATE` syntax. [#73803][#73803]
 - The experimental `ALTER RANGE...RELOCATE` syntax now accepts arbitrary [scalar expressions](../v22.1/scalar-expressions.html) as the source and target store IDs. [#73807][#73807]
 - The output of `EXPLAIN ALTER RANGE ... RELOCATE` now includes the source and target store IDs. [#73807][#73807]

--- a/v22.1/alter-range-relocate.md
+++ b/v22.1/alter-range-relocate.md
@@ -13,10 +13,6 @@ Most users should not need to use this statement; it is for use in emergency sit
 
 {% include {{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
-{{site.data.alerts.callout_info}}
-If you prefer to use a key based approach to relocating replicas and leases, see the experimental [`ALTER TABLE ... EXPERIMENTAL_RELOCATE`](experimental-features.html#relocate-leases-and-replicas) statement.
-{{site.data.alerts.end}}
-
 ## Synopsis
 
 <div>

--- a/v22.1/experimental-features.md
+++ b/v22.1/experimental-features.md
@@ -34,31 +34,6 @@ Log all queries against a table to a file, for security purposes. For more infor
 > ALTER TABLE t EXPERIMENTAL_AUDIT SET READ WRITE;
 ~~~
 
-### Relocate leases and replicas
-
-You have the following options for controlling lease and replica location:
-
-1. Relocate leases and replicas using `EXPERIMENTAL_RELOCATE`
-2. Relocate just leases using `EXPERIMENTAL_RELOCATE LEASE`
-
-For example, to distribute leases and ranges for N primary keys across N stores in the cluster, run a statement with the following structure:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER TABLE t EXPERIMENTAL_RELOCATE SELECT ARRAY[<storeid1>, <storeid2>, ..., <storeidN>], <primarykeycol1>, <primarykeycol2>, ..., <primarykeycolN>;
-~~~
-
-To relocate just the lease without moving the replicas, run a statement like the one shown below, which moves the lease for the range containing primary key 'foo' to store 1.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 'foo';
-~~~
-
-{{site.data.alerts.callout_info}}
-{% include_cached new-in.html version="v22.1" %} If you prefer to use an approach to relocating replicas and leases based on range IDs, see the [`ALTER RANGE ... RELOCATE`](alter-range-relocate.html) statement.
-{{site.data.alerts.end}}
-
 ### Show table fingerprints
 
 Table fingerprints are used to compute an identification string of an entire table, for the purpose of gauging whether two tables have the same data. This is useful, for example, when restoring a table from backup.

--- a/v22.2/alter-range-relocate.md
+++ b/v22.2/alter-range-relocate.md
@@ -13,10 +13,6 @@ Most users should not need to use this statement; it is for use in emergency sit
 
 {% include {{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
-{{site.data.alerts.callout_info}}
-If you prefer to use a key based approach to relocating replicas and leases, see the experimental [`ALTER TABLE ... EXPERIMENTAL_RELOCATE`](experimental-features.html#relocate-leases-and-replicas) statement.
-{{site.data.alerts.end}}
-
 ## Synopsis
 
 <div>

--- a/v22.2/experimental-features.md
+++ b/v22.2/experimental-features.md
@@ -34,31 +34,6 @@ Log all queries against a table to a file, for security purposes. For more infor
 > ALTER TABLE t EXPERIMENTAL_AUDIT SET READ WRITE;
 ~~~
 
-### Relocate leases and replicas
-
-You have the following options for controlling lease and replica location:
-
-1. Relocate leases and replicas using `EXPERIMENTAL_RELOCATE`
-2. Relocate just leases using `EXPERIMENTAL_RELOCATE LEASE`
-
-For example, to distribute leases and ranges for N primary keys across N stores in the cluster, run a statement with the following structure:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER TABLE t EXPERIMENTAL_RELOCATE SELECT ARRAY[<storeid1>, <storeid2>, ..., <storeidN>], <primarykeycol1>, <primarykeycol2>, ..., <primarykeycolN>;
-~~~
-
-To relocate just the lease without moving the replicas, run a statement like the one shown below, which moves the lease for the range containing primary key 'foo' to store 1.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 'foo';
-~~~
-
-{{site.data.alerts.callout_info}}
-If you prefer to use an approach to relocating replicas and leases based on range IDs, see the [`ALTER RANGE ... RELOCATE`](alter-range-relocate.html) statement.
-{{site.data.alerts.end}}
-
 ### Show table fingerprints
 
 Table fingerprints are used to compute an identification string of an entire table, for the purpose of gauging whether two tables have the same data. This is useful, for example, when restoring a table from backup.


### PR DESCRIPTION
In v22.* and greater, users should use `ALTER RANGE ... RELOCATE` to move leases and replicas.

Fixes DOC-5405

Summary of changes:

- Remove mention of `EXPERIMENTAL_RELOCATE` from 'Experimental Features' page

- Remove mention of `EXPERIMENTAL_RELOCATE` as an alternative from the `ALTER RANGE ... RELOCATE` page