### PR TITLE
DOC-6865 TA-96029 add env var

### DIFF
--- a/advisories/a96029.md
+++ b/advisories/a96029.md
@@ -20,13 +20,13 @@ This causes a notable negative impact on observability for all histogram metrics
 
 ## Statement
 
-This issue is resolved in the CockroachDB [v22.2.5](../releases/v22.2.html#v22-2-5) maintenance release, by increasing the fidelity of the histogram buckets.
+This issue is resolved in the CockroachDB v22.2.5 maintenance release, by increasing the fidelity of the histogram buckets.
 
 You can also use the new `COCKROACH_ENABLE_HDR_HISTOGRAMS` [environment variable](../v22.2/cockroach-commands.html#environment-variables) to control which histogram model your deployment uses: setting `COCKROACH_ENABLE_HDR_HISTOGRAMS=true` will use the legacy HdrHistogram model instead of the newer Prometheus-backed histogram model. Note that this is **not recommended** unless you are having difficulties with the newer Prometheus-backed histogram model. Enabling the legacy HdrHistogram model can cause performance issues with timeseries databases like Prometheus, as processing and storing the increased number of buckets is taxing on both CPU and storage. Note that the legacy HdrHistogram model is slated for full deprecation in upcoming releases. The `COCKROACH_ENABLE_HDR_HISTOGRAMS` environment variable defaults to `false`.
 
 ## Mitigation
 
-Users of CockroachDB v22.2.0, v22.2.1, v22.2.2, and v22.2.3 should make use of the [Statement Details](../v22.2/ui-statements-page.html#statement-details-page) page within the [DB Console](../v22.2/ui-overview.html) to verify query latencies, as the latency reported on this page does not rely on histogram metrics. Users are also encouraged to more closely monitor client side latencies in the meantime. Finally, users are encouraged to update to CockroachDB [v22.2.5](../releases/v22.2.html#v22-2-5) or later.
+Users of CockroachDB v22.2.0, v22.2.1, v22.2.2, and v22.2.3 should make use of the [Statement Details](../v22.2/ui-statements-page.html#statement-details-page) page within the [DB Console](../v22.2/ui-overview.html) to verify query latencies, as the latency reported on this page does not rely on histogram metrics. Users are also encouraged to more closely monitor client side latencies in the meantime. Finally, users are encouraged to update to CockroachDB v22.2.5 or later.
 
 ## Impact
 

--- a/advisories/a96029.md
+++ b/advisories/a96029.md
@@ -20,13 +20,13 @@ This causes a notable negative impact on observability for all histogram metrics
 
 ## Statement
 
-This issue will be resolved in the upcoming CockroachDB v22.2.4 maintenance release, by increasing the fidelity of the histogram buckets.
+This issue is resolved in the CockroachDB v22.2.5 maintenance release, by increasing the fidelity of the histogram buckets.
 
 You can also use the new `COCKROACH_ENABLE_HDR_HISTOGRAMS` [environment variable](../v22.2/cockroach-commands.html#environment-variables) to control which histogram model your deployment uses: setting `COCKROACH_ENABLE_HDR_HISTOGRAMS=true` will use the legacy HdrHistogram model instead of the newer Prometheus-backed histogram model. Note that this is **not recommended** unless you are having difficulties with the newer Prometheus-backed histogram model. Enabling the legacy HdrHistogram model can cause performance issues with timeseries databases like Prometheus, as processing and storing the increased number of buckets is taxing on both CPU and storage. Note that the legacy HdrHistogram model is slated for full deprecation in upcoming releases. The `COCKROACH_ENABLE_HDR_HISTOGRAMS` environment variable defaults to `false`.
 
 ## Mitigation
 
-Users of CockroachDB v22.2.0, v22.2.1, v22.2.2, and v22.2.3 should make use of the [Statement Details](../v22.2/ui-statements-page.html#statement-details-page) page within the [DB Console](../v22.2/ui-overview.html) to verify query latencies, as the latency reported on this page does not rely on histogram metrics. Users are also encouraged to more closely monitor client side latencies in the meantime. Finally, users are encouraged to update to CockroachDB v22.2.4 as soon as it is released.
+Users of CockroachDB v22.2.0, v22.2.1, v22.2.2, and v22.2.3 should make use of the [Statement Details](../v22.2/ui-statements-page.html#statement-details-page) page within the [DB Console](../v22.2/ui-overview.html) to verify query latencies, as the latency reported on this page does not rely on histogram metrics. Users are also encouraged to more closely monitor client side latencies in the meantime. Finally, users are encouraged to update to CockroachDB v22.2.5 or later.
 
 ## Impact
 

--- a/advisories/a96029.md
+++ b/advisories/a96029.md
@@ -20,7 +20,9 @@ This causes a notable negative impact on observability for all histogram metrics
 
 ## Statement
 
-This issue will be resolved in the upcoming CockroachDB v22.2.4 maintenance release, by increasing the fidelity of the histogram buckets. Furthermore, an environment variable will be introduced giving users the option to revert to using the legacy histogram model instead of the newer histograms.
+This issue will be resolved in the upcoming CockroachDB v22.2.4 maintenance release, by increasing the fidelity of the histogram buckets.
+
+You can also use the new `COCKROACH_ENABLE_HDR_HISTOGRAMS` [environment variable](../v22.2/cockroach-commands.html#environment-variables) to control which histogram model your deployment uses: setting `COCKROACH_ENABLE_HDR_HISTOGRAMS=true` will use the legacy HdrHistogram model instead of the newer Prometheus-backed histogram model. Note that this is **not recommended** unless you are having difficulties with the newer Prometheus-backed histogram model. Enabling the legacy HdrHistogram model can cause performance issues with timeseries databases like Prometheus, as processing and storing the increased number of buckets is taxing on both CPU and storage. Note that the legacy HdrHistogram model is slated for full deprecation in upcoming releases. The `COCKROACH_ENABLE_HDR_HISTOGRAMS` environment variable defaults to `false`.
 
 ## Mitigation
 

--- a/advisories/a96029.md
+++ b/advisories/a96029.md
@@ -20,13 +20,13 @@ This causes a notable negative impact on observability for all histogram metrics
 
 ## Statement
 
-This issue is resolved in the CockroachDB v22.2.5 maintenance release, by increasing the fidelity of the histogram buckets.
+This issue is resolved in the CockroachDB [v22.2.5](../releases/v22.2.html#v22-2-5) maintenance release, by increasing the fidelity of the histogram buckets.
 
 You can also use the new `COCKROACH_ENABLE_HDR_HISTOGRAMS` [environment variable](../v22.2/cockroach-commands.html#environment-variables) to control which histogram model your deployment uses: setting `COCKROACH_ENABLE_HDR_HISTOGRAMS=true` will use the legacy HdrHistogram model instead of the newer Prometheus-backed histogram model. Note that this is **not recommended** unless you are having difficulties with the newer Prometheus-backed histogram model. Enabling the legacy HdrHistogram model can cause performance issues with timeseries databases like Prometheus, as processing and storing the increased number of buckets is taxing on both CPU and storage. Note that the legacy HdrHistogram model is slated for full deprecation in upcoming releases. The `COCKROACH_ENABLE_HDR_HISTOGRAMS` environment variable defaults to `false`.
 
 ## Mitigation
 
-Users of CockroachDB v22.2.0, v22.2.1, v22.2.2, and v22.2.3 should make use of the [Statement Details](../v22.2/ui-statements-page.html#statement-details-page) page within the [DB Console](../v22.2/ui-overview.html) to verify query latencies, as the latency reported on this page does not rely on histogram metrics. Users are also encouraged to more closely monitor client side latencies in the meantime. Finally, users are encouraged to update to CockroachDB v22.2.5 or later.
+Users of CockroachDB v22.2.0, v22.2.1, v22.2.2, and v22.2.3 should make use of the [Statement Details](../v22.2/ui-statements-page.html#statement-details-page) page within the [DB Console](../v22.2/ui-overview.html) to verify query latencies, as the latency reported on this page does not rely on histogram metrics. Users are also encouraged to more closely monitor client side latencies in the meantime. Finally, users are encouraged to update to CockroachDB [v22.2.5](../releases/v22.2.html#v22-2-5) or later.
 
 ## Impact
 


### PR DESCRIPTION
Addresses: DOC-6865, DOC-6698

- Added guidance on using new `COCKROACH_ENABLE_HDR_HISTOGRAMS` environment variable to TA-96029.
- ~Will only merge once v22.2.4 goes live (likely next week).~
- UPDATE: v22.2.4 has been pulled. This PR is edited to direct users to v22.2.5 instead.

Staging

[a96029.md](https://deploy-preview-16238--cockroachdb-docs.netlify.app/docs/advisories/a96029#statement)