### PR TITLE
Fix testing-release-notice.md

### DIFF
--- a/_includes/releases/testing-release-notice.md
+++ b/_includes/releases/testing-release-notice.md
@@ -1,4 +1,4 @@
-{% if include.major_version.release_date == "N/A" or include.major_version.release_date > today %}{% comment %} check if a release date has been set or if it's in the future {% endcomment %}
+{% if include.major_version.release_date == "N/A" %}{% comment %} check if a release date has been set {% endcomment %}
 {{site.data.alerts.callout_info}}
 The new features and bug fixes noted on this page are not yet documented across CockroachDB's documentation. Links on this page will direct to documentation for the [latest stable release](../releases/index.html).
 {{site.data.alerts.end}}


### PR DESCRIPTION
This will update the logic so that the testing release notice is suppressed if a release date is passed in, to make the deploy previews appear closer to the final product after a major version release note is published.