### PR TITLE
Added docs on changes 22.2 to control schedule privileges

### DIFF
--- a/_includes/v22.2/backups/control-schedule-privileges.md
+++ b/_includes/v22.2/backups/control-schedule-privileges.md
@@ -1,0 +1,2 @@
+- Members of the [`admin` role](security-reference/authorization.html#default-roles). By default, the `root` user belongs to the `admin` role.
+- {% include_cached new-in.html version="v22.2" %} Owners of a backup schedule, i.e., the user that [created the backup schedule](create-schedule-for-backup.html).

--- a/v22.2/drop-schedules.md
+++ b/v22.2/drop-schedules.md
@@ -13,7 +13,9 @@ docs_area: reference.sql
 
 ## Required privileges
 
-Only members of the [`admin` role](security-reference/authorization.html#default-roles) can drop a schedule. By default, the `root` user belongs to the `admin` role.
+The following users can drop a schedule:
+
+{% include {{page.version.version}}/backups/control-schedule-privileges.md %}
 
 ## Synopsis
 

--- a/v22.2/pause-schedules.md
+++ b/v22.2/pause-schedules.md
@@ -11,7 +11,9 @@ After pausing a schedule, you can resume it with [`RESUME SCHEDULES`](resume-sch
 
 ## Required privileges
 
-Only members of the [`admin` role](security-reference/authorization.html#default-roles) can pause a schedule. By default, the `root` user belongs to the `admin` role.
+The following users can pause a schedule:
+
+{% include {{page.version.version}}/backups/control-schedule-privileges.md %}
 
 ## Synopsis
 

--- a/v22.2/resume-schedules.md
+++ b/v22.2/resume-schedules.md
@@ -9,7 +9,9 @@ docs_area: reference.sql
 
 ## Required privileges
 
-Only members of the [`admin` role](security-reference/authorization.html#default-roles) can resume a schedule. By default, the `root` user belongs to the `admin` role.
+The following users can resume a schedule:
+
+{% include {{page.version.version}}/backups/control-schedule-privileges.md %}
 
 ## Synopsis
 

--- a/v22.2/show-schedules.md
+++ b/v22.2/show-schedules.md
@@ -11,7 +11,9 @@ It also lists all of the currently active scheduled jobs for [Row-Level TTL](row
 
 ## Required privileges
 
-Only members of the [`admin` role](security-reference/authorization.html#default-roles) can resume a schedule. By default, the `root` user belongs to the `admin` role.
+The following users can show a schedule:
+
+{% include {{page.version.version}}/backups/control-schedule-privileges.md %}
 
 ## Synopsis
 


### PR DESCRIPTION
Fixes DOC-5616

Adjusted the privileges section for pause, drop, resume, show schedule statements so that it lists owners of scheduled backups can use these statements to control schedules.