### PR TITLE
Rename aarch64 to arm64

### DIFF
--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -301,7 +301,7 @@ v21.2.16,v21.2,2022-09-29,false,False,Production,False,go1.17,5c5501092e833d2a10
 v22.2.0-beta.2,v22.2,2022-10-03,false,False,Testing,False,go1.17,860584a59dee73d7a66ce882c668cef6eb2556f7,cockroachdb/cockroach-unstable,true,true,false,false,true
 v22.2.0-beta.3,v22.2,2022-10-10,false,False,Testing,False,go1.17,0937c6c2f6d727fe27d708bddec14daaa1ccfe94,cockroachdb/cockroach-unstable,true,true,false,false,true
 v22.1.9,v22.1,2022-10-17,false,False,Production,False,go1.18,e438c2f89282e607e0e6ca1d38b2e0a622f94493,cockroachdb/cockroach,true,false,false,false,true
-v22.2.0-beta.4,v22.2,2022-10-17,false,False,Testing,False,go1.18,cc25a7893ea924897fcc6d3e80d116c85666e8eb,cockroachdb/cockroach-unstable,true,true,true,false,true
+v22.2.0-beta.4,v22.2,2022-10-17,false,False,Testing,False,go1.18,cc25a7893ea924897fcc6d3e80d116c85666e8eb,cockroachdb/cockroach-unstable,true,true,false,false,true
 v21.2.17,v21.2,2022-10-17,false,False,Production,False,go1.18,6a8cfc30d1afea8b34a0c902aa5f5f625d2d21cc,cockroachdb/cockroach,false,false,false,false,true
 v22.1.10,v22.1,2022-10-28,false,False,Production,False,go1.18,477af1d876e3e62b26900854c2f33eaa7cec73db,cockroachdb/cockroach,true,false,false,false,true
 v22.2.0-beta.5,v22.2,2022-11-01,false,False,Testing,False,go1.18,388261dcdb873ba60fa1e27eb9132a50a492b36f,cockroachdb/cockroach-unstable,true,true,true,true,true

--- a/_includes/releases/release-downloads-docker-image.md
+++ b/_includes/releases/release-downloads-docker-image.md
@@ -29,13 +29,13 @@ This release was withdrawn, and we've removed the links to the downloads and Doc
     <a href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.linux-amd64.tgz"><button id="linux-intel" class="filter-button" data-scope="linux-intel" data-eventcategory="linux-binary-release-notes">Linux Intel</button></a>
 {% else %}
     <a href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.linux-amd64.tgz"><button id="linux-intel" class="filter-button" data-scope="linux-intel" data-eventcategory="linux-binary-release-notes">Linux Intel</button></a>
-    <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.linux-3.7.10-gnu-aarch64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM<br/>(<b>Experimental</b>)</button></a>
+    <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.linux-arm64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM<br/>(<b>Experimental</b>)</button></a>
 {% endif %}
 {% if release.mac_arm == "false" %}
     <a href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac Intel</button></a>
 {% else %}
     <a href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.darwin-10.9-amd64.tgz"><button id="mac-intel" class="filter-button" data-scope="mac-intel" data-eventcategory="mac-binary-release-notes">Mac Intel</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.darwin-11.0-aarch64.tgz"><button id="mac-arm" class="filter-button" data-scope="mac-arm" data-eventcategory="mac-binary-release-notes">Mac ARM</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.darwin-11.0-arm64.tgz"><button id="mac-arm" class="filter-button" data-scope="mac-arm" data-eventcategory="mac-binary-release-notes">Mac ARM</button></a>
 {% endif %}
     <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-{{ release.version }}.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a target="_blank" rel="noopener" href="https://github.com/cockroachdb/cockroach/releases/tag/{{ release.version }}"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a
@@ -49,13 +49,13 @@ This release was withdrawn, and we've removed the links to the downloads and Doc
     <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.linux-amd64.tgz"><button id="linux-intel" class="filter-button" data-scope="linux-intel" data-eventcategory="linux-binary-release-notes">Linux Intel</button></a>
 {% else %}
     <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.linux-amd64.tgz"><button id="linux-intel" class="filter-button" data-scope="linux-intel" data-eventcategory="linux-binary-release-notes">Linux Intel</button></a>
-    <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.linux-3.7.10-gnu-aarch64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM<br/>(<b>Experimental</b>)</button></a>
+    <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.linux-arm64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM<br/>(<b>Experimental</b>)</button></a>
 {% endif %}
 {% if release.mac_arm == "false" %}
     <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac-intel" data-eventcategory="mac-binary-release-notes">Mac Intel</button></a>
 {% else %}
     <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac-intel" data-eventcategory="mac-binary-release-notes">Mac Intel</button></a>
-    <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.darwin-11.0-aarch64.tgz"><button id="mac-arm" class="filter-button" data-scope="mac-arm" data-eventcategory="mac-binary-release-notes">Mac ARM</button></a>
+    <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.darwin-11.0-arm64.tgz"><button id="mac-arm" class="filter-button" data-scope="mac-arm" data-eventcategory="mac-binary-release-notes">Mac ARM</button></a>
 {% endif %}
     <a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.version }}.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a target="_blank" rel="noopener" href="https://github.com/cockroachdb/cockroach/releases/tag/{{ release.version }}"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a

--- a/releases/index.md
+++ b/releases/index.md
@@ -121,9 +121,9 @@ The following binaries are not suitable for production environments:
                 <td><span class="badge badge-gray">Withdrawn</span></td>
                     {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
                 <td>
-                    <div><a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.linux-3.7.10-gnu-aarch64.tgz">Full Binary</a>{% if r.has_sha256sum == "true" %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.linux-3.7.10-gnu-aarch64.tgz.sha256sum">SHA256</a>{% endif %})</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
+                    <div><a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.linux-arm64.tgz">Full Binary</a>{% if r.has_sha256sum == "true" %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.linux-arm64.tgz.sha256sum">SHA256</a>{% endif %})</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
                         {% if r.has_sql_only != "false" %}
-                    <div><a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.linux-3.7.10-gnu-aarch64.tgz">SQL shell Binary</a>{% if r.has_sha256sum == "true" %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.linux-3.7.10-gnu-aarch64.tgz.sha256sum">SHA256</a>{% endif %})</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
+                    <div><a onclick="{{ experimental_download_js }}" href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.linux-arm64.tgz">SQL shell Binary</a>{% if r.has_sha256sum == "true" %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.linux-arm64.tgz.sha256sum">SHA256</a>{% endif %})</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
                         {% endif %}
                 </td>
                     {% endif %}
@@ -171,9 +171,9 @@ The following binaries are not suitable for production environments:
             <td><span class="badge badge-gray">Withdrawn</span></td>
                   {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
-                <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.darwin-11.0-aarch64.tgz">Full Binary</a> (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.darwin-11.0-aarch64.tgz.sha256sum">SHA256</a>)</div>
+                <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.darwin-11.0-arm64.tgz">Full Binary</a> (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.version }}.darwin-11.0-arm64.tgz.sha256sum">SHA256</a>)</div>
                     {% if r.has_sql_only != "false" %}
-                <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.darwin-11.0-aarch64.tgz">SQL shell Binary</a> (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.darwin-11.0-aarch64.tgz.sha256sum">SHA256</a>)</div>
+                <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.darwin-11.0-arm64.tgz">SQL shell Binary</a> (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.version }}.darwin-11.0-arm64.tgz.sha256sum">SHA256</a>)</div>
                     {% endif %}
             </td>
                 {% endif %}

--- a/v22.2/install-cockroachdb-linux.md
+++ b/v22.2/install-cockroachdb-linux.md
@@ -40,7 +40,7 @@ Use one of the options below to install CockroachDB.
           </div>
           <div class="highlight"><pre><code class="language-shell" data-lang="shell"><span class="nb">mkdir</span> <span class="nt">-p</span> /usr/local/lib/cockroach</code></pre></div>
         </li>
-        <li>Copy the library files to the directory. In the following commands, replace `{ARCHITECTURE}` with `linux-amd64` for Intel, or with `linux-3.7.10-gnu-aarch64` for ARM.</p>
+        <li>Copy the library files to the directory. In the following commands, replace `{ARCHITECTURE}` with `linux-amd64` for Intel, or with `linux-arm64` for ARM.</p>
           <div class="copy-clipboard">
             <svg id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
             <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>


### PR DESCRIPTION
This PR renames Linux and MacOS ARM release tarballs.

`linux-3.7.10-gnu-aarch64` -> `linux-arm64`
`darwin-11.0-aarch64` -> `darwin-11.0-arm64`

Additionally, I removed MacOS ARM64 from beta 4.