### PR TITLE
Added docs for default retryable errors and details for non-retryable errors

### DIFF
--- a/v22.2/changefeed-messages.md
+++ b/v22.2/changefeed-messages.md
@@ -182,7 +182,7 @@ Protected timestamps will protect changefeed data from garbage collection in the
 
 However, if the changefeed lags too far behind, the protected changes could cause data storage issues. To release the protected timestamps and allow garbage collection to resume, you can cancel the changefeed or [resume](resume-job.html) in the case of a paused changefeed. 
 
-We recommend [monitoring](monitor-and-debug-changefeeds.html) storage and the number of running changefeeds. If a changefeed is not advancing and is retrying, it will (without limit) accumulate garbage while it retries to run.
+We recommend [monitoring](monitor-and-debug-changefeeds.html) storage and the number of running changefeeds. If a changefeed is not advancing and is [retrying](monitor-and-debug-changefeeds.html#changefeed-retry-errors), it will (without limit) accumulate garbage while it retries to run.
 
 When `protect_data_from_gc_on_pause` is **unset**, pausing the changefeed will release the existing protected timestamp record. As a result, you could lose the changes if the changefeed remains paused longer than the [garbage collection](configure-replication-zones.html#gc-ttlseconds) window.
 

--- a/v22.2/monitor-and-debug-changefeeds.md
+++ b/v22.2/monitor-and-debug-changefeeds.md
@@ -7,6 +7,21 @@ docs_area: stream_data
 
 Changefeeds work as jobs in CockroachDB, which allows for [monitoring](#monitor-a-changefeed) and [debugging](#debug-a-changefeed) through the [DB Console](ui-overview.html) [**Jobs**](ui-jobs-page.html) page and [`SHOW JOBS`](show-jobs.html) SQL statements using the job ID.
 
+<a name="changefeed-retry-errors"></a>
+
+{% include_cached new-in.html version="v22.2" %} By default, changefeeds treat errors as retryable except for some specific terminal errors that are non-retryable.
+
+- **retryable**: The changefeed will automatically retry whatever caused the error. (You may need to intervene so that the changefeed can resume.)
+- **non-retryable**: The changefeed has encountered a terminal error and fails.
+
+The following define the categories of non-retryable errors:
+
+- When the changefeed cannot verify the target table's schema. For example, the table is offline or there are types within the table that the changefeed cannot handle.
+- The changefeed cannot convert the data to the specified [output format](changefeed-messages.html). For example, there are [Avro](changefeed-messages.html#avro) types that changefeeds do not support, or a [CDC transformation](cdc-transformations.html) is using an unsupported or malformed expression.
+- The terminal error happens as part of established changefeed behavior. For example, you have specified the [`schema_change_policy=stop` option](create-changefeed.html#schema-policy) and a schema change happens.
+
+We recommend monitoring changefeeds to avoid accumulation of garbage after a changefeed encounters an error. See [Garbage collection and changefeeds](changefeed-messages.html#garbage-collection-and-changefeeds) for more detail on how changefeeds interact with protected timestamps and garbage collection. The sections on this page describe the different monitoring and debugging tools for changefeeds.
+
 ## Monitor a changefeed
 
 {{site.data.alerts.callout_info}}

--- a/v22.2/monitor-and-debug-changefeeds.md
+++ b/v22.2/monitor-and-debug-changefeeds.md
@@ -9,7 +9,7 @@ Changefeeds work as jobs in CockroachDB, which allows for [monitoring](#monitor-
 
 <a name="changefeed-retry-errors"></a>
 
-{% include_cached new-in.html version="v22.2" %} By default, changefeeds treat errors as retryable except for some specific terminal errors that are non-retryable.
+{% include_cached new-in.html version="v22.2.1" %} By default, changefeeds treat errors as retryable except for some specific terminal errors that are non-retryable.
 
 - **retryable**: The changefeed will automatically retry whatever caused the error. (You may need to intervene so that the changefeed can resume.)
 - **non-retryable**: The changefeed has encountered a terminal error and fails.


### PR DESCRIPTION
Fixes DOC-1286

Added docs to outline the new default retryable errors in changefeeds. Included descriptions of the kind of non-retryable error users can expect.

This shouldn't be merged until v22.2.1 is released. **NOTE** This is to be added to backward-incompatible changes in the v22.2.1 release notes. [DOC-4610](https://cockroachlabs.atlassian.net/browse/DOC-4610)

## Preview

https://deploy-preview-15723--cockroachdb-docs.netlify.app/docs/dev/monitor-and-debug-changefeeds.html