### PR TITLE
CRDB-18740: Add CSS to handle new table anchors for cluster settings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,6 +72,7 @@
         <script>
           whenAvailable('anchors', function() {
             anchors.add('h2, h3, h4, h5');
+            anchors.add('.anchored');
           });
         </script>
 {% endif %}

--- a/css/customstyles.scss
+++ b/css/customstyles.scss
@@ -90,3 +90,8 @@
     height: 100%;
   }
 }
+
+td > div.anchored
+{
+   scroll-margin-top: 100px;
+}


### PR DESCRIPTION
Part of CRDB-18740

This CSS will allow us to use the `.anchored` class and add page anchors with the hoverable link button.