### PR TITLE
DOC-6228 fix double role options header

### DIFF
--- a/_includes/v22.2/sql/role-options.md
+++ b/_includes/v22.2/sql/role-options.md
@@ -1,5 +1,3 @@
-### Role options
-
 Role option | Description
 ------------|-------------
 `CANCELQUERY`/`NOCANCELQUERY` | Allow or disallow a role to cancel [queries](cancel-query.html) and [sessions](cancel-session.html) of other roles. Without this role option, roles can only cancel their own queries and sessions. Even with the `CANCELQUERY` role option, non-`admin` roles cannot cancel `admin` queries or sessions. This option should usually be combined with `VIEWACTIVITY` so that the role can view other roles' query and session information. <br><br>By default, the role option is set to `NOCANCELQUERY` for all non-`admin` roles.

--- a/v22.2/alter-role.md
+++ b/v22.2/alter-role.md
@@ -35,6 +35,8 @@ Parameter | Description
 `IN DATABASE database_name` | Specify a database for which to apply session variable defaults.<br>When `IN DATABASE` is not specified, the default session variable values apply for a role in all databases.<br>In order for a session to initialize session variable values to database defaults, the database must be specified as a [connection parameter](connection-parameters.html). Database default values will not appear if the database is set after connection with `USE <dbname>`/`SET database=<dbname>`.
 `ROLE ALL ...`/`USER ALL ...` |  Apply session variable settings to all roles.<br>Exception: The `root` user is exempt from session variable settings.
 
+### Role options
+
 {% include {{page.version.version}}/sql/role-options.md %}
 
 ## Examples

--- a/v22.2/alter-user.md
+++ b/v22.2/alter-user.md
@@ -27,6 +27,8 @@ Parameter | Description
 ----------|-------------
 `name` | The name of the user whose password or role options to alter.
 
+### Role options
+
 {% include {{page.version.version}}/sql/role-options.md %}
 
 ## Examples

--- a/v22.2/create-role.md
+++ b/v22.2/create-role.md
@@ -51,6 +51,8 @@ Parameter | Description
 - Cannot start with `pg_` or `crdb_internal`. Object names with these prefixes are reserved for [system catalogs](system-catalogs.html).
 - User and role names share the same namespace and must be unique.
 
+### Role options
+
 {% include {{page.version.version}}/sql/role-options.md %}
 
 ## Examples


### PR DESCRIPTION
Addresses: DOC-6228

- Removed `### Role options` header from include, and ensured it was consistently present in including parent files, thereby removing dupe header on `create-user.md`( [live](https://www.cockroachlabs.com/docs/dev/create-user.html#role-options) | [staging](https://deploy-preview-15669--cockroachdb-docs.netlify.app/docs/dev/create-user.html#role-options) )
- Ensured parent page anchor targets to `#role-options` continue to work as intended.

Staging

[alter-user.md](https://deploy-preview-15669--cockroachdb-docs.netlify.app/docs/dev/alter-user.html#role-options) | [create-role.md](https://deploy-preview-15669--cockroachdb-docs.netlify.app/docs/stable/create-role.html#role-options) | [alter-role.md](https://deploy-preview-15669--cockroachdb-docs.netlify.app/docs/stable/alter-role.html#role-options)