### PR TITLE
DOC-5383 fix auth code broken formatting

### DIFF
--- a/v22.1/security-reference/authentication.md
+++ b/v22.1/security-reference/authentication.md
@@ -78,6 +78,7 @@ Each rule definition contains up to 6 values.
 ## The unstated, unchangeable `root` access rule
 
 The `root` SQL user can always authenticate using username/password or certificate, as if the first rule of the configuration were:
+
 ```
 # TYPE    DATABASE      USER           ADDRESS             METHOD
   host    all           root           all                 root

--- a/v22.2/security-reference/authentication.md
+++ b/v22.2/security-reference/authentication.md
@@ -78,6 +78,7 @@ Each rule definition contains up to 6 values.
 ## The unstated, unchangeable `root` access rule
 
 The `root` SQL user can always authenticate using username/password or certificate, as if the first rule of the configuration were:
+
 ```
 # TYPE    DATABASE      USER           ADDRESS             METHOD
   host    all           root           all                 root


### PR DESCRIPTION
Addresses: DOC-5383

- Added whitespace to avoid render-by-zero.
	- Affects both v22.2 and v22.1

Staging

- [v22.2/security-reference/authentication.html](https://deploy-preview-16120--cockroachdb-docs.netlify.app/docs/stable/security-reference/authentication.html#the-unstated-unchangeable-root-access-rule)
- [v22.1/security-reference/authentication.html](https://deploy-preview-16120--cockroachdb-docs.netlify.app/docs/v22.1/security-reference/authentication#the-unstated-unchangeable-root-access-rule)