### PR TITLE
DOC-6247 invalid_lease metrics

### DIFF
--- a/_includes/v22.1/metric-names.md
+++ b/_includes/v22.1/metric-names.md
@@ -151,6 +151,7 @@ Name | Help
 `replicas.commandqueue.maxsize` | Largest number of commands in any CommandQueue
 `replicas.commandqueue.maxtreesize` | Largest number of intervals in any CommandQueue's interval tree
 `replicas.commandqueue.maxwritecount` | Largest number of read-write commands in any CommandQueue
+`replicas.leaders_invalid_lease` | Number of replicas that are Raft leaders whose lease is invalid
 `replicas.leaders_not_leaseholders` | Number of replicas that are Raft leaders whose range lease is held by another store
 `replicas.leaders` | Number of Raft leaders
 `replicas.leaseholders` | Number of lease holders

--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -186,6 +186,7 @@ Name | Help
 `replicas.commandqueue.maxsize` | Largest number of commands in any CommandQueue
 `replicas.commandqueue.maxtreesize` | Largest number of intervals in any CommandQueue's interval tree
 `replicas.commandqueue.maxwritecount` | Largest number of read-write commands in any CommandQueue
+`replicas.leaders_invalid_lease` | Number of replicas that are Raft leaders whose lease is invalid
 `replicas.leaders_not_leaseholders` | Number of replicas that are Raft leaders whose range lease is held by another store
 `replicas.leaders` | Number of Raft leaders
 `replicas.leaseholders` | Number of lease holders


### PR DESCRIPTION
Addresses: DOC-6247, DOC-6248, DOC-6119
- Added new `replicas.leaders_invalid_lease` metric, for both v22.2 and v22.1 (which will also appear in future v23.1 per DOC-6119).

Staging

[v22.2/metric-names.md](https://deploy-preview-15785--cockroachdb-docs.netlify.app/docs/stable/ui-custom-chart-debug-page.html#available-metrics) | [v22.1/metric-names.md](https://deploy-preview-15785--cockroachdb-docs.netlify.app/docs/v22.1/ui-custom-chart-debug-page#available-metrics)