### PR TITLE
Updated Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ clean:
 	rm -rf vendor
 	rm -rf _site
 	rm -rf .jekyll-cache
+	rm Gemfile.lock
 
 clean-site:
 	rm -rf _site
+
+clean-cache:
+	rm -rf .jekyll-cache


### PR DESCRIPTION
- `make clean` now removes `Gemfile.lock`, which should be rebuilt when running `make vendor`
- Added `make clean-cache` target alongside `make clean-site` to remove the Jekyll cache