### PR TITLE
remove DMS and SCT preview status

### DIFF
--- a/cockroachcloud/migrations-page.md
+++ b/cockroachcloud/migrations-page.md
@@ -8,8 +8,6 @@ docs_area: migrate
 
 {% capture version_prefix %}{{site.current_cloud_version}}/{% endcapture %}
 
-{% include feature-phases/preview.md %}
-
 The **Migrations** page on the {{ site.data.products.db }} Console features a **Schema Conversion Tool** that helps you:
 
 - Convert a schema from a PostgreSQL, MySQL, Oracle, or Microsoft SQL Server database for use with CockroachDB.
@@ -33,6 +31,10 @@ The **Schema Conversion Tool** expects to analyze a SQL dump file containing [da
     <button class="filter-button" data-scope="oracle">Oracle</button>
     <button class="filter-button" data-scope="mssql">SQL Server</button>
 </div>
+
+<section class="filter-content" markdown="1" data-scope="mysql oracle mssql">
+{% include feature-phases/preview.md %}
+</section>
 
 <section class="filter-content" markdown="1" data-scope="postgres">
 To generate an appropriate file, run the [`pg_dump` utility](https://www.postgresql.org/docs/current/app-pgdump.html) and specify the `-s` or `--schema-only` options to extract **only the schema** of a PostgreSQL database to a `.sql` file.

--- a/v22.2/aws-dms.md
+++ b/v22.2/aws-dms.md
@@ -9,8 +9,6 @@ This page has instructions for setting up [AWS Database Migration Service (DMS)]
 
 For a detailed tutorial about using AWS DMS and information about specific migration tasks, see the [AWS DMS documentation site](https://docs.aws.amazon.com/dms/latest/userguide/Welcome.html).
 
-{% include feature-phases/preview.md %}
-
 For any issues related to AWS DMS, aside from its interaction with CockroachDB as a migration target, contact [AWS Support](https://aws.amazon.com/contact-us/).
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
- Remove preview label for AWS DMS (v22.2)
- Remove preview label for SCT in PostgreSQL (keeping for MySQL, Oracle, SQL Server)