### PR TITLE
DOC-2213 added backup descr for prod checklist

### DIFF
--- a/v22.1/recommended-production-settings.md
+++ b/v22.1/recommended-production-settings.md
@@ -312,6 +312,14 @@ For guidance on sizing, validating, and using connection pools with CockroachDB,
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 
+## Backup and restore
+
+CockroachDB is built to be fault-tolerant and to recover automatically, but sometimes disasters happen. Having a [disaster recovery](disaster-recovery.html) plan enables you to recover quickly, while limiting the consequences.
+
+Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling object locking to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
+
+For details about available backup and restore types in CockroachDB, see [Backup and restore types](backup-and-restore-overview.html#backup-and-restore-types).
+
 ## Clock synchronization
 
 {% include {{ page.version.version }}/faq/clock-synchronization-effects.md %}

--- a/v22.1/recommended-production-settings.md
+++ b/v22.1/recommended-production-settings.md
@@ -316,7 +316,7 @@ For guidance on sizing, validating, and using connection pools with CockroachDB,
 
 CockroachDB is built to be fault-tolerant and to recover automatically, but sometimes disasters happen. Having a [disaster recovery](disaster-recovery.html) plan enables you to recover quickly, while limiting the consequences.
 
-Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling object locking to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
+Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling [object locking](use-cloud-storage-for-bulk-operations.html#object-locking) to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
 
 For details about available backup and restore types in CockroachDB, see [Backup and restore types](backup-and-restore-overview.html#backup-and-restore-types).
 

--- a/v22.2/recommended-production-settings.md
+++ b/v22.2/recommended-production-settings.md
@@ -318,7 +318,7 @@ For guidance on sizing, validating, and using connection pools with CockroachDB,
 
 CockroachDB is purpose-built to be fault-tolerant and to recover automatically, but sometimes disasters happen. Having a [disaster recovery](disaster-recovery.html) plan enables you to recover quickly, while limiting the consequences.
 
-Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling object locking to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
+Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling [object locking](use-cloud-storage-for-bulk-operations.html#object-locking) to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
 
 For details about available backup and restore types in CockroachDB, see [Backup and restore types](backup-and-restore-overview.html#backup-and-restore-types).
 

--- a/v22.2/recommended-production-settings.md
+++ b/v22.2/recommended-production-settings.md
@@ -314,6 +314,14 @@ For guidance on sizing, validating, and using connection pools with CockroachDB,
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 
+## Backup and restore
+
+CockroachDB is built to be fault-tolerant and to recover automatically, but sometimes disasters happen. Having a [disaster recovery](disaster-recovery.html) plan enables you to recover quickly, while limiting the consequences.
+
+Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling object locking to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
+
+For details about available backup and restore types in CockroachDB, see [Backup and restore types](backup-and-restore-overview.html#backup-and-restore-types).
+
 ## Clock synchronization
 
 {% include {{ page.version.version }}/faq/clock-synchronization-effects.md %}

--- a/v22.2/recommended-production-settings.md
+++ b/v22.2/recommended-production-settings.md
@@ -316,7 +316,7 @@ For guidance on sizing, validating, and using connection pools with CockroachDB,
 
 ## Backup and restore
 
-CockroachDB is built to be fault-tolerant and to recover automatically, but sometimes disasters happen. Having a [disaster recovery](disaster-recovery.html) plan enables you to recover quickly, while limiting the consequences.
+CockroachDB is purpose-built to be fault-tolerant and to recover automatically, but sometimes disasters happen. Having a [disaster recovery](disaster-recovery.html) plan enables you to recover quickly, while limiting the consequences.
 
 Taking regular backups of your data in production is an operational best practice. You can create [full](take-full-and-incremental-backups.html#full-backups) or [incremental](take-full-and-incremental-backups.html#incremental-backups) backups of a cluster, database, or table. We recommend taking backups to [cloud storage](use-cloud-storage-for-bulk-operations.html) and enabling object locking to protect the validity of your backups. CockroachDB supports Amazon S3, Azure Storage, and Google Cloud Storage for backups.
 


### PR DESCRIPTION
Address DOC-2213, DOC-688
- Added description and links for production purposes

Q's
- Where should the backup section go on the page? Is there a specific order the headings are following for the existing content on the page?
- How detailed should the section be? The page already looks to have a lot of information and the current sections vary in lengths

Staging:
- [Production Settings](https://deploy-preview-15707--cockroachdb-docs.netlify.app/docs/stable/recommended-production-settings.html#backup-and-restore)