### PR TITLE
Update SQL Feature Support reference docs

### DIFF
--- a/_includes/v22.2/sql/unsupported-postgres-features.md
+++ b/_includes/v22.2/sql/unsupported-postgres-features.md
@@ -12,3 +12,4 @@
 - XA syntax.
 - Creating a database from a template.
 - [Dropping a single partition from a table](partitioning.html#known-limitations).
+- Foreign data wrappers.

--- a/v22.2/data-types.md
+++ b/v22.2/data-types.md
@@ -23,6 +23,7 @@ Type | Description | Example
 [`INET`](inet.html) | An IPv4 or IPv6 address.  | `192.168.0.1`
 [`INT`](int.html) | A signed integer, up to 64 bits. | `12345`
 [`INTERVAL`](interval.html) | A span of time.  | `INTERVAL '2h30m30s'`
+[`NULL`](null-handling.html) | The undefined value. | `NULL`
 [`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data.  | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'`
 [`OID`](oid.html) | An unsigned 32-bit integer. | `4294967295`
 [`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html).  | `148591304110702593`

--- a/v22.2/keywords-and-identifiers.md
+++ b/v22.2/keywords-and-identifiers.md
@@ -47,3 +47,4 @@ To bypass either of these rules, simply surround the identifier with double-quot
 
 - [SQL Statements](sql-statements.html)
 - [Full SQL Grammar](sql-grammar.html)
+- [SQL Name Resolution](sql-name-resolution.html)

--- a/v22.2/sql-feature-support.md
+++ b/v22.2/sql-feature-support.md
@@ -42,6 +42,7 @@ table tr td:nth-child(2) {
  `INTERVAL` | ✓ | Standard | [`INTERVAL` documentation](interval.html)
  `JSON`/`JSONB` | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
  `NULL` | ✓ | Standard | [*NULL*-handling documentation](null-handling.html)
+ `OID` | ✓ | PostgreSQL Extension | [`OID` documentation](oid.html)
  `SERIAL`| ✓ | PostgreSQL Extension | [`SERIAL` documentation](serial.html)
  `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
  `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
@@ -49,7 +50,7 @@ table tr td:nth-child(2) {
  `TIMESTAMP`/`TIMESTAMPTZ` | ✓ | Standard | [`TIMESTAMP` documentation](timestamp.html)
  `UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
  `UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
-  Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers)
+  Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers).  See also [SQL Name Resolution](sql-name-resolution.html).
   Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
   XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
 
@@ -128,9 +129,9 @@ table tr td:nth-child(2) {
  Component | Supported | Type | Details
 -----------|-----------|------|---------
  Common clauses | ✓ | Standard | [SQL Grammar documentation](sql-grammar.html)
- `LIMIT` | ✓ | Common Extension | Limit the number of rows a statement returns.
- `LIMIT` with `OFFSET` | ✓ | Common Extension | Skip a number of rows, and then limit the size of the return set.
- `RETURNING` | ✓ | Common Extension | Retrieve a table of rows statements affect.
+ `LIMIT` | ✓ | Common Extension | Limit the number of rows a statement returns. For more information, see [Limit Query Results](limit-offset.html).
+ `LIMIT` with `OFFSET` | ✓ | Common Extension | Skip a number of rows, and then limit the size of the return set. For more information, see [Limit Query Results](limit-offset.html).
+ `RETURNING` | ✓ | Common Extension | Retrieve a table of rows statements affect. For examples, see the [`INSERT`](insert.html) and [`DELETE`](delete.html) documentation.
 
 ### Table expressions
 
@@ -189,7 +190,7 @@ table tr td:nth-child(2) {
  Window functions | ✓ | Standard | [Window Functions documentation](window-functions.html)
  Common table expressions | Partial | Common Extension | [Common Table Expressions documentation](common-table-expressions.html)
  Stored procedures | ✗ | Common Extension | Execute a procedure explicitly. [GitHub issue tracking stored procedures support](https://github.com/cockroachdb/cockroach/issues/17511).
- Cursors | ✗ | Standard | Traverse a table's rows.
+ Cursors | ✗ | Standard | Traverse a table's rows. To support a cursor-like use case, see the example in [Paginate Results](pagination.html).
  Triggers | ✗ | Standard | Execute a set of commands whenever a specified event occurs. [GitHub issue tracking trigger support](https://github.com/cockroachdb/cockroach/issues/28296).
  Row-level TTL | ✓ | Common Extension | Automatically delete expired rows.  For more information, see [Batch-delete expired data with Row-Level TTL](row-level-ttl.html).
  User-defined functions | Partial | Standard | [User-Defined Functions documentation](user-defined-functions.html)

--- a/v22.2/sql-name-resolution.md
+++ b/v22.2/sql-name-resolution.md
@@ -7,7 +7,7 @@ docs_area: reference.sql
 
 This page documents **name resolution** in CockroachDB.
 
-To reference an object (e.g., a table) in a query, you can specify a database, a schema, both, or neither. To resolve which object a query references, CockroachDB scans the [appropriate namespaces](#naming-hierarchy), following the rules in [How name resolution works](#how-name-resolution-works).
+To reference an object (e.g., a table) in a query, you can specify the [identifier](keywords-and-identifiers.html#identifiers) that refers to a database, a schema, both, or neither. To resolve which object a query references, CockroachDB scans the [appropriate namespaces](#naming-hierarchy), following the rules in [How name resolution works](#how-name-resolution-works).
 
 ## Naming hierarchy
 
@@ -275,3 +275,4 @@ fully qualified name, as follows:
 - [`SHOW DATABASES`](show-databases.html)
 - [`SHOW SCHEMAS`](show-schemas.html)
 - [Information Schema](information-schema.html)
+- [Keywords and Identifiers](keywords-and-identifiers.html)


### PR DESCRIPTION
Fixes DOC-5814
Fixes DOC-2158
Informs closing of old issue DOC-299

Summary of changes:

- In a few cases, we have docs for workarounds to standard SQL features, so I added links

- There were a few things missing from the SQL feature support that were in e.g. the Data Types page, so I added them

- Also updated our PG compat page with the lack of foreign data wrappers

- Took the opportunity to add some linkage between keywords/identifiers and SQL name resolution docs that could be useful, since they are related