### PR TITLE
Statement and Transactions pages correction

### DIFF
--- a/_includes/v21.2/ui/statistics.md
+++ b/_includes/v21.2/ui/statistics.md
@@ -1,6 +1,6 @@
 Statistics aggregation is controlled by the [aggregation interval]({{ page_prefix }}statements-page.html#statements-table) property, set to 1 hour. Statistics between two hourly intervals belong to the nearest hour rounded down. For example, a statement execution ending at 1:50 would have its statistics aggregated in the 1:00-2:00 interval.
 
-Aggregated statistics are flushed from memory to statistics tables in the [`crdb_internal`]({{ link_prefix }}crdb-internal.html) system catalog every 10 minutes. The default retention period of the statistics tables is based on the number of rows up to 10 million records. When this threshold is reached, the oldest records are deleted.
+Aggregated statistics are flushed from memory to statistics tables in the [`crdb_internal`]({{ link_prefix }}crdb-internal.html) system catalog every 10 minutes. The default retention period of the statistics tables is based on the number of rows up to 1 million records. When this threshold is reached, the oldest records are deleted.
 
 To reset SQL statistics in the DB Console UI and `crdb_internal` system catalog, click **clear SQL stats**.
 

--- a/_includes/v22.1/ui/statistics.md
+++ b/_includes/v22.1/ui/statistics.md
@@ -2,6 +2,6 @@ Statistics aggregation is controlled by the `sql.stats.aggregation.interval` [cl
 
 Aggregated statistics are flushed from memory to statistics tables in the [`crdb_internal`]({{ link_prefix }}crdb-internal.html) system catalog every 10 minutes. The flushing interval is controlled by the `sql.stats.flush.interval` cluster setting.
 
-The default retention period of the statistics tables is based on the number of rows up to 10 million records. When this threshold is reached, the oldest records are deleted. The `diagnostics.forced_sql_stat_reset.interval` [cluster setting]({{ link_prefix }}cluster-settings.html) controls when persisted statistics are deleted only if the internal cleanup service experiences a failure.
+The default retention period of the statistics tables is based on the number of rows up to 1 million records. When this threshold is reached, the oldest records are deleted. The `diagnostics.forced_sql_stat_reset.interval` [cluster setting]({{ link_prefix }}cluster-settings.html) controls when persisted statistics are deleted only if the internal cleanup service experiences a failure.
 
 To reset SQL statistics in the DB Console UI and `crdb_internal` system catalog, click **clear SQL stats**.

--- a/_includes/v22.2/ui/statistics.md
+++ b/_includes/v22.2/ui/statistics.md
@@ -2,6 +2,6 @@ Statistics aggregation is controlled by the `sql.stats.aggregation.interval` [cl
 
 Aggregated statistics are flushed from memory to statistics tables in the [`crdb_internal`]({{ link_prefix }}crdb-internal.html) system catalog every 10 minutes. The flushing interval is controlled by the `sql.stats.flush.interval` cluster setting.
 
-The default retention period of the statistics tables is based on the number of rows up to 10 million records. When this threshold is reached, the oldest records are deleted. The `diagnostics.forced_sql_stat_reset.interval` [cluster setting]({{ link_prefix }}cluster-settings.html) controls when persisted statistics are deleted only if the internal cleanup service experiences a failure.
+The default retention period of the statistics tables is based on the number of rows up to 1 million records. When this threshold is reached, the oldest records are deleted. The `diagnostics.forced_sql_stat_reset.interval` [cluster setting]({{ link_prefix }}cluster-settings.html) controls when persisted statistics are deleted only if the internal cleanup service experiences a failure.
 
 To reset SQL statistics in the DB Console UI and `crdb_internal` system catalog, click **clear SQL stats**.


### PR DESCRIPTION
Statement and Transactions pages incorrectly list 10mil rows as default limit for persisted stats, 1 mil is correct.
https://cockroachlabs.atlassian.net/browse/DOC-5893