### PR TITLE
Clarify where backups are stored

### DIFF
--- a/cockroachcloud/backups-page.md
+++ b/cockroachcloud/backups-page.md
@@ -20,7 +20,7 @@ Cockroach Labs runs [full cluster backups](../{{site.current_cloud_version}}/tak
 </section>
 
 <section class="filter-content" markdown="1" data-scope="dedicated">
-Cockroach Labs runs [full cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days. Backups are stored in the same region that a single-region cluster is running in or the primary region of a multi-region cluster.
+Cockroach Labs runs [full cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days. Backups are stored in the same region that a [single-region cluster](plan-your-cluster.html#cluster-configuration) is running in or the primary region of a [multi-region cluster](plan-your-cluster.html#multi-region-clusters).
 
 {{site.data.alerts.callout_info}}
 Currently, you can only restore [databases](#restore-a-database) and [tables](#restore-a-table) to the same cluster that the backup was taken from.

--- a/cockroachcloud/backups-page.md
+++ b/cockroachcloud/backups-page.md
@@ -20,7 +20,7 @@ Cockroach Labs runs [full cluster backups](../{{site.current_cloud_version}}/tak
 </section>
 
 <section class="filter-content" markdown="1" data-scope="dedicated">
-Cockroach Labs runs [full cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days.
+Cockroach Labs runs [full cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#full-backups) daily and [incremental cluster backups](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html#incremental-backups) hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days, while incremental backups are retained for 7 days. Backups are stored in the same region that a single-region cluster is running in or the primary region of a multi-region cluster.
 
 {{site.data.alerts.callout_info}}
 Currently, you can only restore [databases](#restore-a-database) and [tables](#restore-a-table) to the same cluster that the backup was taken from.


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-6022

Customer requested info on where their multi-region cluster's backups would be stored. Added clarification that they are stored in the primary region.