### PR TITLE
DOC-6674 recapitalize product names - obs

### DIFF
--- a/cockroachcloud/export-logs.md
+++ b/cockroachcloud/export-logs.md
@@ -1,6 +1,6 @@
 ---
-title: Export Logs From a CockroachDB dedicated Cluster
-summary: Export Logs From a CockroachDB dedicated Cluster
+title: Export Logs From a CockroachDB Dedicated Cluster
+summary: Export Logs From a CockroachDB Dedicated Cluster
 toc: true
 docs_area: manage
 ---

--- a/cockroachcloud/export-metrics.md
+++ b/cockroachcloud/export-metrics.md
@@ -1,6 +1,6 @@
 ---
-title: Export Metrics From a CockroachDB dedicated Cluster
-summary: Export Metrics From a CockroachDB dedicated Cluster
+title: Export Metrics From a CockroachDB Dedicated Cluster
+summary: Export Metrics From a CockroachDB Dedicated Cluster
 toc: true
 docs_area: manage
 ---


### PR DESCRIPTION
Addresses: DOC-6674

- Recapitalizes two instances of manual lowercase product name for Dedicated in two locations that couldn't make use of liquid tags (because front matter), now that Marketing has recanted and Gemma has merged https://github.com/cockroachdb/docs/pull/16065.