### PR TITLE
DOC-4611 v22.2.2 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -132,12 +132,12 @@ release_info:
     start_time: 2022-12-12 12:29:20.391677 +0000 UTC
     version: v22.1.12
   v22.2:
-    build_time: 2022-12-22 00:00:00 (go1.19)
+    build_time: 2023-01-04 00:00:00 (go1.19)
     crdb_branch_name: release-22.2
     docker_image: cockroachdb/cockroach
-    name: v22.2.1
-    start_time: 2022-12-19 15:28:42.642744 +0000 UTC
-    version: v22.2.1
+    name: v22.2.2
+    start_time: 2023-01-03 11:22:46.206439 +0000 UTC
+    version: v22.2.2
   v23.1:
     build_time: 2022-12-19 00:00:00 (go1.19)
     crdb_branch_name: master

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -313,3 +313,4 @@ v22.2.0,v22.2,2022-12-06,false,False,Production,False,go1.18,77667a1b0101cd32309
 v22.1.12,v22.1,2022-12-12,false,False,Production,False,go1.18,3b76f78d724dfc1e7bc8d697f5a7de960d8d1e98,cockroachdb/cockroach,true,false,false,false,true
 v23.1.0-alpha.1,v23.1,2022-12-19,false,False,Testing,False,go1.19,d6f98e90684894fd36f53596e6aac355676d232e,cockroachdb/cockroach-unstable,true,true,true,true,true
 v22.2.1,v22.2,2022-12-22,false,False,Production,False,go1.19,cf1e7e6bc6ef9e55510b9ed13bd068bb3894cd92,cockroachdb/cockroach,true,true,true,true,true
+v22.2.2,v22.2,2023-01-04,false,False,Production,False,go1.19,07a53a36601e9ca5fcffcff55f69b43c6dfbf1c1,cockroachdb/cockroach,true,true,true,true,true

--- a/_includes/releases/v22.2/v22.2.2.md
+++ b/_includes/releases/v22.2/v22.2.2.md
@@ -1,0 +1,69 @@
+## v22.2.2
+
+Release Date: January 4, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-2-2-sql-language-changes">SQL language changes</h3>
+
+- Fixed a bug where CockroachDB could crash if a user creates a [user-defined function (UDF)](../v22.2/user-defined-functions.html) whose function signature includes an implicit record type which has a column using a user-defined enum type. [#94241][#94241]
+- Added the `log_timezone` [session variable](../v22.2/set-vars.html), which is read only and always UTC. [#94346][#94346]
+- Implemented the `pg_timezone_names` pg_catalog table, which lists all supported timezones. [#94346][#94346]
+
+<h3 id="v22-2-2-db-console-changes">DB Console changes</h3>
+
+- Updated metric graph tooltip styling to prevent content collapse. [#93928][#93928]
+- Updated UI to show correct login information in the top right corner for secure clusters, and fixed documentation links to correctly reference the current cluster version as necessary. [#94067][#94067]
+
+<h3 id="v22-2-2-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug where the `session_id` [session variable](../v22.2/set-vars.html) would not be properly set if used from a subquery, [#93856][#93856]
+- Fix a bug that would result in incomplete backups when non-default, non-public resource limiting settings (`kv.bulk_sst.max_request_time` or `admission.elastic_cpu.enabled`) were enabled. [#93728][#93728]
+- Updated the volatility of the `hmac`, `digest`, and `crypt` [built-in functions](../v22.2/functions-and-operators.html) to be immutable. [#93924][#93924]
+- Server logs will now correctly `fsync` at every `syncInterval`. [#93995][#93995]
+- The `stxnamespace`, `stxkind` and `stxstattarget` columns are now defined in `pg_statistics_ext`. [#94009][#94009]
+- The [`CREATE ROLE`](../v22.2/create-role.html), [`DROP ROLE`](../v22.2/drop-role.html), [`GRANT`](../v22.2/grant.html), and [`REVOKE`](../v22.2/revoke.html) statements no longer work when the transaction is in read-only mode. [#94103][#94103]
+- Fixed a bug where CockroachDB could crash in rare circumstances when evaluating lookup and index joins. The bug has been present since the 22.2.0 release. [#94100][#94100]
+- Fixed a bug where, when experimental MVCC range tombstones are enabled (they are disabled by default), a bulk ingestion (e.g. an [`IMPORT`](../v22.2/import.html)) could fail to take a committed-but-unresolved write intent into account during conflict checks when written above an MVCC range tombstone. It was therefore possible in very rare circumstances for the ingestion to write a value below the timestamp of the committed intent, causing the ingested value to disappear. [#94006][#94006]
+- Fixed a bug that could prevent CASE expressions that used placeholder return values from type-checking correctly. [#93923][#93923]
+- Fixed a bug where, when experimental MVCC range tombstones are enabled (they're disabled by default), a bulk ingestion (e.g. an [`IMPORT`](../v22.2/import.html)) could in some situations fail to properly check for conflicts with existing MVCC range tombstones. This could cause the ingestion to write below a recently written MVCC range tombstone, in turn losing the ingested data. This could only happen in rare circumstances where a bulk ingestion was applied concurrently with an import cancellation. [#94115][#94115]
+- Fixed a bug that could happen when type-checking an array expression that only contains NULLs and placeholder values. The bug was only present in v22.2.1. [#94243][#94243]
+- Fixed a bug introduced in 22.1 where tables which receive writes concurrent with portions of an `ALTER TABLE ... SET LOCALITY REGIONAL BY ROW` statement may fail with an error: `duplicate key value violates unique constraint "new_primary_key"`. [#94251][#94251]
+- Previously, CockroachDB could encounter an internal error when evaluating [window functions](../v22.2/window-functions.html) with `RANGE` window frame mode with `OFFSET PRECEDING` or `OFFSET FOLLOWING` boundary when an `ORDER BY` clause has the `NULLS LAST` option set. This will now result in a regular error since the feature is marked as unsupported. [#94352][#94352]
+- Record types can now be encoded with the binary encoding of the PostgreSQL wire protocol. Previously, trying to use this encoding could case a panic. [#94419][#94419]
+- Fixed a bug where CockroachDB could delay the release of the locks acquired when evaluating `SELECT FOR UPDATE` statements in some cases. This delay (up to 5s) could then block the future readers. The bug was introduced in 22.2.0. [#94401][#94401]
+
+<h3 id="v22-2-2-performance-improvements">Performance improvements</h3>
+
+- The optimizer can now avoid planning a sort in more cases with joins that perform lookups into an index with one or more columns sorted in descending order. This can significantly decrease the number of rows that have to be scanned in order to satisfy a `LIMIT` clause. [#93770][#93770]
+- Improved the performance of `crdb_internal.default_privileges` population. [#94336][#94336]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v22-2-2-contributors">Contributors</h3>
+
+This release includes 46 merged PRs by 25 authors.
+
+</div>
+
+[#93728]: https://github.com/cockroachdb/cockroach/pull/93728
+[#93770]: https://github.com/cockroachdb/cockroach/pull/93770
+[#93856]: https://github.com/cockroachdb/cockroach/pull/93856
+[#93923]: https://github.com/cockroachdb/cockroach/pull/93923
+[#93924]: https://github.com/cockroachdb/cockroach/pull/93924
+[#93928]: https://github.com/cockroachdb/cockroach/pull/93928
+[#93995]: https://github.com/cockroachdb/cockroach/pull/93995
+[#94006]: https://github.com/cockroachdb/cockroach/pull/94006
+[#94009]: https://github.com/cockroachdb/cockroach/pull/94009
+[#94067]: https://github.com/cockroachdb/cockroach/pull/94067
+[#94100]: https://github.com/cockroachdb/cockroach/pull/94100
+[#94103]: https://github.com/cockroachdb/cockroach/pull/94103
+[#94115]: https://github.com/cockroachdb/cockroach/pull/94115
+[#94241]: https://github.com/cockroachdb/cockroach/pull/94241
+[#94243]: https://github.com/cockroachdb/cockroach/pull/94243
+[#94251]: https://github.com/cockroachdb/cockroach/pull/94251
+[#94336]: https://github.com/cockroachdb/cockroach/pull/94336
+[#94346]: https://github.com/cockroachdb/cockroach/pull/94346
+[#94352]: https://github.com/cockroachdb/cockroach/pull/94352
+[#94401]: https://github.com/cockroachdb/cockroach/pull/94401
+[#94419]: https://github.com/cockroachdb/cockroach/pull/94419


### PR DESCRIPTION
Addresses: DOC-4611

- CRDB v22.2.2 release notes.

Staging

[v22.2.md](https://deploy-preview-15910--cockroachdb-docs.netlify.app/docs/releases/v22.2.html#v22-2-2)