### PR TITLE
Correction on CDC expressions to transformations naming rn

### DIFF
--- a/_includes/releases/v23.1/v23.1.0-alpha.1.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.1.md
@@ -36,7 +36,7 @@ Release Date: December 19, 2022
 - Changefeeds will now treat all errors, unless otherwise indicated, as retryable errors. [#90810][#90810]
 - CockroachDB now supports passing in the optional external ID when [assuming a role](../v22.2/cloud-storage-authentication.html). This is done by extending the values of the comma-separated string value of the `ASSUME_ROLE` parameter to the format `<role>;external_id=<id>`. Users can still use the previous format of just `<role>` to specify a role without any external ID. When using role chaining, each role in the chain can be associated with a different external ID. [#91040][#91040]
 - [JWT authentication](../v22.2/sso-sql.html) [cluster settings](../v22.2/cluster-settings.html) can now be modified from within tenants to better support serverless use cases. [#92406][#92406]
-- [CDC](../v22.2/change-data-capture-overview.html) expressions are now planned and evaluated using the SQL optimizer and distSQL execution. The state of the previous row is now exposed as the `cdc_prev` tuple. [#85177][#85177]
+- [CDC transformations](../v22.2/cdc-transformations.html) are now planned and evaluated using the SQL optimizer and distSQL execution. The state of the previous row is now exposed as the `cdc_prev` tuple. [#85177][#85177]
 - Changefeeds no longer require the `COCKROACH_EXPERIMENTAL_ENABLE_PER_CHANGEFEED_METRICS` environment variable to be set in order to use the `metrics_label` option. [#93423][#93423]
 - Changefeeds can now be scheduled at intervals specified in crontab notation. [#92232][#92232]
 


### PR DESCRIPTION
Quick fix to 23.1 alpha.1 release notes for naming of Change Data Capture transformations (no longer named CDC expressions)