### PR TITLE
[DOC-6275] remove bulk from content pages

### DIFF
--- a/v22.2/use-cloud-storage-for-bulk-operations.md
+++ b/v22.2/use-cloud-storage-for-bulk-operations.md
@@ -1,6 +1,6 @@
 ---
-title: Use Cloud Storage for Bulk Operations
-summary: CockroachDB constructs a secure API call to the cloud storage specified in a URL passed to bulk operation statements.
+title: Use Cloud Storage
+summary: CockroachDB constructs a secure API call to the cloud storage specified in a URL passed to various operation statements.
 toc: true
 docs_area: manage
 ---
@@ -45,7 +45,7 @@ The location parameters often contain special characters that need to be URI-enc
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
-You can disable the use of implicit credentials when accessing external cloud storage services for various bulk operations by using the [`--external-io-disable-implicit-credentials` flag](cockroach-start.html#security).
+You can disable the use of implicit credentials when accessing external cloud storage services for various operations by using the [`--external-io-disable-implicit-credentials` flag](cockroach-start.html#security).
 {{site.data.alerts.end}}
 
 <a name="considerations"></a>
@@ -99,9 +99,9 @@ CockroachDB also provides client-side encryption of backup data, for more inform
 
 ## Storage permissions
 
-This section describes the minimum permissions required to run CockroachDB bulk operations. While we provide the required permissions for Amazon S3 and Google Cloud Storage, the provider's documentation provides detail on the setup process and different options regarding access management.
+This section describes the minimum permissions required to run CockroachDB operations. While we provide the required permissions for Amazon S3 and Google Cloud Storage, the provider's documentation provides detail on the setup process and different options regarding access management.
 
-Depending on the actions a bulk operation performs, it will require different access permissions to a cloud storage bucket.
+Depending on the actions an operation performs, it will require different access permissions to a cloud storage bucket.
 
 This table outlines the actions that each operation performs against the storage bucket:
 

--- a/v23.1/use-cloud-storage-for-bulk-operations.md
+++ b/v23.1/use-cloud-storage-for-bulk-operations.md
@@ -1,6 +1,6 @@
 ---
-title: Use Cloud Storage for Bulk Operations
-summary: CockroachDB constructs a secure API call to the cloud storage specified in a URL passed to bulk operation statements.
+title: Use Cloud Storage
+summary: CockroachDB constructs a secure API call to the cloud storage specified in a URL passed to various operation statements.
 toc: true
 docs_area: manage
 ---
@@ -45,7 +45,7 @@ The location parameters often contain special characters that need to be URI-enc
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
-You can disable the use of implicit credentials when accessing external cloud storage services for various bulk operations by using the [`--external-io-disable-implicit-credentials` flag](cockroach-start.html#security).
+You can disable the use of implicit credentials when accessing external cloud storage services for various operations by using the [`--external-io-disable-implicit-credentials` flag](cockroach-start.html#security).
 {{site.data.alerts.end}}
 
 <a name="considerations"></a>
@@ -99,9 +99,9 @@ CockroachDB also provides client-side encryption of backup data, for more inform
 
 ## Storage permissions
 
-This section describes the minimum permissions required to run CockroachDB bulk operations. While we provide the required permissions for Amazon S3 and Google Cloud Storage, the provider's documentation provides detail on the setup process and different options regarding access management.
+This section describes the minimum permissions required to run CockroachDB operations. While we provide the required permissions for Amazon S3 and Google Cloud Storage, the provider's documentation provides detail on the setup process and different options regarding access management.
 
-Depending on the actions a bulk operation performs, it will require different access permissions to a cloud storage bucket.
+Depending on the actions an operation performs, it will require different access permissions to a cloud storage bucket.
 
 This table outlines the actions that each operation performs against the storage bucket:
 


### PR DESCRIPTION
Addresses DOC-6275:
- removes "bulk ops" from page name and fixes affected changes on other pages
- change for v22.2 and v23.1

Preview:
- [Use Cloud Storage](https://deploy-preview-16076--cockroachdb-docs.netlify.app/docs/stable/use-cloud-storage.html)