### PR TITLE
Recommend size limits on indexed columns

### DIFF
--- a/_includes/v21.2/sql/add-size-limits-to-indexed-columns.md
+++ b/_includes/v21.2/sql/add-size-limits-to-indexed-columns.md
@@ -1,0 +1,22 @@
+We **strongly recommend** adding size limits to all [indexed columns](indexes.html), which includes columns in [primary keys](primary-key.html).
+
+Values exceeding 1 MiB can lead to [storage layer write amplification](architecture/storage-layer.html#write-amplification) and cause significant performance degradation or even [crashes due to OOMs (out of memory errors)](cluster-setup-troubleshooting.html#out-of-memory-oom-crash).
+
+To add a size limit using [`CREATE TABLE`](create-table.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE name (first STRING(100), last STRING(100));
+~~~
+
+To add a size limit using [`ALTER TABLE ... ALTER COLUMN`](alter-column.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET enable_experimental_alter_column_type_general = true;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE name ALTER first TYPE STRING(99);
+~~~

--- a/_includes/v22.1/sql/add-size-limits-to-indexed-columns.md
+++ b/_includes/v22.1/sql/add-size-limits-to-indexed-columns.md
@@ -1,0 +1,22 @@
+We **strongly recommend** adding size limits to all [indexed columns](indexes.html), which includes columns in [primary keys](primary-key.html).
+
+Values exceeding 1 MiB can lead to [storage layer write amplification](architecture/storage-layer.html#write-amplification) and cause significant performance degradation or even [crashes due to OOMs (out of memory errors)](cluster-setup-troubleshooting.html#out-of-memory-oom-crash).
+
+To add a size limit using [`CREATE TABLE`](create-table.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE name (first STRING(100), last STRING(100));
+~~~
+
+To add a size limit using [`ALTER TABLE ... ALTER COLUMN`](alter-column.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET enable_experimental_alter_column_type_general = true;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE name ALTER first TYPE STRING(99);
+~~~

--- a/_includes/v22.2/sql/add-size-limits-to-indexed-columns.md
+++ b/_includes/v22.2/sql/add-size-limits-to-indexed-columns.md
@@ -1,0 +1,22 @@
+We **strongly recommend** adding size limits to all [indexed columns](indexes.html), which includes columns in [primary keys](primary-key.html).
+
+Values exceeding 1 MiB can lead to [storage layer write amplification](architecture/storage-layer.html#write-amplification) and cause significant performance degradation or even [crashes due to OOMs (out of memory errors)](cluster-setup-troubleshooting.html#out-of-memory-oom-crash).
+
+To add a size limit using [`CREATE TABLE`](create-table.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE name (first STRING(100), last STRING(100));
+~~~
+
+To add a size limit using [`ALTER TABLE ... ALTER COLUMN`](alter-column.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET enable_experimental_alter_column_type_general = true;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER TABLE name ALTER first TYPE STRING(99);
+~~~

--- a/v21.2/bytes.md
+++ b/v21.2/bytes.md
@@ -29,7 +29,11 @@ is otherwise expected.
 
 ## Size
 
-The size of a `BYTES` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.  
+The size of a `BYTES` value is variable, but it's recommended to keep values under 1 MB to ensure adequate performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_success}}
 If your application requires large binary input in single queries, you can store the blobs somewhere your client can access them (using a cloud storage service, for example), and then reference their addresses from a statement.

--- a/v21.2/cluster-setup-troubleshooting.md
+++ b/v21.2/cluster-setup-troubleshooting.md
@@ -288,7 +288,7 @@ See the following FAQs:
 You may encounter the following issues when your cluster nears 100% resource capacity:
 
 -   Running CPU at close to 100% utilization with high run queue will result in poor performance.
--   Running RAM at close to 100% utilization triggers Linux OOM and/or swapping that will result in poor performance or stability issues.
+-   Running RAM at close to 100% utilization triggers Linux [OOM](#out-of-memory-oom-crash) and/or swapping that will result in poor performance or stability issues.
 -   Running storage at 100% capacity causes writes to fail, which in turn can cause various processes to stop.
 -   Running storage at 100% utilization read/write causes poor service time and [node shutdown](operational-faqs.html#what-happens-when-a-node-runs-out-of-disk-space).
 -   Running network at 100% utilization causes response between databases and client to be poor.

--- a/v21.2/collate.md
+++ b/v21.2/collate.md
@@ -19,6 +19,10 @@ Collated strings are important because different languages have [different rules
 
 - Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Supported collations
 
 CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.

--- a/v21.2/common-errors.md
+++ b/v21.2/common-errors.md
@@ -189,7 +189,7 @@ When importing into an existing table with [`IMPORT INTO`](import-into.html), th
 
 ## memory budget exceeded
 
-This message usually indicates that `--max-sql-memory`, the memory allocated to the SQL layer, was exceeded by the operation referenced in the error. A `memory budget exceeded` error also suggests that a node is close to an OOM crash, which might be prevented by failing the query.
+This message usually indicates that `--max-sql-memory`, the memory allocated to the SQL layer, was exceeded by the operation referenced in the error. A `memory budget exceeded` error also suggests that a node is close to an [OOM crash](cluster-setup-troubleshooting.html#out-of-memory-oom-crash), which might be prevented by failing the query.
 
 {% include {{ page.version.version }}/prod-deployment/resolution-untuned-query.md %}
 

--- a/v21.2/common-issues-to-monitor.md
+++ b/v21.2/common-issues-to-monitor.md
@@ -118,7 +118,7 @@ If nodes have shut down, this can also be caused by [insufficient storage capaci
 
 ## Memory
 
-CockroachDB is [resilient](demo-fault-tolerance-and-recovery.html) to node crashes. However, frequent node restarts caused by out-of-memory (OOM) crashes can impact cluster stability and performance.
+CockroachDB is [resilient](demo-fault-tolerance-and-recovery.html) to node crashes. However, frequent node restarts caused by [out-of-memory (OOM) crashes](cluster-setup-troubleshooting.html#out-of-memory-oom-crash) can impact cluster stability and performance.
 
 ### Memory planning
 
@@ -130,7 +130,7 @@ Provision enough memory and allocate an appropriate portion for data caching:
 
 ### Memory monitoring
 
-Monitor memory usage and node behavior for OOM errors:
+Monitor memory usage and node behavior for [OOM errors](cluster-setup-troubleshooting.html#out-of-memory-oom-crash):
 
 | Metric or event                                 | Description                                 |
 |-------------------------------------------------|---------------------------------------------|
@@ -152,7 +152,7 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 ##### Verify OOM errors
 
-If you observe nodes frequently restarting, confirm that the crashes are caused by OOM errors:
+If you observe nodes frequently restarting, confirm that the crashes are caused by [OOM errors](cluster-setup-troubleshooting.html#out-of-memory-oom-crash):
 
 - Monitor `dmesg` to determine if a node crashed because it ran out of memory:
 
@@ -193,6 +193,10 @@ An untuned SQL query can consume significant resources and impact the performanc
 
 {{site.data.alerts.callout_success}}
 {% include {{ page.version.version }}/prod-deployment/resolution-untuned-query.md %}
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
 {{site.data.alerts.end}}
 
 #### Database memory usage

--- a/v21.2/indexes.md
+++ b/v21.2/indexes.md
@@ -58,6 +58,10 @@ Indexes create a trade-off: they greatly improve the speed of queries, but may s
 
 To maximize your indexes' performance, we recommend following the [secondary index best practices](schema-design-indexes.html#best-practices).
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}
 For more information about how to tune CockroachDB's performance, see [SQL Performance Best Practices](performance-best-practices-overview.html).
 {{site.data.alerts.end}}

--- a/v21.2/jsonb.md
+++ b/v21.2/jsonb.md
@@ -47,6 +47,10 @@ Examples:
 
 The size of a `JSONB` value is variable, but we recommend that you keep values under 1 MB to ensure satisfactory performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Functions
 
 Function | Description

--- a/v21.2/kubernetes-performance.md
+++ b/v21.2/kubernetes-performance.md
@@ -168,7 +168,7 @@ When you ask Kubernetes to run a pod, either directly or indirectly through anot
 
 #### Resource requests
 
-Resource requests allow you to reserve a certain amount of CPU or memory for your container. If you add resource requests to your CockroachDB YAML file, Kubernetes will schedule each CockroachDB pod onto a node with sufficient unreserved resources and will ensure the pods are guaranteed the reserved resources using the applicable Linux container primitives. If you are running other workloads in your Kubernetes cluster, setting resource requests is very strongly recommended to ensure good performance, because if you do not set them then CockroachDB could be starved of CPU cycles or OOM stopped before less important processes.
+Resource requests allow you to reserve a certain amount of CPU or memory for your container. If you add resource requests to your CockroachDB YAML file, Kubernetes will schedule each CockroachDB pod onto a node with sufficient unreserved resources and will ensure the pods are guaranteed the reserved resources using the applicable Linux container primitives. If you are running other workloads in your Kubernetes cluster, setting resource requests is very strongly recommended to ensure good performance, because if you do not set them then CockroachDB could be starved of CPU cycles or [OOM stopped](cluster-setup-troubleshooting.html#out-of-memory-oom-crash) before less important processes.
 
 To determine how many resources are usable on your Kubernetes nodes, you can run:
 

--- a/v21.2/primary-key.md
+++ b/v21.2/primary-key.md
@@ -77,6 +77,10 @@ To ensure each row has a unique identifier, the `PRIMARY KEY` constraint combine
 
 For best practices, see [Schema Design: Select primary key columns](schema-design-table.html#select-primary-key-columns).
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Example
 
 {% include_cached copy-clipboard.html %}

--- a/v21.2/schema-design-indexes.md
+++ b/v21.2/schema-design-indexes.md
@@ -139,6 +139,10 @@ Here are some best practices for creating and using indexes:
 
 - {% include {{page.version.version}}/sql/dev-schema-change-limits.md %}
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Example
 
 Suppose you want the MovR application to display all of the bikes available to the users of the MovR platform.

--- a/v21.2/schema-design-table.md
+++ b/v21.2/schema-design-table.md
@@ -115,6 +115,10 @@ Here are some best practices to follow when defining table columns:
 
 - Review the best practices and examples for [adding additional constraints](#add-additional-constraints), and decide if you need to add any additional constraints to your columns.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 #### Column definition examples
 
 In the `max_init.sql` file, add a few column definitions to the `users` table's `CREATE TABLE` statement, for user names and email addresses:
@@ -224,6 +228,10 @@ Here are some best practices to follow when selecting primary key columns:
 - For single-column primary keys, use [`UUID`](uuid.html)-typed columns with default values randomly-generated, using the `gen_random_uuid()` [SQL function](functions-and-operators.html#id-generation-functions).
 
     Randomly generating `UUID` values ensures that the primary key values will be unique and well-distributed across a cluster. For an example, see [below](#primary-key-examples).
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
 
 #### Primary key examples
 

--- a/v21.2/string.md
+++ b/v21.2/string.md
@@ -32,6 +32,10 @@ CockroachDB also supports the single-byte `"char"` special character type. As in
 
 To limit the length of a string column, use `STRING(n)`, where `n` is the maximum number of Unicode code points (normally thought of as "characters") allowed. This applies to all related types as well (e.g., to limit the length of a `VARCHAR` type, use `VARCHAR(n)`). To reduce performance issues caused by storing very large string values in indexes, Cockroach Labs recommends setting length limits on string-typed columns.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 When inserting a `STRING` value or a `STRING`-related-type value:
 
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.

--- a/v22.1/bytes.md
+++ b/v22.1/bytes.md
@@ -29,7 +29,11 @@ is otherwise expected.
 
 ## Size
 
-The size of a `BYTES` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.  
+The size of a `BYTES` value is variable, but it's recommended to keep values under 1 MB to ensure adequate performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_success}}
 If your application requires large binary input in single queries, you can store the blobs somewhere your client can access them (using a cloud storage service, for example), and then reference their addresses from a statement.

--- a/v22.1/cluster-setup-troubleshooting.md
+++ b/v22.1/cluster-setup-troubleshooting.md
@@ -316,7 +316,7 @@ See the following FAQs:
 You may encounter the following issues when your cluster nears 100% resource capacity:
 
 -   Running CPU at close to 100% utilization with high run queue will result in poor performance.
--   Running RAM at close to 100% utilization triggers Linux OOM and/or swapping that will result in poor performance or stability issues.
+-   Running RAM at close to 100% utilization triggers Linux [OOM](#out-of-memory-oom-crash) and/or swapping that will result in poor performance or stability issues.
 -   Running storage at 100% capacity causes writes to fail, which in turn can cause various processes to stop.
 -   Running storage at 100% utilization read/write causes poor service time and [node shutdown](operational-faqs.html#what-happens-when-a-node-runs-out-of-disk-space).
 -   Running network at 100% utilization causes response between databases and client to be poor.

--- a/v22.1/collate.md
+++ b/v22.1/collate.md
@@ -19,6 +19,10 @@ Collated strings are important because different languages have [different rules
 
 - Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Supported collations
 
 CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.

--- a/v22.1/common-errors.md
+++ b/v22.1/common-errors.md
@@ -189,7 +189,7 @@ When importing into an existing table with [`IMPORT INTO`](import-into.html), th
 
 ## memory budget exceeded
 
-This message usually indicates that `--max-sql-memory`, the memory allocated to the SQL layer, was exceeded by the operation referenced in the error. A `memory budget exceeded` error also suggests that a node is close to an OOM crash, which might be prevented by failing the query.
+This message usually indicates that `--max-sql-memory`, the memory allocated to the SQL layer, was exceeded by the operation referenced in the error. A `memory budget exceeded` error also suggests that a node is close to an [OOM crash](cluster-setup-troubleshooting.html#out-of-memory-oom-crash), which might be prevented by failing the query.
 
 {% include {{ page.version.version }}/prod-deployment/resolution-untuned-query.md %}
 

--- a/v22.1/common-issues-to-monitor.md
+++ b/v22.1/common-issues-to-monitor.md
@@ -118,7 +118,7 @@ If nodes have shut down, this can also be caused by [insufficient storage capaci
 
 ## Memory
 
-CockroachDB is [resilient](demo-fault-tolerance-and-recovery.html) to node crashes. However, frequent node restarts caused by out-of-memory (OOM) crashes can impact cluster stability and performance.
+CockroachDB is [resilient](demo-fault-tolerance-and-recovery.html) to node crashes. However, frequent node restarts caused by [out-of-memory (OOM) crashes](cluster-setup-troubleshooting.html#out-of-memory-oom-crash) can impact cluster stability and performance.
 
 ### Memory planning
 
@@ -130,7 +130,7 @@ Provision enough memory and allocate an appropriate portion for data caching:
 
 ### Memory monitoring
 
-Monitor memory usage and node behavior for OOM errors:
+Monitor memory usage and node behavior for [OOM errors](cluster-setup-troubleshooting.html#out-of-memory-oom-crash):
 
 | Metric or event                                 | Description                                 |
 |-------------------------------------------------|---------------------------------------------|
@@ -152,7 +152,7 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 ##### Verify OOM errors
 
-If you observe nodes frequently restarting, confirm that the crashes are caused by OOM errors:
+If you observe nodes frequently restarting, confirm that the crashes are caused by [OOM errors](cluster-setup-troubleshooting.html#out-of-memory-oom-crash):
 
 - Monitor `dmesg` to determine if a node crashed because it ran out of memory:
 
@@ -193,6 +193,10 @@ An untuned SQL query can consume significant resources and impact the performanc
 
 {{site.data.alerts.callout_success}}
 {% include {{ page.version.version }}/prod-deployment/resolution-untuned-query.md %}
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
 {{site.data.alerts.end}}
 
 #### Database memory usage

--- a/v22.1/indexes.md
+++ b/v22.1/indexes.md
@@ -58,6 +58,10 @@ Indexes create a trade-off: they greatly improve the speed of queries, but may s
 
 To maximize your indexes' performance, Cockroach Labs recommends following the [secondary index best practices](schema-design-indexes.html#best-practices).
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}
 For more information about how to tune CockroachDB performance, see [SQL Performance Best Practices](performance-best-practices-overview.html).
 {{site.data.alerts.end}}

--- a/v22.1/jsonb.md
+++ b/v22.1/jsonb.md
@@ -43,6 +43,10 @@ Examples:
 
 The size of a `JSONB` value is variable, but we recommend that you keep values under 1 MB to ensure satisfactory performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Operators
 
 Operator | Description | Example |

--- a/v22.1/kubernetes-performance.md
+++ b/v22.1/kubernetes-performance.md
@@ -168,7 +168,7 @@ When you ask Kubernetes to run a pod, either directly or indirectly through anot
 
 #### Resource requests
 
-Resource requests allow you to reserve a certain amount of CPU or memory for your container. If you add resource requests to your CockroachDB YAML file, Kubernetes will schedule each CockroachDB pod onto a node with sufficient unreserved resources and will ensure the pods are guaranteed the reserved resources using the applicable Linux container primitives. If you are running other workloads in your Kubernetes cluster, setting resource requests is very strongly recommended to ensure good performance, because if you do not set them then CockroachDB could be starved of CPU cycles or OOM stopped before less important processes.
+Resource requests allow you to reserve a certain amount of CPU or memory for your container. If you add resource requests to your CockroachDB YAML file, Kubernetes will schedule each CockroachDB pod onto a node with sufficient unreserved resources and will ensure the pods are guaranteed the reserved resources using the applicable Linux container primitives. If you are running other workloads in your Kubernetes cluster, setting resource requests is very strongly recommended to ensure good performance, because if you do not set them then CockroachDB could be starved of CPU cycles or [OOM stopped](cluster-setup-troubleshooting.html#out-of-memory-oom-crash) before less important processes.
 
 To determine how many resources are usable on your Kubernetes nodes, you can run:
 

--- a/v22.1/primary-key.md
+++ b/v22.1/primary-key.md
@@ -77,6 +77,10 @@ To ensure each row has a unique identifier, the `PRIMARY KEY` constraint combine
 
 For best practices, see [Select primary key columns](schema-design-table.html#select-primary-key-columns).
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Example
 
 {% include_cached copy-clipboard.html %}

--- a/v22.1/schema-design-indexes.md
+++ b/v22.1/schema-design-indexes.md
@@ -101,6 +101,10 @@ The [`EXPLAIN`](explain.html#success-responses) command provides index recommend
 
     - If you need to [change a primary key](constraints.html#change-constraints), and you do not plan to filter queries on the existing primary key column(s), do not use [`ALTER PRIMARY KEY`](alter-primary-key.html) because it creates a secondary index from an existing primary key. Instead, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key), which does not create a secondary index.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ### Index management
 
 - Limit creation and deletion of secondary indexes to off-peak hours. Performance impacts are likely if done during peak business hours.

--- a/v22.1/schema-design-table.md
+++ b/v22.1/schema-design-table.md
@@ -115,6 +115,10 @@ Here are some best practices to follow when defining table columns:
 
 - Review the best practices and examples for [adding additional constraints](#add-additional-constraints), and decide if you need to add any additional constraints to your columns.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 #### Column definition examples
 
 In the `max_init.sql` file, add a few column definitions to the `users` table's `CREATE TABLE` statement, for user names and email addresses:
@@ -224,6 +228,10 @@ Here are some best practices to follow when selecting primary key columns:
 - For single-column primary keys, use [`UUID`](uuid.html)-typed columns with default values randomly-generated, using the `gen_random_uuid()` [SQL function](functions-and-operators.html#id-generation-functions).
 
     Randomly generating `UUID` values ensures that the primary key values will be unique and well-distributed across a cluster. For an example, see [below](#primary-key-examples).
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
 
 #### Primary key examples
 

--- a/v22.1/string.md
+++ b/v22.1/string.md
@@ -32,6 +32,10 @@ CockroachDB also supports the single-byte `"char"` special character type. As in
 
 To limit the length of a string column, use `STRING(n)`, where `n` is the maximum number of Unicode code points (normally thought of as "characters") allowed. This applies to all related types as well (e.g., to limit the length of a `VARCHAR` type, use `VARCHAR(n)`). To reduce performance issues caused by storing very large string values in indexes, Cockroach Labs recommends setting length limits on string-typed columns.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 When inserting a `STRING` value or a `STRING`-related-type value:
 
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.

--- a/v22.2/bytes.md
+++ b/v22.2/bytes.md
@@ -29,7 +29,11 @@ is otherwise expected.
 
 ## Size
 
-The size of a `BYTES` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.  
+The size of a `BYTES` value is variable, but it's recommended to keep values under 1 MB to ensure adequate performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_success}}
 If your application requires large binary input in single queries, you can store the blobs somewhere your client can access them (using a cloud storage service, for example), and then reference their addresses from a statement.

--- a/v22.2/cluster-setup-troubleshooting.md
+++ b/v22.2/cluster-setup-troubleshooting.md
@@ -316,7 +316,7 @@ See the following FAQs:
 You may encounter the following issues when your cluster nears 100% resource capacity:
 
 -   Running CPU at close to 100% utilization with high run queue will result in poor performance.
--   Running RAM at close to 100% utilization triggers Linux OOM and/or swapping that will result in poor performance or stability issues.
+-   Running RAM at close to 100% utilization triggers Linux [OOM](#out-of-memory-oom-crash) and/or swapping that will result in poor performance or stability issues.
 -   Running storage at 100% capacity causes writes to fail, which in turn can cause various processes to stop.
 -   Running storage at 100% utilization read/write causes poor service time and [node shutdown](operational-faqs.html#what-happens-when-a-node-runs-out-of-disk-space).
 -   Running network at 100% utilization causes response between databases and client to be poor.

--- a/v22.2/collate.md
+++ b/v22.2/collate.md
@@ -19,6 +19,10 @@ Collated strings are important because different languages have [different rules
 
 - Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Supported collations
 
 CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.

--- a/v22.2/common-errors.md
+++ b/v22.2/common-errors.md
@@ -191,7 +191,7 @@ When importing into an existing table with [`IMPORT INTO`](import-into.html), th
 
 ## memory budget exceeded
 
-This message usually indicates that `--max-sql-memory`, the memory allocated to the SQL layer, was exceeded by the operation referenced in the error. A `memory budget exceeded` error also suggests that a node is close to an OOM crash, which might be prevented by failing the query.
+This message usually indicates that `--max-sql-memory`, the memory allocated to the SQL layer, was exceeded by the operation referenced in the error. A `memory budget exceeded` error also suggests that a node is close to an [OOM crash](cluster-setup-troubleshooting.html#out-of-memory-oom-crash), which might be prevented by failing the query.
 
 {% include {{ page.version.version }}/prod-deployment/resolution-untuned-query.md %}
 

--- a/v22.2/common-issues-to-monitor.md
+++ b/v22.2/common-issues-to-monitor.md
@@ -118,7 +118,7 @@ If nodes have shut down, this can also be caused by [insufficient storage capaci
 
 ## Memory
 
-CockroachDB is [resilient](demo-fault-tolerance-and-recovery.html) to node crashes. However, frequent node restarts caused by out-of-memory (OOM) crashes can impact cluster stability and performance.
+CockroachDB is [resilient](demo-fault-tolerance-and-recovery.html) to node crashes. However, frequent node restarts caused by [out-of-memory (OOM) crashes](cluster-setup-troubleshooting.html#out-of-memory-oom-crash) can impact cluster stability and performance.
 
 ### Memory planning
 
@@ -130,7 +130,7 @@ Provision enough memory and allocate an appropriate portion for data caching:
 
 ### Memory monitoring
 
-Monitor memory usage and node behavior for OOM errors:
+Monitor memory usage and node behavior for [OOM errors](cluster-setup-troubleshooting.html#out-of-memory-oom-crash):
 
 | Metric or event                                 | Description                                 |
 |-------------------------------------------------|---------------------------------------------|
@@ -152,7 +152,7 @@ CockroachDB attempts to restart nodes after they crash. Nodes that frequently re
 
 ##### Verify OOM errors
 
-If you observe nodes frequently restarting, confirm that the crashes are caused by OOM errors:
+If you observe nodes frequently restarting, confirm that the crashes are caused by [OOM errors](cluster-setup-troubleshooting.html#out-of-memory-oom-crash):
 
 - Monitor `dmesg` to determine if a node crashed because it ran out of memory:
 
@@ -193,6 +193,10 @@ An untuned SQL query can consume significant resources and impact the performanc
 
 {{site.data.alerts.callout_success}}
 {% include {{ page.version.version }}/prod-deployment/resolution-untuned-query.md %}
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
 {{site.data.alerts.end}}
 
 #### Database memory usage

--- a/v22.2/indexes.md
+++ b/v22.2/indexes.md
@@ -64,6 +64,10 @@ To observe the impact of an index without affecting a production workload, you c
 
 Indexes that are not visible are still used to enforce `UNIQUE` and `FOREIGN KEY` [constraints](constraints.html). For more considerations, see [Index visibility considerations](alter-index.html#index-visibility-considerations).
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}
 For more information about how to tune CockroachDB performance, see [SQL Performance Best Practices](performance-best-practices-overview.html).
 {{site.data.alerts.end}}

--- a/v22.2/jsonb.md
+++ b/v22.2/jsonb.md
@@ -43,6 +43,10 @@ Examples:
 
 The size of a `JSONB` value is variable, but we recommend that you keep values under 1 MB to ensure satisfactory performance. Above that threshold, [write amplification](architecture/storage-layer.html#write-amplification) and other considerations may cause significant performance degradation.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Operators
 
 Operator | Description | Example Query and Output |

--- a/v22.2/kubernetes-performance.md
+++ b/v22.2/kubernetes-performance.md
@@ -168,7 +168,7 @@ When you ask Kubernetes to run a pod, either directly or indirectly through anot
 
 #### Resource requests
 
-Resource requests allow you to reserve a certain amount of CPU or memory for your container. If you add resource requests to your CockroachDB YAML file, Kubernetes will schedule each CockroachDB pod onto a node with sufficient unreserved resources and will ensure the pods are guaranteed the reserved resources using the applicable Linux container primitives. If you are running other workloads in your Kubernetes cluster, setting resource requests is very strongly recommended to ensure good performance, because if you do not set them then CockroachDB could be starved of CPU cycles or OOM stopped before less important processes.
+Resource requests allow you to reserve a certain amount of CPU or memory for your container. If you add resource requests to your CockroachDB YAML file, Kubernetes will schedule each CockroachDB pod onto a node with sufficient unreserved resources and will ensure the pods are guaranteed the reserved resources using the applicable Linux container primitives. If you are running other workloads in your Kubernetes cluster, setting resource requests is very strongly recommended to ensure good performance, because if you do not set them then CockroachDB could be starved of CPU cycles or [OOM stopped](cluster-setup-troubleshooting.html#out-of-memory-oom-crash) before less important processes.
 
 To determine how many resources are usable on your Kubernetes nodes, you can run:
 

--- a/v22.2/primary-key.md
+++ b/v22.2/primary-key.md
@@ -77,6 +77,10 @@ To ensure each row has a unique identifier, the `PRIMARY KEY` constraint combine
 
 For best practices, see [Select primary key columns](schema-design-table.html#select-primary-key-columns).
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ## Example
 
 {% include_cached copy-clipboard.html %}

--- a/v22.2/schema-design-indexes.md
+++ b/v22.2/schema-design-indexes.md
@@ -101,6 +101,10 @@ The [`EXPLAIN`](explain.html#success-responses) command provides index recommend
 
     - If you need to [change a primary key](constraints.html#change-constraints), and you do not plan to filter queries on the existing primary key column(s), do not use [`ALTER PRIMARY KEY`](alter-primary-key.html) because it creates a secondary index from an existing primary key. Instead, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key), which does not create a secondary index.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 ### Index management
 
 - Limit creation and deletion of secondary indexes to off-peak hours. Performance impacts are likely if done during peak business hours.

--- a/v22.2/schema-design-table.md
+++ b/v22.2/schema-design-table.md
@@ -115,6 +115,10 @@ Here are some best practices to follow when defining table columns:
 
 - Review the best practices and examples for [adding additional constraints](#add-additional-constraints), and decide if you need to add any additional constraints to your columns.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 #### Column definition examples
 
 In the `max_init.sql` file, add a few column definitions to the `users` table's `CREATE TABLE` statement, for user names and email addresses:
@@ -224,6 +228,10 @@ Here are some best practices to follow when selecting primary key columns:
 - For single-column primary keys, use [`UUID`](uuid.html)-typed columns with default values randomly-generated, using the `gen_random_uuid()` [SQL function](functions-and-operators.html#id-generation-functions).
 
     Randomly generating `UUID` values ensures that the primary key values will be unique and well-distributed across a cluster. For an example, see [below](#primary-key-examples).
+
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
 
 {% include {{page.version.version}}/sql/sql-defaults-cluster-settings-deprecation-notice.md %}
 

--- a/v22.2/string.md
+++ b/v22.2/string.md
@@ -32,6 +32,10 @@ CockroachDB also supports the single-byte `"char"` special character type. As in
 
 To limit the length of a string column, use `STRING(n)`, where `n` is the maximum number of Unicode code points (normally thought of as "characters") allowed. This applies to all related types as well (e.g., to limit the length of a `VARCHAR` type, use `VARCHAR(n)`). To reduce performance issues caused by storing very large string values in indexes, Cockroach Labs recommends setting length limits on string-typed columns.
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/add-size-limits-to-indexed-columns.md %}
+{{site.data.alerts.end}}
+
 When inserting a `STRING` value or a `STRING`-related-type value:
 
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.


### PR DESCRIPTION
Fixes DOC-4873

Summary of changes:

- Add a note that *strongly* recommends adding size limits to indexed columns, that links to write amp/OOO stuff, and shows how to quickly do it

- Link to that note from various places where it (hopefully) makes sense

- Since we are looking at OOM things, do some housekeeping on mentions of "OOM" and variations that should have links to the troubleshooting docs on OOMs, but did not.  Now they do