### PR TITLE
Add info on RU estimates using EXPLAIN ANALYZE

### DIFF
--- a/_includes/cockroachcloud/serverless-usage.md
+++ b/_includes/cockroachcloud/serverless-usage.md
@@ -1,1 +1,3 @@
 The best way to estimate your resource usage is to [enter a spend limit](serverless-cluster-management.html#edit-your-spend-limit) you're comfortable with and run your workload. You can see the RUs and storage your cluster has used in the **Usage this month** section of the [**Cluster Overview**](serverless-cluster-management.html#view-cluster-overview) page. Once enough usage data is available, you can also see a graph of your monthly resource usage and recommended spend limit on the [**Edit cluster**](serverless-cluster-management.html#edit-your-spend-limit) page.
+
+To estimate the RU consumption of individual SQL statements, you can use the [`EXPLAIN ANALYZE` SQL command](optimize-serverless-workload.html#example-request-unit-calculation).

--- a/v22.2/explain-analyze.md
+++ b/v22.2/explain-analyze.md
@@ -62,6 +62,7 @@ Property        | Description
 `network usage` | The amount of data transferred over the network while the statement was executed. If the value is 0 B, the statement was executed on a single node and didn't use the network.
 `regions` | The [regions](show-regions.html) where the affected nodes were located.
 `max sql temp disk usage` | ([`DISTSQL`](#distsql-option) option only) How much disk spilling occurs when executing a query. This property is displayed only when the disk usage is greater than zero.
+`estimated RUs consumed` | The estimated number of [Request Units (RUs)](../cockroachcloud/learn-about-request-units.html) consumed by the statement. This property is only visible on {{ site.data.products.serverless }} clusters.
 
 ### Statement plan tree properties
 


### PR DESCRIPTION
This PR adds information on estimating RU consumption using the EXPLAIN ANALYZE SQL command, added in v23.1 but backported to v22.2.

Closes DOC-6625.