### PR TITLE
document 22.2 session vars workaround

### DIFF
--- a/v22.1/aws-dms.md
+++ b/v22.1/aws-dms.md
@@ -24,6 +24,15 @@ Complete the following items before starting this tutorial:
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
 - Ensure you have a secure, publicly available CockroachDB cluster running v22.1.8 or later.
+    - If your CockroachDB cluster is running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+
+        {% include_cached copy-clipboard.html %}
+        ~~~ sql
+        ALTER ROLE {username} SET copy_from_retries_enabled = true;
+        ~~~
+
+        This prevents a potential issue when migrating especially large tables.
+
 - Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
@@ -177,6 +186,15 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
     ~~~
 
     Try selecting **Full LOB mode** in your [task settings](#step-2-2-task-settings). If this does not resolve the error, select **Limited LOB mode** and gradually increase the **Maximum LOB size** until the error goes away. For more information about LOB (large binary object) modes, see the [AWS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.LOBSupport.html).
+
+- If you encounter an `ABORT_REASON_CLIENT_REJECT` error when migrating an especially large table, and are running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    ALTER ROLE {username} SET copy_from_retries_enabled = true;
+    ~~~
+
+    Then retry the migration.
 
 - Run the following query from within the target CockroachDB cluster to identify common problems with any tables that were migrated. If problems are found, explanatory messages will be returned in the `cockroach sql` shell.
 

--- a/v22.1/aws-dms.md
+++ b/v22.1/aws-dms.md
@@ -23,7 +23,7 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.8 or later. If you are migrating especially large tables with millions of rows, upgrade to v22.1.14 or later.
+- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.14 or later.
     - If your CockroachDB cluster is running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
         {% include_cached copy-clipboard.html %}

--- a/v22.1/aws-dms.md
+++ b/v22.1/aws-dms.md
@@ -23,7 +23,7 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.8 or later.
+- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.8 or later. If you are migrating especially large tables with millions of rows, upgrade to v22.1.14 or later.
     - If your CockroachDB cluster is running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
         {% include_cached copy-clipboard.html %}
@@ -31,7 +31,7 @@ Complete the following items before starting this tutorial:
         ALTER ROLE {username} SET copy_from_retries_enabled = true;
         ~~~
 
-        This prevents a potential issue when migrating especially large tables.
+        This prevents a potential issue when migrating especially large tables with millions of rows.
 
 - Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
@@ -187,7 +187,7 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
 
     Try selecting **Full LOB mode** in your [task settings](#step-2-2-task-settings). If this does not resolve the error, select **Limited LOB mode** and gradually increase the **Maximum LOB size** until the error goes away. For more information about LOB (large binary object) modes, see the [AWS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.LOBSupport.html).
 
-- If you encounter an `ABORT_REASON_CLIENT_REJECT` error when migrating an especially large table, and are running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+- If you encounter a `TransactionRetryWithProtoRefreshError` error in the [Amazon CloudWatch logs](#step-2-2-task-settings) or [CockroachDB logs](logging-overview.html) when migrating an especially large table with millions of rows, and are running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql

--- a/v22.2/aws-dms.md
+++ b/v22.2/aws-dms.md
@@ -22,6 +22,18 @@ Complete the following items before starting this tutorial:
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
 - Ensure you have a secure, publicly available CockroachDB cluster running v22.1.0 or later.
+    - If your CockroachDB cluster is running v22.2.3 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+
+        {% include_cached copy-clipboard.html %}
+        ~~~ sql
+        ALTER ROLE {username} SET copy_from_atomic_enabled = false;
+        ~~~
+
+        {% include_cached copy-clipboard.html %}
+        ~~~ sql
+        ALTER ROLE {username} SET copy_from_retries_enabled = true;
+        ~~~
+
 - Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 

--- a/v22.2/aws-dms.md
+++ b/v22.2/aws-dms.md
@@ -21,7 +21,7 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.2.0 or later, and have created a [SQL user](security-reference/authorization.html#sql-users) that you can use for your AWS DMS [target endpoint](#step-1-create-a-target-endpoint-pointing-to-cockroachdb).
+- Ensure you have a secure, publicly available CockroachDB cluster running v22.2.4 or later, and have created a [SQL user](security-reference/authorization.html#sql-users) that you can use for your AWS DMS [target endpoint](#step-1-create-a-target-endpoint-pointing-to-cockroachdb).
     - If your CockroachDB cluster is running v22.2.4 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
         {% include_cached copy-clipboard.html %}
@@ -34,7 +34,7 @@ Complete the following items before starting this tutorial:
         ALTER ROLE {username} SET copy_from_atomic_enabled = false;
         ~~~
 
-        This prevents a potential issue when migrating especially large tables.
+        This prevents a potential issue when migrating especially large tables with millions of rows.
 
 - Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
@@ -190,7 +190,7 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
 
     Try selecting **Full LOB mode** in your [task settings](#step-2-2-task-settings). If this does not resolve the error, select **Limited LOB mode** and gradually increase the **Maximum LOB size** until the error goes away. For more information about LOB (large binary object) modes, see the [AWS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.LOBSupport.html).
 
-- If you encounter an `ABORT_REASON_CLIENT_REJECT` error when migrating an especially large table, and are running v22.2.4 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+- If you encounter a `TransactionRetryWithProtoRefreshError` error in the [Amazon CloudWatch logs](#step-2-2-task-settings) or [CockroachDB logs](logging-overview.html) when migrating an especially large table with millions of rows, and are running v22.2.4 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql

--- a/v22.2/aws-dms.md
+++ b/v22.2/aws-dms.md
@@ -21,18 +21,20 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.0 or later.
-    - If your CockroachDB cluster is running v22.2.3 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+- Ensure you have a secure, publicly available CockroachDB cluster running v22.2.0 or later, and have created a [SQL user](security-reference/authorization.html#sql-users) that you can use for your AWS DMS [target endpoint](#step-1-create-a-target-endpoint-pointing-to-cockroachdb).
+    - If your CockroachDB cluster is running v22.2.4 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+
+        {% include_cached copy-clipboard.html %}
+        ~~~ sql
+        ALTER ROLE {username} SET copy_from_retries_enabled = true;
+        ~~~
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
         ALTER ROLE {username} SET copy_from_atomic_enabled = false;
         ~~~
 
-        {% include_cached copy-clipboard.html %}
-        ~~~ sql
-        ALTER ROLE {username} SET copy_from_retries_enabled = true;
-        ~~~
+        This prevents a potential issue when migrating especially large tables.
 
 - Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
@@ -187,6 +189,20 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
     ~~~
 
     Try selecting **Full LOB mode** in your [task settings](#step-2-2-task-settings). If this does not resolve the error, select **Limited LOB mode** and gradually increase the **Maximum LOB size** until the error goes away. For more information about LOB (large binary object) modes, see the [AWS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.LOBSupport.html).
+
+- If you encounter an `ABORT_REASON_CLIENT_REJECT` error when migrating an especially large table, and are running v22.2.4 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    ALTER ROLE {username} SET copy_from_retries_enabled = true;
+    ~~~
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    ALTER ROLE {username} SET copy_from_atomic_enabled = false;
+    ~~~
+
+    Then retry the migration.
 
 - Run the following query from within the target CockroachDB cluster to identify common problems with any tables that were migrated. If problems are found, explanatory messages will be returned in the `cockroach sql` shell.
 


### PR DESCRIPTION
[DOC-6689](https://cockroachlabs.atlassian.net/browse/DOC-6689)

This can't be merged until `copy_from_retries_enabled` is in a point release.