### PR TITLE
DOC-6510 correct disk ops include values

### DIFF
--- a/_includes/v21.2/prod-deployment/healthy-disk-ops-in-progress.md
+++ b/_includes/v21.2/prod-deployment/healthy-disk-ops-in-progress.md
@@ -1,1 +1,1 @@
-**Expected values for a healthy cluster**: This value should be 0 or single-digit milliseconds for short periods of time. If the values persist in double digits, you may have an I/O bottleneck.
+**Expected values for a healthy cluster**: This value should be 0 or single-digit values for short periods of time. If the values persist in double digits, you may have an I/O bottleneck.

--- a/_includes/v22.1/prod-deployment/healthy-disk-ops-in-progress.md
+++ b/_includes/v22.1/prod-deployment/healthy-disk-ops-in-progress.md
@@ -1,1 +1,1 @@
-**Expected values for a healthy cluster**: This value should be 0 or single-digit milliseconds for short periods of time. If the values persist in double digits, you may have an I/O bottleneck.
+**Expected values for a healthy cluster**: This value should be 0 or single-digit values for short periods of time. If the values persist in double digits, you may have an I/O bottleneck.

--- a/_includes/v22.2/prod-deployment/healthy-disk-ops-in-progress.md
+++ b/_includes/v22.2/prod-deployment/healthy-disk-ops-in-progress.md
@@ -1,1 +1,1 @@
-**Expected values for a healthy cluster**: This value should be 0 or single-digit milliseconds for short periods of time. If the values persist in double digits, you may have an I/O bottleneck.
+**Expected values for a healthy cluster**: This value should be 0 or single-digit values for short periods of time. If the values persist in double digits, you may have an I/O bottleneck.


### PR DESCRIPTION
Addresses: DOC-6510

- Corrected include that referred to disk ops counter in milliseconds, as it is a raw numeric increment.
	- The modified include is included in two places: verified that this change is correct to make for both.

Thanks Mark for the great feedback!!

Staging

[ui-hardware-dashboard.html](https://deploy-preview-16116--cockroachdb-docs.netlify.app/docs/stable/ui-hardware-dashboard.html#disk-ops-in-progress)