### PR TITLE
Style fix

### DIFF
--- a/cockroachcloud/export-logs.md
+++ b/cockroachcloud/export-logs.md
@@ -281,7 +281,7 @@ Perform the following steps to enable log export from your {{ site.data.products
 
 	1. In the GCP console, visit the [IAM admin page](https://console.cloud.google.com/iam-admin) for your project.
  1. Click the **+ Grant Access** button.
- 1. In the box labeled **New principals**, enter the log export service account for the {{ site.data.products.dedicated }}-managed service account, as determined in step 3.
+ 1. In the box labeled **New principals**, enter the name of the {{ site.data.products.db }} service account you determined in step 3.
  1. In the **Select a role** dropdown, select the role you created in step 4.
 	1. Click **SAVE**.
 


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-6425

"CockroachDB Dedicated-managed service account" is technically incorrect because service accounts are created for your CockroachDB Cloud organization, not Serverless or Dedicated clusters specifically. Removed hyphen and changed to "CockroachDB Cloud service account."