### PR TITLE
DOC-6643 fix links missed by builder

### DIFF
--- a/advisories/c20230118.md
+++ b/advisories/c20230118.md
@@ -29,9 +29,9 @@ All users assigned the Developer role in a CockroachDB Cloud organization will n
 - `CONTROLJOB`
 - Cluster node metadata
 
-See [Role Options](../alter-user.html#role-options) for more information on these roles.
+See [Role Options](../{{site.current_cloud_version}}/alter-user.html#role-options) for more information on these roles.
 
-The users assigned the [Console Admin role](../cockroachcloud/console-access-management.html#console-admin) in a CockroachDB Cloud organization will continue to access the relevant pages in Cloud Console using an underlying per-cluster [SQL admin user](security-reference/authorization.html#admin-role), as it is intended to be an all-access, highly privileged role.
+The users assigned the [Console Admin role](../cockroachcloud/console-access-management.html#console-admin) in a CockroachDB Cloud organization will continue to access the relevant pages in Cloud Console using an underlying per-cluster [SQL admin user](../{{site.current_cloud_version}}/security-reference/authorization.html#admin-role), as it is intended to be an all-access, highly privileged role.
 
 ## Mitigation
 
@@ -39,14 +39,14 @@ A fix has been automatically applied to all CockroachDB Cloud organizations. Wit
 
 It is recommended that admins in a CockroachDB Cloud organization follow the authorization best practice of the principle of least privilege - whereby a user is granted exactly the minimum set of permissions necessary to perform the task required - and grant the [Console Admin role](../cockroachcloud/console-access-management.html#console-admin) to only those users who are required to have access to all the data in a cluster. In all other cases, the [Developer role](../cockroachcloud/console-access-management.html#developer) should be assigned to reduce the insider risk of data exfiltration. 
 
-Admins should also ensure that when users access a cluster’s DB Console directly from the CockroachDB Cloud’s [Monitoring page](../cockroachcloud/monitoring-page.html#access-the-db-console), they authenticate with specific SQL users that have been assigned only the required SQL privileges within the cluster. See [Authorization (Self-Hosted)](authorization.html) and [Authorization in CockroachDB](security-reference/authorization.html) for more information.
+Admins should also ensure that when users access a cluster’s DB Console directly from the CockroachDB Cloud’s [Monitoring page](../cockroachcloud/monitoring-page.html#access-the-db-console), they authenticate with specific SQL users that have been assigned only the required SQL privileges within the cluster. See [Authorization (Self-Hosted)](../{{site.current_cloud_version}}/authorization.html) and [Authorization in CockroachDB](../{{site.current_cloud_version}}/security-reference/authorization.html) for more information.
 
 ## Impact
 
-We have had no reports of customers impacted by this vulnerability and have not found any evidence that this exploit was utilized before it was patched. We’ve analyzed the product usage metrics which indicate that the vulnerability wasn’t exploited in a cloud organization. We are not able to share pertinent logs for this scenario, but recommend that customers configure [log export for CockroachDB Dedicated clusters](../cockroachcloud/export-logs.html) and enable the [SQL audit log](sql-audit-logging.html) for tables containing confidential data as a general best practice.
+We have had no reports of customers impacted by this vulnerability and have not found any evidence that this exploit was utilized before it was patched. We’ve analyzed the product usage metrics which indicate that the vulnerability wasn’t exploited in a cloud organization. We are not able to share pertinent logs for this scenario, but recommend that customers configure [log export for CockroachDB Dedicated clusters](../cockroachcloud/export-logs.html) and enable the [SQL audit log](../{{site.current_cloud_version}}/sql-audit-logging.html) for tables containing confidential data as a general best practice.
 
 Cockroach Labs discovered the issue when developing a related capability for CockroachDB Cloud Console and doing thorough threat modeling and testing for it. This triggered our security incident response process and we addressed the issue immediately.
 
-If any of your users with the Developer role in your cloud organization are not able to access a functionality that they were previously able to, we expect this is an intentional outcome of applying the principle of least privilege (refer the “Statement” section above). For Developer-level users unable to perform required functions, please grant them [direct SQL access](cockroach-sql.html) to the cluster via SQL or to the [DB Console](ui-overview.html) from the CockroachDB Cloud’s [Monitoring page](monitoring-page.html#access-the-db-console).
+If any of your users with the Developer role in your cloud organization are not able to access a functionality that they were previously able to, we expect this is an intentional outcome of applying the principle of least privilege (refer the “Statement” section above). For Developer-level users unable to perform required functions, please grant them [direct SQL access](../{{site.current_cloud_version}}/cockroach-sql.html) to the cluster via SQL or to the [DB Console](../{{site.current_cloud_version}}/ui-overview.html) from the CockroachDB Cloud’s [Monitoring page](../{{site.current_cloud_version}}/monitoring-page.html#access-the-db-console).
 
 Please reach out to the [support team](https://support.cockroachlabs.com/) if more information or assistance is needed.


### PR DESCRIPTION
Addresses: DOC-6643

- Fixes links to non-CC content that 404d. These links were not caught as broken by the builder, as https://github.com/cockroachdb/docs/pull/16016 passed all checks for build & merge - spawning separate investigation in D O C - 6 6 4 4 to troubleshoot.

Staging

WIP