### PR TITLE
Minor correction for "Runnable goroutines per CPU" threshold on Admission Control page

### DIFF
--- a/v21.2/architecture/admission-control.md
+++ b/v21.2/architecture/admission-control.md
@@ -33,7 +33,7 @@ This is particularly important for {{ site.data.products.serverless }}, where on
 
 If your cluster has degraded performance due to the following types of node overload scenarios, enabling admission control can help:
 
-- The node has more than 50 runnable goroutines per CPU, visible in the **Runnable goroutines per CPU** graph in the [**Overload** dashboard](../ui-overload-dashboard.html#runnable-goroutines-per-cpu).
+- The node has more than 32 runnable goroutines per CPU, visible in the **Runnable goroutines per CPU** graph in the [**Overload** dashboard](../ui-overload-dashboard.html#runnable-goroutines-per-cpu).
 - The node has a high number of files in level 0 of the Pebble LSM tree, visible in the **LSM L0 Health** graph in the [**Overload** dashboard](../ui-overload-dashboard.html#lsm-l0-health).
 - The node has high CPU usage, visible in the **CPU percent** graph in the [**Overload** dashboard](../ui-overload-dashboard.html#cpu-percent).
 - The node is experiencing out-of-memory errors, visible in the **Memory Usage** graph in the [**Hardware** dashboard](../ui-hardware-dashboard.html#memory-usage). Even though admission control does not explicitly target controlling memory usage, it can reduce memory usage as a side effect of delaying the start of operation execution when the CPU is overloaded.

--- a/v22.1/admission-control.md
+++ b/v22.1/admission-control.md
@@ -19,7 +19,7 @@ This is particularly important for {{ site.data.products.serverless }}, where on
 
 Admission control can help if your cluster has degraded performance due to the following types of node overload scenarios:
 
-- The node has more than 50 runnable goroutines per CPU, visible in the **Runnable goroutines per CPU** graph in the [**Overload** dashboard](ui-overload-dashboard.html#runnable-goroutines-per-cpu).
+- The node has more than 32 runnable goroutines per CPU, visible in the **Runnable goroutines per CPU** graph in the [**Overload** dashboard](ui-overload-dashboard.html#runnable-goroutines-per-cpu).
 - The node has a high number of files in level 0 of the Pebble LSM tree, visible in the **LSM L0 Health** graph in the [**Overload** dashboard](ui-overload-dashboard.html#lsm-l0-health).
 - The node has high CPU usage, visible in the **CPU percent** graph in the [**Overload** dashboard](ui-overload-dashboard.html#cpu-percent).
 - The node is experiencing out-of-memory errors, visible in the **Memory Usage** graph in the [**Hardware** dashboard](ui-hardware-dashboard.html#memory-usage). Even though admission control does not explicitly target controlling memory usage, it can reduce memory usage as a side effect of delaying the start of operation execution when the CPU is overloaded.

--- a/v22.2/admission-control.md
+++ b/v22.2/admission-control.md
@@ -19,7 +19,7 @@ This is particularly important for {{ site.data.products.serverless }}, where on
 
 Admission control can help if your cluster has degraded performance due to the following types of node overload scenarios:
 
-- The node has more than 50 runnable goroutines per CPU, visible in the **Runnable goroutines per CPU** graph in the [**Overload** dashboard](ui-overload-dashboard.html#runnable-goroutines-per-cpu).
+- The node has more than 32 runnable goroutines per CPU, visible in the **Runnable goroutines per CPU** graph in the [**Overload** dashboard](ui-overload-dashboard.html#runnable-goroutines-per-cpu).
 - The node has a high number of files in level 0 of the Pebble LSM tree, visible in the **LSM L0 Health** graph in the [**Overload** dashboard](ui-overload-dashboard.html#lsm-l0-health).
 - The node has high CPU usage, visible in the **CPU percent** graph in the [**Overload** dashboard](ui-overload-dashboard.html#cpu-percent).
 - The node is experiencing out-of-memory errors, visible in the **Memory Usage** graph in the [**Hardware** dashboard](ui-hardware-dashboard.html#memory-usage). Even though admission control does not explicitly target controlling memory usage, it can reduce memory usage as a side effect of delaying the start of operation execution when the CPU is overloaded.


### PR DESCRIPTION
This threshold is incorrect, it's 32 (by default). See: 

https://github.com/cockroachdb/cockroach/blob/af9c69c17232cccfb19452956045da23ea18e5ad/pkg/util/admission/kv_slot_adjuster.go#L21-L29