### PR TITLE
Release notes for v22.2.5

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -133,12 +133,12 @@ release_info:
     start_time: 2023-02-02 13:05:22.995201 +0000 UTC
     version: v22.1.14
   v22.2:
-    build_time: 2023-02-13 00:00:00 (go1.19)
+    build_time: 2023-02-16 00:00:00 (go1.19)
     crdb_branch_name: release-22.2
     docker_image: cockroachdb/cockroach
-    name: v22.2.4
-    start_time: 2023-02-13 12:06:15.798656 +0000 UTC
-    version: v22.2.4
+    name: v22.2.5
+    start_time: 2023-02-16 11:31:24.747610 +0000 UTC
+    version: v22.2.5
   v23.1:
     build_time: 2022-02-13 00:00:00 (go1.19)
     crdb_branch_name: master

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -319,3 +319,4 @@ v22.2.3,v22.2,2023-01-23,false,False,Production,False,go1.19,81a114c2bc2ef8ef76f
 v22.1.14,v22.1,2023-02-06,false,False,Production,False,go1.19,35d3784791d9a884858b11b7270c234841146779,cockroachdb/cockroach,true,false,false,false,true
 v22.2.4,v22.2,2023-02-13,true,False,Production,False,go1.19,c84abdeb3074aef7008b41591ac5738d3b84caf3,cockroachdb/cockroach,true,true,true,true,true
 v23.1.0-alpha.2,v23.1,2023-02-13,false,False,Testing,False,go1.19,eb158026c50d8fa856e42f928d844831ea9e6b28,cockroachdb/cockroach-unstable,true,true,true,true,true
+v22.2.5,v22.2,2023-02-16,false,False,Production,False,go1.19,0c6903954dc9cd6c38c78ce5192cfd9a8183c110,cockroachdb/cockroach,true,true,true,true,true

--- a/_includes/releases/v22.2/v22.2.5.md
+++ b/_includes/releases/v22.2/v22.2.5.md
@@ -1,0 +1,9 @@
+## v22.2.5
+
+Release Date: February 16, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-2-5-miscellaneous">Bug fixes</h3>
+
+- Fixed a bug that prevented non-admin users from connecting to a cluster that was upgraded to v22.2.4 after a previous major version upgrade to v22.2.x was not finalized. [#97183](https://github.com/cockroachdb/cockroach/pull/97183)


### PR DESCRIPTION
Release notes for v22.2.5

## Preview
[releases/v22.2.md#v22-2-5](https://deploy-preview-16278--cockroachdb-docs.netlify.app/docs/releases/v22.2.html#v22-2-5)


## Tests
- [x] Local build
- [x] Linkcheck 