### PR TITLE
[DOC-5483] Document new limitation when upgrading to an alpha version or manual build

### DIFF
--- a/releases/index.md
+++ b/releases/index.md
@@ -17,6 +17,11 @@ After downloading your desired release, learn how to [install CockroachDB](../{{
 The following binaries are not suitable for production environments:
 
 - **Testing** binaries allow you to validate the next major or minor version of CockroachDB while it is in development. A testing release is categorized by its level of maturity, moving from Alpha to Beta to Release Candidate (RC).
+
+  {{site.data.alerts.callout_danger}}
+  In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary of CockroachDB or a binary that was manually built from the `master` branch cannot subsequently be upgraded to a production release.
+  {{site.data.alerts.end}}
+
 - **Experimental** binaries allow you to deploy CockroachDB on architectures that are not yet qualified for production use.
 
 {{ experimental_js_warning }}

--- a/v22.2/upgrade-cockroach-version.md
+++ b/v22.2/upgrade-cockroach-version.md
@@ -31,6 +31,10 @@ There are no "minor releases" of CockroachDB.
 
 ## Step 1. Verify that you can upgrade
 
+{{site.data.alerts.callout_danger}}
+In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary of CockroachDB or a binary that was manually built from the `master` branch cannot subsequently be upgraded to a production release.
+{{site.data.alerts.end}}
+
 Run [`cockroach sql`](cockroach-sql.html) against any node in the cluster to open the SQL shell. Then check your current cluster version:
 
 {% include_cached copy-clipboard.html %}


### PR DESCRIPTION
[DOC-5483]
Relates to https://github.com/cockroachdb/cockroach/pull/86345

## Previews
[releases/index.md](https://deploy-preview-15666--cockroachdb-docs.netlify.app/docs/releases/index.html)
[v22.2/upgrade-cockroach-version.md](https://deploy-preview-15666--cockroachdb-docs.netlify.app/docs/v22.2/upgrade-cockroach-version.html)

## Tests
- [x] Local build
- [x] Linkcheck 