### PR TITLE
DOC-6405 standardize sys priv language - Rich's PRs

### DIFF
--- a/_includes/releases/v22.2/v22.2.0-alpha.1.md
+++ b/_includes/releases/v22.2/v22.2.0-alpha.1.md
@@ -94,7 +94,7 @@ Release Date: August 30, 2022
 - [`COPY ... FROM CSV HEADER`](../v22.2/copy-from.html) is now supported. [#82457][#82457]
 - Added `rowCount` to TTL job progress. [#81917][#81917]
 - Added logic for `GRANT ... ON` sequence names. [#82458][#82458]
-- Introduced `GLOBAL` privileges, which live above the database level. Example: `GRANT SYSTEM MODIFYCLUSTERSETTING TO foo`. Currently `MODIFYCLUSTERSETTING` is the only global privilege, it allows users to query the [`crdb_internal.cluster_settings`](../v22.2/crdb-internal.html) table. [#82166][#82166]
+- Introduced [system-level privileges](../v22.2/security-reference/authorization.html#system-level-privileges), which apply cluster-wide. Example: `GRANT SYSTEM MODIFYCLUSTERSETTING TO foo`. Currently `MODIFYCLUSTERSETTING` is the only system-level privilege, it allows users to query the [`crdb_internal.cluster_settings`](../v22.2/crdb-internal.html) table. [#82166][#82166]
 - Added a `cluster.preserve-downgrade-option.last-updated` metric that reports the Unix timestamp of the last updated time of the `cluster.preserve_downgrade_option` setting. This metric is now also emitted to Prometheus, and used to display a banner to the DB Console if `cluster.preserve_downgrade_option` has been set for greater than 48 hours. This change provides increased observability into upgrade finalization. [#82633][#82633]
 - Added support for `DROP OWNED BY`. [#82936][#82936]
 - Created two invariants for the `stream_ingestion_stats` built-in, for protobuf and JSON respectively, and extended them to return more details. [#83066][#83066]
@@ -189,7 +189,7 @@ Release Date: August 30, 2022
     - `RESTORE` will verify that all data can be read and rekeyed to the restoring cluster
     - `RESTORE` will verify that all data passes a checksum check [#86136][#86136]
 - The [`CREATE EXTERNAL CONNECTION`](../v22.2/create-external-connection.html) statement can be used to represent an `aws-kms` scheme that represents an Amazon S3 KMS resource. [#86402][#86402]
-- `DROP OWNED BY` can no longer be performed if the user has synthetic privileges (in `system.privileges`). [#86619][#86619]
+- `DROP OWNED BY` can no longer be performed if the user has [system-level privileges](../v22.2/security-reference/authorization.html#system-level-privileges) defined (in `system.privileges`). [#86619][#86619]
 - Added support for `DISCARD SEQUENCES`, which discards all sequence-related state data such as `currval`/`lastval`. `DISCARD ALL` now also discards sequence-related state. [#86230][#86230]
 - [`EXPLAIN ANALYZE`](../v22.2/explain-analyze.html) output now contains a warning when the estimated row count for scans is inaccurate and includes a hint to collect the table statistics manually. [#86677][#86677]
 - The new `sql.stats.response.show_internal` [cluster setting](../v22.2/cluster-settings.html) can be used to display information about internal stats on the SQL Activity page, with the `fingerprint` option. The setting defaults to `false`. [#86679][#86679]

--- a/_includes/v22.2/known-limitations/drop-owned-by-role-limitations.md
+++ b/_includes/v22.2/known-limitations/drop-owned-by-role-limitations.md
@@ -1,7 +1,9 @@
-- If the [role](security-reference/authorization.html#roles) for which you are trying to `DROP OWNED BY` was granted a privilege using the [`GRANT SYSTEM ...`](grant.html#grant-global-privileges-on-the-entire-cluster) statement, the error shown below will be signalled.  The workaround is to use [`SHOW SYSTEM GRANTS FOR {role}`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-global-privileges-on-the-entire-cluster) for each privilege in the result. For more information about this known limitation, see [cockroachdb/cockroach#88149](https://github.com/cockroachdb/cockroach/issues/88149).
+- If the [role](security-reference/authorization.html#roles) for which you are trying to `DROP OWNED BY` was granted a [system-level privilege](security-reference/authorization.html#system-level-privileges) (i.e., using the [`GRANT SYSTEM ...`](grant.html#grant-system-level-privileges-on-the-entire-cluster) statement), the error shown below will be signalled.  The workaround is to use [`SHOW SYSTEM GRANTS FOR {role}`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-system-level-privileges-on-the-entire-cluster) for each privilege in the result. For more information about this known limitation, see [cockroachdb/cockroach#88149](https://github.com/cockroachdb/cockroach/issues/88149).
 
     ~~~
     ERROR: cannot perform drop owned by if role has synthetic privileges; foo has entries in system.privileges
     SQLSTATE: 0A000
     HINT: perform REVOKE SYSTEM ... for the relevant privileges foo has in system.privileges
     ~~~
+
+Note that the phrase "synthetic privileges" in the above error message refers to [system-level privileges](security-reference/authorization.html#system-level-privileges).

--- a/_includes/v22.2/sql/privileges.md
+++ b/_includes/v22.2/sql/privileges.md
@@ -16,4 +16,4 @@ Privilege | Levels
 `BACKUP` | System, Database, Table
 `RESTORE` | System, Database
 `EXTERNALIOIMPLICITACCESS` | System
-`MODIFYCLUSTERSETTING` | <a name="modifyclustersetting"></a> {% if page.name == "authorization.md" %} [Global privilege](../grant.html#grant-global-privileges-on-the-entire-cluster) that allows users to use the [`SET CLUSTER SETTING`](../set-cluster-setting.html) statement. {% else %} [Global privilege](grant.html#grant-global-privileges-on-the-entire-cluster) that allows users to use the [`SET CLUSTER SETTING`](set-cluster-setting.html) statement. {% endif %}
+`MODIFYCLUSTERSETTING` | System

--- a/v22.2/drop-owned-by.md
+++ b/v22.2/drop-owned-by.md
@@ -13,7 +13,7 @@ The `DROP OWNED BY` [statement](sql-statements.html) drops all objects owned by 
 
 The [role](security-reference/authorization.html#roles) must have the `DROP` [privilege](security-reference/authorization.html#managing-privileges) on the specified objects.
 
-`DROP OWNED BY` will result in an error if the user was granted a privilege using the [`GRANT SYSTEM ...`](grant.html#grant-global-privileges-on-the-entire-cluster) command. To work around this, use [`SHOW SYSTEM GRANTS FOR <role>`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-global-privileges-on-the-entire-cluster) for each privilege in the result.
+`DROP OWNED BY` will result in an error if the user was granted a [system-level privilege](security-reference/authorization.html#system-level-privileges) (i.e., using the [`GRANT SYSTEM ...`](grant.html#grant-system-level-privileges-on-the-entire-cluster) statement). To work around this, use [`SHOW SYSTEM GRANTS FOR <role>`](show-system-grants.html) and then use [`REVOKE SYSTEM ...`](revoke.html#revoke-system-level-privileges-on-the-entire-cluster) for each system-level privilege in the result.
 
 ## Synopsis
 

--- a/v22.2/grant.md
+++ b/v22.2/grant.md
@@ -166,22 +166,18 @@ SHOW GRANTS ON TABLE movr.public.*;
 (24 rows)
 ~~~
 
-### Grant global privileges on the entire cluster
+### Grant system-level privileges on the entire cluster
 
-Global level [privileges](security-reference/authorization.html#supported-privileges) live above the database level and apply to the entire cluster.
+[System-level privileges](security-reference/authorization.html#system-level-privileges) live above the database level and apply to the entire cluster.
 
-`root` and [`admin`](security-reference/authorization.html#admin-role) users have global privileges by default, and are capable of granting it to other users and roles using the `GRANT` statement.
+`root` and [`admin`](security-reference/authorization.html#admin-role) users have system-level privileges by default, and are capable of granting it to other users and roles using the `GRANT` statement.
 
-For example, the following statement allows the user `maxroach` to use [`SET CLUSTER SETTING`](set-cluster-setting.html):
+For example, the following statement allows the user `maxroach` to use the [`SET CLUSTER SETTING`](set-cluster-setting.html) statement by assigning the `MODIFYCLUSTERSETTING` system privilege:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;
 ~~~
-
-{{site.data.alerts.callout_info}}
-Global privileges in this context mean "cluster-wide" privileges, and have no relation to the term "global" as used by [multi-region SQL statements](multiregion-overview.html).
-{{site.data.alerts.end}}
 
 ### Make a table readable to every user in the system
 

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -72,7 +72,7 @@ If this is seen to happen, the behavior can be disabled by setting `kv.rangefeed
 
 {% include {{page.version.version}}/known-limitations/drop-owned-by-function-limitations.md %}
 
-#### `DROP OWNED BY` is not supported where role has synthetic privileges
+#### `DROP OWNED BY` is not supported where role has system-level privileges
 
 {% include {{page.version.version}}/known-limitations/drop-owned-by-role-limitations.md %}
 

--- a/v22.2/revoke.md
+++ b/v22.2/revoke.md
@@ -220,22 +220,18 @@ REVOKE DELETE ON movr.public.* FROM max;
 (22 rows)
 ~~~
 
-### Revoke global privileges on the entire cluster
+### Revoke system-level privileges on the entire cluster
 
-Global level [privileges](security-reference/authorization.html#supported-privileges) live above the database level and apply to the entire cluster.
+[System-level privileges](security-reference/authorization.html#system-level-privileges) live above the database level and apply to the entire cluster.
 
-`root` and [`admin`](security-reference/authorization.html#admin-role) users have global privileges by default, and are capable of revoking it from other users and roles using the `REVOKE` statement.
+`root` and [`admin`](security-reference/authorization.html#admin-role) users have system-level privileges by default, and are capable of revoking it from other users and roles using the `REVOKE` statement.
 
-For example, the following statement removes the ability to use [`SET CLUSTER SETTING`](set-cluster-setting.html) from the user `maxroach`
+For example, the following statement removes the ability to use the [`SET CLUSTER SETTING`](set-cluster-setting.html) statement from the user `maxroach` by revoking the `MODIFYCLUSTERSETTING` system privilege:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 REVOKE SYSTEM MODIFYCLUSTERSETTING FROM maxroach;
 ~~~
-
-{{site.data.alerts.callout_info}}
-Global privileges in this context mean "cluster-wide" privileges, and have no relation to the term "global" as used by [multi-region SQL statements](multiregion-overview.html).
-{{site.data.alerts.end}}
 
 ### Revoke privileges on schemas
 

--- a/v22.2/set-cluster-setting.md
+++ b/v22.2/set-cluster-setting.md
@@ -14,7 +14,7 @@ The `SET CLUSTER SETTING` [statement](sql-statements.html) modifies a [cluster-w
 To use the `SET CLUSTER SETTING` statement, a user must have one of the following attributes:
 
 - Be a member of the `admin` role. (By default, the `root` user belongs to the `admin` role.)
-- Have the [`MODIFYCLUSTERSETTING` global privilege](security-reference/authorization.html#modifyclustersetting) granted. `root` and [`admin`](security-reference/authorization.html#admin-role) users have this global privilege by default and are capable of granting it to other users and roles using the [`GRANT`](grant.html) statement. For example to grant this privilege to user `maxroach`:
+- Have the `MODIFYCLUSTERSETTING` [system-level privilege](security-reference/authorization.html#system-level-privileges) granted. `root` and [`admin`](security-reference/authorization.html#admin-role) users have this system-level privilege by default and are capable of granting it to other users and roles using the [`GRANT`](grant.html) statement. For example to grant this system-level privilege to user `maxroach`:
 
     ~~~ sql
     GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;


### PR DESCRIPTION
Addresses: DOC-6405

- Standardized language around v22.2's RBAC feature: system-level privileges.
	- This is just for Rich's PRs -- those organically his and those inherited from others (See https://github.com/cockroachdb/docs/pull/15826 for Kathryn's side of things). Essentially:
		- `MODIFYCLUSTERSETTING`
		- `GRANT`
		- `REVOKE`
		- `DROP OWNED BY`
	- Standardized linking to new [central resource](https://www.cockroachlabs.com/docs/stable/security-reference/authorization.html#system-level-privileges).

Staging (selected):

[v22.2.md](https://deploy-preview-15824--cockroachdb-docs.netlify.app/docs/releases/v22.2.html) | [drop-owned-by.md](https://deploy-preview-15824--cockroachdb-docs.netlify.app/docs/stable/drop-owned-by.html#required-privileges) | [grant.md](https://deploy-preview-15824--cockroachdb-docs.netlify.app/docs/stable/grant.html#grant-system-level-privileges-on-the-entire-cluster) | [revoke.md](https://deploy-preview-15824--cockroachdb-docs.netlify.app/docs/stable/revoke.html#revoke-system-level-privileges-on-the-entire-cluster) | [set-cluster-setting.md](https://deploy-preview-15824--cockroachdb-docs.netlify.app/docs/stable/set-cluster-setting.html#required-privileges)