### PR TITLE
Added docs for the Azure cluster setting for additional buffers

### DIFF
--- a/v22.1/backup.md
+++ b/v22.1/backup.md
@@ -140,7 +140,16 @@ This improves performance by decreasing the likelihood that the `BACKUP` will be
 
 {% include_cached new-in.html version="v22.1" %} A backup job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the backup has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
 
-{% include {{ page.version.version }}/backups/file-size-setting.md %}
+### Backup performance configuration
+
+Cluster settings provide a means to tune a CockroachDB cluster. The following cluster settings are helpful for configuring backup files and performance:
+
+Setting    | Description
+-----------+-----------------
+`bulkio.backup.file_size` | Set a target for the amount of backup data written to each backup file.<br><br>**Default:** `128 MiB`
+`cloudstorage.azure.concurrent_upload_buffers` | Improve the speed of backups to Azure Storage by increasing `cloudstorage.azure.concurrent_upload_buffers` to `3`. This setting configures the number of concurrent buffers that are used during file uploads to Azure Storage. It is important to note that the higher this setting the more data that is held in memory, which can increase the risk of OOMs if there is not sufficient memory on each node.<br><br>**Default:** `1`
+
+For a complete list, including all cluster settings related to backups, see the [Cluster Settings](cluster-settings.html) page.
 
 ## Viewing and controlling backups jobs
 

--- a/v22.2/backup.md
+++ b/v22.2/backup.md
@@ -150,7 +150,16 @@ This improves performance by decreasing the likelihood that the `BACKUP` will be
 
 A backup job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the backup has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
 
-{% include {{ page.version.version }}/backups/file-size-setting.md %}
+### Backup performance configuration
+
+Cluster settings provide a means to tune a CockroachDB cluster. The following cluster settings are helpful for configuring backup files and performance:
+
+Setting    | Description
+-----------+-----------------
+`bulkio.backup.file_size` | Set a target for the amount of backup data written to each backup file.<br><br>**Default:** `128 MiB`
+`cloudstorage.azure.concurrent_upload_buffers` | Improve the speed of backups to Azure Storage by increasing `cloudstorage.azure.concurrent_upload_buffers` to `3`. This setting configures the number of concurrent buffers that are used during file uploads to Azure Storage. It is important to note that the higher this setting the more data that is held in memory, which can increase the risk of OOMs if there is not sufficient memory on each node.<br><br>**Default:** `1`
+
+For a complete list, including all cluster settings related to backups, see the [Cluster Settings](cluster-settings.html) page.
 
 ## Viewing and controlling backups jobs
 


### PR DESCRIPTION
Fixes [DOC-6005](https://cockroachlabs.atlassian.net/browse/DOC-6005), [DOC-6015](https://cockroachlabs.atlassian.net/browse/DOC-6015), [DOC-6026](https://cockroachlabs.atlassian.net/browse/DOC-6026), [DOC-6003](https://cockroachlabs.atlassian.net/browse/DOC-6003)

Added docs in the Performance section of the `BACKUP` docs for the Azure buffer cluster setting.

Introduced a new subsection in Performance related to the two cluster settings we already had called out. 

(Future work to consider Performance its own page and build out the backup-related settings here with further descriptions/tuning information over what the Cluster Settings page holds. Audit settings for backups on cluster page, consider something along the lines of: https://www.cockroachlabs.com/docs/stable/advanced-changefeed-configuration.html for backups)

