### PR TITLE
remove preview flag from cloud org sso stuff

### DIFF
--- a/cockroachcloud/cloud-org-sso.md
+++ b/cockroachcloud/cloud-org-sso.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-{% include feature-phases/preview.md %}
-
 {% include_cached cockroachcloud/sso-intro.md %}
 
 This page describes Basic SSO and Cloud Organization SSO. To enable Cloud Organization SSO, refer to [Configure Cloud Organization SSO](configure-cloud-org-sso.html).

--- a/cockroachcloud/configure-cloud-org-sso.md
+++ b/cockroachcloud/configure-cloud-org-sso.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-{% include_cached feature-phases/preview-opt-in.md %}
-
 {% include_cached cockroachcloud/sso-intro.md %}
 
 This page describes how to enable [Cloud Organization SSO](cloud-org-sso.html) and manage your SSO configuration.


### PR DESCRIPTION
Cloud Org SSO is no longer in preview, this came in as a one-off request to remove the preview flag ASAP as the feature is being opened up on production.