### PR TITLE
Update SELECT FOR UPDATE re: serialization errors

### DIFF
--- a/_includes/v22.2/sql/select-for-update-overview.md
+++ b/_includes/v22.2/sql/select-for-update-overview.md
@@ -6,6 +6,8 @@ Because this queueing happens during the read operation, the [thrashing](https:/
 
 As a result, using `SELECT FOR UPDATE` leads to increased throughput and decreased tail latency for contended operations.
 
+Note that using `SELECT FOR UPDATE` does not completely eliminate the chance of [serialization errors](transaction-retry-error-reference.html), which use the `SQLSTATE` error code `40001`, and emit error messages with the string `restart transaction`. These errors can also arise due to [time uncertainty](architecture/transaction-layer.html#transaction-conflicts). To eliminate the need for application-level retry logic, in addition to `SELECT FOR UPDATE` your application also needs to use a [driver that implements automatic retry handling](transactions.html#client-side-intervention).
+
 CockroachDB does not support the `FOR SHARE` or `FOR KEY SHARE` [locking strengths](select-for-update.html#locking-strengths).
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
Fixes DOC-6257

Summary of changes:

- Add a paragraph to the "SELECT FOR UPDATE" overview that notes that the locking provided by SFU does not guarantee ordering in *all* cases and can result in serializable errors (40001)

  - We also make sure the magic "retry error" strings appear for searchability: specifically, `40001` and `restart transaction`.

- h/t @kai-niemi for the language here, which is adapted from his work in an internal design document (hence no link, otherwise we would add it)