### PR TITLE
Cloud version update

### DIFF
--- a/_config_cockroachdb.yml
+++ b/_config_cockroachdb.yml
@@ -3,8 +3,8 @@ destination: _site/docs
 homepage_title: CockroachDB Docs
 current_cloud_date: "2022-12-05"
 current_cloud_version: v22.1
-current_dedicated_hotfix: v22.1.10
-current_serverless_hotfix: v22.1.11
+current_dedicated_hotfix: v22.2.2
+current_serverless_hotfix: v22.1.12
 versions:
   stable: v22.2
   dev: v22.2


### PR DESCRIPTION
Dedicated on 22.2.2 and serverless on 22.1.12
(Some serverless clusters are on 22.2 now but rollout will be completed on Jan 18)