### PR TITLE
Include reference to enterprise changefeeds created without a sink

### DIFF
--- a/v22.1/create-and-configure-changefeeds.md
+++ b/v22.1/create-and-configure-changefeeds.md
@@ -73,11 +73,6 @@ When you create a changefeed **without** specifying a sink, CockroachDB sends th
 - If you do not define a display format, the client will buffer forever waiting for the query to finish because the default format needs to know the maximum row length. 
 - If you create a changefeed without a sink but specify a display format (e.g., `--format=csv`), it will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL client.
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE CHANGEFEED FOR TABLE table_name, table_name2 WITH format=csv;
-~~~
-
 For more information, see [`CREATE CHANGEFEED`](create-changefeed.html).
 
 ### Pause

--- a/v22.1/create-and-configure-changefeeds.md
+++ b/v22.1/create-and-configure-changefeeds.md
@@ -63,10 +63,20 @@ To create an {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE CHANGEFEED FOR TABLE table_name, table_name2 INTO '{scheme}://{host}:{port}?{query_parameters}';
+CREATE CHANGEFEED FOR TABLE table_name, table_name2 INTO '{scheme}://{host}:{port}?{query_parameters}';
 ~~~
 
 {% include {{ page.version.version }}/cdc/url-encoding.md %}
+
+When you create a changefeed **without** specifying a sink, CockroachDB sends the changefeed events to the SQL client. Consider the following regarding the [display format](cockroach-sql.html#sql-flag-format) in your SQL client:
+
+- If you do not define a display format, the client will buffer forever waiting for the query to finish because the default format needs to know the maximum row length. 
+- If you create a changefeed without a sink but specify a display format (e.g., `--format=csv`), it will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL client.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE CHANGEFEED FOR TABLE table_name, table_name2 WITH format=csv;
+~~~
 
 For more information, see [`CREATE CHANGEFEED`](create-changefeed.html).
 
@@ -76,7 +86,7 @@ To pause an {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> PAUSE JOB job_id;
+PAUSE JOB job_id;
 ~~~
 
 For more information, see [`PAUSE JOB`](pause-job.html).
@@ -87,7 +97,7 @@ To resume a paused {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESUME JOB job_id;
+RESUME JOB job_id;
 ~~~
 
 For more information, see [`RESUME JOB`](resume-job.html).
@@ -98,7 +108,7 @@ To cancel an {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CANCEL JOB job_id;
+CANCEL JOB job_id;
 ~~~
 
 For more information, see [`CANCEL JOB`](cancel-job.html).
@@ -123,7 +133,7 @@ To create a core changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> EXPERIMENTAL CHANGEFEED FOR table_name;
+EXPERIMENTAL CHANGEFEED FOR table_name;
 ~~~
 
 For more information, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).

--- a/v22.1/create-changefeed.md
+++ b/v22.1/create-changefeed.md
@@ -28,7 +28,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 Parameter | Description
 ----------|------------
 `table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Before creating a changefeed, consider the number of changefeeds versus the number of tables to include in a single changefeed. Each scenario can have an impact on total memory usage or changefeed performance. See [Create and Configure Changefeeds](create-and-configure-changefeeds.html) for more detail. 
-`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri) below.<br><br>**Note:** If you create a changefeed without a sink and the [`format=csv` option](#format), your changefeed will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL session. If you do not specify a sink or the `format` option, then the changefeed will hang until canceled. 
+`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri) below.<br><br>**Note:** If you create a changefeed without a sink, your changefeed will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL client. For more detail, see [create-and-configure-changefeed.html#create].
 `option` / `value` | For a list of available options and their values, see [Options](#options) below.
 
 ### Sink URI

--- a/v22.1/create-changefeed.md
+++ b/v22.1/create-changefeed.md
@@ -28,7 +28,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 Parameter | Description
 ----------|------------
 `table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Before creating a changefeed, consider the number of changefeeds versus the number of tables to include in a single changefeed. Each scenario can have an impact on total memory usage or changefeed performance. See [Create and Configure Changefeeds](create-and-configure-changefeeds.html) for more detail. 
-`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri) below.
+`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri) below.<br><br>**Note:** If you create a changefeed without a sink and the [`format=csv` option](#format), your changefeed will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL session. If you do not specify a sink or the `format` option, then the changefeed will hang until canceled. 
 `option` / `value` | For a list of available options and their values, see [Options](#options) below.
 
 ### Sink URI

--- a/v22.2/create-and-configure-changefeeds.md
+++ b/v22.2/create-and-configure-changefeeds.md
@@ -63,10 +63,21 @@ To create an {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE CHANGEFEED FOR TABLE table_name, table_name2 INTO '{scheme}://{host}:{port}?{query_parameters}';
+CREATE CHANGEFEED FOR TABLE table_name, table_name2 INTO '{scheme}://{host}:{port}?{query_parameters}';
 ~~~
 
 {% include {{ page.version.version }}/cdc/url-encoding.md %}
+
+When you create a changefeed **without** specifying a sink, CockroachDB sends the changefeed events to the SQL client. Consider the following regarding the [display format](cockroach-sql.html#sql-flag-format) in your SQL client:
+
+- If you do not define a display format, the CockroachDB SQL client will automatically use `ndjson` format.
+- If you specify a format, the client will use that format (e.g., `--format=csv`).
+- If you set the client display format to `ndjson` and set the changefeed [`format`](create-changefeed.html#format) to `csv`, you'll receive JSON format with CSV nested inside. In the reverse situation, you'll receive a comma-separated list of JSON values.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE CHANGEFEED FOR TABLE table_name, table_name2 WITH format=csv;
+~~~
 
 For more information, see [`CREATE CHANGEFEED`](create-changefeed.html).
 
@@ -76,7 +87,7 @@ To pause an {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> PAUSE JOB job_id;
+PAUSE JOB job_id;
 ~~~
 
 For more information, see [`PAUSE JOB`](pause-job.html).
@@ -87,7 +98,7 @@ To resume a paused {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESUME JOB job_id;
+RESUME JOB job_id;
 ~~~
 
 For more information, see [`RESUME JOB`](resume-job.html).
@@ -98,7 +109,7 @@ To cancel an {{ site.data.products.enterprise }} changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CANCEL JOB job_id;
+CANCEL JOB job_id;
 ~~~
 
 For more information, see [`CANCEL JOB`](cancel-job.html).
@@ -123,7 +134,7 @@ To create a core changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> EXPERIMENTAL CHANGEFEED FOR table_name;
+EXPERIMENTAL CHANGEFEED FOR table_name;
 ~~~
 
 For more information, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).

--- a/v22.2/create-and-configure-changefeeds.md
+++ b/v22.2/create-and-configure-changefeeds.md
@@ -74,11 +74,6 @@ When you create a changefeed **without** specifying a sink, CockroachDB sends th
 - If you specify a format, the client will use that format (e.g., `--format=csv`).
 - If you set the client display format to `ndjson` and set the changefeed [`format`](create-changefeed.html#format) to `csv`, you'll receive JSON format with CSV nested inside. In the reverse situation, you'll receive a comma-separated list of JSON values.
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE CHANGEFEED FOR TABLE table_name, table_name2 WITH format=csv;
-~~~
-
 For more information, see [`CREATE CHANGEFEED`](create-changefeed.html).
 
 ### Pause

--- a/v22.2/create-and-configure-changefeeds.md
+++ b/v22.2/create-and-configure-changefeeds.md
@@ -71,8 +71,9 @@ CREATE CHANGEFEED FOR TABLE table_name, table_name2 INTO '{scheme}://{host}:{por
 When you create a changefeed **without** specifying a sink, CockroachDB sends the changefeed events to the SQL client. Consider the following regarding the [display format](cockroach-sql.html#sql-flag-format) in your SQL client:
 
 - If you do not define a display format, the CockroachDB SQL client will automatically use `ndjson` format.
-- If you specify a format, the client will use that format (e.g., `--format=csv`).
-- If you set the client display format to `ndjson` and set the changefeed [`format`](create-changefeed.html#format) to `csv`, you'll receive JSON format with CSV nested inside. In the reverse situation, you'll receive a comma-separated list of JSON values.
+- If you specify a display format, the client will use that format (e.g., `--format=csv`).
+- If you set the client display format to `ndjson` and set the changefeed [`format`](create-changefeed.html#format) to `csv`, you'll receive JSON format with CSV nested inside.
+- If you set the client display format to `csv` and set the changefeed [`format`](create-changefeed.html#format) to `json`, you'll receive a comma-separated list of JSON values.
 
 For more information, see [`CREATE CHANGEFEED`](create-changefeed.html).
 

--- a/v22.2/create-changefeed.md
+++ b/v22.2/create-changefeed.md
@@ -38,7 +38,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 Parameter | Description
 ----------|------------
 `table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Before creating a changefeed, consider the number of changefeeds versus the number of tables to include in a single changefeed. Each scenario can have an impact on total memory usage or changefeed performance. See [Create and Configure Changefeeds](create-and-configure-changefeeds.html) for more detail.
-`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri).
+`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri).<br><br>**Note:** If you create a changefeed without a sink and the [`format=csv` option](#format), your changefeed will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL session. If you do not specify a sink or the `format` option, then the changefeed will hang until canceled.
 `option` / `value` | For a list of available options and their values, see [Options](#options).
 
 ### CDC transformation parameters

--- a/v22.2/create-changefeed.md
+++ b/v22.2/create-changefeed.md
@@ -38,7 +38,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 Parameter | Description
 ----------|------------
 `table_name` | The name of the table (or tables in a comma separated list) to create a changefeed for.<br><br>**Note:** Before creating a changefeed, consider the number of changefeeds versus the number of tables to include in a single changefeed. Each scenario can have an impact on total memory usage or changefeed performance. See [Create and Configure Changefeeds](create-and-configure-changefeeds.html) for more detail.
-`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri).<br><br>**Note:** If you create a changefeed without a sink and the [`format=csv` option](#format), your changefeed will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL session. If you do not specify a sink or the `format` option, then the changefeed will hang until canceled.
+`sink` | The location of the configurable sink. The scheme of the URI indicates the type. For more information, see [Sink URI](#sink-uri).<br><br>**Note:** If you create a changefeed without a sink, your changefeed will run as a [core-style changefeed](changefeed-for.html) sending messages to the SQL client. For more detail, see [create-and-configure-changefeed.html#create].
 `option` / `value` | For a list of available options and their values, see [Options](#options).
 
 ### CDC transformation parameters


### PR DESCRIPTION
Fixes DOC-5180

Brief update to mention that enterprise changefeeds created without a sink and the format option will create a core-style changefeed. 

Currently, we only mention this in an example on the CDC Transformations page https://www.cockroachlabs.com/docs/v22.2/cdc-transformations#view-recent-changes-to-a-row. 

This PR adds to the `CREATE CHANGEFEED` page and the Create and Configure Changefeed overview page. 

(A couple of small tidy-up edits too.)

## Preview

https://deploy-preview-16025--cockroachdb-docs.netlify.app/docs/stable/create-and-configure-changefeeds.html#create