### PR TITLE
Add new known limitations for 22.2 / Remove resolved limitations

### DIFF
--- a/_includes/v22.2/known-limitations/old-multi-col-stats.md
+++ b/_includes/v22.2/known-limitations/old-multi-col-stats.md
@@ -1,3 +1,0 @@
-When a column is dropped from a multi-column index, the {% if page.name == "cost-based-optimizer.md" %} optimizer {% else %} [optimizer](cost-based-optimizer.html) {% endif %} will not collect new statistics for the deleted column. However, the optimizer never deletes the old [multi-column statistics](create-statistics.html#create-statistics-on-multiple-columns). This can cause a buildup of statistics in `system.table_statistics` leading the optimizer to use stale statistics, which could result in sub-optimal plans. To workaround this issue and avoid these scenarios, explicitly [delete those statistics](create-statistics.html#delete-statistics) from the `system.table_statistics` table.
-
-    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/_includes/v22.2/known-limitations/single-col-stats-deletion.md
+++ b/_includes/v22.2/known-limitations/single-col-stats-deletion.md
@@ -1,3 +1,0 @@
-[Single-column statistics](create-statistics.html#create-statistics-on-a-single-column) are not deleted when columns are dropped, which could cause minor performance issues.
-
-    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/v22.2/cost-based-optimizer.md
+++ b/v22.2/cost-based-optimizer.md
@@ -410,8 +410,6 @@ If you have an index named `FORCE_ZIGZAG` and use the hint `table@{FORCE_ZIGZAG}
 
 ## Known limitations
 
-* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
-* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
 * {% include {{page.version.version}}/known-limitations/stats-refresh-upgrade.md %}
 
 ## See also

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -50,20 +50,24 @@ Instead, you can use `REVOKE SYSTEM` for the relevant privileges the role has in
 
 ### Limitations for user-defined functions (UDFs)
 
-#### Support for user-defined functions
+#### Limitations on use of UDFs
 
-User-defined functions are not supported in:
+User-defined functions are not currently supported in:
 
 - Expressions (column, index, constraint) in tables.
 - Views.
 - Other user-defined functions.
 - [CDC transformations](https://www.cockroachlabs.com/docs/v22.2/cdc-transformations).
 
-#### Expressions with `*` are not supported in user defined functions
+#### Limitations on expressions allowed within UDFs
 
-Expressions such as `SELECT *` are not currently allowed within the body of a UDF.
+The following are not currently allowed within the body of a UDF:
 
-[Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
+* Subqueries in statements. [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87291)
+* Mutation statements such as `INSERT`, `UPDATE`, `DELETE`, and `UPSERT`. [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87289)
+* Expressions with `*` such as `SELECT *`. [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
+* CTEs (common table expressions). [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92961)
+* Other user-defined functions.
 
 ### Default `range_stuck_threshold` value may cause unwanted changefeed restarts
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -63,11 +63,23 @@ User-defined functions are not currently supported in:
 
 The following are not currently allowed within the body of a UDF:
 
-* Subqueries in statements. [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87291)
-* Mutation statements such as `INSERT`, `UPDATE`, `DELETE`, and `UPSERT`. [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87289)
-* Expressions with `*` such as `SELECT *`. [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
-* CTEs (common table expressions). [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92961)
-* Other user-defined functions.
+- Subqueries in statements.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87291)
+
+- Mutation statements such as `INSERT`, `UPDATE`, `DELETE`, and `UPSERT`.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87289)
+
+- Expressions with `*` such as `SELECT *`.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
+
+- CTEs (common table expressions).
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92961)
+
+- Other user-defined functions.
 
 ### Default `range_stuck_threshold` value may cause unwanted changefeed restarts
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -18,35 +18,19 @@ In its current implementation, this statement does not drop functions. Users mus
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/90476)
 
-{% comment %}
-    initial DROP OWNED BY implementation PR/issue:
-    https://github.com/cockroachdb/cockroach/pull/82936
-    https://github.com/cockroachdb/cockroach/issues/55381
-    doc work in progress (to link to after merge):
-    https://github.com/cockroachdb/docs/pull/15094/files
-    https://cockroachlabs.atlassian.net/browse/DOC-4770 
-    review: rafiss (or devadvocado)
-{% endcomment %}
-
 ### DROP OWNED BY not supported where role has synthetic privileges
 
 `DROP OWNED BY` drops all owned objects as well as any grants on objects not owned by the role.
 
-In its current implentation, this operation cannot be performed for roles that have synthetic privileges (entries in `system.privileges`).
+If the [role](security-reference/authorization.html#roles) for which you are trying to `DROP OWNED BY` was granted a privilege using the [`GRANT SYSTEM ...`](grant.html#grant-global-privileges-on-the-entire-cluster) statement, the error shown below will be signalled. The workaround is to use [`SHOW SYSTEM GRANTS FOR {role}`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-global-privileges-on-the-entire-cluster) for each privilege in the result.
 
-Instead, you can use `REVOKE SYSTEM` for the relevant privileges the role has in `system.privileges`.
+    ~~~
+    ERROR: cannot perform drop owned by if role has synthetic privileges; foo has entries in system.privileges
+    SQLSTATE: 0A000
+    HINT: perform REVOKE SYSTEM ... for the relevant privileges foo has in system.privileges
+    ~~~
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/88149)
-
-{% comment %}
-    initial DROP OWNED BY implementation PR/issue:
-    https://github.com/cockroachdb/cockroach/pull/82936
-    https://github.com/cockroachdb/cockroach/issues/55381
-    doc work in progress (to link to after merge):
-    https://github.com/cockroachdb/docs/pull/15094/files
-    https://cockroachlabs.atlassian.net/browse/DOC-4770 
-    review: rafiss
-{% endcomment %}
 
 ### Limitations for user-defined functions (UDFs)
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -314,12 +314,6 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 {% include {{page.version.version}}/sql/expressions-as-on-conflict-targets.md %}
 
-### Optimizer stale statistics deletion when columns are dropped
-
-- {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
-
-- {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
-
 ### Automatic statistics refresher may not refresh after upgrade
 
 {% include {{page.version.version}}/known-limitations/stats-refresh-upgrade.md %}

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -36,7 +36,7 @@ If the [role](security-reference/authorization.html#roles) for which you are try
 
 #### Limitations on use of UDFs
 
-User-defined functions are not currently supported in:
+[User-defined functions](user-defined-functions.html) are not currently supported in:
 
 - Expressions (column, index, constraint) in tables.
 
@@ -50,11 +50,11 @@ User-defined functions are not currently supported in:
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
 
-{% include {{ page.version.version }}/known-limitations/udf-cdc-transformations.md %}.
+- [CDC transformations](https://www.cockroachlabs.com/docs/v22.2/cdc-transformations).
 
 #### Limitations on expressions allowed within UDFs
 
-The following are not currently allowed within the body of a UDF:
+The following are not currently allowed within the body of a [UDF](user-defined-functions.html):
 
 - Subqueries in statements.
 
@@ -68,7 +68,7 @@ The following are not currently allowed within the body of a UDF:
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
 
-- CTEs (common table expressions).
+- Common table expressions (CTEs).
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92961)
 
@@ -78,7 +78,7 @@ The following are not currently allowed within the body of a UDF:
 
 ### Default `range_stuck_threshold` value may cause unwanted changefeed restarts
 
-The cluster setting `kv.rangefeed.range_stuck_threshold` will automatically restart a rangefeed that appears to be stuck if it does not emit events for some time. Rangefeeds are used to stream per-range changefeed events. This setting was introduced in CockroachDB v22.1.7, disabled by default, but is enabled by default in v22.2.0, set to 1 minute.
+The [cluster setting](cluster-settings.html) `kv.rangefeed.range_stuck_threshold` will automatically restart a rangefeed that appears to be stuck if it does not emit events for some time. Rangefeeds are used to stream per-range changefeed events. This setting was introduced in CockroachDB v22.1.7, disabled by default, but is enabled by default in v22.2.0, set to 1 minute.
 
 This setting can erroneously trigger if the client fails to consume events for the configured duration, for example, in the case of an overloaded changefeed sink. Furthermore, this can cause the entire changefeed to fail and restart with error "context canceled", instead of only restarting the internal per-range rangefeed.
 
@@ -663,11 +663,6 @@ If the execution of a [join](joins.html) query exceeds the limit set for memory-
 ### Remove a `UNIQUE` index created as part of `CREATE TABLE`
 
 {% include {{ page.version.version }}/known-limitations/drop-unique-index-from-create-table.md %}
-
-### User-defined functions
-
-{% include {{ page.version.version }}/known-limitations/udf-cdc-transformations.md %}
-{% include {{ page.version.version }}/known-limitations/udf-limitations.md %}
 
 ### Row-Level TTL limitations
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -50,7 +50,7 @@ User-defined functions are not currently supported in:
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
 
-- [CDC transformations](https://www.cockroachlabs.com/docs/v22.2/cdc-transformations).
+{% include {{ page.version.version }}/known-limitations/udf-cdc-transformations.md %}.
 
 #### Limitations on expressions allowed within UDFs
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -39,8 +39,17 @@ If the [role](security-reference/authorization.html#roles) for which you are try
 User-defined functions are not currently supported in:
 
 - Expressions (column, index, constraint) in tables.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87699)
+
 - Views.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87699)
+
 - Other user-defined functions.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
+
 - [CDC transformations](https://www.cockroachlabs.com/docs/v22.2/cdc-transformations).
 
 #### Limitations on expressions allowed within UDFs
@@ -63,7 +72,9 @@ The following are not currently allowed within the body of a UDF:
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92961)
 
-- Other user-defined functions.
+- References to other user-defined functions.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
 
 ### Default `range_stuck_threshold` value may cause unwanted changefeed restarts
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -10,28 +10,6 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 ## New limitations
 
-### DROP OWNED BY does not support drop functions
-
-`DROP OWNED BY` drops all owned objects as well as any grants on objects not owned by the role.
-
-In its current implementation, this statement does not drop functions. Users must drop their functions manually.
-
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/90476)
-
-### DROP OWNED BY not supported where role has synthetic privileges
-
-`DROP OWNED BY` drops all owned objects as well as any grants on objects not owned by the role.
-
-If the [role](security-reference/authorization.html#roles) for which you are trying to `DROP OWNED BY` was granted a privilege using the [`GRANT SYSTEM ...`](grant.html#grant-global-privileges-on-the-entire-cluster) statement, the error shown below will be signalled. The workaround is to use [`SHOW SYSTEM GRANTS FOR {role}`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-global-privileges-on-the-entire-cluster) for each privilege in the result.
-
-    ~~~
-    ERROR: cannot perform drop owned by if role has synthetic privileges; foo has entries in system.privileges
-    SQLSTATE: 0A000
-    HINT: perform REVOKE SYSTEM ... for the relevant privileges foo has in system.privileges
-    ~~~
-
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/88149)
-
 ### Limitations for user-defined functions (UDFs)
 
 #### Limitations on use of UDFs
@@ -85,6 +63,30 @@ This setting can erroneously trigger if the client fails to consume events for t
 If this is seen to happen, the behavior can be disabled by setting `kv.rangefeed.range_stuck_threshold = '0s'`. A fix is under development, and will be included in an upcoming 22.2 patch release.
 
 [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92570)
+
+### Limitations for DROP OWNED BY
+
+#### DROP OWNED BY does not support drop functions
+
+`DROP OWNED BY` drops all owned objects as well as any grants on objects not owned by the role.
+
+In its current implementation, this statement does not drop functions. Users must drop their functions manually.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/90476)
+
+#### DROP OWNED BY is not supported where role has synthetic privileges
+
+`DROP OWNED BY` drops all owned objects as well as any grants on objects not owned by the role.
+
+If the [role](security-reference/authorization.html#roles) for which you are trying to `DROP OWNED BY` was granted a privilege using the [`GRANT SYSTEM ...`](grant.html#grant-global-privileges-on-the-entire-cluster) statement, the error shown below will be signalled. The workaround is to use [`SHOW SYSTEM GRANTS FOR {role}`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-global-privileges-on-the-entire-cluster) for each privilege in the result.
+
+    ~~~
+    ERROR: cannot perform drop owned by if role has synthetic privileges; foo has entries in system.privileges
+    SQLSTATE: 0A000
+    HINT: perform REVOKE SYSTEM ... for the relevant privileges foo has in system.privileges
+    ~~~
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/88149)
 
 ## Unresolved limitations
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -80,11 +80,11 @@ In its current implementation, this statement does not drop functions. Users mus
 
 If the [role](security-reference/authorization.html#roles) for which you are trying to `DROP OWNED BY` was granted a privilege using the [`GRANT SYSTEM ...`](grant.html#grant-global-privileges-on-the-entire-cluster) statement, the error shown below will be signalled. The workaround is to use [`SHOW SYSTEM GRANTS FOR {role}`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-global-privileges-on-the-entire-cluster) for each privilege in the result.
 
-    ~~~
-    ERROR: cannot perform drop owned by if role has synthetic privileges; foo has entries in system.privileges
-    SQLSTATE: 0A000
-    HINT: perform REVOKE SYSTEM ... for the relevant privileges foo has in system.privileges
-    ~~~
+~~~
+ERROR: cannot perform drop owned by if role has synthetic privileges; foo has entries in system.privileges
+SQLSTATE: 0A000
+HINT: perform REVOKE SYSTEM ... for the relevant privileges foo has in system.privileges
+~~~
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/88149)
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -48,29 +48,22 @@ Instead, you can use `REVOKE SYSTEM` for the relevant privileges the role has in
     review: rafiss
 {% endcomment %}
 
-### Expressions with `*` not supported in user defined functions (UDFs)
+### Limitations for user-defined functions (UDFs)
+
+#### Support for user-defined functions
+
+User-defined functions are not supported in:
+
+- Expressions (column, index, constraint) in tables.
+- Views.
+- Other user-defined functions.
+- [CDC transformations](https://www.cockroachlabs.com/docs/v22.2/cdc-transformations).
+
+#### Expressions with `*` are not supported in user defined functions
 
 Expressions such as `SELECT *` are not currently allowed within the body of a UDF.
 
 [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
-
-{% comment %}
-    review: mgartner
-    see also https://github.com/cockroachdb/cockroach/issues/86070
-    Link to UDF docs?
-{% endcomment %}
-
-### PARTITION ALL BY can lead to poor performance
-
-`PARTITION ALL BY` was added to support multi-region abstractions. In that setting it typically performs well due to locality optimized search. In other cases, unique indexes can result in poor performance because uniqueness validation may need to perform full index scans. Additionally, creating an index does not mean that there will be any acceleration on queries constraining that column.
-
-[Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/83419)
-
-{% comment %}
-    discussion https://cockroachlabs.slack.com/archives/C04U1BTF8/p1656339354201849
-    review: ajwerner
-    notes: can't find this statement in docs or relevant implementation issues
-{% endcomment %}
 
 ### Default `range_stuck_threshold` value may cause unwanted changefeed restarts
 
@@ -80,12 +73,7 @@ This setting can erroneously trigger if the client fails to consume events for t
 
 If this is seen to happen, the behavior can be disabled by setting `kv.rangefeed.range_stuck_threshold = '0s'`. A fix is under development, and will be included in an upcoming 22.2 patch release.
 
-{% comment %}
-    supplied by @erikgrinaker https://cockroachlabs.slack.com/archives/C4A9ALLRL/p1669645971093569
-    asked for issue
-{% endcomment %}
-
-[Tracking GitHub issue](#)
+[Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92570)
 
 ## Unresolved limitations
 

--- a/v22.2/user-defined-functions.md
+++ b/v22.2/user-defined-functions.md
@@ -107,10 +107,47 @@ If you do not specify a schema for the function `add` when you create it, the de
 
 ## Known limitations
 
-User-defined functions are not supported in:
+### Limitations on use of UDFs
 
-{% include {{ page.version.version }}/known-limitations/udf-limitations.md %}
-{% include {{ page.version.version }}/known-limitations/udf-cdc-transformations.md %}
+User-defined functions are not currently supported in:
+
+- Expressions (column, index, constraint) in tables.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87699)
+
+- Views.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87699)
+
+- Other user-defined functions.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
+
+{% include {{ page.version.version }}/known-limitations/udf-cdc-transformations.md %}.
+
+### Limitations on expressions allowed within UDFs
+
+The following are not currently allowed within the body of a UDF:
+
+- Subqueries in statements.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87291)
+
+- Mutation statements such as `INSERT`, `UPDATE`, `DELETE`, and `UPSERT`.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87289)
+
+- Expressions with `*` such as `SELECT *`.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
+
+- CTEs (common table expressions).
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/92961)
+
+- References to other user-defined functions.
+
+    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
 
 ## See also
 

--- a/v22.2/user-defined-functions.md
+++ b/v22.2/user-defined-functions.md
@@ -123,7 +123,7 @@ User-defined functions are not currently supported in:
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/93049)
 
-{% include {{ page.version.version }}/known-limitations/udf-cdc-transformations.md %}.
+- [CDC transformations](https://www.cockroachlabs.com/docs/v22.2/cdc-transformations).
 
 ### Limitations on expressions allowed within UDFs
 


### PR DESCRIPTION
Fixes DOC-5810
Fixes DOC-5811

* Add https://github.com/cockroachdb/cockroach/issues/90476
* Add https://github.com/cockroachdb/cockroach/issues/88149
* Add https://github.com/cockroachdb/cockroach/issues/87699
* Add https://github.com/cockroachdb/cockroach/issues/93049
* Add https://github.com/cockroachdb/cockroach/issues/87291
* Add https://github.com/cockroachdb/cockroach/issues/87289
* Add https://github.com/cockroachdb/cockroach/issues/90080
* Add https://github.com/cockroachdb/cockroach/issues/92961
* Add https://github.com/cockroachdb/cockroach/issues/93049
* Add https://github.com/cockroachdb/cockroach/issues/92570
* Remove https://github.com/cockroachdb/cockroach/issues/67407
  * Delete `_includes/v22.2/known-limitations/old-multi-col-stats.md`
  * Delete `_includes/v22.2/known-limitations/single-col-stats-deletion.md`
  * Remove their references on `v22.2/known-limitations.md` & `v22.2/cost-based-optimizer.md`