### PR TITLE
DROP INDEX behavior in hash-sharded indexes

### DIFF
--- a/v21.2/hash-sharded-indexes.md
+++ b/v21.2/hash-sharded-indexes.md
@@ -13,6 +13,14 @@ If you are working with a table that must be indexed on sequential keys, you sho
 
 CockroachDB automatically splits ranges of data in [the key-value store](architecture/storage-layer.html) based on [the size of the range](architecture/distribution-layer.html#range-splits), and on [the load streaming to the range](load-based-splitting.html). To split a range based on load, the system looks for a point in the range that evenly divides incoming traffic. If the range is indexed on a column of data that is sequential in nature (e.g., [an ordered sequence](sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid), or a series of increasing, non-repeating [`TIMESTAMP`s](timestamp.html)), then all incoming writes to the range will be the last (or first) item in the index and appended to the end of the range. As a result, the system cannot find a point in the range that evenly divides the traffic, and the range cannot benefit from load-based splitting, creating a [hot spot](performance-best-practices-overview.html#hot-spots) at the single range.
 
+Hash-sharded indexes solve this problem by distributing sequential data across multiple nodes within your cluster, eliminating hotspots. The trade-off to this, however, is a small performance impact on reading sequential data or ranges of data, as it's not guaranteed that sequentially close values will be on the same node.
+
+Hash-sharded indexes create a physical `STORED` [computed column](computed-columns.html), known as a shard column. CockroachDB uses this shard column, as opposed to the sequential column in the index, to control the distribution of values across the index. The shard column is hidden by default but can be seen with [`SHOW COLUMNS`](show-columns.html). 
+
+{{site.data.alerts.callout_danger}}
+When dropping a hash-sharded index, the shard column will also be dropped. This will require a rewrite of the table.
+{{site.data.alerts.end}}
+
 For details about the mechanics and performance improvements of hash-sharded indexes in CockroachDB, see our [Hash Sharded Indexes Unlock Linear Scaling for Sequential Workloads](https://www.cockroachlabs.com/blog/hash-sharded-indexes-unlock-linear-scaling-for-sequential-workloads/) blog post.
 
 ## Create a hash-sharded index

--- a/v22.1/hash-sharded-indexes.md
+++ b/v22.1/hash-sharded-indexes.md
@@ -21,6 +21,10 @@ Hash-sharded indexes solve this problem by distributing sequential data across m
 
 Hash-sharded indexes contain a [virtual computed column](computed-columns.html#virtual-computed-columns), known as a shard column. CockroachDB uses this shard column, as opposed to the sequential column in the index, to control the distribution of values across the index. The shard column is hidden by default but can be seen with [`SHOW COLUMNS`](show-columns.html).
 
+{{site.data.alerts.callout_danger}}
+In v21.2 and earlier, hash-sharded indexes create a physical `STORED` [computed column](computed-columns.html) instead of a virtual computed column. If you are using a hash-sharded index that was created in v21.2 or earlier, the `STORED` column still exists in your database. When dropping a hash-sharded index that has created a physical shard column, the shard column will also be dropped. This will require a rewrite of the table.
+{{site.data.alerts.end}}
+
 For details about the mechanics and performance improvements of hash-sharded indexes in CockroachDB, see our [Hash Sharded Indexes Unlock Linear Scaling for Sequential Workloads](https://www.cockroachlabs.com/blog/hash-sharded-indexes-unlock-linear-scaling-for-sequential-workloads/) blog post.
 
 {{site.data.alerts.callout_info}}

--- a/v22.2/hash-sharded-indexes.md
+++ b/v22.2/hash-sharded-indexes.md
@@ -21,6 +21,10 @@ Hash-sharded indexes solve this problem by distributing sequential data across m
 
 Hash-sharded indexes contain a [virtual computed column](computed-columns.html#virtual-computed-columns), known as a shard column. CockroachDB uses this shard column, as opposed to the sequential column in the index, to control the distribution of values across the index. The shard column is hidden by default but can be seen with [`SHOW COLUMNS`](show-columns.html).
 
+{{site.data.alerts.callout_info}}
+In v21.2 and earlier, hash-sharded indexes create a physical `STORED` [computed column](computed-columns.html) instead of a virtual computed column. If you are using a hash-sharded index that was created in v21.2 or earlier, the `STORED` column still exists in your database. When dropping a hash-sharded index that has created a physical shard column, you must include the [`CASCADE`](drop-index.html#remove-an-index-and-dependent-objects-with-cascade) clause to drop the shard column. Doing so will require a rewrite of the table.
+{{site.data.alerts.end}}
+
 For details about the mechanics and performance improvements of hash-sharded indexes in CockroachDB, see our [Hash Sharded Indexes Unlock Linear Scaling for Sequential Workloads](https://www.cockroachlabs.com/blog/hash-sharded-indexes-unlock-linear-scaling-for-sequential-workloads/) blog post.
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
DOC-3491

- Document `DROP INDEX ... CASCADE` for dropping `STORED` columns created by hash-sharded indexes
- Update v21.2-v22.2 docs (added some basic info on hash-sharded indexes that appeared to be missing in v21.2; not sure if fully correct)

It looks like the `CASCADE` requirement is only in v22.2, which means the guidance will differ in both v22.1 and v21.2. Let me know if this isn't correct.