### PR TITLE
[DOC-3269] Remove misleading section, add clarifying details about decommissioning with too few nodes

### DIFF
--- a/v22.1/node-shutdown.md
+++ b/v22.1/node-shutdown.md
@@ -277,9 +277,10 @@ To determine an appropriate termination grace period:
 - Increasing the termination grace period does not increase the duration of a node shutdown. However, the termination grace period should not be excessively long, in case an underlying hardware or software issue causes node shutdown to become "stuck".
 
 <section class="filter-content" markdown="1" data-scope="decommission">
+
 ### Size and replication factor
 
-Before decommissioning a node, make sure other nodes are available to take over the range replicas from the node. If no other nodes are available, the decommissioning process will hang indefinitely.
+Before decommissioning a node, make sure other nodes are available to take over the range replicas from the node. If fewer nodes are available than the replication factor, CockroachDB will automatically reduce the replication factor (for example, from 5 to 3) to try to allow the decommission to succeed. However, the replication factor will not be reduced lower than 3. If three nodes are not available, the decommissioning process will hang indefinitely until nodes are added or you update the zone configurations to use a replication factor of 1.
 
 #### 3-node cluster with 3-way replication
 
@@ -305,19 +306,6 @@ If you decommission a node, the process will run successfully because the cluste
 
 <div style="text-align: center;"><img src="{{ 'images/v22.1/decommission-scenario2.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 
-#### 5-node cluster with 5-way replication for a specific table
-
-In this scenario, a [custom replication zone](configure-replication-zones.html#create-a-replication-zone-for-a-table) has been set to replicate a specific table 5 times (range 6), while all other data is replicated 3 times:
-
-<div style="text-align: center;"><img src="{{ 'images/v22.1/decommission-scenario3.1.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
-
-If you try to decommission a node, the cluster will successfully rebalance all ranges but range 6. Since range 6 requires 5 replicas (based on the table-specific replication zone), and since CockroachDB will not allow more than a single replica of any range on a single node, the decommissioning process will hang indefinitely:
-
-<div style="text-align: center;"><img src="{{ 'images/v22.1/decommission-scenario3.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
-
-To successfully decommission a node in this cluster, you need to **add a 6th node** (or reduce the replication factor on the table). The decommissioning process can then complete:
-
-<div style="text-align: center;"><img src="{{ 'images/v22.1/decommission-scenario3.3.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 </section>
 
 ## Perform node shutdown
@@ -789,7 +777,7 @@ The value of `is_decommissioning` will change back to `false`:
 ~~~
   id | is_live | replicas | is_decommissioning | membership | is_draining
 -----+---------+----------+--------------------+------------+--------------
-   1 |  false  |       73 |       false        |   active   |    true  
+   1 |  false  |       73 |       false        |   active   |    true
 (1 row)
 ~~~
 

--- a/v22.2/node-shutdown.md
+++ b/v22.2/node-shutdown.md
@@ -286,7 +286,7 @@ To determine an appropriate termination grace period:
 
 ### Size and replication factor
 
-Before decommissioning a node, make sure other nodes are available to take over the range replicas from the node. If no other nodes are available, the decommissioning process will hang indefinitely.
+Before decommissioning a node, make sure other nodes are available to take over the range replicas from the node. If fewer nodes are available than the replication factor, CockroachDB will automatically reduce the replication factor (for example, from 5 to 3) to try to allow the decommission to succeed. However, the replication factor will not be reduced lower than 3. If three nodes are not available, the decommissioning process will hang indefinitely until nodes are added or you update the zone configurations to use a replication factor of 1.
 
 #### 3-node cluster with 3-way replication
 
@@ -312,19 +312,6 @@ If you decommission a node, the process will run successfully because the cluste
 
 <div style="text-align: center;"><img src="{{ 'images/v22.2/decommission-scenario2.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 
-#### 5-node cluster with 5-way replication for a specific table
-
-In this scenario, a [custom replication zone](configure-replication-zones.html#create-a-replication-zone-for-a-table) has been set to replicate a specific table 5 times (range 6), while all other data is replicated 3 times:
-
-<div style="text-align: center;"><img src="{{ 'images/v22.2/decommission-scenario3.1.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
-
-If you try to decommission a node, the cluster will successfully rebalance all ranges but range 6. Since range 6 requires 5 replicas (based on the table-specific replication zone), and since CockroachDB will not allow more than a single replica of any range on a single node, the decommissioning process will hang indefinitely:
-
-<div style="text-align: center;"><img src="{{ 'images/v22.2/decommission-scenario3.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
-
-To successfully decommission a node in this cluster, you need to **add a 6th node** (or reduce the replication factor on the table). The decommissioning process can then complete:
-
-<div style="text-align: center;"><img src="{{ 'images/v22.2/decommission-scenario3.3.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 </section>
 
 ## Perform node shutdown


### PR DESCRIPTION
[DOC-3269]

## Previews
[v22.2/node-shutdown.md](https://deploy-preview-15678--cockroachdb-docs.netlify.app/docs/v22.2/node-shutdown.html)
[v22.1/node-shutdown.md](https://deploy-preview-15678--cockroachdb-docs.netlify.app/docs/v22.1/node-shutdown.html)
[v21.2/node-shutdown.md](https://deploy-preview-15678--cockroachdb-docs.netlify.app/docs/v21.2/node-shutdown.html)

## Tests
- [x] Local build
- [x] Linkcheck 