### PR TITLE
Properly indent secondary region in examples list

### DIFF
--- a/v22.2/create-database.md
+++ b/v22.2/create-database.md
@@ -165,7 +165,7 @@ Use the following command to specify regions and survival goals at database crea
 (3 rows)
 ~~~
 
-## Create a multi-region database with a secondary region
+### Create a multi-region database with a secondary region
 
 {% include enterprise-feature.md %}
 


### PR DESCRIPTION
Previously, it was using an h2 which was causing it not to nest properly under the *Example* section in the page TOC.

With this change, it's an h3 and does nest properly.