### PR TITLE
Add overlaps operator precedence info and example

### DIFF
--- a/v21.2/array.md
+++ b/v21.2/array.md
@@ -139,6 +139,44 @@ You can use the [operators](functions-and-operators.html#supported-operations) `
 (1 row)
 ~~~
 
+### Using the overlaps operator
+
+You can use the `&&` (overlaps) [operator](functions-and-operators.html#supported-operations) to select array columns by checking if another array overlaps the column array. Arrays overlap if they have any elements in common.
+
+1. Create the table:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE a (b STRING[]);
+    ~~~
+
+1. Insert two new arrays:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    INSERT INTO a VALUES (ARRAY['runway', 'houses', 'city', 'clouds']);
+    INSERT INTO a VALUES (ARRAY['runway', 'houses', 'city']);
+    INSERT INTO a VALUES (ARRAY['sun','moon']);
+    ~~~
+
+1. Use the `&&` operator in a where clause to a query:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM a WHERE b && ARRAY['clouds','moon'];
+    ~~~
+
+    ~~~
+                      b
+    -------------------------------
+      {runway,houses,city,clouds}
+      {sun,moon}
+    (2 rows)
+
+
+    Time: 30ms total (execution 2ms / network 28ms)
+    ~~~
+
 ### Appending an element to an array
 
 #### Using the `array_append` function

--- a/v21.2/functions-and-operators.md
+++ b/v21.2/functions-and-operators.md
@@ -62,16 +62,17 @@ The following table lists all CockroachDB operators from highest to lowest prece
 | 1 | `.` | Member field access operator | binary |
 | 2 | `::` | [Type cast](scalar-expressions.html#explicit-type-coercions) | binary |
 | 3 | `-` | Unary minus | unary (prefix) |
-|  | `~` | Bitwise not | unary (prefix) |
+|   | `~` | Bitwise not | unary (prefix) |
 | 4 | `^` | Exponentiation | binary |
 | 5 | `*` | Multiplication | binary |
-|  | `/` | Division | binary |
-|  | `//` | Floor division | binary |
-|  | `%` | Modulo | binary |
+|   | `/` | Division | binary |
+|   | `//` | Floor division | binary |
+|   | `%` | Modulo | binary |
 | 6 | `+` | Addition | binary |
-|  | `-` | Subtraction | binary |
+|   | `-` | Subtraction | binary |
 | 7 | `<<` | Bitwise left-shift | binary |
-|  | `>>` | Bitwise right-shift | binary |
+|   | `>>` | Bitwise right-shift | binary |
+|   | `&&` | Overlaps | binary |
 | 8 | `&` | Bitwise AND | binary |
 | 9 | `#` | Bitwise XOR | binary |
 | 10 | <code>&#124;</code> | Bitwise OR | binary |

--- a/v22.1/array.md
+++ b/v22.1/array.md
@@ -139,6 +139,44 @@ You can use the [operators](functions-and-operators.html#supported-operations) `
 (1 row)
 ~~~
 
+### Using the overlaps operator
+
+You can use the `&&` (overlaps) [operator](functions-and-operators.html#supported-operations) to select array columns by checking if another array overlaps the column array. Arrays overlap if they have any elements in common.
+
+1. Create the table:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE a (b STRING[]);
+    ~~~
+
+1. Insert two new arrays:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    INSERT INTO a VALUES (ARRAY['runway', 'houses', 'city', 'clouds']);
+    INSERT INTO a VALUES (ARRAY['runway', 'houses', 'city']);
+    INSERT INTO a VALUES (ARRAY['sun','moon']);
+    ~~~
+
+1. Use the `&&` operator in a where clause to a query:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM a WHERE b && ARRAY['clouds','moon'];
+    ~~~
+
+    ~~~
+                      b
+    -------------------------------
+      {runway,houses,city,clouds}
+      {sun,moon}
+    (2 rows)
+
+
+    Time: 30ms total (execution 2ms / network 28ms)
+    ~~~
+
 ### Appending an element to an array
 
 #### Using the `array_append` function

--- a/v22.1/functions-and-operators.md
+++ b/v22.1/functions-and-operators.md
@@ -83,6 +83,7 @@ The following table lists all CockroachDB operators from highest to lowest prece
 |   | `-` | Subtraction | binary |
 | 7 | `<<` | Bitwise left-shift | binary |
 |   | `>>` | Bitwise right-shift | binary |
+|   | `&&` | Overlaps | binary |
 | 8 | `&` | Bitwise AND | binary |
 | 9 | `#` | Bitwise XOR | binary |
 | 10 | <code>&#124;</code> | Bitwise OR | binary |

--- a/v22.2/array.md
+++ b/v22.2/array.md
@@ -139,6 +139,44 @@ You can use the [operators](functions-and-operators.html#supported-operations) `
 (1 row)
 ~~~
 
+### Using the overlaps operator
+
+You can use the `&&` (overlaps) [operator](functions-and-operators.html#supported-operations) to select array columns by checking if another array overlaps the column array. Arrays overlap if they have any elements in common.
+
+1. Create the table:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE a (b STRING[]);
+    ~~~
+
+1. Insert two new arrays:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    INSERT INTO a VALUES (ARRAY['runway', 'houses', 'city', 'clouds']);
+    INSERT INTO a VALUES (ARRAY['runway', 'houses', 'city']);
+    INSERT INTO a VALUES (ARRAY['sun','moon']);
+    ~~~
+
+1. Use the `&&` operator in a where clause to a query:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM a WHERE b && ARRAY['clouds','moon'];
+    ~~~
+
+    ~~~
+                      b
+    -------------------------------
+      {runway,houses,city,clouds}
+      {sun,moon}
+    (2 rows)
+
+
+    Time: 30ms total (execution 2ms / network 28ms)
+    ~~~
+
 ### Appending an element to an array
 
 #### Using the `array_append` function

--- a/v22.2/functions-and-operators.md
+++ b/v22.2/functions-and-operators.md
@@ -86,6 +86,7 @@ The following table lists all CockroachDB operators from highest to lowest prece
 |   | `-` | Subtraction | binary |
 | 7 | `<<` | Bitwise left-shift | binary |
 |   | `>>` | Bitwise right-shift | binary |
+|   | `&&` | Overlaps | binary |
 | 8 | `&` | Bitwise AND | binary |
 | 9 | `#` | Bitwise XOR | binary |
 | 10 | <code>&#124;</code> | Bitwise OR | binary |
@@ -100,8 +101,8 @@ The following table lists all CockroachDB operators from highest to lowest prece
 |    | `[NOT] ILIKE ANY`, `[NOT] ILIKE SOME`, `[NOT] ILIKE ALL` | [Multi-valued] `ILIKE` comparison | binary |
 |    |  `->` | Access a JSONB field, returning a JSONB value. | binary |
 |    |  `->>` | Access a JSONB field, returning a string. | binary |
-|    |  `@>` | Tests whether the left JSONB field contains the right JSONB field. | binary |
-|    |  `>@` | Tests whether the left JSONB field is contained by the right JSONB field. | binary |
+|    |  `@>` | Tests whether the left JSONB or array field contains the right JSONB or array field. | binary |
+|    |  `>@` | Tests whether the left JSONB or array field is contained by the right JSONB or array field. | binary |
 |    |  `#>` | Access a JSONB field at the specified path, returning a JSONB value. | binary |
 |    |  `#>>` | Access a JSONB field at the specified path, returning a string. | binary |
 |    |  `?` | Does the key or element string exist within the JSONB value? | binary |


### PR DESCRIPTION
This PR adds the overlaps (&&) operator to the operator precedence table and adds an example of how to use overlaps with arrays.

Fixes DOC-5592.