### PR TITLE
Add markdown="1" to all release note contributor divs

### DIFF
--- a/_includes/releases/v1.0/beta-20160728.md
+++ b/_includes/releases/v1.0/beta-20160728.md
@@ -35,7 +35,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Updated [Recommended Production Settings](../v1.0/recommended-production-settings.html) to clarify how CockroachDB allocates file descriptors when the limit is under the recommended amount. [#480](https://github.com/cockroachdb/docs/pull/480)
 - [SQL statements](../v1.0/sql-statements.html), [data types](../v1.0/data-types.html), and data definition topics are now available at-a-glance in the sidebar. [#483](https://github.com/cockroachdb/docs/pull/483)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20160728-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20160829.md
+++ b/_includes/releases/v1.0/beta-20160829.md
@@ -72,7 +72,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Updated [Recommended Production Settings](../v1.0/recommended-production-settings.html) to include cache size recommendations for machines running multiple applications and `systemd`-specific instructions for increasing the file descriptors limit. [#532](https://github.com/cockroachdb/docs/pull/532), [#554](https://github.com/cockroachdb/docs/pull/554)
 - Fixed errors in the commands for [starting CockroachDB in Docker](../v1.0/start-a-local-cluster-in-docker.html). [#567](https://github.com/cockroachdb/docs/pull/567)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20160829-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20160908.md
+++ b/_includes/releases/v1.0/beta-20160908.md
@@ -48,7 +48,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Each version's release notes now link to the corresponding Mac and Linux binaries. [#604](https://github.com/cockroachdb/docs/pull/604)
 - Updated docs on [secure local](../v1.0/secure-a-cluster.html) and [secure distributed](../v1.0/manual-deployment.html) deployment to show how to stop nodes. [#619](https://github.com/cockroachdb/docs/pull/619)  
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20160908-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20160929.md
+++ b/_includes/releases/v1.0/beta-20160929.md
@@ -47,7 +47,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
     - Changing the name of a table column or index: [`RENAME COLUMN`](../v1.0/rename-column.html) and [`RENAME INDEX`](../v1.0/rename-index.html). [#678](https://github.com/cockroachdb/docs/pull/678), [#679](https://github.com/cockroachdb/docs/pull/679)
 - Updated high-level overviews of primary [CockroachDB features](../v1.0/strong-consistency.html) and added related links. [#699](https://github.com/cockroachdb/docs/pull/699)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20160929-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20161027.md
+++ b/_includes/releases/v1.0/beta-20161027.md
@@ -54,7 +54,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - More complex expressions involving window functions are now supported. [#10186](https://github.com/cockroachdb/cockroach/pull/10186)
 - Fixed a deadlock that could occur when using the Prometheus metrics endpoint. [#10228](https://github.com/cockroachdb/cockroach/pull/10228)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20161027-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20161103.md
+++ b/_includes/releases/v1.0/beta-20161103.md
@@ -55,7 +55,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added language-specific examples for [`INSERT` statements with `RETURNING`](../v1.0/insert.html#insert-and-return-values). [#813](https://github.com/cockroachdb/docs/pull/813)
 - Updated the [SQL Feature Support](../v1.0/sql-feature-support.html) page to reflect support for [views](../v1.0/views.html) (SQL standard) and [interleaved tables](../v1.0/interleave-in-parent.html) (CockroachDB extensions).
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20161103-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20161201.md
+++ b/_includes/releases/v1.0/beta-20161201.md
@@ -130,7 +130,7 @@ We realize that "stop the world" upgrades are overly interruptive and are active
 - Updated the [`cockroach zone`](../v1.0/configure-replication-zones.html) command documentation to reflect the correct YAML structure. [#902](https://github.com/cockroachdb/docs/pull/902)
 - Fixed the Rust code samples on [Build an App](../v1.0/build-a-rust-app-with-cockroachdb.html). [#863](https://github.com/cockroachdb/docs/pull/863)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20161201-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20161208.md
+++ b/_includes/releases/v1.0/beta-20161208.md
@@ -51,7 +51,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Requests no longer get stuck forever after a timeout. [#12000](https://github.com/cockroachdb/cockroach/pull/12000)
 - Comparisons of SQL tuples now work for all types. [#10475](https://github.com/cockroachdb/cockroach/pull/10475)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20161208-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170105.md
+++ b/_includes/releases/v1.0/beta-20170105.md
@@ -80,7 +80,7 @@ Raft traffic to that node is suspended until it becomes responsive again. [#1263
 - Added documentation on the [`SHOW USERS`](../v1.0/show-users.html) statement. [#939](https://github.com/cockroachdb/docs/pull/939)
 - Clarified that [password-based authentication](../v1.0/create-and-manage-users.html#user-authentication) cannot be used for the `root` user. [#938](https://github.com/cockroachdb/docs/pull/938)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170105-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170112.md
+++ b/_includes/releases/v1.0/beta-20170112.md
@@ -56,7 +56,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added a Java code sample for transaction retry logic to the [Build a Java App with CockroachDB](../v1.0/build-a-java-app-with-cockroachdb.html) tutorial. [#987](https://github.com/cockroachdb/docs/pull/987)
 - Added documentation on [SQL type conversions](../v1.0/data-types.html#data-type-conversions-casts). [#977](https://github.com/cockroachdb/docs/pull/977)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170112-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170126.md
+++ b/_includes/releases/v1.0/beta-20170126.md
@@ -78,7 +78,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Updated the [`cockroach zone`](../v1.0/configure-replication-zones.html) documentation to explain how node-level locality settings and zone configuration constraints influence the location of replicas, and added [scenario-based examples](../v1.0/configure-replication-zones.html#scenario-based-examples). [#1027](https://github.com/cockroachdb/docs/pull/1027)
 - Updated cluster topology guidance in [Recommended Production Settings](../v1.0/recommended-production-settings.html#cluster-topology). [#1027](https://github.com/cockroachdb/docs/pull/1027)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170126-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170209.md
+++ b/_includes/releases/v1.0/beta-20170209.md
@@ -62,7 +62,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - New FAQ on [how CockroachDB is both highly available and strongly consistent without violating the CAP theorem](../v1.0/frequently-asked-questions.html#how-is-cockroachdb-both-highly-available-and-strongly-consistent). [#1061](https://github.com/cockroachdb/docs/pull/1061)
 - Expanded documentation on [simple `CASE` expressions](../v1.0/sql-expressions.html#simple-case-expressions) and [searched `CASE` expressions](../v1.0/sql-expressions.html#searched-case-expressions). [#1036](https://github.com/cockroachdb/docs/pull/1036)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170209-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170216.md
+++ b/_includes/releases/v1.0/beta-20170216.md
@@ -37,7 +37,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - The [Build a Java App with CockroachDB](../v1.0/build-a-java-app-with-cockroachdb.html) tutorial now covers using the Hibernate ORM in addition to the jdbc driver. [#1100](https://github.com/cockroachdb/docs/pull/1100)
 - The [Start a Cluster in Docker](../v1.0/start-a-local-cluster-in-docker.html) tutorial now offers OS-specific instructions, with specific improvements for running on Windows. [#1095](https://github.com/cockroachdb/docs/pull/1095)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170216-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170309.md
+++ b/_includes/releases/v1.0/beta-20170309.md
@@ -56,7 +56,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added details about [using the `BIT` type to constrain integers](../v1.0/int.html#size) based on their corresponding binary values. [#1116](https://github.com/cockroachdb/docs/pull/1116)
 - Added details about [building a binary](../v1.0/install-cockroachdb.html) that excludes enterprise functionality covered by the CockroachDB Community License (CCL). [#1130](https://github.com/cockroachdb/docs/pull/1130)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170309-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170323.md
+++ b/_includes/releases/v1.0/beta-20170323.md
@@ -78,7 +78,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added OS-specific instructions for [starting a local CockroachDB cluster in Docker](../v1.0/start-a-local-cluster-in-docker.html). [#1167](https://github.com/cockroachdb/docs/pull/1167)
 - Improved the [install from binary instructions](../v1.0/install-cockroachdb.html) to include moving the binary into the `PATH`. [#1196](https://github.com/cockroachdb/docs/pull/1196)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170323-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170413.md
+++ b/_includes/releases/v1.0/beta-20170413.md
@@ -99,7 +99,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Updated the [build from source](../v1.0/install-cockroachdb.html) instructions to use a source tarball instead of the `cockroach` GitHub repository. The source tarball downloads faster and doesn't need to be extracted in the `GOPATH`. Developers who want to contribute to CockroachDB should use the instructions in [CONTRIBUTING.md](https://github.com/cockroachdb/cockroach/blob/master/CONTRIBUTING.md) instead. [#1209](https://github.com/cockroachdb/docs/issues/1209)
 - Added Google Cloud Spanner to the [CockroachDB in Comparison](../v1.0/cockroachdb-in-comparison.html) chart. [#1264](https://github.com/cockroachdb/docs/pull/1264)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170413-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/beta-20170420.md
+++ b/_includes/releases/v1.0/beta-20170420.md
@@ -68,7 +68,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Expanded the [`TRUNCATE`](../v1.0/truncate.html) documentation to cover using `CASCADE` to truncate dependent tables. [#1297](https://github.com/cockroachdb/docs/pull/1297)
 - Minor improvements to the [`ROLLBACK`](../v1.0/rollback-transaction.html) documentation. [#1296](https://github.com/cockroachdb/docs/pull/1296)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="beta-20170420-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/v1.0-rc.1.md
+++ b/_includes/releases/v1.0/v1.0-rc.1.md
@@ -106,7 +106,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Documented the known list of [differences between PostgreSQL and CockroachDB](../v1.0/porting-postgres.html) for identical SQL input, with porting instructions. [#1328](https://github.com/cockroachdb/docs/pull/1328)
 - Expanded best practices when [using the `--locality` setting](../v1.0/recommended-production-settings.html) to replicate evenly across datacenters. [#1334](https://github.com/cockroachdb/docs/pull/1334)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v1-0-rc-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.0/v1.0-rc.2.md
+++ b/_includes/releases/v1.0/v1.0-rc.2.md
@@ -61,7 +61,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added an FAQ on different [ways to log SQL queries](../v1.0/sql-faqs.html). [#1359](https://github.com/cockroachdb/docs/pull/1359)
 - Updated [local deployment tutorials](../v1.0/start-a-local-cluster.html) to have nodes listen only on `localhost`. This ensures these tutorials work even on machines whose hostnames aren’t resolvable. [#1358](https://github.com/cockroachdb/docs/pull/1358)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v1-0-rc-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v1.1/v1.1.6.md
+++ b/_includes/releases/v1.1/v1.1.6.md
@@ -28,7 +28,7 @@ This release includes several bug fixes and stability improvements.
 - Fixed a bug that caused SQL connection errors during node startup. [#22663][#22663]
 - Fixed a bug that included [decommissioned nodes](../v1.1/remove-nodes.html) in cluster stats aggregates. [#22864][#22864]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v1-1-6-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.0-beta.20190225.md
+++ b/_includes/releases/v19.1/v19.1.0-beta.20190225.md
@@ -60,7 +60,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.1.0-beta.20190225
 
 - Documented the built-in [`ycsb` workload](../v19.1/cockroach-workload.html). [#4343][#4343]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-0-beta-20190225-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.0-beta.20190304.md
+++ b/_includes/releases/v19.1/v19.1.0-beta.20190304.md
@@ -64,7 +64,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.1.0-beta.20190304
 - Documented CockroachDB's partial support for the [Intellij IDEA](../v19.1/intellij-idea.html). [#4391](https://github.com/cockroachdb/docs/pull/4391)
 - Clarified the guidance on [preparing to decommission nodes](../v19.1/remove-nodes.html). [#4406](https://github.com/cockroachdb/docs/pull/4406)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-0-beta-20190304-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.0-beta.20190318.md
+++ b/_includes/releases/v19.1/v19.1.0-beta.20190318.md
@@ -95,7 +95,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.1.0-beta.20190318
 - Documented the `bytea_output` session variable, and fixed the documentation on bytes/string conversions. [#4452](https://github.com/cockroachdb/docs/pull/4452)
 - Updated [Configure Replication Zones](../v19.1/configure-replication-zones.html) documentation to reflect that unset variables in a replication zone now inherit their values from the parent zone. [#4446](https://github.com/cockroachdb/docs/pull/4446)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-0-beta-20190318-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.0-rc.1.md
+++ b/_includes/releases/v19.1/v19.1.0-rc.1.md
@@ -89,7 +89,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.1.0-rc.1
 - Corrected the syntax for [per-replica replication zone constraints](../v19.1/configure-replication-zones.html#scope-of-constraints). [#4569](https://github.com/cockroachdb/docs/pull/4569)
 - Added more thorough documentation on [CockroachDB dependencies](../v19.1/recommended-production-settings.html#dependencies). [#4567](https://github.com/cockroachdb/docs/pull/4567)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-0-rc-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.10.md
+++ b/_includes/releases/v19.1/v19.1.10.md
@@ -43,7 +43,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.1.10
 - Updated the Releases navigation in the sidebar to expose the latest Production and Testing releases. [#7550][#7550]
 - Fixed scrollbar visibility on Chrome. [#7487][#7487]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-10-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.2.md
+++ b/_includes/releases/v19.1/v19.1.2.md
@@ -54,7 +54,7 @@ $ docker pull cockroachdb/cockroach:v19.1.2
 
 - Stack memory used by CockroachDB is now marked as non-executable, improving security and compatibility with SELinux. [#38011][#38011]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v19.1.8.md
+++ b/_includes/releases/v19.1/v19.1.8.md
@@ -46,7 +46,7 @@ $ docker pull cockroachdb/cockroach:v19.1.8
 - Fixed an internal error that could happen in the planner when table statistics were collected manually using [`CREATE STATISTICS`](../v19.1/create-statistics.html) for different columns at different times. [#44443][#44443]
 - CockroachDB no longer repeatedly looks for non-existing jobs, which may cause  high memory usage, when cleaning up schema changes. [#44824][#44824]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-1-8-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v2.2.0-alpha.20181119.md
+++ b/_includes/releases/v19.1/v2.2.0-alpha.20181119.md
@@ -101,7 +101,7 @@ $ docker pull cockroachdb/cockroach-unstable:v2.2.0-alpha.20181119
 - Reduced the amount of allocated memory by pooling allocations of `rocksDBBatch` and `RocksDBBatchBuilder` objects. [#30523][#30523]
 - Cache zone configuration values to avoid repetitive deserialization. [#30143][#30143]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-2-0-alpha-20181119-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v2.2.0-alpha.20181217.md
+++ b/_includes/releases/v19.1/v2.2.0-alpha.20181217.md
@@ -113,7 +113,7 @@ $ docker pull cockroachdb/cockroach-unstable:v2.2.0-alpha.20181217
 - Fixed a method in the [Build a C# (.NET) App with CockroachDB](../v19.1/build-a-csharp-app-with-cockroachdb.html) code samples. [#4161](https://github.com/cockroachdb/docs/pull/4161)
 - Expanded the [Build a Rust App with CockroachDB](../v19.1/build-a-rust-app-with-cockroachdb.html) tutorial to cover secure clusters. [#4127](https://github.com/cockroachdb/docs/pull/4127)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-2-0-alpha-20181217-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v2.2.0-alpha.20190114.md
+++ b/_includes/releases/v19.1/v2.2.0-alpha.20190114.md
@@ -108,7 +108,7 @@ Mutation statements like [`UPDATE`](../v19.1/update.html) and [`INSERT`](../v19.
 - Updated the [Production Checklist](../v19.1/recommended-production-settings.html) with more current hardware recommendations and additional guidance on storage, file systems, and clock synch. [#4153](https://github.com/cockroachdb/docs/pull/4153)
 - Expanded the [SQLAlchemy tutorial](../v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.html) to provide code for transaction retries and best practices for using SQLAlchemy with CockroachDB. [#4142](https://github.com/cockroachdb/docs/pull/4142)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-2-0-alpha-20190114-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.1/v2.2.0-alpha.20190211.md
+++ b/_includes/releases/v19.1/v2.2.0-alpha.20190211.md
@@ -120,7 +120,7 @@ $ docker pull cockroachdb/cockroach-unstable:v2.2.0-alpha.20190211
 - Added a note that when a table that was previously [split](../v19.1/split-at.html) is truncated, the table must be pre-split again. [#4274](https://github.com/cockroachdb/docs/pull/4274)
 - Updated the [SQL Performance Best Practices](../v19.1/performance-best-practices-overview.html#interleave-tables) with caveats around interleaving tables. [#4273](https://github.com/cockroachdb/docs/pull/4273)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-2-0-alpha-20190211-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.0-alpha.20190606.md
+++ b/_includes/releases/v19.2/v19.2.0-alpha.20190606.md
@@ -123,7 +123,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.2.0-alpha.20190606
 
 - Stack memory used by CockroachDB is now marked as non-executable, improving security and compatibility with SELinux. [#37939][#37939]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-0-alpha-20190606-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.0-alpha.20190701.md
+++ b/_includes/releases/v19.2/v19.2.0-alpha.20190701.md
@@ -93,7 +93,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.2.0-alpha.20190701
 
 - Only check `CN` on first certificate in file. [#38163][#38163] {% comment %}doc{% endcomment %}
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-0-alpha-20190701-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.0-alpha.20190805.md
+++ b/_includes/releases/v19.2/v19.2.0-alpha.20190805.md
@@ -94,7 +94,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.2.0-alpha.20190805
 - Documented a [known limitation](../v19.2/known-limitations.html) about hanged requests to a restarted node that needs Raft snapshots. [#5018](https://github.com/cockroachdb/docs/pull/5018)
 - Updated the [`BACKUP`](../v19.2/backup.html) and [`RESTORE`](../v19.2/restore.html) docs to specify that the `system.users` table is not included with a backup. To restore the table, you must explicitly include it. [#5072](https://github.com/cockroachdb/docs/pull/5072)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-0-alpha-20190805-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.0-beta.20190930.md
+++ b/_includes/releases/v19.2/v19.2.0-beta.20190930.md
@@ -207,7 +207,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.2.0-beta.20190930
 - Added an [overview of MovR](../v19.2/movr.html), CockroachDB's fictional vehicle-sharing dataset and application, and updated several SQL pages and examples to use the built-in MovR dataset, for example, [Learn CockroachDB SQL](../v19.2/learn-cockroachdb-sql.html). [#5075](https://github.com/cockroachdb/docs/pull/5075), [#5216](https://github.com/cockroachdb/docs/pull/5216)
 - Added a tutorial on [how to use `EXPLAIN` to identify and resolve common SQL performance problems](../v19.2/learn-cockroachdb-sql.html). [#5178](https://github.com/cockroachdb/docs/pull/5178)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-0-beta-20190930-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.12.md
+++ b/_includes/releases/v19.2/v19.2.12.md
@@ -27,7 +27,7 @@ $ docker pull cockroachdb/cockroach:v19.2.12
 - Fixed a panic in protobuf decoding. [#58876][#58876]
 - Fixed a bug where the `age` [function](../v19.2/functions-and-operators.html#date-and-time-functions) did not normalize the duration for large day or `H:M:S` values in the same way PostgreSQL does. [#55528][#55528]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-12-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.2.md
+++ b/_includes/releases/v19.2/v19.2.2.md
@@ -149,7 +149,7 @@ The list of HTTP endpoints affected by the first change above includes:
 - CockroachDB did not previously handle date casts from `TIMESTAMP`/`TIMESTAMPZ` with time attached for times before the UNIX epoch correctly. For example, `'1969-12-30 01:00:00'::timestamp` would round to `'1969-12-31'` instead of `'1969-12-30'`. This is now fixed. [#43022][#43022]
 - CockroachDB is now less likely to hang in an inconvenient or inoperative state if it attempts to access an external HTTP server that is blocked or overloaded. Nodes failing to shut down with [`cockroach quit`](../v19.2/cockroach-quit.html) were a symptom of this bug. [#42539][#42539]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.3.md
+++ b/_includes/releases/v19.2/v19.2.3.md
@@ -124,7 +124,7 @@ $ docker pull cockroachdb/cockroach:v19.2.3
 - Corrected the description of the [possible result of clock skew outside the configured clock offset bounds](../v19.2/operational-faqs.html#what-happens-when-node-clocks-are-not-properly-synchronized). [#6329](https://github.com/cockroachdb/docs/pull/6329)
 - Expanded the [data types overview](../v19.2/data-types.html) to indicate whether or not a type supports [vectorized execution](../v19.2/vectorized-execution.html). [#6327](https://github.com/cockroachdb/docs/pull/6327)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-3-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.7.md
+++ b/_includes/releases/v19.2/v19.2.7.md
@@ -96,7 +96,7 @@ $ docker pull cockroachdb/cockroach:v19.2.7
 - Histograms used by the optimizer for query planning now have more accurate row counts per histogram bucket, particularly for columns that have many `NULL` values. This results in better plans in some cases. [#48645][#48645]
 - Fixed a performance inefficiency in the [vectorized execution engine](../v19.2/vectorized-execution.html). This fix speeds up all queries that are executed with the vectorized engine, with most noticeable gains on the queries that output many rows. [#48733][#48733]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-7-contributors">Contributors</h3>
 

--- a/_includes/releases/v19.2/v19.2.8.md
+++ b/_includes/releases/v19.2/v19.2.8.md
@@ -61,7 +61,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.2.8
 - Updated the Releases navigation in the sidebar to expose the latest Production and Testing releases. [#7550][#7550]
 - Fixed scrollbar visibility on Chrome. [#7487][#7487]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v19-2-8-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0-alpha.20180122.md
+++ b/_includes/releases/v2.0/v2.0-alpha.20180122.md
@@ -162,7 +162,7 @@ control](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171220
 - Various improvements to the docs on the [`IMPORT`](../v2.0/import.html), [`BACKUP`](../v2.0/backup.html), and [`RESTORE`](../v2.0/restore.html) statements. [#2340](https://github.com/cockroachdb/docs/pull/2340)
 - Improved the styling of code samples and page tocs. [#2323](https://github.com/cockroachdb/docs/pull/2323) [#2371](https://github.com/cockroachdb/docs/pull/2371)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-alpha-20180122-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0-alpha.20180129.md
+++ b/_includes/releases/v2.0/v2.0-alpha.20180129.md
@@ -55,7 +55,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Sped up the performance of low-level delete operations. [#21507][#21507]
 - Prevented the jobs table from growing excessively large during jobs table updates. [#21575][#21575]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-alpha-20180129-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0-alpha.20180212.md
+++ b/_includes/releases/v2.0/v2.0-alpha.20180212.md
@@ -74,7 +74,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added docs on the [`INET`](../v2.0/inet.html) data type. [#2439](https://github.com/cockroachdb/docs/pull/2439)
 - Added docs on the [`SHOW CREATE SEQUENCE`](../v2.0/show-create-sequence.html) statement. [#2406](https://github.com/cockroachdb/docs/pull/2406)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-alpha-20180212-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0-beta.20180305.md
+++ b/_includes/releases/v2.0/v2.0-beta.20180305.md
@@ -212,7 +212,7 @@ This week's release includes:
 - Updated docs on [supporting castings for `ARRAY` values](../v2.0/array.html#supported-casting-conversionnew-in-v2-0). [#2549](https://github.com/cockroachdb/docs/pull/2549)
 - Various improvements to docs on the [built-in SQL client](../v2.0/use-the-built-in-sql-client.html). [#2544](https://github.com/cockroachdb/docs/pull/2544)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-beta-20180305-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0-beta.20180326.md
+++ b/_includes/releases/v2.0/v2.0-beta.20180326.md
@@ -75,7 +75,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added a local cluster tutorial demonstrating [JSON Support](../v2.0/demo-json-support.html). [#2716](https://github.com/cockroachdb/docs/pull/2716)
 - Added full documentation for the [`VALIDATE CONSTRAINT`](../v2.0/validate-constraint.html) statement. [#2730](https://github.com/cockroachdb/docs/pull/2730)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-beta-20180326-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0-rc.1.md
+++ b/_includes/releases/v2.0/v2.0-rc.1.md
@@ -29,7 +29,7 @@ This is the first release candidate for CockroachDB v2.0. All known bugs have ei
 - Fixed a crash while performing rolling restarts. [#24260][#24260]
 - Fixed a bug where [privileges](../v2.0/privileges.html) were sometimes set incorrectly after upgrading from an older release. [#24393][#24393]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-rc-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0.2.md
+++ b/_includes/releases/v2.0/v2.0.2.md
@@ -56,7 +56,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 
 - Improved the documentation of the `now()`, `current_time()`, `current_date()`, `current_timestamp()`, `clock_timestamp()`, `statement_timestamp()`, `cluster_logical_timestamp()`, and `age()` [built-in functions](../v2.0/functions-and-operators.html). [#25383][#25383] [#25145][#25145]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0.4.md
+++ b/_includes/releases/v2.0/v2.0.4.md
@@ -42,7 +42,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added `systemd` configs and instructions to [deployment tutorials](../v2.0/manual-deployment.html). [#3268][#3268]
 - Updated the [Kubernetes tutorials](../v2.0/orchestrate-cockroachdb-with-kubernetes.html) to reflect that pods aren't "Ready" before init. [#3291][#3291]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-4-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.0/v2.0.5.md
+++ b/_includes/releases/v2.0/v2.0.5.md
@@ -30,7 +30,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Expanded the [Kubernetes tutorials](../v2.0/orchestrate-cockroachdb-with-kubernetes.html) to include setting up monitoring and alerting with Prometheus and Alertmanager. [#3370][#3370]
 - Updated the [OpenSSL certificate tutorial](../v2.0/create-security-certificates-openssl.html) to allow multiple node certificates with the same subject. [#3423][#3423]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-0-5-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-alpha.20180416.md
+++ b/_includes/releases/v2.1/v2.1.0-alpha.20180416.md
@@ -112,7 +112,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 
 - Release binaries are now built with enough debug information to produce useful CPU profiles and backtraces. [#24296][#24296]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-alpha-20180416-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-alpha.20180507.md
+++ b/_includes/releases/v2.1/v2.1.0-alpha.20180507.md
@@ -99,7 +99,7 @@ This release includes usability enhancements, PostgreSQL compatibility improveme
 - Documented the `--temp-dir` flag for [`cockroach start`](../v2.1/start-a-node.html). [#2955][#2955]
 - Expanded the [Production Checklist](../v2.1/recommended-production-settings.html) to recommend a higher replication factor when using local disks rather than a cloud providers' network-attached disks that are often replicated underneath the covers. [#3001][#3001]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-alpha-20180507-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-alpha.20180604.md
+++ b/_includes/releases/v2.1/v2.1.0-alpha.20180604.md
@@ -102,7 +102,7 @@ Please give this feature and the ones below a try. If you see something that can
 - Documented the [`TIMETZ`](../v2.1/time.html) data type. [#3102][#3102]
 - Added FAQs on [generating unique, slowly increasing sequential numbers](../v2.1/sql-faqs.html#how-do-i-generate-unique-slowly-increasing-sequential-numbers-in-cockroachdb) and [the differences between `UUID`, sequences, and `unique_rowid()`](../v2.1/sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid). [#3104][#3104]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-alpha-20180604-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-alpha.20180702.md
+++ b/_includes/releases/v2.1/v2.1.0-alpha.20180702.md
@@ -130,7 +130,7 @@ Please give these features and the ones below a try. If you see something that c
 - Expanded the first level of the 2.1 docs sidenav by default. [#3270][#3270]
 - Updated the [Kubernetes tutorials](../v2.1/orchestrate-cockroachdb-with-kubernetes.html) to reflect that pods aren't "Ready" before init. [#3291][#3291]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-alpha-20180702-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-alpha.20180730.md
+++ b/_includes/releases/v2.1/v2.1.0-alpha.20180730.md
@@ -140,7 +140,7 @@ Please give these features and the ones below a try. If you see something that c
 - Updated the [OpenSSL certificate tutorial](../v2.1/create-security-certificates-openssl.html) to allow multiple node certificates with the same subject. [#3423][#3423]
 - Added an example on [editing SQL statements in an external editor from within the built-in SQL shell](../v2.1/use-the-built-in-sql-client.html#edit-sql-statements-in-an-external-editor). [#3425][#3425]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-alpha-20180730-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-beta.20180827.md
+++ b/_includes/releases/v2.1/v2.1.0-beta.20180827.md
@@ -209,7 +209,7 @@ CREATE`](../v2.1/show-create.html) page; and removed the experimental status fro
 - Documented the [`cockroach demo`](../v2.1/cockroach-demo.html) command. [#3509](https://github.com/cockroachdb/docs/pull/3509)
 - Various updates to the [`cockroach sql`](../v2.1/use-the-built-in-sql-client.html) documentation. [#3499](https://github.com/cockroachdb/docs/pull/3499)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-beta-20180827-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.0-beta.20180917.md
+++ b/_includes/releases/v2.1/v2.1.0-beta.20180917.md
@@ -80,7 +80,7 @@ Release Date: {{ include.release_date | date: "%B %-d, %Y" }}
 - Added documentation of the `public` role, which all users belong to. [#3722](https://github.com/cockroachdb/docs/pull/3722)
 - Update the [Diagnostics Reporting](../v2.1/diagnostics-reporting.html) page with a summary of details reported and how to view the details yourself. [#3737](https://github.com/cockroachdb/docs/pull/3737)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-0-beta-20180917-contributors">Contributors</h3>
 

--- a/_includes/releases/v2.1/v2.1.1.md
+++ b/_includes/releases/v2.1/v2.1.1.md
@@ -56,7 +56,7 @@ $ docker pull cockroachdb/cockroach:v2.1.1
 - Made it easier to find and link to specific [installation methods](../v2.1/install-cockroachdb.html), and updated the Homebrew instructions to note potential conflicts in cases where CockroachDB was previously installed using a different method. [#4032](https://github.com/cockroachdb/docs/pull/4032), [#4036](https://github.com/cockroachdb/docs/pull/4036)
 - Updated the [`IMPORT`](../v2.1/import.html) documentation to cover [importing CockroachDB dump files](../v2.1/import.html#import-a-cockroachdb-dump-file). [#4029](https://github.com/cockroachdb/docs/pull/4029)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v2-1-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-alpha.20191118.md
+++ b/_includes/releases/v20.1/v20.1.0-alpha.20191118.md
@@ -89,7 +89,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-alpha.20191118
 - Individual response messages in a response batch no longer each contain information about transaction state changes. [#42139][#42139]
 - `BACKUP` work is now more evenly spread across clusters that have non-uniform leaseholder distributions. [#42274][#42274]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-alpha-20191118-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-alpha.20200123.md
+++ b/_includes/releases/v20.1/v20.1.0-alpha.20200123.md
@@ -173,7 +173,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-alpha.20200123
 - Corrected the description of the [possible result of clock skew outside the configured clock offset bounds](../v20.1/operational-faqs.html#what-happens-when-node-clocks-are-not-properly-synchronized). [#6329](https://github.com/cockroachdb/docs/pull/6329)
 - Expanded the [data types overview](../v20.1/data-types.html) to indicate whether or not a type supports [vectorized execution](../v20.1/vectorized-execution.html). [#6327](https://github.com/cockroachdb/docs/pull/6327)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-alpha-20200123-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-alpha20191216.md
+++ b/_includes/releases/v20.1/v20.1.0-alpha20191216.md
@@ -192,7 +192,7 @@ The list of HTTP endpoints affected by the first change above includes:
 - Go version 1.12.10+ is now required to build CockroachDB successfully. [#42474][#42474] {% comment %}doc{% endcomment %}
 - `make buildshort` is now able to produce valid CCL binaries with all enterprise features (minus UI). [#42541][#42541] {% comment %}doc{% endcomment %}
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-alpha20191216-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-beta.1.md
+++ b/_includes/releases/v20.1/v20.1.0-beta.1.md
@@ -222,7 +222,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-beta.1
 - Improved the [Django "build an app" code sample](../v20.1/build-a-python-app-with-cockroachdb-django.html). [#6404](https://github.com/cockroachdb/docs/pull/6404), [#6412](https://github.com/cockroachdb/docs/pull/6412)
 - Updated [Change Data Capture examples](../v20.1/change-data-capture.html#create-a-changefeed-connected-to-kafka) to show more than one table in a changefeed. [#6511](https://github.com/cockroachdb/docs/pull/6511)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-beta-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-beta.2.md
+++ b/_includes/releases/v20.1/v20.1.0-beta.2.md
@@ -92,7 +92,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-beta.2
 - Added a [tutorial for using PonyORM with CockroachDB](../v20.1/build-a-python-app-with-cockroachdb-pony.html). [#6531][#6531]
 - Added a [tutorial for using the jOOQ ORM with CockroachDB](../v20.1/build-a-java-app-with-cockroachdb-jooq.html). [#6684][#6684]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-beta-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-beta.3.md
+++ b/_includes/releases/v20.1/v20.1.0-beta.3.md
@@ -258,7 +258,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-beta.3
 - Added the "Duplicate Indexes" Youtube video to the [Duplicate Indexes Topology doc](../v20.1/topology-duplicate-indexes.html). [#6796][#6796]
 - Updated the [`cockroach demo`](../v20.1/cockroach-demo.html) doc to include new flags. [#6841][#6841]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-beta-3-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-beta.4.md
+++ b/_includes/releases/v20.1/v20.1.0-beta.4.md
@@ -68,7 +68,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-beta.4
 - Added [guidance](../v20.1/create-table.html#create-a-table-with-a-hash-sharded-primary-index) on using [hash-sharded indexes](../v20.1/indexes.html#hash-sharded-indexes). [#6820][#6820]
 - Updated [production checklist](../v20.1/recommended-production-settings.html#azure) and [Azure deployment guides](../v20.1/deploy-cockroachdb-on-microsoft-azure.html) to recommend compute-optimize F-series VMs in Azure deployments. [#7005][#7005]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-beta-4-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.0-rc.1.md
+++ b/_includes/releases/v20.1/v20.1.0-rc.1.md
@@ -153,7 +153,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-rc.1
 - Documented [`INTERVAL`](../v20.1/interval.html) duration fields and updated the syntax and precision details. [#7000](https://github.com/cockroachdb/docs/pull/7000)
 - Various updates related to [role-based access control (RBAC)](../v20.1/authorization.html) moving under the BSL license. [#7003](https://github.com/cockroachdb/docs/pull/7003)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-0-rc-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.1.md
+++ b/_includes/releases/v20.1/v20.1.1.md
@@ -139,7 +139,7 @@ $ docker pull cockroachdb/cockroach:v20.1.1
 
 - Added a tutorial on [using Flyway with CockroachDB](../v20.1/flyway.html). [#7329][#7329]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.12.md
+++ b/_includes/releases/v20.1/v20.1.12.md
@@ -31,7 +31,7 @@ $ docker pull cockroachdb/cockroach:v20.1.12
 - Fixed a bug where CockroachDB could encounter an internal error when executing queries with [`BYTES`](../v20.1/bytes.html) or [`STRING`](../v20.1/string.html) types via the [vectorized engine](../v20.1/vectorized-execution.html). [#59257][#59257]
 - Fixed a bug where CockroachDB could crash when executing an [`ALTER INDEX ... SPLIT/UNSPLIT AT`](../v20.1/split-at.html) statement when more values are provided than are explicitly specified in the [index](../v20.1/indexes.html). [#59272][#59272]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-12-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.17.md
+++ b/_includes/releases/v20.1/v20.1.17.md
@@ -30,7 +30,7 @@ $ docker pull cockroachdb/cockroach:v20.1.17
 - Fixed a race condition where read-write requests during replica removal (for example, during range merges or rebalancing) could be evaluated on the removed replica. These cases would not result in data being written to persistent storage, but could result in errors that should not have been returned. [#64604][#64604]
 - Fixed a bug where users of OSS builds of CockroachDB would see "Page Not Found" when loading the DB Console. [#64126][#64126]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-17-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.8.md
+++ b/_includes/releases/v20.1/v20.1.8.md
@@ -35,7 +35,7 @@ $ docker pull cockroachdb/cockroach:v20.1.8
 - Fixed a bug where CockroachDB did not account for all the memory used by the vectorized hash aggregation which could lead to an OOM crash. [#55571][#55571]
 - Fixed a bug where using the `MIN`/`MAX` aggregates in a prepared statement did not report the correct [data type](../v20.1/data-types.html) size. [#55621][#55621]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-8-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.1/v20.1.9.md
+++ b/_includes/releases/v20.1/v20.1.9.md
@@ -52,7 +52,7 @@ $ docker pull cockroachdb/cockroach:v20.1.9
 - Fixed a race between job completion and sending the result of the job to the client. CockroachDB now sends results to the client after a job completes. [#56146][#56146]
 - In [v20.1.8](v20.1.html#v20-1-8), we attempted to fix the `age()` [function](../v20.1/functions-and-operators.html)'s normalization of `H:M:S` input into years, months, and days. However, the v20.1.8 fix was broken for values greater than 1 month, and for `a::timestamp(tz) - b::timestamp(tz)` expressions. This bug has been resolved. [commit 59b2bc218][59b2bc218]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-1-9-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.0-alpha.1.md
+++ b/_includes/releases/v20.2/v20.2.0-alpha.1.md
@@ -382,7 +382,7 @@ Release Date: June 17, 2020
 - It's now possible to build CockroachDB with the Clang++ v10 compiler. [#46859][#46859]
 - Release Docker images are now built on Debian 9.12. [#49593][#49593]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-0-alpha-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.0-alpha.2.md
+++ b/_includes/releases/v20.2/v20.2.0-alpha.2.md
@@ -158,7 +158,7 @@ Release Date: July 27, 2020
 - Better execution plans in some cases involving [`EXISTS`](../v20.2/functions-and-operators.html#conditional-and-function-like-operators). [#50846][#50846]
 - Smoothed out disk writes when transferring Range snapshots to avoid latency spikes for other concurrent operations. [#50866][#50866]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-0-alpha-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.0-alpha.3.md
+++ b/_includes/releases/v20.2/v20.2.0-alpha.3.md
@@ -236,7 +236,7 @@ For instructions showing how to get started with CockroachDB Spatial, see [Worki
 - Unnecessary mutex contention observed in heavy read workloads has been removed. [#51055][#51055]
 - Ranges recover moderately faster when their leaseholder is briefly down before becoming live again. [#51888][#51888]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-0-alpha-3-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.0-beta.1.md
+++ b/_includes/releases/v20.2/v20.2.0-beta.1.md
@@ -227,7 +227,7 @@ In addition to various updates, enhancements, and bug fixes, this first v20.2 be
 - Published a tutorial on orchestrating a secure [CockroachDB multi-region deployment on Amazon EKS](../v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.html). [#7782][#7782]
 - Published [best practices for optimizing import performance](../v20.2/import-performance-best-practices.html) in CockroachDB. [#8035][#8035]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-0-beta-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.0-beta.3.md
+++ b/_includes/releases/v20.2/v20.2.0-beta.3.md
@@ -78,7 +78,7 @@ Release Date: September 30, 2020
 - Left outer spatial joins can now be index-accelerated, which can lead to performance improvements in some cases. [#54110][#54110]
 - Spatial anti joins can now be index-accelerated, which can lead to performance improvements in some cases. [#54471][#54471]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-0-beta-3-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.0-rc.1.md
+++ b/_includes/releases/v20.2/v20.2.0-rc.1.md
@@ -60,7 +60,7 @@ Release Date: October 15, 2020
 - Options set on users (e.g., `ALTER USER u CREATEDB`) were not included in cluster backups and thus not restored. [Role options](../v20.2/alter-user.html) have been introduced in v20.2. [#55250][#55250]
 - Previously, all tables in any schema showed up as `public` in the `schema_name` column in the `crdb_internal` table. They now display the correct schema. [#55264][#55264]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-0-rc-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.10.md
+++ b/_includes/releases/v20.2/v20.2.10.md
@@ -26,7 +26,7 @@ Release Date: May 17, 2021
 - Limit scans are no longer counted as full scans. [#64852][#64852]
 - Providing a constant value as an [`ORDER BY`](../v20.2/order-by.html) value in an ordered set aggregate, such as `percentile_dist` or `percentile_cont`, no longer errors. This bug has been present since order set aggregates were added in v20.2.0. [#64903][#64903]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-10-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.11.md
+++ b/_includes/releases/v20.2/v20.2.11.md
@@ -53,7 +53,7 @@ Release Date: June 14, 2021
 
 - Fixed an issue in the optimizer that prevented spatial predicates of the form `(column && value) = true` from being index-accelerated. These queries can now use a [spatial index](../v20.2/spatial-indexes.html), if one is available. [#65988][#65988]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-11-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.14.md
+++ b/_includes/releases/v20.2/v20.2.14.md
@@ -45,7 +45,7 @@ Release Date: August 16, 2021
 - Updated the cost model in the [optimizer](../v20.2/cost-based-optimizer.html) to make index joins more expensive and better reflect the reality of their cost. As a result, the optimizer will choose index joins less frequently, generally resulting in more efficient query plans. [#67530][#67530]
 - Improved the performance of the [`pg_table_is_visible` built-in function](../v20.2/functions-and-operators.html). [#68113][#68113]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-14-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.19.md
+++ b/_includes/releases/v20.2/v20.2.19.md
@@ -10,7 +10,7 @@ Release Date: February 9, 2022
 - Fixed a bug which prevented the Data Distribution page from working on clusters which were upgraded from 19.2 or earlier. [#72506][#72506]
 - The `CancelSession` endpoint now correctly propagates gateway metadata when forwarding requests. [#75885][#75885]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-19-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.2.md
+++ b/_includes/releases/v20.2/v20.2.2.md
@@ -131,7 +131,7 @@ Release Date: November 25, 2020
 - Some boolean [session variables](../v20.2/set-vars.html) would only accept quoted string values `"true"` or `"false"`. Now they accept unquoted `true` or `false` values too. [#56813][#56813]
 - Fixed an internal error that could occur when collecting a [statement diagnostic bundle](../v20.2/explain-analyze.html#debug-option). [#56784][#56784]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.3.md
+++ b/_includes/releases/v20.2/v20.2.3.md
@@ -55,7 +55,7 @@ Release Date: December 14, 2020
 
 - Interactions between [Raft](../v20.2/architecture/replication-layer.html) heartbeats and the Raft goroutine pool scheduler are now more efficient and avoid excessive mutex contention. This was observed to prevent instability on large machines (32+ vCPU) in clusters with many ranges (50k+ per node). [#57008][#57008]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-3-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.5.md
+++ b/_includes/releases/v20.2/v20.2.5.md
@@ -50,7 +50,7 @@ Release Date: February 16, 2021
 - Previously, the `substring` [function](../v20.2/functions-and-operators.html) on [`BYTES`](../v20.2/bytes.html) arrays would treat its input as unicode code points, which would cause the wrong bytes to be returned. Now it only operates on the raw bytes. [#59170][#59170]
 - Previously, the `substring(byte[])` [functions](../v20.2/functions-and-operators.html) were not able to interpret bytes that had the `\` character, as the functions were treating the character as the beginning of an escape sequence. This is now fixed. [#59170][#59170]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-5-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.7.md
+++ b/_includes/releases/v20.2/v20.2.7.md
@@ -35,7 +35,7 @@ Release Date: March 29, 2021
 - Fix a bug where [full cluster restore](../v20.2/restore.html#full-cluster) would sometimes (very rarely) fail after retrying. [#61217][#61217]
 - Fixed a bug where an enum with large numbers of values might cause unexpected errors when attempting to read from tables with columns using that enum. [#62211][#62211]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-7-contributors">Contributors</h3>
 

--- a/_includes/releases/v20.2/v20.2.9.md
+++ b/_includes/releases/v20.2/v20.2.9.md
@@ -42,7 +42,7 @@ This page lists additions and changes in v20.2.9 since v20.2.8.
 
 - CockroachDB now builds on Ubuntu 20.10 and other distros using gcc-10. [#62201][#62201]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v20-2-9-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.0-alpha.1.md
+++ b/_includes/releases/v21.1/v21.1.0-alpha.1.md
@@ -247,7 +247,7 @@ Release Date: December 8, 2020
 - Updated several Hello World tutorials to use `cockroach demo` as the backend and an external repository for code samples, including Go with [pgx](../v21.1/build-a-go-app-with-cockroachdb.html) and [GORM](../v21.1/build-a-go-app-with-cockroachdb-gorm.html), Java with [JDBC](../v21.1/build-a-java-app-with-cockroachdb.html) and [Hibernate](../v21.1/build-a-java-app-with-cockroachdb-hibernate.html), and Python with [psycopg2](../v21.1/build-a-python-app-with-cockroachdb.html), [SQLAlchemy](../v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.html), and [Django](../v21.1/build-a-python-app-with-cockroachdb-django.html). [#9025](https://github.com/cockroachdb/docs/pull/9025),[#8991](https://github.com/cockroachdb/docs/pull/8991),
 - Updated the [Production Checklist](../v21.1/recommended-production-settings.html) to recommend disabling Linux memory swapping to avoid over-allocating memory. [#8979](https://github.com/cockroachdb/docs/pull/8979)
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-0-alpha-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.0-alpha.2.md
+++ b/_includes/releases/v21.1/v21.1.0-alpha.2.md
@@ -283,7 +283,7 @@ is needed for logging and metrics for SQL tenants. [#58317][#58317] {% comment %
 - The cluster event logging system has been standardized. [Reference documentation](https://github.com/cockroachdb/cockroach/blob/master/docs/generated/eventlog.md) is now available (auto-generated from source code); changes to non-reserved payloads will now be announced at least one release version in advance. The event types are organized into broad categories: SQL Logical Schema Changes, SQL Privilege Changes, SQL User Management, CLuster-level events and SQL Miscellaneous operations. [#57737][#57737]
 - A report of the possible logging severities and channels is now [automatically generated](https://github.com/cockroachdb/cockroach/blob/master/docs/generated/logging.md). [#57134][#57134]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-0-alpha-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.0-alpha.3.md
+++ b/_includes/releases/v21.1/v21.1.0-alpha.3.md
@@ -88,7 +88,7 @@ Release Date: February 8, 2021
 - Fixed a bug included in 20.2.1 for the [`JSON`](../v21.1/jsonb.html) fetch value operator, `->` which resulted in chained `->` operators in query filters not being index accelerated (e.g., `j->'a'->'b' = '1'`). Chained `->` operators are now index accelerated. [#59494][#59494]
 - Improved the allocation performance of workloads that use the [`EXTRACT`](../v21.1/functions-and-operators.html) built-in. [#59598][#59598]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-0-alpha-3-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.0-beta.1.md
+++ b/_includes/releases/v21.1/v21.1.0-beta.1.md
@@ -257,7 +257,7 @@ Release Date: March 22, 2021
 - Fixed cases where the optimizer was doing unnecessary full table scans when the table was very small (according to the last collected statistics). [#61805][#61805]
 - The optimizer now estimates the cost of evaluating query filters more accurately for queries with a `LIMIT`. Previously, it was assumed that the filter would be evaluated on each input row. Now, the optimizer assumes that the filter will only be evaluated on the number of rows required to produce the LIMIT's number of rows after filtering. This may lead to more efficient query plans in some cases. [#61947][#61947]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-0-beta-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.0-beta.2.md
+++ b/_includes/releases/v21.1/v21.1.0-beta.2.md
@@ -51,7 +51,7 @@ Release Date: March 30, 2021
 - Fixed a bug where setting the `kv.closed_timestamp.target_duration` to 0 did not disable routing requests to [follower replicas](../v21.1/follower-reads.html). [#62439][#62439]
 - Fixed a bug where a failed [restore from a backup](../v21.1/restore.html) including [user defined types](../v21.1/create-type.html) would require manual cleanup. [#62454][#62454]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-0-beta-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.0-beta.5.md
+++ b/_includes/releases/v21.1/v21.1.0-beta.5.md
@@ -51,7 +51,7 @@ $ docker pull cockroachdb/cockroach-unstable:v21.1.0-beta.5
 - CockroachDB now limits a series of heap allocations when serving read-only queries. [#63972][#63972]
 - CockroachDB now limits the amount of memory that can be used in internal buffers for Kafka and cloud sinks. [#63611][#63611]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-0-beta-5-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.1.md
+++ b/_includes/releases/v21.1/v21.1.1.md
@@ -94,7 +94,7 @@ Release Date: May 24, 2021
 - Adjusted the estimated cost of locality-optimized anti joins in the optimizer so that they are always chosen over non-locality-optimized anti joins when possible. This makes it more likely that queries involving anti joins (such as inserts with foreign key checks) can avoid visiting remote regions. This results in lower latency. [#65131][#65131]
 - The optimizer can now avoid full table scans for queries with a `LIMIT` and [`ORDER BY`](../v21.1/order-by.html) clause, where the `ORDER BY` columns form a prefix on an index in a `REGIONAL BY ROW` table (excluding the hidden `crdb_region` column). Instead of a full table scan, at most `LIMIT` rows are scanned per region. [#65287][#65287]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.2.md
+++ b/_includes/releases/v21.1/v21.1.2.md
@@ -62,7 +62,7 @@ Release Date: June 7, 2021
 - The [optimizer](../v21.1/cost-based-optimizer.html) now generates query plans that scan indexes on virtual collated string columns, regardless of the casing or formatting of the collated locale in the query. [#65531][#65531]
 - CockroachDB now reduces the number of round-trips required to call `pg_table_is_visible` in the context of [`pg_catalog` queries](../v21.1/pg-catalog.html). [#65807][#65807]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.1/v21.1.6.md
+++ b/_includes/releases/v21.1/v21.1.6.md
@@ -48,7 +48,7 @@ Release Date: July 20, 2021
 - The [optimizer](../v21.1/cost-based-optimizer.html) now prefers performing a reverse scan over a forward scan + sort if the reverse scan eliminates the need for a sort and the plans are otherwise equivalent. This was previously the case in most cases, but some edge cases with a small number of rows have been fixed. [#67388][#67388]
 - When choosing between index scans that are estimated to have the same number of rows, the [optimizer](../v21.1/cost-based-optimizer.html) now prefers indexes for which it has higher certainty about the maximum number of rows over indexes for which there is more uncertainty in the estimated row count. This helps to avoid choosing suboptimal plans for small tables or if the statistics are stale. [#67388][#67388]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-1-6-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.2/v21.2.0-beta.1.md
+++ b/_includes/releases/v21.2/v21.2.0-beta.1.md
@@ -587,7 +587,7 @@ This testing release includes a known bug. We do **not** recommend upgrading to 
 
 - Added go-swagger dependency. Updated Makefile to call it to rebuild spec in `docs/generated/swagger/`, which will eventually be used for API docs. [#62560][#62560]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-2-0-beta-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.2/v21.2.11.md
+++ b/_includes/releases/v21.2/v21.2.11.md
@@ -25,7 +25,7 @@ Release Date: May 23, 2022
 - Fixed a goroutine leak when internal [rangefeed](../v21.2/use-changefeeds.html#enable-rangefeeds) clients received certain kinds of retryable errors. [#80797][#80797]
 - Fixed a bug in which some prepared statements could result in incorrect results when executed. This could occur when the prepared statement included an equality comparison between an [index column](../v21.2/schema-design-indexes.html) and a placeholder, and the placeholder was cast to a [type](../v21.2/data-types.html) that was different from the column type. For example, if column a was of type [`DECIMAL`](../v21.2/decimal.html), the following prepared query could produce incorrect results when executed: `SELECT * FROM t_dec WHERE a = $1::INT8;` [#81364][#81364]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-2-11-contributors">Contributors</h3>
 

--- a/_includes/releases/v21.2/v21.2.2.md
+++ b/_includes/releases/v21.2/v21.2.2.md
@@ -101,7 +101,7 @@ Release Date: December 1, 2021
 - Fixed a limitation that made creating [partial indexes](../v21.2/partial-indexes.html) inefficient. [#70205][#70205]
 - Backfills initiated by schema changes now periodically checkpoint progress to avoid excessive re-emitting of already emitted spans. [#72788][#72788]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v21-2-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.0-alpha.1.md
+++ b/_includes/releases/v22.1/v22.1.0-alpha.1.md
@@ -286,7 +286,7 @@ Release Date: January 24, 2022
 
 - Env variables and init scripts in `docker-entrypoint-initdb.d` for the [`start-single-node`](../v22.1/cockroach-start-single-node.html) command are now supported. [#70238][#70238]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-1-0-alpha-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.0-alpha.2.md
+++ b/_includes/releases/v22.1/v22.1.0-alpha.2.md
@@ -399,7 +399,7 @@ Release Date: March 7, 2022
 
 - Upgrade to Go 1.17.6 [#74655][#74655]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-1-0-alpha-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.0-alpha.4.md
+++ b/_includes/releases/v22.1/v22.1.0-alpha.4.md
@@ -58,7 +58,7 @@ Release Date: March 21, 2022
 - Improved the [optimizer](../v22.1/cost-based-optimizer.html)'s cardinality estimates for predicates involving many constrained columns. This may result in better index selection for these queries. [#76786][#76786]
 - Improved jobs system resilience to scheduled jobs that may lock up jobs/scheduled job table for long periods of time. Each schedule now has a limited amount of time to complete its execution. The timeout is controlled via the `jobs.scheduler.schedule_execution.timeout` setting. [#77372][#77372]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-1-0-alpha-4-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.1.md
+++ b/_includes/releases/v22.1/v22.1.1.md
@@ -106,7 +106,7 @@ Release Date: June 6, 2022
 
 - Refactored the initialization process of the Docker image to accomodate initialization scripts with memory storage. [#80355][#80355]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-1-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.12.md
+++ b/_includes/releases/v22.1/v22.1.12.md
@@ -55,7 +55,7 @@ Release Date: December 12, 2022
 - CockroachDB in some cases now correctly incorporates the value of the `OFFSET` clause when determining the number of rows that need to be read when the `LIMIT` clause is also present. Note that there was no correctness issue here - only that extra unnecessary rows could be read. [#92839][#92839]
 - [`SHOW BACKUP`](../v22.1/show-backup.html) on a backup containing several table descriptors is now more performant. [#93143][#93143]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-1-12-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.1/v22.1.2.md
+++ b/_includes/releases/v22.1/v22.1.2.md
@@ -35,7 +35,7 @@ Release Date: June 22, 2022
 - Previously, using [`AS OF SYSTEM TIME`](../v22.1/as-of-system-time.html) of two different statements in the same line would result in an assertion error. This is now a PG error with code `0A000`. [#82654][#82654]
 - Fixed a bug where KV requests, in particular export requests issued during a [backup](../v22.1/backup.html), were rejected incorrectly causing the backup to fail with a `batch timestamp <ts> must be after replica GC threshold` error. The requests were rejected on the pretext that their timestamp was below the [garbage collection threshold](../v22.1/architecture/storage-layer.html#garbage-collection) of the key span. This was because the [protected timestamps](../v22.1/architecture/storage-layer.html#protected-timestamps) were not considered when computing the garbage collection threshold for the key span being backed up. Protected timestamp records hold up the garbage collection threshold of a span during long-running operations such as backups to prevent revisions from being garbage collected. [#82757][#82757]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-1-2-contributors">Contributors</h3>
 

--- a/_includes/releases/v22.2/v22.2.0-alpha.1.md
+++ b/_includes/releases/v22.2/v22.2.0-alpha.1.md
@@ -459,7 +459,7 @@ re-emitting the majority of spans due to a small minority that is experiencing i
 - Upgraded to Go 1.18.4. [#84590][#84590]
 - Build **experimental** Linux ARM64 binary. [#86043][#86043]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v22-2-0-alpha-1-contributors">Contributors</h3>
 

--- a/_includes/releases/v23.1/v23.1.0-alpha.1.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.1.md
@@ -294,7 +294,7 @@ Release Date: December 19, 2022
 - CockroachDB in some cases now correctly incorporates the value of the `OFFSET` clause when determining the number of rows that need to be read when the `LIMIT` clause is also present. Note that there was no correctness issue here, only that extra unnecessary rows could be read. [#92779][#92779]
 - In 22.2, privileges on virtual tables (system catalogs like `pg_catalog`, `information_schema`, and `crdb_internal`) were introduced. A problem with this new feature is that we now must fetch those privileges into a cache before we can use those tables or determine their visibility in other system catalogs. This process used to occur on-demand, when the privilege was needed. Now, CockroachDB will fetch these privileges eagerly during startup to mitigate latency when accessing `pg_catalog` right after the server boots up. [#93557][#93557]
 
-<div class="release-note-contributors">
+<div class="release-note-contributors" markdown="1">
 
 <h3 id="v23-1-0-alpha-1-contributors">Contributors</h3>
 


### PR DESCRIPTION
It seems that adding the div block stopped allowing markdown text inside the div from rendering. This should fix that. An accompanying PR to fix the `release-notes.py` script will follow.