### PR TITLE
Lock jekyll-sass-converter to an older version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :jekyll_plugins do
     gem 'jekyll-remote-include', github: 'ianjevans/jekyll-remote-include', tag: 'v1.1.7'
     gem "jekyll-last-modified-at"
     gem "jekyll-get-json"
+    gem "jekyll-sass-converter", "~> 2.0"
   end


### PR DESCRIPTION
This is to help work around the build failures in Cloudflare.