### PR TITLE
Add lost serverless pages back to nav

### DIFF
--- a/_includes/v22.2/sidebar-data/deploy.json
+++ b/_includes/v22.2/sidebar-data/deploy.json
@@ -24,6 +24,29 @@
               "title": "CockroachDB Serverless",
               "items": [
                 {
+                  "title": "CockroachDB Serverless Pricing",
+                  "items": [
+                    {
+                      "title": "Pricing Overview",
+                      "urls": [
+                        "/cockroachcloud/learn-about-pricing.html"
+                      ]
+                    },
+                    {
+                      "title": "Learn about Request Units",
+                      "urls": [
+                        "/cockroachcloud/learn-about-request-units.html"
+                      ]
+                    },                                    
+                    {
+                      "title": "Optimize Your CockroachDB Serverless Workload",
+                      "urls": [
+                        "/cockroachcloud/optimize-serverless-workload.html"
+                      ]
+                    }
+                  ]
+                },  
+                {
                   "title": "Create a CockroachDB Serverless Cluster",
                   "urls": [
                     "/cockroachcloud/create-a-serverless-cluster.html"


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-6513

The serverless pricing and RU info pages got removed from the nav in v22.2. This PR adds them back in.