### PR TITLE
Update 'Learn CockroachDB SQL' (Cloud version)

### DIFF
--- a/cockroachcloud/learn-cockroachdb-sql.md
+++ b/cockroachcloud/learn-cockroachdb-sql.md
@@ -5,39 +5,32 @@ toc: true
 docs_area: get_started
 ---
 
-This tutorial walks you through some of the most essential CockroachDB SQL statements. For a complete list of supported SQL statements and related details, see [SQL Statements](../{{site.current_cloud_version}}/sql-statements.html).
+This tutorial walks you through some of the most important CockroachDB SQL statements. For a list of all supported SQL statements, see [SQL Statements](../{{site.current_cloud_version}}/sql-statements.html).
+
+{{site.data.alerts.callout_info}}
+This tutorial is for {{site.data.products.dedicated}} or {{site.data.products.serverless}} users. If you are working with {{site.data.products.core}}, you can run this tutorial against [a local `cockroach demo` cluster](../{{site.current_cloud_version}}/learn-cockroachdb-sql.html).
+{{site.data.alerts.end}}
 
 ## Before you begin
 
-Make sure you have already [connected the CockroachDB SQL client](connect-to-your-cluster.html#step-3-connect-to-your-cluster) to your cluster. Alternatively, you can [use a local demo cluster](../{{site.current_cloud_version}}/learn-cockroachdb-sql.html) or click below to run through the tutorial entirely in your browser.
-
-<div class="clearfix">
-  <a class="btn btn-outline-primary" href="../tutorials/learn-cockroachdb-sql-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
-</div>
+Make sure that you can connect the [`cockroach-sql`](../{{site.current_cloud_version}}/cockroach-sql-binary.html) client to a [{{site.data.products.serverless}}](connect-to-a-serverless-cluster.html?filters=cockroachdb-client) or [{{site.data.products.dedicated}}](connect-to-your-cluster.html) cluster.
 
 ## Create a database
 
-Your {{ site.data.products.db }} cluster comes with a `defaultdb` for testing and some internal databases.
+Your {{ site.data.products.db }} cluster comes with a database called `defaultdb`. This is used for testing and some internal databases.
 
-To create a new database, connect with your initial "admin" user and use [`CREATE DATABASE`](../{{site.current_cloud_version}}/create-database.html) followed by a database name:
+To create a new database, use [`CREATE DATABASE`](../{{site.current_cloud_version}}/create-database.html) followed by a database name:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE DATABASE bank;
+CREATE DATABASE bank;
 ~~~
 
-Database names must follow [these identifier rules](../{{site.current_cloud_version}}/keywords-and-identifiers.html#identifiers). To avoid an error in case the database already exists, you can include `IF NOT EXISTS`:
+Database names must follow [these identifier rules](../{{site.current_cloud_version}}/keywords-and-identifiers.html#identifiers). To avoid an error in case the database already exists, use the `IF NOT EXISTS` clause:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE DATABASE IF NOT EXISTS bank;
-~~~
-
-When you no longer need a database, use [`DROP DATABASE`](../{{site.current_cloud_version}}/drop-database.html) followed by the database name to remove the database and all its objects:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> DROP DATABASE bank;
+CREATE DATABASE IF NOT EXISTS bank;
 ~~~
 
 ## Show databases
@@ -46,7 +39,7 @@ To see all databases, use the [`SHOW DATABASES`](../{{site.current_cloud_version
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW DATABASES;
+SHOW DATABASES;
 ~~~
 
 ~~~
@@ -65,14 +58,14 @@ It's best to set the default database directly in your [connection string](conne
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SET DATABASE = bank;
+SET DATABASE = bank;
 ~~~
 
 When working in the default database, you do not need to reference it explicitly in statements. To see which database is currently the default, use the `SHOW DATABASE` statement (note the singular form):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW DATABASE;
+SHOW DATABASE;
 ~~~
 
 ~~~
@@ -88,10 +81,7 @@ To create a table, use [`CREATE TABLE`](../{{site.current_cloud_version}}/create
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE TABLE accounts (
-    id INT PRIMARY KEY,
-    balance DECIMAL
-);
+CREATE TABLE accounts (id INT8 PRIMARY KEY, balance DECIMAL);
 ~~~
 
 Table and column names must follow [these rules](../{{site.current_cloud_version}}/keywords-and-identifiers.html#identifiers). Also, when you do not explicitly define a [primary key](../{{site.current_cloud_version}}/primary-key.html), CockroachDB will automatically add a hidden `rowid` column as the primary key.
@@ -100,9 +90,8 @@ To avoid an error in case the table already exists, you can include `IF NOT EXIS
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE TABLE IF NOT EXISTS accounts (
-    id INT PRIMARY KEY,
-    balance DECIMAL
+CREATE TABLE IF NOT EXISTS accounts (
+    id INT8 PRIMARY KEY, balance DECIMAL
 );
 ~~~
 
@@ -110,7 +99,7 @@ To show all of the columns from a table, use the [`SHOW COLUMNS FROM <table>`](.
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW COLUMNS FROM accounts;
+SHOW COLUMNS FROM accounts;
 ~~~
 
 ~~~
@@ -121,20 +110,13 @@ To show all of the columns from a table, use the [`SHOW COLUMNS FROM <table>`](.
 (2 rows)
 ~~~
 
-When you no longer need a table, use [`DROP TABLE`](../{{site.current_cloud_version}}/drop-table.html) followed by the table name to remove the table and all its data:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> DROP TABLE accounts;
-~~~
-
 ## Show tables
 
 To see all tables in the active database, use the [`SHOW TABLES`](../{{site.current_cloud_version}}/show-tables.html) statement or the `\dt` [shell command](../{{site.current_cloud_version}}/cockroach-sql.html#commands):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW TABLES;
+SHOW TABLES;
 ~~~
 
 ~~~
@@ -150,43 +132,38 @@ To insert a row into a table, use [`INSERT INTO`](../{{site.current_cloud_versio
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts VALUES (1, 10000.50);
+INSERT INTO accounts VALUES (1, 10000.50);
 ~~~
 
 If you want to pass column values in a different order, list the column names explicitly and provide the column values in the corresponding order:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts (balance, id) VALUES
-    (25000.00, 2);
+INSERT INTO accounts (balance, id) VALUES (25000.00, 2);
 ~~~
 
 To insert multiple rows into a table, use a comma-separated list of parentheses, each containing column values for one row:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts VALUES
-    (3, 8100.73),
-    (4, 9400.10);
+INSERT INTO accounts VALUES (3, 8100.73), (4, 9400.10);
 ~~~
 
 [Default values](../{{site.current_cloud_version}}/default-value.html) are used when you leave specific columns out of your statement, or when you explicitly request default values. For example, both of the following statements would create a row with `balance` filled with its default value, in this case `NULL`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts (id) VALUES
-    (5);
+INSERT INTO accounts (id) VALUES (5);
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts (id, balance) VALUES
-    (6, DEFAULT);
+INSERT INTO accounts (id, balance) VALUES (6, DEFAULT);
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT * FROM accounts WHERE id in (5, 6);
+SELECT * FROM accounts WHERE id IN (5, 6);
 ~~~
 
 ~~~
@@ -201,20 +178,19 @@ To insert multiple rows into a table, use a comma-separated list of parentheses,
 
 [Indexes](../{{site.current_cloud_version}}/indexes.html) help locate data without having to look through every row of a table. They're automatically created for the [primary key](../{{site.current_cloud_version}}/primary-key.html) of a table and any columns with a [`UNIQUE` constraint](../{{site.current_cloud_version}}/unique.html).
 
-To create an index for non-unique columns, use [`CREATE INDEX`](../{{site.current_cloud_version}}/create-index.html) followed by an optional index name and an `ON` clause identifying the table and column(s) to index.  For each column, you can choose whether to sort ascending (`ASC`) or descending (`DESC`).
+To create an index for non-unique columns, use [`CREATE INDEX`](../{{site.current_cloud_version}}/create-index.html) followed by an optional index name and an `ON` clause identifying the table and column(s) to index. For each column, you can choose whether to sort ascending (`ASC`) or descending (`DESC`).
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE INDEX balance_idx ON accounts (balance DESC);
+CREATE INDEX balance_idx ON accounts (balance DESC);
 ~~~
 
 You can create indexes during table creation as well; just include the `INDEX` keyword followed by an optional index name and the column(s) to index:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE TABLE accounts (
-    id INT PRIMARY KEY,
-    balance DECIMAL,
+CREATE TABLE IF NOT EXISTS accounts (
+    id INT8 PRIMARY KEY, balance DECIMAL,
     INDEX balance_idx (balance)
 );
 ~~~
@@ -225,7 +201,7 @@ To show the indexes on a table, use [`SHOW INDEX FROM`](../{{site.current_cloud_
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW INDEX FROM accounts;
+SHOW INDEX FROM accounts;
 ~~~
 
 ~~~
@@ -244,7 +220,7 @@ To query a table, use [`SELECT`](../{{site.current_cloud_version}}/select-clause
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT balance FROM accounts;
+SELECT balance FROM accounts;
 ~~~
 
 ~~~
@@ -263,7 +239,7 @@ To retrieve all columns, use the `*` wildcard:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT * FROM accounts;
+SELECT * FROM accounts;
 ~~~
 
 ~~~
@@ -278,11 +254,11 @@ To retrieve all columns, use the `*` wildcard:
 (6 rows)
 ~~~
 
-To filter the results, add a `WHERE` clause identifying the columns and values to filter on:
+To filter the results, add a [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) identifying the columns and values to filter on:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT id, balance FROM accounts WHERE balance > 9000;
+SELECT id, balance FROM accounts WHERE balance > 9000;
 ~~~
 
 ~~~
@@ -294,11 +270,11 @@ To filter the results, add a `WHERE` clause identifying the columns and values t
 (3 rows)
 ~~~
 
-To sort the results, add an `ORDER BY` clause identifying the columns to sort by. For each column, you can choose whether to sort ascending (`ASC`) or descending (`DESC`).
+To sort the results, add an [`ORDER BY`](../{{site.current_cloud_version}}/order-by.html) clause identifying the columns to sort by. For each column, you can choose whether to sort ascending (`ASC`) or descending (`DESC`).
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT id, balance FROM accounts ORDER BY balance DESC;
+SELECT id, balance FROM accounts ORDER BY balance DESC;
 ~~~
 
 ~~~
@@ -315,16 +291,21 @@ To sort the results, add an `ORDER BY` clause identifying the columns to sort by
 
 ## Update rows
 
-To update rows in a table, use [`UPDATE`](../{{site.current_cloud_version}}/update.html) followed by the table name, a `SET` clause identifying the columns to update and their new values, and a `WHERE` clause identifying the rows to update:
+To update rows in a table, use [`UPDATE`](../{{site.current_cloud_version}}/update.html) followed by the table name, a `SET` clause identifying the columns to update and their new values, and a [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) identifying the rows to update:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> UPDATE accounts SET balance = balance - 5.50 WHERE balance < 10000;
+UPDATE
+    accounts
+SET
+    balance = balance - 5.50
+WHERE
+    balance < 10000;
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT * FROM accounts;
+SELECT * FROM accounts;
 ~~~
 
 ~~~
@@ -339,20 +320,20 @@ To update rows in a table, use [`UPDATE`](../{{site.current_cloud_version}}/upda
 (6 rows)
 ~~~
 
-If a table has a primary key, you can use that in the `WHERE` clause to reliably update specific rows; otherwise, each row matching the `WHERE` clause is updated. When there's no `WHERE` clause, all rows in the table are updated.
+If a table has a primary key, you can use that in the [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) to reliably update specific rows; otherwise, each row matching the [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) is updated. When there's no [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause), all rows in the table are updated.
 
 ## Delete rows
 
-To delete rows from a table, use [`DELETE FROM`](../{{site.current_cloud_version}}/delete.html) followed by the table name and a `WHERE` clause identifying the rows to delete:
+To delete rows from a table, use [`DELETE FROM`](../{{site.current_cloud_version}}/delete.html) followed by the table name and a [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) identifying the rows to delete:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> DELETE FROM accounts WHERE id in (5, 6);
+DELETE FROM accounts WHERE id in (5, 6);
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT * FROM accounts;
+SELECT * FROM accounts;
 ~~~
 
 ~~~
@@ -365,4 +346,38 @@ To delete rows from a table, use [`DELETE FROM`](../{{site.current_cloud_version
 (4 rows)
 ~~~
 
-Just as with the `UPDATE` statement, if a table has a primary key, you can use that in the `WHERE` clause to reliably delete specific rows; otherwise, each row matching the `WHERE` clause is deleted. When there's no `WHERE` clause, all rows in the table are deleted.
+Just as with the `UPDATE` statement, if a table has a primary key, you can use that in the [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) to reliably delete specific rows; otherwise, each row matching the [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause) is deleted. When there's no [`WHERE` clause](../{{site.current_cloud_version}}/select-clause.html#where-clause), all rows in the table are deleted.
+
+## Drop a table
+
+When you no longer need a table, use [`DROP TABLE`](../{{site.current_cloud_version}}/drop-table.html) followed by the table name to remove the table and all its data:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+DROP TABLE accounts;
+~~~
+
+## Drop a database
+
+When you no longer need a database, use [`DROP DATABASE`](../{{site.current_cloud_version}}/drop-database.html) followed by the database name to remove the database and all its objects:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+DROP DATABASE bank;
+~~~
+
+## See also
+
+- [Developer Guide Overview](../{{site.current_cloud_version}}/developer-guide-overview.html)
+- [Deploy a Netlify App Built on CockroachDB](../{{site.current_cloud_version}}/deploy-app-netlify.html)
+- [Deploy a Web App built on CockroachDB with Vercel](../{{site.current_cloud_version}}/deploy-app-vercel.html)
+- [Build a Simple CRUD Node.js App with CockroachDB and the node-postgres Driver](../{{site.current_cloud_version}}/build-a-nodejs-app-with-cockroachdb.html)
+- [Build a Simple CRUD Python App with CockroachDB and SQLAlchemy](../{{site.current_cloud_version}}/build-a-python-app-with-cockroachdb-sqlalchemy.html)
+- [Build a Python App with CockroachDB and Django](../{{site.current_cloud_version}}/build-a-python-app-with-cockroachdb-django.html)
+- [Build a Simple CRUD Go App with CockroachDB and the Go pgx Driver](../{{site.current_cloud_version}}/build-a-go-app-with-cockroachdb.html)
+- [Connect to a {{site.data.products.serverless}} cluster](connect-to-a-serverless-cluster.html?filters=cockroachdb-client)
+- [Connect to a {{site.data.products.dedicated}} cluster](connect-to-your-cluster.html)
+- [Serverless FAQs](serverless-faqs.html)
+- [Dedicated FAQs](frequently-asked-questions.html)
+- [SQL FAQs](../{{site.current_cloud_version}}/drop-database.html)
+- [SQL Statements](../{{site.current_cloud_version}}/sql-statements.html)

--- a/v22.1/learn-cockroachdb-sql.md
+++ b/v22.1/learn-cockroachdb-sql.md
@@ -9,6 +9,10 @@ This tutorial guides you through some of the most essential CockroachDB SQL stat
 
 For a complete list of supported SQL statements and related details, see [SQL Statements](sql-statements.html).
 
+{{site.data.alerts.callout_info}}
+This tutorial is for {{site.data.products.core}} users. If you are working with {{site.data.products.dedicated}} or {{site.data.products.serverless}}, you can run this tutorial against [a cluster running in the cloud](../cockroachcloud/learn-cockroachdb-sql.html).
+{{site.data.alerts.end}}
+
 <div class="clearfix">
   <a class="btn btn-outline-primary" href="../tutorials/learn-cockroachdb-sql-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
 </div>

--- a/v22.2/learn-cockroachdb-sql.md
+++ b/v22.2/learn-cockroachdb-sql.md
@@ -9,9 +9,9 @@ This tutorial guides you through some of the most essential CockroachDB SQL stat
 
 For a complete list of supported SQL statements and related details, see [SQL Statements](sql-statements.html).
 
-<div class="clearfix">
-  <a class="btn btn-outline-primary" href="../tutorials/learn-cockroachdb-sql-interactive.html" target="_blank" rel="noopener">Run this in your browser &rarr;</a>
-</div>
+{{site.data.alerts.callout_info}}
+This tutorial is for {{site.data.products.core}} users. If you are working with {{site.data.products.dedicated}} or {{site.data.products.serverless}}, you can run this tutorial against [a cluster running in the cloud](../cockroachcloud/learn-cockroachdb-sql.html).
+{{site.data.alerts.end}}
 
 ## Start CockroachDB
 


### PR DESCRIPTION
Fixes DOC-6493

Summary of changes:

- Update Cloud version of 'Learn CockroachDB SQL' to address various issues with the page that were leading to low CSAT, including:

  - Remove Instruqt tutorial that had various issues (very slow load times, sometimes "crashes" from user POV, etc., strange UX of being punted to external platform with different button location, etc.)

  - Fix logic errors in order of presentation of SQL commands that would lead to errors when typed into the SQL client in order

  - Add 'See Also' section at bottom of page with links to relevant SQL statements, FAQs, app tutorials, etc. so users have a "next place" to go

  - Add note to page making clearer that this page is for Cloud users, with link to Self-hosted version of these instructions

- Update Self-hosted version of the page to make it clearer that that page is for SH users, with link to Cloud version of the instructions