### PR TITLE
Update SQL FAQ, PG compat doc re: trigram indexes

### DIFF
--- a/_includes/v22.2/sql/unsupported-postgres-features.md
+++ b/_includes/v22.2/sql/unsupported-postgres-features.md
@@ -2,6 +2,7 @@
 - Triggers.
 - Events.
 - `FULLTEXT` functions and indexes.
+  - Depending on your use case, you may be able to get by using [trigram indexes](trigram-indexes.html) to do fuzzy string matching and pattern matching.
 - Drop primary key.
 
     {{site.data.alerts.callout_info}}

--- a/v22.2/sql-faqs.md
+++ b/v22.2/sql-faqs.md
@@ -133,9 +133,11 @@ require('long').fromString(idString).add(1).toString(); // GOOD: returns '235191
 
 ## Does CockroachDB support full text search?
 
-No. For full text search, Cockroach Labs recommends that you use a search engine like [Elasticsearch](https://www.elastic.co/elasticsearch) or [Solr](https://solr.apache.org/). You can use CockroachDB [change data capture (CDC)](change-data-capture-overview.html) to set up a change feed to keep Elasticsearch and Solr indexes synchronized to your CockroachDB tables.
+If you need full text search in a production environment, Cockroach Labs recommends that you use a search engine like [Elasticsearch](https://www.elastic.co/elasticsearch) or [Solr](https://solr.apache.org/). You can use CockroachDB [change data capture (CDC)](change-data-capture-overview.html) to set up a [changefeed](changefeed-messages.html) to keep Elasticsearch and Solr indexes synchronized to your CockroachDB tables.
 
-For details, see [Full Text Indexing and Search in CockroachDB](https://www.cockroachlabs.com/blog/full-text-indexing-search/).
+Depending on your use case, you may be able to get by using [trigram indexes](trigram-indexes.html) to do fuzzy string matching and pattern matching. For more information about use cases for trigram indexes that could make having full text search unnecessary, see the 2022 blog post [Use cases for trigram indexes (when not to use Full Text Search)](https://www.cockroachlabs.com/blog/use-cases-trigram-indexes/).
+
+For an example showing how to build a simplified full text indexing and search solution using CockroachDB's support for [generalized inverted indexes (also known as GIN indexes)](inverted-indexes.html), see the 2020 blog post [Full Text Indexing and Search in CockroachDB](https://www.cockroachlabs.com/blog/full-text-indexing-search/).
 
 ## See also
 

--- a/v22.2/trigram-indexes.md
+++ b/v22.2/trigram-indexes.md
@@ -357,4 +357,5 @@ The following PostgreSQL syntax and features are currently unsupported. For deta
 - [`SHOW INDEX`](show-index.html)
 - [Inverted indexes](inverted-indexes.html)
 - [Indexes](indexes.html)
+- [Use cases for trigram indexes (When not to use Full Text Search)](https://www.cockroachlabs.com/blog/use-cases-trigram-indexes/) (2022 blog post)
 - [SQL Statements](sql-statements.html)


### PR DESCRIPTION
Fixes DOC-6318

Summary of changes:

- Update the SQL FAQ entry on full text search to mention that we do have trigram indexes, which may meet some users' needs, and link to stuff about trigram indexes

- Update the list of unsupported Postgres features on the PG compat page to mention that even though we don't have full text search, we do have trigram indexes now, which could help

- Add a link from the official trigram indexes doc to the also very informative trigram indexes blog post (which also has a video showing them off)