### PR TITLE
Add reference to Egress Perimeter Controls in CDC/Backup docs

### DIFF
--- a/_includes/v22.2/misc/note-egress-perimeter-cdc-backup.md
+++ b/_includes/v22.2/misc/note-egress-perimeter-cdc-backup.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+We recommend enabling Egress Perimeter Controls on {{ site.data.products.dedicated }} clusters to mitigate the risk of data exfiltration when accessing external resources, such as cloud storage for change data capture or backup and restore operations. See [Egress Perimeter Controls for CockroachDB Dedicated (Preview)](../cockroachcloud/egress-perimeter-controls.html) for detail and setup instructions.
+{{site.data.alerts.end}}

--- a/v22.2/backup-and-restore-overview.md
+++ b/v22.2/backup-and-restore-overview.md
@@ -69,6 +69,8 @@ For detail on additional cloud storage features CockroachDB supports:
 - [Object locking](use-cloud-storage-for-bulk-operations.html#object-locking) to prevent backups from being overwritten or deleted.
 - [Storage Class (AWS S3 only)](use-cloud-storage-for-bulk-operations.html#amazon-s3-storage-classes) to set a specific storage class for your backups.
 
+{% include {{ page.version.version }}/misc/note-egress-perimeter-cdc-backup.md %}
+
 ## See also
 
 - Considerations for using [backup](backup.html#considerations) and [restore](restore.html#considerations)

--- a/v22.2/changefeed-sinks.md
+++ b/v22.2/changefeed-sinks.md
@@ -33,6 +33,8 @@ URI Component      | Description
 
 To set a different sink URI to an existing changefeed, use the [`sink` option](alter-changefeed.html#sink-example) with `ALTER CHANGEFEED`.
 
+{% include {{ page.version.version }}/misc/note-egress-perimeter-cdc-backup.md %}
+
 ## Kafka
 
 Example of a Kafka sink URI:

--- a/v22.2/use-cloud-storage-for-bulk-operations.md
+++ b/v22.2/use-cloud-storage-for-bulk-operations.md
@@ -13,6 +13,8 @@ CockroachDB constructs a secure API call to the cloud storage specified in a URL
 - [`EXPORT`](export.html)
 - [`CREATE CHANGEFEED`](create-changefeed.html)
 
+{% include {{ page.version.version }}/misc/note-egress-perimeter-cdc-backup.md %}
+
 {{site.data.alerts.callout_success}}
 We strongly recommend using cloud/remote storage.
 {{site.data.alerts.end}}


### PR DESCRIPTION
Fixes DOC-6226

Adds a note that reference Egress Perimeter Controls to the Changefeed Sink, Backup/Restore Overview/storage page, and Cloud Storage page.