### PR TITLE
remove "please" from instructions

### DIFF
--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -76,6 +76,8 @@ Other general guidance about language and tone:
 
     **Example:** `table name`: The name of the table to create audit logs for.
 
+- Avoid using "please" when giving an instruction, except when asking the user to go outside the scope of the task (such as contacting Cockroach Labs or filing a support issue).
+
 - To expand upon the idea of "free from hyperbolic language", avoid the use of the word "simple" (along with "just", "easily", "actually", etc.) since it's not really possible to tell what might be easy or hard for the user. Something you think is simple may be challenging for them.
 
 - Use contractions to simplify language, but not in cases where a clear directive or prohibition is being given (e.g., `do not` / `cannot` / `should not` instead of `don't` / `can't` / `shouldn't`).

--- a/v22.2/cluster-settings.md
+++ b/v22.2/cluster-settings.md
@@ -31,7 +31,7 @@ Use the [`SHOW CLUSTER SETTING`](show-cluster-setting.html) statement.
 
 Use the [`SET CLUSTER SETTING`](set-cluster-setting.html) statement.
 
-Before changing a cluster setting, please note the following:
+Before changing a cluster setting, note the following:
 
 - 	Changing a cluster setting is not instantaneous, as the change must be propagated to other nodes in the cluster.
 

--- a/v22.2/file-an-issue.md
+++ b/v22.2/file-an-issue.md
@@ -24,7 +24,7 @@ To file an issue in GitHub, we need the following information:
     $ grep -F '[config]' cockroach-data/logs/cockroach.log
     ~~~
     {{site.data.alerts.callout_info}}You might need to replace <code>cockroach-data/logs</code> with the location of your <a href="logging-overview.html">logs</a>.{{site.data.alerts.end}}
-    If the logs are not available, please include the output of `cockroach version` for each node in the cluster.
+    If the logs are not available, include the output of `cockroach version` for each node in the cluster.
 
 ### Template
 

--- a/v22.2/foreign-key.md
+++ b/v22.2/foreign-key.md
@@ -59,7 +59,7 @@ A `NOT NULL` constraint cannot be added to existing tables.
 
 By default, composite foreign keys are matched using the `MATCH SIMPLE` algorithm (which is the same default as PostgreSQL). `MATCH FULL` is available if specified. You can specify both `MATCH FULL` and `MATCH SIMPLE`.
 
-All composite key matches defined prior to version 19.1 use the `MATCH SIMPLE` comparison method. If you had a composite foreign key constraint and have just upgraded to version 19.1, then please check that `MATCH SIMPLE` works for your schema and consider replacing that foreign key constraint with a `MATCH FULL` one.
+All composite key matches defined prior to version 19.1 use the `MATCH SIMPLE` comparison method. If you had a composite foreign key constraint and have just upgraded to version 19.1, then check that `MATCH SIMPLE` works for your schema and consider replacing that foreign key constraint with a `MATCH FULL` one.
 
 #### How it works
 

--- a/v22.2/recommended-production-settings.md
+++ b/v22.2/recommended-production-settings.md
@@ -372,7 +372,7 @@ In Docker-based deployments of CockroachDB, these dependencies do not need to be
 
 ## File descriptors limit
 
-CockroachDB can use a large number of open file descriptors, often more than is available by default. Therefore, please note the following recommendations.
+CockroachDB can use a large number of open file descriptors, often more than is available by default. Therefore, note the following recommendations.
 
 For each CockroachDB node:
 

--- a/v22.2/srid-4326.md
+++ b/v22.2/srid-4326.md
@@ -114,7 +114,7 @@ ERROR: st_contains(): operation on mixed SRIDs forbidden: (Point, 0) != (Point, 
 ## Known limitations
 
 {{site.data.alerts.callout_info}}
-Defining a custom SRID by inserting rows into [`spatial_ref_sys`](spatial-glossary.html#spatial_ref_sys) is not currently supported.  For more information, please see the tracking issue [cockroachdb/cockroach#55903](https://github.com/cockroachdb/cockroach/issues/55903).
+Defining a custom SRID by inserting rows into [`spatial_ref_sys`](spatial-glossary.html#spatial_ref_sys) is not currently supported.  For more information, see the tracking issue [cockroachdb/cockroach#55903](https://github.com/cockroachdb/cockroach/issues/55903).
 {{site.data.alerts.end}}
 
 ## See also


### PR DESCRIPTION
[DOC-2070](https://cockroachlabs.atlassian.net/browse/DOC-2070)

- Removed "please" specifically for technical instructions.
- Updated style guide. I'm not sure if this wording is clear enough.