### PR TITLE
Update SELECT FOR UPDATE re: serialization errors

### DIFF
--- a/_includes/v21.2/sql/select-for-update-overview.md
+++ b/_includes/v21.2/sql/select-for-update-overview.md
@@ -6,6 +6,8 @@ Because this queueing happens during the read operation, the [thrashing](https:/
 
 As a result, using `SELECT FOR UPDATE` leads to increased throughput and decreased tail latency for contended operations.
 
+Note that using `SELECT FOR UPDATE` does not completely eliminate the chance of [serialization errors](transaction-retry-error-reference.html), which use the `SQLSTATE` error code `40001`, and emit error messages with the string `restart transaction`. These errors can also arise due to [time uncertainty](architecture/transaction-layer.html#transaction-conflicts). To eliminate the need for application-level retry logic, in addition to `SELECT FOR UPDATE` your application also needs to use a [driver that implements automatic retry handling](transactions.html#client-side-intervention).
+
 CockroachDB currently does not support the `FOR SHARE`/`FOR KEY SHARE` [locking strengths](select-for-update.html#locking-strengths), or the `SKIP LOCKED` [wait policy](select-for-update.html#wait-policies).
 
 {{site.data.alerts.callout_info}}

--- a/_includes/v22.1/sql/select-for-update-overview.md
+++ b/_includes/v22.1/sql/select-for-update-overview.md
@@ -6,6 +6,8 @@ Because this queueing happens during the read operation, the [thrashing](https:/
 
 As a result, using `SELECT FOR UPDATE` leads to increased throughput and decreased tail latency for contended operations.
 
+Note that using `SELECT FOR UPDATE` does not completely eliminate the chance of [serialization errors](transaction-retry-error-reference.html), which use the `SQLSTATE` error code `40001`, and emit error messages with the string `restart transaction`. These errors can also arise due to [time uncertainty](architecture/transaction-layer.html#transaction-conflicts). To eliminate the need for application-level retry logic, in addition to `SELECT FOR UPDATE` your application also needs to use a [driver that implements automatic retry handling](transactions.html#client-side-intervention).
+
 CockroachDB does not support the `FOR SHARE` or `FOR KEY SHARE` [locking strengths](select-for-update.html#locking-strengths), or the `SKIP LOCKED` [wait policy](select-for-update.html#wait-policies).
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
Followup work for DOC-6257

This commit ports the changes to the SELECT FOR UPDATE docs that were added in cockroachdb/docs#15820 to the v21.2 and v22.1 docs as well, since those versions are still supported.