### PR TITLE
Correct error in description of Interval casting.

### DIFF
--- a/v19.1/interval.md
+++ b/v19.1/interval.md
@@ -96,7 +96,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v19.2/interval.md
+++ b/v19.2/interval.md
@@ -103,7 +103,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v2.1/interval.md
+++ b/v2.1/interval.md
@@ -95,7 +95,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (nanosecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (nanosecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v20.1/interval.md
+++ b/v20.1/interval.md
@@ -121,7 +121,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v20.2/interval.md
+++ b/v20.2/interval.md
@@ -121,7 +121,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v21.1/interval.md
+++ b/v21.1/interval.md
@@ -121,7 +121,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v21.2/interval.md
+++ b/v21.2/interval.md
@@ -118,7 +118,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v22.1/interval.md
+++ b/v22.1/interval.md
@@ -112,7 +112,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 

--- a/v22.2/interval.md
+++ b/v22.2/interval.md
@@ -114,7 +114,7 @@ Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
 `DECIMAL` | Converts to number of seconds (microsecond precision)
-`FLOAT` | Converts to number of picoseconds
+`FLOAT` | Converts to number of seconds (microsecond precision)
 `STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 


### PR DESCRIPTION
Previous versions described the Interval::Float cast as producing picoseconds.

Since v2.1.0 (SHA f0dd1dc2d2500155c8b36330ae3d6932c13c1027), this has actually been in seconds

(Updated in 2018, SHA 01de891d9149f007cf439398e62e75cb3a18ecfd, by knz).