### PR TITLE
DOC-5444 debug tsdump

### DIFF
--- a/_includes/v21.2/misc/debug-subcommands.md
+++ b/_includes/v21.2/misc/debug-subcommands.md
@@ -1,4 +1,4 @@
-While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
+While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), [`tsdump`](cockroach-debug-tsdump.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
 
 We recommend using the [`job-trace`](cockroach-debug-job-trace.html) subcommand only when directed by the [Cockroach Labs support team](support-resources.html).
 

--- a/_includes/v21.2/sidebar-data/reference.json
+++ b/_includes/v21.2/sidebar-data/reference.json
@@ -1482,6 +1482,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach debug tsdump</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-debug-tsdump.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach debug zip</code>",
                 "urls": [
                   "/${VERSION}/cockroach-debug-zip.html"

--- a/_includes/v22.1/misc/debug-subcommands.md
+++ b/_includes/v22.1/misc/debug-subcommands.md
@@ -1,4 +1,4 @@
-While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
+While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), [`tsdump`](cockroach-debug-tsdump.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
 
 We recommend using the [`job-trace`](cockroach-debug-job-trace.html) subcommand only when directed by the [Cockroach Labs support team](support-resources.html).
 

--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -1554,6 +1554,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach debug tsdump</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-debug-tsdump.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach debug zip</code>",
                 "urls": [
                   "/${VERSION}/cockroach-debug-zip.html"

--- a/_includes/v22.2/misc/debug-subcommands.md
+++ b/_includes/v22.2/misc/debug-subcommands.md
@@ -1,4 +1,4 @@
-While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
+While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), [`tsdump`](cockroach-debug-tsdump.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
 
 We recommend using the [`job-trace`](cockroach-debug-job-trace.html) subcommand only when directed by the [Cockroach Labs support team](support-resources.html).
 

--- a/_includes/v22.2/sidebar-data/reference.json
+++ b/_includes/v22.2/sidebar-data/reference.json
@@ -1632,6 +1632,12 @@
                 ]
               },
               {
+               "title": "<code>cockroach debug tsdump</code>",
+               "urls": [
+                 "/${VERSION}/cockroach-debug-tsdump.html"
+               ]
+              },
+              {
                 "title": "<code>cockroach debug zip</code>",
                 "urls": [
                   "/${VERSION}/cockroach-debug-zip.html"

--- a/v21.2/cockroach-commands.md
+++ b/v21.2/cockroach-commands.md
@@ -28,8 +28,9 @@ Command | Usage
 [`cockroach debug ballast`](cockroach-debug-ballast.html) | Create a large, unused file in a node's storage directory that you can delete if the node runs out of disk space.
 [`cockroach debug encryption-active-key`](cockroach-debug-encryption-active-key.html) | View the encryption algorithm and store key.
 [`cockroach debug job-trace`](cockroach-debug-job-trace.html) | Generate trace payloads for an executing job from a particular node.
-[`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge multiple log files from different machines into a single stream.
+[`cockroach debug tsdump`](cockroach-debug-tsdump.html) | Generate a diagnostic dump of timeseries metrics that can help Cockroach Labs troubleshoot issues with your cluster.
+[`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers) | **New in v21.2:** Convert a connection URL to a format recognized by a [supported client driver](third-party-database-tools.html#drivers).
 [`cockroach workload`](cockroach-workload.html) | Run a built-in load generator against a cluster.
 [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) |  Upload a file to the `externalIODir` on a node's local file system.

--- a/v21.2/cockroach-debug-tsdump.md
+++ b/v21.2/cockroach-debug-tsdump.md
@@ -1,0 +1,111 @@
+---
+title: cockroach debug tsdump
+summary: Learn the commands for collecting timeseries debug information from all nodes in your cluster.
+toc: true
+key: debug-tsdump.html
+docs_area: reference.cli
+---
+
+The `cockroach debug tsdump` [command](cockroach-commands.html) connects to your cluster and collects timeseries diagnostic data from each active node (inactive nodes are not included). This includes both current and historical runtime metrics for your cluster, including those exposed in the [DB Console Metrics](ui-overview-dashboard.html) pages as well as internal metrics.
+
+`cockroach debug tsdump` is mostly used in tandem with the [`cockroach debug zip`](cockroach-debug-zip.html) command to gather diagnostic data during escalations to Cockroach Labs support. Follow the steps in this procedure to gather and prepare the timeseries diagnostic data and prepare it for transit to Cockroach Labs.
+
+## Subcommands
+
+{% include {{ page.version.version }}/misc/debug-subcommands.md %}
+
+## Synopsis
+
+~~~ shell
+$ cockroach debug tsdump {flags} > {dump file destination} 
+~~~
+
+{{site.data.alerts.callout_info}}
+The following [flags](#flags) must apply to an active CockroachDB node. If no nodes are live, you must [start at least one node](cockroach-start.html).
+{{site.data.alerts.end}}
+
+## Flags
+
+The `debug tsdump` subcommand supports the following [general-use](#general), [client connection](#client-connection), and [logging](#logging) flags.
+
+### General
+
+Flag | Description
+-----|-----------
+`--format` | The output format to write the collected diagnostic data. Valid options are `text`, `csv`, `tsv`, `raw`.<br><br>**Default:** `text`
+`--from` | The oldest timestamp to include (inclusive), in the format `YYYY-MM-DD [HH:MM[:SS]]`.<br><br>**Default:** `0001-01-01 00:00:00`
+`--to` | The newest timestamp to include (inclusive), in the format `YYYY-MM-DD [HH:MM[:SS]]`.<br><br>**Default:** Current timestamp plus 29 hours
+
+### Client connection
+
+Flag | Description
+-----|------------
+`--cert-principal-map` | A comma-separated list of `<cert-principal>:<db-principal>` mappings. This allows mapping the principal in a cert to a DB principal such as `node` or `root` or any SQL user. This is intended for use in situations where the certificate management system places restrictions on the `Subject.CommonName` or `SubjectAlternateName` fields in the certificate (e.g., disallowing a `CommonName` like `node` or `root`). If multiple mappings are provided for the same `<cert-principal>`, the last one specified in the list takes precedence. A principal not specified in the map is passed through as-is via the identity function. A cert is allowed to authenticate a DB principal if the DB principal name is contained in the mapped `CommonName` or DNS-type `SubjectAlternateName` fields.
+`--certs-dir` | The path to the [certificate directory](cockroach-cert.html) containing the CA and client certificates and client key.<br><br>**Env Variable:** `COCKROACH_CERTS_DIR`<br>**Default:** `${HOME}/.cockroach-certs/`
+`--cluster-name` | The cluster name to use to verify the cluster's identity. If the cluster has a cluster name, you must include this flag. For more information, see [`cockroach start`](cockroach-start.html#general).
+`--disable-cluster-name-verification` | Disables the cluster name check for this command. This flag must be paired with `--cluster-name`. For more information, see [`cockroach start`](cockroach-start.html#general).
+`--host` | The server host and port number to connect to. This can be the address of any node in the cluster.<br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
+`--insecure` | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
+<a name="sql-flag-url"></a> `--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments. To convert a connection URL to the syntax that works with your client driver, run [`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers).<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
+
+### Logging
+
+By default, this command logs messages to `stdout`. If you need to troubleshoot this command's behavior, you can [customize its logging behavior](configure-logs.html).
+
+## Examples
+
+### Generate a tsdump `gob` file
+
+Generate the tsdump `gob` file for an insecure CockroachDB cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --insecure > tsdump.gob
+~~~
+
+Generate the tsdump `gob` file for a secure CockroachDB cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --certs-dir=${HOME}/.cockroach-certs/ > tsdump.gob
+~~~
+
+{{site.data.alerts.callout_info}}
+Secure examples assume you have the appropriate certificates in the default certificate directory, `${HOME}/.cockroach-certs/`. See the [`cockroach cert`](cockroach-cert.html) documentation for more information.
+{{site.data.alerts.end}}
+
+### Generate a tsdump `gob` file and compress using `gzip`
+
+Generate a tsdump `gob` file for an insecure CockroachDB cluster, and compress using `gzip` in preparation to send to Cockroach Labs for troubleshooting. Your server must have `gzip` installed:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --insecure > tsdump.gob
+$ gzip tsdump.gob
+~~~
+
+Generate a tsdump `gob` file for a secure CockroachDB cluster, and compress using `gzip` in preparation to send to Cockroach Labs for troubleshooting. Your server must have `gzip` installed:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --certs-dir=${HOME}/.cockroach-certs/ > tsdump.gob
+$ gzip tsdump.gob
+~~~
+
+{{site.data.alerts.callout_info}}
+Secure examples assume you have the appropriate certificates in the default certificate directory, `${HOME}/.cockroach-certs/`. See the [`cockroach cert`](cockroach-cert.html) documentation for more information.
+{{site.data.alerts.end}}
+
+### Generate a tsdump `gob` file with a custom timestamp range
+
+Generate a tsdump `gob` file specifying a custom timestamp range to limit the data collection to a specific interval. This is useful for reducing the size of the resulting `gob` file if the data needed to troubleshoot falls within a known timestamp range:
+
+~~~ shell
+$ cockroach debug tsdump --format=raw --from='2023-01-10 01:00:00' --to='2023-01-20 23:59:59' > tsdump.gob
+~~~
+
+## See also
+
+- [File an Issue](file-an-issue.html)
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [Troubleshooting Overview](troubleshooting-overview.html)

--- a/v22.1/cockroach-commands.md
+++ b/v22.1/cockroach-commands.md
@@ -28,6 +28,7 @@ Command | Usage
 [`cockroach debug job-trace`](cockroach-debug-job-trace.html) | Generate trace payloads for an executing job from a particular node.
 [`cockroach debug list-files`](cockroach-debug-list-files.html) | Show the files that will be collected by using `cockroach debug zip`.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node.
+[`cockroach debug tsdump`](cockroach-debug-tsdump.html) | Generate a diagnostic dump of timeseries metrics that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers) | Convert a connection URL to a format recognized by a [supported client driver](third-party-database-tools.html#drivers).
 [`cockroach gen`](cockroach-gen.html) | Generate man pages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.

--- a/v22.1/cockroach-debug-tsdump.md
+++ b/v22.1/cockroach-debug-tsdump.md
@@ -1,0 +1,111 @@
+---
+title: cockroach debug tsdump
+summary: Learn the commands for collecting timeseries debug information from all nodes in your cluster.
+toc: true
+key: debug-tsdump.html
+docs_area: reference.cli
+---
+
+The `cockroach debug tsdump` [command](cockroach-commands.html) connects to your cluster and collects timeseries diagnostic data from each active node (inactive nodes are not included). This includes both current and historical runtime metrics for your cluster, including those exposed in the [DB Console Metrics](ui-overview-dashboard.html) pages as well as internal metrics.
+
+`cockroach debug tsdump` is mostly used in tandem with the [`cockroach debug zip`](cockroach-debug-zip.html) command to gather diagnostic data during escalations to Cockroach Labs support. Follow the steps in this procedure to gather and prepare the timeseries diagnostic data and prepare it for transit to Cockroach Labs.
+
+## Subcommands
+
+{% include {{ page.version.version }}/misc/debug-subcommands.md %}
+
+## Synopsis
+
+~~~ shell
+$ cockroach debug tsdump {flags} > {dump file destination} 
+~~~
+
+{{site.data.alerts.callout_info}}
+The following [flags](#flags) must apply to an active CockroachDB node. If no nodes are live, you must [start at least one node](cockroach-start.html).
+{{site.data.alerts.end}}
+
+## Flags
+
+The `debug tsdump` subcommand supports the following [general-use](#general), [client connection](#client-connection), and [logging](#logging) flags.
+
+### General
+
+Flag | Description
+-----|-----------
+`--format` | The output format to write the collected diagnostic data. Valid options are `text`, `csv`, `tsv`, `raw`.<br><br>**Default:** `text`
+`--from` | The oldest timestamp to include (inclusive), in the format `YYYY-MM-DD [HH:MM[:SS]]`.<br><br>**Default:** `0001-01-01 00:00:00`
+`--to` | The newest timestamp to include (inclusive), in the format `YYYY-MM-DD [HH:MM[:SS]]`.<br><br>**Default:** Current timestamp plus 29 hours
+
+### Client connection
+
+Flag | Description
+-----|------------
+`--cert-principal-map` | A comma-separated list of `<cert-principal>:<db-principal>` mappings. This allows mapping the principal in a cert to a DB principal such as `node` or `root` or any SQL user. This is intended for use in situations where the certificate management system places restrictions on the `Subject.CommonName` or `SubjectAlternateName` fields in the certificate (e.g., disallowing a `CommonName` like `node` or `root`). If multiple mappings are provided for the same `<cert-principal>`, the last one specified in the list takes precedence. A principal not specified in the map is passed through as-is via the identity function. A cert is allowed to authenticate a DB principal if the DB principal name is contained in the mapped `CommonName` or DNS-type `SubjectAlternateName` fields.
+`--certs-dir` | The path to the [certificate directory](cockroach-cert.html) containing the CA and client certificates and client key.<br><br>**Env Variable:** `COCKROACH_CERTS_DIR`<br>**Default:** `${HOME}/.cockroach-certs/`
+`--cluster-name` | The cluster name to use to verify the cluster's identity. If the cluster has a cluster name, you must include this flag. For more information, see [`cockroach start`](cockroach-start.html#general).
+`--disable-cluster-name-verification` | Disables the cluster name check for this command. This flag must be paired with `--cluster-name`. For more information, see [`cockroach start`](cockroach-start.html#general).
+`--host` | The server host and port number to connect to. This can be the address of any node in the cluster.<br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
+`--insecure` | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
+<a name="sql-flag-url"></a> `--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments. To convert a connection URL to the syntax that works with your client driver, run [`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers).<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
+
+### Logging
+
+By default, this command logs messages to `stdout`. If you need to troubleshoot this command's behavior, you can [customize its logging behavior](configure-logs.html).
+
+## Examples
+
+### Generate a tsdump `gob` file
+
+Generate the tsdump `gob` file for an insecure CockroachDB cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --insecure > tsdump.gob
+~~~
+
+Generate the tsdump `gob` file for a secure CockroachDB cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --certs-dir=${HOME}/.cockroach-certs/ > tsdump.gob
+~~~
+
+{{site.data.alerts.callout_info}}
+Secure examples assume you have the appropriate certificates in the default certificate directory, `${HOME}/.cockroach-certs/`. See the [`cockroach cert`](cockroach-cert.html) documentation for more information.
+{{site.data.alerts.end}}
+
+### Generate a tsdump `gob` file and compress using `gzip`
+
+Generate a tsdump `gob` file for an insecure CockroachDB cluster, and compress using `gzip` in preparation to send to Cockroach Labs for troubleshooting. Your server must have `gzip` installed:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --insecure > tsdump.gob
+gzip tsdump.gob
+~~~
+
+Generate a tsdump `gob` file for a secure CockroachDB cluster, and compress using `gzip` in preparation to send to Cockroach Labs for troubleshooting. Your server must have `gzip` installed:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --certs-dir=${HOME}/.cockroach-certs/ > tsdump.gob
+gzip tsdump.gob
+~~~
+
+{{site.data.alerts.callout_info}}
+Secure examples assume you have the appropriate certificates in the default certificate directory, `${HOME}/.cockroach-certs/`. See the [`cockroach cert`](cockroach-cert.html) documentation for more information.
+{{site.data.alerts.end}}
+
+### Generate a tsdump `gob` file with a custom timestamp range
+
+Generate a tsdump `gob` file specifying a custom timestamp range to limit the data collection to a specific interval. This is useful for reducing the size of the resulting `gob` file if the data needed to troubleshoot falls within a known timestamp range:
+
+~~~ shell
+$ cockroach debug tsdump --format=raw --from='2023-01-10 01:00:00' --to='2023-01-20 23:59:59' > tsdump.gob
+~~~
+
+## See also
+
+- [File an Issue](file-an-issue.html)
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [Troubleshooting Overview](troubleshooting-overview.html)

--- a/v22.2/cockroach-commands.md
+++ b/v22.2/cockroach-commands.md
@@ -28,6 +28,7 @@ Command | Usage
 [`cockroach debug job-trace`](cockroach-debug-job-trace.html) | Generate trace payloads for an executing job from a particular node.
 [`cockroach debug list-files`](cockroach-debug-list-files.html) | Show the files that will be collected by using `cockroach debug zip`.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node.
+[`cockroach debug tsdump`](cockroach-debug-tsdump.html) | Generate a diagnostic dump of timeseries metrics that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers) | Convert a connection URL to a format recognized by a [supported client driver](third-party-database-tools.html#drivers).
 [`cockroach gen`](cockroach-gen.html) | Generate man pages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.

--- a/v22.2/cockroach-debug-tsdump.md
+++ b/v22.2/cockroach-debug-tsdump.md
@@ -1,0 +1,111 @@
+---
+title: cockroach debug tsdump
+summary: Learn the commands for collecting timeseries debug information from all nodes in your cluster.
+toc: true
+key: debug-tsdump.html
+docs_area: reference.cli
+---
+
+The `cockroach debug tsdump` [command](cockroach-commands.html) connects to your cluster and collects timeseries diagnostic data from each active node (inactive nodes are not included). This includes both current and historical runtime metrics for your cluster, including those exposed in the [DB Console Metrics](ui-overview-dashboard.html) pages as well as internal metrics.
+
+`cockroach debug tsdump` is mostly used in tandem with the [`cockroach debug zip`](cockroach-debug-zip.html) command to gather diagnostic data during escalations to Cockroach Labs support. Follow the steps in this procedure to gather and prepare the timeseries diagnostic data and prepare it for transit to Cockroach Labs.
+
+## Subcommands
+
+{% include {{ page.version.version }}/misc/debug-subcommands.md %}
+
+## Synopsis
+
+~~~ shell
+$ cockroach debug tsdump {flags} > {dump file destination} 
+~~~
+
+{{site.data.alerts.callout_info}}
+The following [flags](#flags) must apply to an active CockroachDB node. If no nodes are live, you must [start at least one node](cockroach-start.html).
+{{site.data.alerts.end}}
+
+## Flags
+
+The `debug tsdump` subcommand supports the following [general-use](#general), [client connection](#client-connection), and [logging](#logging) flags.
+
+### General
+
+Flag | Description
+-----|-----------
+`--format` | The output format to write the collected diagnostic data. Valid options are `text`, `csv`, `tsv`, `raw`.<br><br>**Default:** `text`
+`--from` | The oldest timestamp to include (inclusive), in the format `YYYY-MM-DD [HH:MM[:SS]]`.<br><br>**Default:** `0001-01-01 00:00:00`
+`--to` | The newest timestamp to include (inclusive), in the format `YYYY-MM-DD [HH:MM[:SS]]`.<br><br>**Default:** Current timestamp plus 29 hours
+
+### Client connection
+
+Flag | Description
+-----|------------
+`--cert-principal-map` | A comma-separated list of `<cert-principal>:<db-principal>` mappings. This allows mapping the principal in a cert to a DB principal such as `node` or `root` or any SQL user. This is intended for use in situations where the certificate management system places restrictions on the `Subject.CommonName` or `SubjectAlternateName` fields in the certificate (e.g., disallowing a `CommonName` like `node` or `root`). If multiple mappings are provided for the same `<cert-principal>`, the last one specified in the list takes precedence. A principal not specified in the map is passed through as-is via the identity function. A cert is allowed to authenticate a DB principal if the DB principal name is contained in the mapped `CommonName` or DNS-type `SubjectAlternateName` fields.
+`--certs-dir` | The path to the [certificate directory](cockroach-cert.html) containing the CA and client certificates and client key.<br><br>**Env Variable:** `COCKROACH_CERTS_DIR`<br>**Default:** `${HOME}/.cockroach-certs/`
+`--cluster-name` | The cluster name to use to verify the cluster's identity. If the cluster has a cluster name, you must include this flag. For more information, see [`cockroach start`](cockroach-start.html#general).
+`--disable-cluster-name-verification` | Disables the cluster name check for this command. This flag must be paired with `--cluster-name`. For more information, see [`cockroach start`](cockroach-start.html#general).
+`--host` | The server host and port number to connect to. This can be the address of any node in the cluster.<br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
+`--insecure` | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
+<a name="sql-flag-url"></a> `--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments. To convert a connection URL to the syntax that works with your client driver, run [`cockroach convert-url`](connection-parameters.html#convert-a-url-for-different-drivers).<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
+
+### Logging
+
+By default, this command logs messages to `stdout`. If you need to troubleshoot this command's behavior, you can [customize its logging behavior](configure-logs.html).
+
+## Examples
+
+### Generate a tsdump `gob` file
+
+Generate the tsdump `gob` file for an insecure CockroachDB cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --insecure > tsdump.gob
+~~~
+
+Generate the tsdump `gob` file for a secure CockroachDB cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --certs-dir=${HOME}/.cockroach-certs/ > tsdump.gob
+~~~
+
+{{site.data.alerts.callout_info}}
+Secure examples assume you have the appropriate certificates in the default certificate directory, `${HOME}/.cockroach-certs/`. See the [`cockroach cert`](cockroach-cert.html) documentation for more information.
+{{site.data.alerts.end}}
+
+### Generate a tsdump `gob` file and compress using `gzip`
+
+Generate a tsdump `gob` file for an insecure CockroachDB cluster, and compress using `gzip` in preparation to send to Cockroach Labs for troubleshooting. Your server must have `gzip` installed:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --insecure > tsdump.gob
+gzip tsdump.gob
+~~~
+
+Generate a tsdump `gob` file for a secure CockroachDB cluster, and compress using `gzip` in preparation to send to Cockroach Labs for troubleshooting. Your server must have `gzip` installed:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ cockroach debug tsdump --format=raw --certs-dir=${HOME}/.cockroach-certs/ > tsdump.gob
+gzip tsdump.gob
+~~~
+
+{{site.data.alerts.callout_info}}
+Secure examples assume you have the appropriate certificates in the default certificate directory, `${HOME}/.cockroach-certs/`. See the [`cockroach cert`](cockroach-cert.html) documentation for more information.
+{{site.data.alerts.end}}
+
+### Generate a tsdump `gob` file with a custom timestamp range
+
+Generate a tsdump `gob` file specifying a custom timestamp range to limit the data collection to a specific interval. This is useful for reducing the size of the resulting `gob` file if the data needed to troubleshoot falls within a known timestamp range:
+
+~~~ shell
+$ cockroach debug tsdump --format=raw --from='2023-01-10 01:00:00' --to='2023-01-20 23:59:59' > tsdump.gob
+~~~
+
+## See also
+
+- [File an Issue](file-an-issue.html)
+- [`cockroach` Commands Overview](cockroach-commands.html)
+- [Troubleshooting Overview](troubleshooting-overview.html)

--- a/vale/Vocab/CockroachDB/accept.txt
+++ b/vale/Vocab/CockroachDB/accept.txt
@@ -399,6 +399,7 @@ toolchains?
 tooltips?
 touchpoints?
 transactionally
+tsdump
 ttl
 twirp
 txns?


### PR DESCRIPTION
Addresses: DOC-5444

- Added new reference page for `cockroach debug tsdump` and added to various commands list includes.
	- Added to docs for v22.2, v22.1, and v21.2. All changes identical across versions.

Staging

[v22.2/cockroach-debug-tsdump.md](https://deploy-preview-15980--cockroachdb-docs.netlify.app/docs/stable/cockroach-debug-tsdump.html) | [v22.2/cockroach-commands.md](https://deploy-preview-15980--cockroachdb-docs.netlify.app/docs/stable/cockroach-commands.html#commands)