### PR TITLE
Update performance benchmarking docs for v22.2

### DIFF
--- a/v21.2/performance.md
+++ b/v21.2/performance.md
@@ -16,7 +16,7 @@ This document is about CockroachDB performance on benchmarks. For guidance on tu
 
 ## Scale
 
-TPC-C provides the most realistic and objective measure for OLTP performance at various scale factors. CockroachDB can process **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%.** As shown in the following chart, this is a 40% improvement over the results from CockroachDB 19.2.
+TPC-C provides the most realistic and objective measure for OLTP performance at various scale factors. During testing, CockroachDB v21.1 processed **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%.** As shown in the following chart, this was a 40% improvement over the results from CockroachDB 19.2.
 
 For a refresher on what exactly TPC-C is and how it is measured, see [Benchmarks used](#benchmarks-used).
 
@@ -31,7 +31,6 @@ CockroachDB achieves this performance in [`SERIALIZABLE` isolation](demo-seriali
 | Efficiency (%)                                  |            98.81 |            95.45 |
 | Max number of rows (billion)                    |             49.8 |             69.7 |
 | Max unreplicated data (TB)                      |                8 |             11.2 |
-| p95 latency for New Order transactions (ms)     |           486.50 |           2684.4 |
 | Number of nodes                                 |               81 |               81 |
 
 ### Linear scaling

--- a/v22.1/performance.md
+++ b/v22.1/performance.md
@@ -16,7 +16,7 @@ This document is about CockroachDB performance on benchmarks. For guidance on tu
 
 ## Scale
 
-TPC-C provides the most realistic and objective measure for OLTP performance at various scale factors. CockroachDB can process **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%.** As shown in the following chart, this is a 40% improvement over the results from CockroachDB 19.2.
+TPC-C provides the most realistic and objective measure for OLTP performance at various scale factors. During testing, CockroachDB v21.1 processed **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%.** As shown in the following chart, this was a 40% improvement over the results from CockroachDB 19.2.
 
 For a refresher on what exactly TPC-C is and how it is measured, see [Benchmarks used](#benchmarks-used).
 
@@ -31,7 +31,6 @@ CockroachDB achieves this performance in [`SERIALIZABLE` isolation](demo-seriali
 | Efficiency (%)                                  |            98.81 |            95.45 |
 | Max number of rows (billion)                    |             49.8 |             69.7 |
 | Max unreplicated data (TB)                      |                8 |             11.2 |
-| p95 latency for New Order transactions (ms)     |           486.50 |           2684.4 |
 | Number of nodes                                 |               81 |               81 |
 
 ### Linear scaling

--- a/v22.2/performance.md
+++ b/v22.2/performance.md
@@ -16,7 +16,7 @@ This document is about CockroachDB performance on benchmarks. For guidance on tu
 
 ## Scale
 
-TPC-C provides the most realistic and objective measure for OLTP performance at various scale factors. CockroachDB can process **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%.** As shown in the following chart, this is a 40% improvement over the results from CockroachDB 19.2.
+TPC-C provides the most realistic and objective measure for OLTP performance at various scale factors. During testing, CockroachDB v21.1 processed **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%.** As shown in the following chart, this was a 40% improvement over the results from CockroachDB 19.2.
 
 For a refresher on what exactly TPC-C is and how it is measured, see [Benchmarks used](#benchmarks-used).
 
@@ -31,7 +31,6 @@ CockroachDB achieves this performance in [`SERIALIZABLE` isolation](demo-seriali
 | Efficiency (%)                                  |            98.81 |            95.45 |
 | Max number of rows (billion)                    |             49.8 |             69.7 |
 | Max unreplicated data (TB)                      |                8 |             11.2 |
-| p95 latency for New Order transactions (ms)     |           486.50 |           2684.4 |
 | Number of nodes                                 |               81 |               81 |
 
 ### Linear scaling


### PR DESCRIPTION
Fixes DOC-5815
Partially addresses DOC-5511

Summary of changes:

- Update performance overview page to:

  - Clarify that the versions under discussion are v21.1 and v19.2

  - Remove the misleading "p95 latency" metric from the chart on that page, which was confusing because it showed a higher value for the "better" result.  More docs are needed around this to explain the nuances (based on the convo in DOC-5511), but at least removing the misleading stuff for now

- Reviewed other pages in the performance benchmarking section and did not find anything else that mentions specific versions of CockroachDB