### PR TITLE
Add/remove regions in the console is temporarily disabled

### DIFF
--- a/cockroachcloud/cluster-management.md
+++ b/cockroachcloud/cluster-management.md
@@ -30,8 +30,7 @@ For each cluster, the following details display:
     - [**Increase storage**](?filters=dedicated#increase-storage-for-a-cluster)
     - [**Change compute**](?filters=dedicated#change-compute-for-a-cluster)
     - [**Upgrade major version**](upgrade-to-{{site.current_cloud_version}}.html)
-    - [**Add regions**](?filters=dedicated#add-regions-to-a-cluster)
-<!--    - [**Add/remove regions**](?filters=dedicated#add-or-remove-regions-from-a-cluster) -->
+{% comment %} - [**Add/remove regions**](?filters=dedicated#add-or-remove-regions-from-a-cluster) {% endcomment %}
     - [**Delete cluster**](#delete-cluster)
 
 To view and manage a specific cluster, click the name of the cluster. The [**Overview**](#view-cluster-overview) page will display.
@@ -114,7 +113,8 @@ AWS disks can only be scaled once every six hours.
 1. On the **Summary** page, verify your new cluster configuration.
 1. Click **Update**.
 
-<!-- ## Add or remove regions from a cluster
+{% comment %}
+## Add or remove regions from a cluster
 
 You can add or remove up to nine regions at a time through the Console. Note that you cannot have a two-region cluster, and it will take about 30 minutes to add or remove each region. See [Planning your cluster](plan-your-cluster.html) for cluster requirements and recommendations before proceeding. -->
 
@@ -142,7 +142,6 @@ The ability to remove a region from a cluster through the Console is temporarily
 1. In the **Confirmation** dialog, verify your new cluster configuration.
 1. Click **OK**.
 
-<!-- 
 ### Remove a region from your cluster
 
 When you remove a region from a [multi-region](plan-your-cluster.html#multi-region-clusters) cluster, the node in that region with the highest ordinal will be [decommissioned](../{{site.versions["stable"]}}/node-shutdown.html?filters=decommission#decommission-the-node) first. Any ranges on that node will be [up-replicated](../{{site.versions["stable"]}}/ui-replication-dashboard.html#snapshot-data-received) to other nodes, and once decommission is complete that node will be shut down. This process is then repeated for every other node in the region. To remove a region from your cluster:
@@ -157,7 +156,7 @@ When you remove a region from a [multi-region](plan-your-cluster.html#multi-regi
 1. Click **Continue to payment**.
 1. In the **Confirmation** dialog, verify your new cluster configuration.
 1. Click **OK**.
--->
+{% endcomment %}
 
 ## Create a database
 

--- a/cockroachcloud/cluster-management.md
+++ b/cockroachcloud/cluster-management.md
@@ -30,7 +30,8 @@ For each cluster, the following details display:
     - [**Increase storage**](?filters=dedicated#increase-storage-for-a-cluster)
     - [**Change compute**](?filters=dedicated#change-compute-for-a-cluster)
     - [**Upgrade major version**](upgrade-to-{{site.current_cloud_version}}.html)
-    - [**Add/remove regions**](?filters=dedicated#add-or-remove-regions-from-a-cluster)
+    - [**Add regions**](?filters=dedicated#add-regions-to-a-cluster)
+<!--    - [**Add/remove regions**](?filters=dedicated#add-or-remove-regions-from-a-cluster) -->
     - [**Delete cluster**](#delete-cluster)
 
 To view and manage a specific cluster, click the name of the cluster. The [**Overview**](#view-cluster-overview) page will display.
@@ -113,11 +114,17 @@ AWS disks can only be scaled once every six hours.
 1. On the **Summary** page, verify your new cluster configuration.
 1. Click **Update**.
 
-## Add or remove regions from a cluster
+<!-- ## Add or remove regions from a cluster
 
-You can add or remove up to nine regions at a time through the Console. Note that you cannot have a two-region cluster, and it will take about 30 minutes to add or remove each region. See [Planning your cluster](plan-your-cluster.html) for cluster requirements and recommendations before proceeding.
+You can add or remove up to nine regions at a time through the Console. Note that you cannot have a two-region cluster, and it will take about 30 minutes to add or remove each region. See [Planning your cluster](plan-your-cluster.html) for cluster requirements and recommendations before proceeding. -->
 
-### Add a region to your cluster
+## Add a region to your cluster
+
+You can add up to nine regions at a time through the Console. See [Planning your cluster](plan-your-cluster.html) for cluster requirements and recommendations before proceeding.
+
+{{site.data.alerts.callout_info}}
+The ability to remove a region from a cluster through the Console is temporarily disabled. If you need to remove a region, [contact support](https://support.cockroachlabs.com).
+{{site.data.alerts.end}}
 
 1. Navigate to the cluster's **Overview** page.
 1. Select **Actions > Edit cluster**.
@@ -135,6 +142,7 @@ You can add or remove up to nine regions at a time through the Console. Note tha
 1. In the **Confirmation** dialog, verify your new cluster configuration.
 1. Click **OK**.
 
+<!-- 
 ### Remove a region from your cluster
 
 When you remove a region from a [multi-region](plan-your-cluster.html#multi-region-clusters) cluster, the node in that region with the highest ordinal will be [decommissioned](../{{site.versions["stable"]}}/node-shutdown.html?filters=decommission#decommission-the-node) first. Any ranges on that node will be [up-replicated](../{{site.versions["stable"]}}/ui-replication-dashboard.html#snapshot-data-received) to other nodes, and once decommission is complete that node will be shut down. This process is then repeated for every other node in the region. To remove a region from your cluster:
@@ -149,6 +157,7 @@ When you remove a region from a [multi-region](plan-your-cluster.html#multi-regi
 1. Click **Continue to payment**.
 1. In the **Confirmation** dialog, verify your new cluster configuration.
 1. Click **OK**.
+-->
 
 ## Create a database
 

--- a/cockroachcloud/plan-your-cluster.md
+++ b/cockroachcloud/plan-your-cluster.md
@@ -28,12 +28,12 @@ You can have a maximum of 9 regions per cluster through the Console. If you need
 ### Cluster scaling
 
 {{site.data.alerts.callout_info}}
-The ability to remove a region from a cluster through the Console is temporarily disabled. If you need to remove a region, [contact support](https://support.cockroachlabs.com).
+The ability to add and remove regions from a cluster through the Console is temporarily disabled. If you need to do this, [contact support](https://support.cockroachlabs.com).
 {{site.data.alerts.end}}
 
 When scaling up your cluster, it is generally more effective to increase node size up to 16 vCPUs before adding more nodes. For example, if you have a 3 node cluster with 2 vCPUs per node, consider scaling up to 8 vCPUs before adding a fourth node. For most production applications, we recommend at least 4 to 8 vCPUs per node.
 
-We recommend you add or remove regions or nodes from a cluster when the cluster isn't experiencing heavy traffic. Adding or removing nodes incurs a non-trivial amount of load on the cluster and takes about 30 minutes per region. Changing the cluster configuration during times of heavy traffic can result in degraded application performance or longer times for node modifications. Before removing nodes from a cluster, ensure that the reduced disk space will be sufficient for the existing and anticipated data. Before removing regions from a cluster, be aware that access to the database from that region will no longer be as fast.
+We recommend you add or remove nodes from a cluster when the cluster isn't experiencing heavy traffic. Adding or removing nodes incurs a non-trivial amount of load on the cluster and takes about 30 minutes per region. Changing the cluster configuration during times of heavy traffic can result in degraded application performance or longer times for node modifications. Before removing nodes from a cluster, ensure that the reduced disk space will be sufficient for the existing and anticipated data. Before removing regions from a cluster, be aware that access to the database from that region will no longer be as fast.
 
 If you have changed the [replication factor](../{{site.current_cloud_version}}/configure-replication-zones.html) for a cluster, you might not be able to remove nodes from the cluster. For example, suppose you have a 5-node cluster and you had previously changed the replication factor from its default value of 3 to 5. Now if you want to scale down the cluster to 3 nodes, the decommissioning nodes operation might fail. To successfully remove nodes from the cluster in this example, change the replication factor back to 3, and then remove the nodes.
 

--- a/cockroachcloud/plan-your-cluster.md
+++ b/cockroachcloud/plan-your-cluster.md
@@ -27,6 +27,10 @@ You can have a maximum of 9 regions per cluster through the Console. If you need
 
 ### Cluster scaling
 
+{{site.data.alerts.callout_info}}
+The ability to remove a region from a cluster through the Console is temporarily disabled. If you need to remove a region, [contact support](https://support.cockroachlabs.com).
+{{site.data.alerts.end}}
+
 When scaling up your cluster, it is generally more effective to increase node size up to 16 vCPUs before adding more nodes. For example, if you have a 3 node cluster with 2 vCPUs per node, consider scaling up to 8 vCPUs before adding a fourth node. For most production applications, we recommend at least 4 to 8 vCPUs per node.
 
 We recommend you add or remove regions or nodes from a cluster when the cluster isn't experiencing heavy traffic. Adding or removing nodes incurs a non-trivial amount of load on the cluster and takes about 30 minutes per region. Changing the cluster configuration during times of heavy traffic can result in degraded application performance or longer times for node modifications. Before removing nodes from a cluster, ensure that the reduced disk space will be sufficient for the existing and anticipated data. Before removing regions from a cluster, be aware that access to the database from that region will no longer be as fast.

--- a/releases/cloud.md
+++ b/releases/cloud.md
@@ -182,7 +182,7 @@ Get future release notes emailed to you:
 
 <h3>General changes</h3>
 
-- You can now [add and remove regions](../cockroachcloud/cluster-management.html#add-or-remove-regions-from-a-cluster) from {{ site.data.products.dedicated }} clusters through the {{ site.data.products.db }} Console. This change makes it easier to support users in new locations or scale down your cluster.
+- You can now [add and remove regions](../cockroachcloud/cluster-management.html) from {{ site.data.products.dedicated }} clusters through the {{ site.data.products.db }} Console. This change makes it easier to support users in new locations or scale down your cluster.
 
 ## July 6, 2022
 

--- a/releases/cloud.md
+++ b/releases/cloud.md
@@ -15,6 +15,12 @@ Get future release notes emailed to you:
 
 {% include releases/current-cloud-version.md %}
 
+## February 9, 2023
+
+<h3> General changes </h3>
+
+- For {{ site.data.products.dedicated }} clusters, the ability to add and remove regions through the {{ site.data.products.db }} Console has been temporarily disabled. If you need to add or remove regions from a cluster, [contact Support](https://support.cockroachlabs.com/).
+
 ## February 6, 2023
 
 <h3> General changes </h3>


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-6895

The ability to add or remove a region from a dedicated cluster in the console is temporarily disabled. Commented out relevant sections and added a release note.