### PR TITLE
display filtered content inline

### DIFF
--- a/css/components/_filtertabs.scss
+++ b/css/components/_filtertabs.scss
@@ -262,7 +262,7 @@
 	display: none;
 
 	&.current {
-		display: block;
+		display: inline;
 	}
 }
 

--- a/v21.2/node-shutdown.md
+++ b/v21.2/node-shutdown.md
@@ -124,13 +124,15 @@ Each of the [node shutdown steps](#node-shutdown-sequence) is performed in order
 
 Before you [perform node shutdown](#perform-node-shutdown), review the following prerequisites to graceful shutdown:
 
-- Configure your [load balancer](#load-balancing) to monitor node health.
-- Review and adjust [cluster settings](#cluster-settings) and [drain timeout](#drain-timeout) as needed for your deployment.
-- Implement [connection retry logic](#connection-retry-loop) to handle closed connections.
-- Configure the [termination grace period](#termination-grace-period) of your process manager or orchestration system.
+<ul>
+<li>Configure your <a href="#load-balancing">load balancer</a> to monitor node health.</li>
+<li>Review and adjust <a href="#cluster-settings">cluster settings</a> and <a href="#drain-timeout">drain timeout</a> as needed for your deployment.</li>
+<li>Implement <a href="#connection-retry-loop">connection retry logic</a> to handle closed connections.</li>
+<li>Configure the <a href="#termination-grace-period">termination grace period</a> of your process manager or orchestration system.</li>
 <section class="filter-content" markdown="1" data-scope="decommission">
-- Ensure that the [size and replication factor](#size-and-replication-factor) of your cluster are sufficient to handle decommissioning.
+<li>Ensure that the <a href="#size-and-replication-factor">size and replication factor</a> of your cluster are sufficient to handle decommissioning.</li>
 </section>
+</ul>
 
 ### Load balancing
 

--- a/v22.1/node-shutdown.md
+++ b/v22.1/node-shutdown.md
@@ -126,13 +126,15 @@ Each of the [node shutdown steps](#node-shutdown-sequence) is performed in order
 
 Before you [perform node shutdown](#perform-node-shutdown), review the following prerequisites to graceful shutdown:
 
-- Configure your [load balancer](#load-balancing) to monitor node health.
-- Review and adjust [cluster settings](#cluster-settings) and [drain timeout](#drain-timeout) as needed for your deployment.
-- Implement [connection retry logic](#connection-retry-loop) to handle closed connections.
-- Configure the [termination grace period](#termination-grace-period) of your process manager or orchestration system.
+<ul>
+<li>Configure your <a href="#load-balancing">load balancer</a> to monitor node health.</li>
+<li>Review and adjust <a href="#cluster-settings">cluster settings</a> and <a href="#drain-timeout">drain timeout</a> as needed for your deployment.</li>
+<li>Implement <a href="#connection-retry-loop">connection retry logic</a> to handle closed connections.</li>
+<li>Configure the <a href="#termination-grace-period">termination grace period</a> of your process manager or orchestration system.</li>
 <section class="filter-content" markdown="1" data-scope="decommission">
-- Ensure that the [size and replication factor](#size-and-replication-factor) of your cluster are sufficient to handle decommissioning.
+<li>Ensure that the <a href="#size-and-replication-factor">size and replication factor</a> of your cluster are sufficient to handle decommissioning.</li>
 </section>
+</ul>
 
 ### Load balancing
 

--- a/v22.2/node-shutdown.md
+++ b/v22.2/node-shutdown.md
@@ -125,13 +125,15 @@ Each of the [node shutdown steps](#node-shutdown-sequence) is performed in order
 
 Before you [perform node shutdown](#perform-node-shutdown), review the following prerequisites to graceful shutdown:
 
-- Configure your [load balancer](#load-balancing) to monitor node health.
-- Review and adjust [cluster settings](#cluster-settings) and [drain timeout](#drain-timeout) as needed for your deployment.
-- Implement [connection retry logic](#connection-retry-loop) to handle closed connections.
-- Configure the [termination grace period](#termination-grace-period) of your process manager or orchestration system.
+<ul>
+<li>Configure your <a href="#load-balancing">load balancer</a> to monitor node health.</li>
+<li>Review and adjust <a href="#cluster-settings">cluster settings</a> and <a href="#drain-timeout">drain timeout</a> as needed for your deployment.</li>
+<li>Implement <a href="#connection-retry-loop">connection retry logic</a> to handle closed connections.</li>
+<li>Configure the <a href="#termination-grace-period">termination grace period</a> of your process manager or orchestration system.</li>
 <section class="filter-content" markdown="1" data-scope="decommission">
-- Ensure that the [size and replication factor](#size-and-replication-factor) of your cluster are sufficient to handle decommissioning.
+<li>Ensure that the <a href="#size-and-replication-factor">size and replication factor</a> of your cluster are sufficient to handle decommissioning.</li>
 </section>
+</ul>
 
 ### Load balancing
 


### PR DESCRIPTION
Filtered content does not filter or display correctly when a section block is part of a list (I think I'm the only one who has tried this). In order to filter and display properly, the entire list can be formatted in HTML rather than Markdown. Example:

```
<ul>
<li>blah</li>
<li>blah</li>
<section class="filter-content" markdown="1" data-scope="filter">
<li>filtered blah</li>
</section>
<li>blah</li>
</ul>
```

To avoid inconsistent line spacing, the filtered section needs to display as `inline` rather than `block`. After testing on some existing docs, this CSS change doesn't appear to affect how other filtered content is displayed. I believe it only improves the situation described above. Let me know if I should add any explicit tests to this PR.