### PR TITLE
Performance fix on the sidebar

### DIFF
--- a/_includes/corestyle.scss
+++ b/_includes/corestyle.scss
@@ -26,7 +26,7 @@
 @import "utils/backgrounds";
 @import "utils/type";
 
-$images-url: "{{site.url}}/docs/images/";
+$images-url: "{% if site.url == "https://www.cockroachlabs.com" %}{{site.url}}{% endif %}/docs/images/";
 
 html {
   height: 100%;
@@ -838,7 +838,7 @@ a.accordion-toggle {
   color: $neutral-800;
 }
 
-@import "{{site.url}}/docs/css/theme-blue.css";
+@import "{% if site.url == "https://www.cockroachlabs.com" %}{{site.url}}{% endif %}/docs/css/theme-blue.css";
 
 a.btn-primary {
   &:hover {

--- a/_includes/sidebar.js.html
+++ b/_includes/sidebar.js.html
@@ -97,7 +97,7 @@
             // This condition makes it possible to use external
             // urls in the sidebar.
             if (!/^https?:/.test(url)) {
-              url = '{{ site.url }}' + sidebar.baseUrl + url;
+              url = {% if site.url == "https://www.cockroachlabs.com" %}'{{ site.url }}' + {% endif %}sidebar.baseUrl + url;
             }
             return url;
           });
@@ -105,7 +105,7 @@
           // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
           var activePathname
           if (!/^https?:/.test(location.pathname)) {
-            activePathname = '{{ site.url }}' + location.pathname
+            activePathname = {% if site.url == "https://www.cockroachlabs.com" %}'{{ site.url }}' + {% endif %}location.pathname
           }
           else {
             activePathname = location.pathname


### PR DESCRIPTION
We added an SEO tweak to ensure that our sidebar produced full URLs
in our sidebar to limit the scope to which Google could crawl URLs on
our docs site. The problem is we're now using absolute URLs instead of
relative URLs in each of our Netlify builds, which are adding a hamper
on the speed of our builds. This PR should fix that.