### PR TITLE
Release notes for Operator 2.9.0

### DIFF
--- a/releases/kubernetes-operator.md
+++ b/releases/kubernetes-operator.md
@@ -21,6 +21,14 @@ To be notified about updates to the Helm chart, visit the [CockroachDB Helm char
 
 <!-- Copy the top section below and bump the variable -->
 
+## December 16, 2022
+
+{% assign operator_version = "2.9.0" %}
+CockroachDB Kubernetes Operator {{ operator_version }} is available.
+
+- [Changelog](https://github.com/cockroachdb/cockroach-operator/blob/master/CHANGELOG.md#v{{ operator_version }})
+- [Download](https://github.com/cockroachdb/cockroach-operator/releases/tag/v{{ operator_version }})
+
 ## July 13, 2022
 
 {% assign operator_version = "2.8.0" %}


### PR DESCRIPTION
Relates to https://github.com/cockroachdb/cockroach-operator/commit/54d6fcdd7eeec7147c1be026ffc9c5d8e10050e9

## Previews
[releases/kubernetes-operator.md](https://deploy-preview-15875--cockroachdb-docs.netlify.app/docs/releases/kubernetes-operator.html)

## Tests
- [x] Local build
- [x] Linkcheck 