### PR TITLE
DOC-5514 show grants external connection

### DIFF
--- a/v22.2/show-grants.md
+++ b/v22.2/show-grants.md
@@ -9,7 +9,7 @@ docs_area: reference.sql
 The `SHOW GRANTS` [statement](sql-statements.html) lists one of the following:
 
 - The [roles](security-reference/authorization.html#sql-users) granted to [users](security-reference/authorization.html#sql-users) in a cluster.
-- The [privileges](security-reference/authorization.html#managing-privileges) [granted](grant.html) to [users](security-reference/authorization.html#sql-users) on [databases](create-database.html), [user-defined functions](create-function.html), [schemas](create-schema.html), [tables](create-table.html), or [user-defined types](enum.html).
+- The [privileges](security-reference/authorization.html#managing-privileges) [granted](grant.html) to [users](security-reference/authorization.html#sql-users) on [databases](create-database.html), [user-defined functions](create-function.html), [schemas](create-schema.html), [tables](create-table.html), [user-defined types](enum.html), or [external connections](create-external-connection.html).
 
 ## Syntax
 
@@ -18,7 +18,7 @@ The `SHOW GRANTS` [statement](sql-statements.html) lists one of the following:
 Use the following syntax to show the privileges granted to users on database objects:
 
 ~~~
-SHOW GRANTS [ON [DATABASE | FUNCTION | SCHEMA | TABLE | TYPE] <targets...>] [FOR <users...>]
+SHOW GRANTS [ON [DATABASE | FUNCTION | SCHEMA | TABLE | TYPE | EXTERNAL CONNECTION] <targets...>] [FOR <users...>]
 ~~~
 
 When `DATABASE` is omitted, the schema, tables, and types in the [current database](sql-name-resolution.html#current-database) are listed.
@@ -43,7 +43,7 @@ Parameter    | Description
 
 ### Privilege grants
 
-The `SHOW GRANTS ON [DATABASE | FUNCTION | SCHEMA | TABLE | TYPE]` statement can return the following fields, depending on the target object specified:
+The `SHOW GRANTS ON [DATABASE | FUNCTION | SCHEMA | TABLE | TYPE | EXTERNAL CONNECTION]` statement can return the following fields, depending on the target object specified:
 
 Field            | Description
 -----------------|-----------------------------------------------------------------------------------------------------
@@ -52,6 +52,7 @@ Field            | Description
 `schema_name`    | The name of the schema.
 `table_name`     | The name of the table.
 `type_name`      | The name of the user-defined type.
+`name`           | The name of the external connection.
 `grantee`        | The name of the user or role that was granted the [privilege](security-reference/authorization.html#managing-privileges).
 `privilege_type` | The name of the privilege.
 `is_grantable`   | `TRUE` if the grantee has the grant option on the object; `FALSE` if not.
@@ -346,6 +347,43 @@ SHOW GRANTS ON FUNCTION num_users;
 ----------------+-------------+-------------+--------------------+---------+----------------+---------------
   movr          | public      |      100113 | num_users()        | root    | EXECUTE        |      t
 (1 row)
+~~~
+
+### Show all grants on external connections
+
+To show all grants defined on an [external connection](create-external-connection.html), run:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW GRANTS ON EXTERNAL CONNECTION my_backup_bucket;
+~~~
+
+~~~
+  name              |  grantee  | privilege | grantable
+--------------------+-----------+-----------+------------
+  my_backup_bucket  | alice     | DROP      |     t
+  my_backup_bucket  | alice     | USAGE     |     t
+  my_backup_bucket  | max       | DROP      |     f
+  my_backup_bucket  | max       | USAGE     |     f
+  my_backup_bucket  | root      | ALL       |     f
+(5 rows)
+~~~
+
+### Show grants on external connections by user
+
+To show the grants defined on an [external connection](create-external-connection.html) for a specific user, run:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW GRANTS ON EXTERNAL CONNECTION my_backup_bucket FOR alice;
+~~~
+
+~~~
+  name              |  grantee  | privilege | grantable
+--------------------+-----------+-----------+------------
+  my_backup_bucket  | alice     | DROP      |     t
+  my_backup_bucket  | alice     | USAGE     |     t
+(2 rows)
 ~~~
 
 ### Show role memberships


### PR DESCRIPTION
Addresses: DOC-5514

- Added notice of support for `EXTERNAL CONNECTION` grant target to `SHOW GRANTS`, with two examples.

Question:

- Command output returns the following columns: ` name | grantee | privilege | grantable` which differs in 3/4 of these headers from the existing `SHOW GRANTS ON X` output for other grant targets, as listed in [this table](https://deploy-preview-15683--cockroachdb-docs.netlify.app/docs/dev/show-grants.html#privilege-grants). I've listed verbatim output `name` here, retained existing `privilege_type` over this PR's `privilege` and retained existing `is_grantable` over this PR's `grantable`. But probably we need a CRDB issue to match the latter two to existing, and update our `name` to `connection_name` or similar. What do you think?

Staging:

- [show-grants.md](https://deploy-preview-15683--cockroachdb-docs.netlify.app/docs/dev/show-grants.html)