### PR TITLE
Fix Vale errors

### DIFF
--- a/vale/Vocab/CockroachDB/accept.txt
+++ b/vale/Vocab/CockroachDB/accept.txt
@@ -105,6 +105,7 @@ favicons
 filepath
 fillfactor
 firewall(ed|ing)
+Flowable
 fluentd
 forecasted
 francecentral
@@ -162,7 +163,7 @@ ints
 io
 japaneast
 japanwest
-javascript
+JavaScript
 jdbc
 Jepsen
 johnstown
@@ -263,6 +264,7 @@ pipelin(ed|ing)
 pipenv
 plaintext
 pointcut
+Postgres
 PostgreSQL
 Postgrex
 Postico
@@ -320,9 +322,8 @@ schemaless
 scrollable
 scrollbars
 seeked
-selinux
-SELinux
-sequelize
+[sS][eE][lL]inux
+Sequelize
 serializab(ility|le)
 serverless
 servlet
@@ -344,7 +345,7 @@ spammy
 spinny
 Splunk
 SQL
-sqlalchemy
+SQLAlchemy
 sqlx
 src
 SSDs?


### PR DESCRIPTION
The `accept.txt` file is case-sensitive.