### PR TITLE
DOC-6611 metrics reference page

### DIFF
--- a/_includes/v22.1/metric-names.md
+++ b/_includes/v22.1/metric-names.md
@@ -1,5 +1,5 @@
-Name | Help
------|-----
+Name | Description
+-----|------------
 `addsstable.applications` | Number of SSTable ingestions applied (i.e., applied by Replicas)
 `addsstable.copies` | Number of SSTable ingestions that required copying files during application
 `addsstable.proposals` | Number of SSTable ingestions proposed (i.e., sent to Raft by lease holders)

--- a/_includes/v22.1/sidebar-data/reference.json
+++ b/_includes/v22.1/sidebar-data/reference.json
@@ -1766,6 +1766,12 @@
         ]
       },
       {
+       "title": "Metrics",
+       "urls": [
+         "/${VERSION}/metrics.html"
+       ]
+     },
+      {
         "title": "Transaction Retry Error Reference",
         "urls": [
           "/${VERSION}/transaction-retry-error-reference.html"

--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -1,5 +1,5 @@
-Name | Help
------|-----
+Name | Description
+-----|------------
 `addsstable.applications` | Number of SSTable ingestions applied (i.e., applied by Replicas)
 `addsstable.copies` | Number of SSTable ingestions that required copying files during application
 `addsstable.proposals` | Number of SSTable ingestions proposed (i.e., sent to Raft by lease holders)

--- a/_includes/v22.2/sidebar-data/reference.json
+++ b/_includes/v22.2/sidebar-data/reference.json
@@ -1862,6 +1862,12 @@
         ]
       },
       {
+        "title": "Metrics",
+        "urls": [
+          "/${VERSION}/metrics.html"
+        ]
+      },
+      {
         "title": "Transaction Retry Error Reference",
         "urls": [
           "/${VERSION}/transaction-retry-error-reference.html"

--- a/cockroachcloud/monitoring-page.md
+++ b/cockroachcloud/monitoring-page.md
@@ -97,6 +97,8 @@ To preview the metrics being collected, you can:
 - Click on your cluster's entry in the [Infrastructure List](https://docs.datadoghq.com/infrastructure/list/) to display time-series graphs for each available metric.
 - Use the [Metrics Explorer](https://docs.datadoghq.com/metrics/explorer/) to search for and view `crdb_dedicated` metrics.
 
+See [Metrics](../{{site.current_cloud_version}}/metrics.html) for the full list of metrics available in CockroachDB.
+
 ### Monitor health of metrics export
 
 To monitor the health of metrics export, we recommend that you [create a new Monitor](https://docs.datadoghq.com/monitors/create/types/metric/?tab=threshold).

--- a/v22.1/cockroach-debug-zip.md
+++ b/v22.1/cockroach-debug-zip.md
@@ -60,7 +60,7 @@ The following information is also contained in the `.zip` file, and cannot be fi
 - Range details
 - Jobs
 - [Cluster Settings](cluster-settings.html)
-- [Metrics](ui-custom-chart-debug-page.html#available-metrics)
+- [Metrics](metrics.html)
 - [Replication Reports](query-replication-reports.html)
 - Problem ranges
 - CPU profiles

--- a/v22.1/common-issues-to-monitor.md
+++ b/v22.1/common-issues-to-monitor.md
@@ -316,4 +316,5 @@ Because each node needs to update a liveness record on disk, maxing out disk ban
 - [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html)
 - [Troubleshoot SQL Behavior](query-behavior-troubleshooting.html)
 - [Admission Control](admission-control.html)
+- [Metrics](metrics.html)
 - [Alerts Page](../cockroachcloud/alerts-page.html) ({{ site.data.products.dedicated }})

--- a/v22.1/datadog.md
+++ b/v22.1/datadog.md
@@ -180,3 +180,4 @@ The timeseries graph at the top of the page indicates the configured metric and 
 - [Monitoring and Alerting](monitoring-and-alerting.html)
 - [DB Console Overview](ui-overview.html)
 - [Logging Overview](logging-overview.html)
+- [Metrics](metrics.html)

--- a/v22.1/metrics.md
+++ b/v22.1/metrics.md
@@ -9,7 +9,7 @@ As part of normal operation, CockroachDB continuously records metrics that track
 
 ## Available metrics
 
-Select your CockroachDB deployment to see the metrics available:
+Select your CockroachDB deployment to see the metrics available: 
 
 {{site.data.alerts.callout_info}}
 This list is taken directly from the source code and is subject to change.

--- a/v22.1/metrics.md
+++ b/v22.1/metrics.md
@@ -9,7 +9,7 @@ As part of normal operation, CockroachDB continuously records metrics that track
 
 ## Available metrics
 
-Select your CockroachDB deployment to see the metrics available: 
+Select your CockroachDB deployment to see the metrics available:
 
 {{site.data.alerts.callout_info}}
 This list is taken directly from the source code and is subject to change.

--- a/v22.1/metrics.md
+++ b/v22.1/metrics.md
@@ -1,0 +1,39 @@
+---
+title: Metrics
+summary: Learn about available metrics for monitoring your CockroachDB cluster.
+toc: false
+docs_area: reference.metrics
+---
+
+As part of normal operation, CockroachDB continuously records metrics that track performance, latency, usage, and many other runtime indicators. These metrics are often useful in diagnosing problems, troubleshooting performance, or planning cluster infrastructure modifications. This page documents locations where metrics are exposed for analysis, and includes the full list of available metrics in CockroachDB.
+
+## Available metrics
+
+Select your CockroachDB deployment to see the metrics available:
+
+{{site.data.alerts.callout_info}}
+This list is taken directly from the source code and is subject to change.
+{{site.data.alerts.end}}
+
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="metric-names">Self-Hosted and Dedicated</button>
+  <button class="filter-button" data-scope="metric-names-serverless">Serverless</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="metric-names">
+
+{% include {{page.version.version}}/metric-names.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="metric-names-serverless">
+
+{% include {{page.version.version}}/metric-names-serverless.md %}
+
+</section>
+
+## See also
+
+- [Troubleshooting Overview](troubleshooting-overview.html)
+- [Support Resources](support-resources.html)
+- [Raw Status Endpoints](monitoring-and-alerting.html#raw-status-endpoints)

--- a/v22.1/monitor-cockroachdb-kubernetes.md
+++ b/v22.1/monitor-cockroachdb-kubernetes.md
@@ -431,3 +431,8 @@ In this example, CockroachDB has already been deployed on a Kubernetes cluster. 
     $ kubectl exec cockroachdb-2 -- cat cockroach-data/logs/cockroach-dev.log
     ~~~  
 </section>
+
+## See also
+
+- [Monitoring and Alerting](monitoring-and-alerting.html)
+- [Metrics](metrics.html)

--- a/v22.1/monitor-cockroachdb-with-prometheus.md
+++ b/v22.1/monitor-cockroachdb-with-prometheus.md
@@ -201,3 +201,4 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 ## See also
 
 - [Monitoring and Alerting](monitoring-and-alerting.html)
+- [Metrics](metrics.html)

--- a/v22.1/monitoring-and-alerting.md
+++ b/v22.1/monitoring-and-alerting.md
@@ -335,3 +335,4 @@ Currently, not all events listed have corresponding alert rule definitions avail
 - [Orchestrated Deployment](kubernetes-overview.html)
 - [Local Deployment](start-a-local-cluster.html)
 - [Third-Party Monitoring Integrations](third-party-monitoring-tools.html)
+- [Metrics](metrics.html)

--- a/v22.1/third-party-monitoring-tools.md
+++ b/v22.1/third-party-monitoring-tools.md
@@ -18,3 +18,4 @@ CockroachDB is officially integrated with the following third-party monitoring p
 - [Monitoring and Alerting](monitoring-and-alerting.html)
 - [DB Console Overview](ui-overview.html)
 - [Logging Overview](logging-overview.html)
+- [Metrics](metrics.html)

--- a/v22.2/cockroach-debug-zip.md
+++ b/v22.2/cockroach-debug-zip.md
@@ -70,7 +70,7 @@ The following information is also contained in the `.zip` file, and cannot be fi
 - Range details
 - Jobs
 - [Cluster Settings](cluster-settings.html)
-- [Metrics](ui-custom-chart-debug-page.html#available-metrics)
+- [Metrics](metrics.html)
 - [Replication Reports](query-replication-reports.html)
 - Problem ranges
 - CPU profiles

--- a/v22.2/common-issues-to-monitor.md
+++ b/v22.2/common-issues-to-monitor.md
@@ -316,4 +316,5 @@ Because each node needs to update a liveness record on disk, maxing out disk ban
 - [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html)
 - [Troubleshoot SQL Behavior](query-behavior-troubleshooting.html)
 - [Admission Control](admission-control.html)
+- [Metrics](metrics.html)
 - [Alerts Page](../cockroachcloud/alerts-page.html) ({{ site.data.products.dedicated }})

--- a/v22.2/datadog.md
+++ b/v22.2/datadog.md
@@ -180,3 +180,4 @@ The timeseries graph at the top of the page indicates the configured metric and 
 - [Monitoring and Alerting](monitoring-and-alerting.html)
 - [DB Console Overview](ui-overview.html)
 - [Logging Overview](logging-overview.html)
+- [Metrics](metrics.html)

--- a/v22.2/metrics.md
+++ b/v22.2/metrics.md
@@ -1,0 +1,39 @@
+---
+title: Metrics
+summary: Learn about available metrics for monitoring your CockroachDB cluster.
+toc: false
+docs_area: reference.metrics
+---
+
+As part of normal operation, CockroachDB continuously records metrics that track performance, latency, usage, and many other runtime indicators. These metrics are often useful in diagnosing problems, troubleshooting performance, or planning cluster infrastructure modifications. This page documents locations where metrics are exposed for analysis, and includes the full list of available metrics in CockroachDB.
+
+## Available metrics
+
+Select your CockroachDB deployment to see the metrics available:
+
+{{site.data.alerts.callout_info}}
+This list is taken directly from the source code and is subject to change.
+{{site.data.alerts.end}}
+
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="metric-names">Self-Hosted and Dedicated</button>
+  <button class="filter-button" data-scope="metric-names-serverless">Serverless</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="metric-names">
+
+{% include {{page.version.version}}/metric-names.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="metric-names-serverless">
+
+{% include {{page.version.version}}/metric-names-serverless.md %}
+
+</section>
+
+## See also
+
+- [Troubleshooting Overview](troubleshooting-overview.html)
+- [Support Resources](support-resources.html)
+- [Raw Status Endpoints](monitoring-and-alerting.html#raw-status-endpoints)

--- a/v22.2/monitor-cockroachdb-kubernetes.md
+++ b/v22.2/monitor-cockroachdb-kubernetes.md
@@ -431,3 +431,8 @@ In this example, CockroachDB has already been deployed on a Kubernetes cluster. 
     $ kubectl exec cockroachdb-2 -- cat cockroach-data/logs/cockroach-dev.log
     ~~~  
 </section>
+
+## See also
+
+- [Monitoring and Alerting](monitoring-and-alerting.html)
+- [Metrics](metrics.html)

--- a/v22.2/monitor-cockroachdb-with-prometheus.md
+++ b/v22.2/monitor-cockroachdb-with-prometheus.md
@@ -201,3 +201,4 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 ## See also
 
 - [Monitoring and Alerting](monitoring-and-alerting.html)
+- [Metrics](metrics.html)

--- a/v22.2/monitoring-and-alerting.md
+++ b/v22.2/monitoring-and-alerting.md
@@ -335,3 +335,4 @@ Currently, not all events listed have corresponding alert rule definitions avail
 - [Orchestrated Deployment](kubernetes-overview.html)
 - [Local Deployment](start-a-local-cluster.html)
 - [Third-Party Monitoring Integrations](third-party-monitoring-tools.html)
+- [Metrics](metrics.html)

--- a/v22.2/third-party-monitoring-tools.md
+++ b/v22.2/third-party-monitoring-tools.md
@@ -20,3 +20,4 @@ CockroachDB is officially integrated with the following third-party monitoring p
 - [Monitoring and Alerting](monitoring-and-alerting.html)
 - [DB Console Overview](ui-overview.html)
 - [Logging Overview](logging-overview.html)
+- [Metrics](metrics.html)


### PR DESCRIPTION
Addresses: DOC-6611

- Added new `metrics.md` page, which includes current `metric-names.md` and `metric-names-serverless.md` includes.
	- Updated `reference` left-nav to include `metrics.md` page at top-level underneath it.
	- Updated all links site-wide that previously pointed to `ui-custom-chart-debug-page.html#available-metrics` to point instead to `metrics.html` (there were only a few).
	- Added new **See Also** links to new metrics page where it seemed to make sense.
- Because we modify one cloud page ( `cockroachcloud/monitoring-page.md`), and because `{{site.current_cloud_version}}` is still at v22.1, I have to perform all of this to v22.1 also.

Staging

- [v22.2/metrics.md](https://deploy-preview-16136--cockroachdb-docs.netlify.app/docs/stable/metrics.html)
- [v22.1/metrics.md](https://deploy-preview-16136--cockroachdb-docs.netlify.app/docs/v22.1/metrics)