### PR TITLE
Multi-DDL statements shouldn't be run in txns

### DIFF
--- a/_includes/v22.1/known-limitations/schema-changes-within-transactions.md
+++ b/_includes/v22.1/known-limitations/schema-changes-within-transactions.md
@@ -5,5 +5,5 @@ Within a single [transaction](transactions.html):
 - [`DROP COLUMN`](drop-column.html) can result in data loss if one of the other schema changes in the transaction fails or is canceled. To work around this, move the `DROP COLUMN` statement to its own explicit transaction or run it in a single statement outside the existing transaction.
 
 {{site.data.alerts.callout_info}}
-If a schema change within a transaction fails, manual intervention may be needed to determine which has failed. After determining which schema change(s) failed, you can then retry the schema changes.
+If a schema change within a transaction fails, manual intervention may be needed to determine which statement has failed. After determining which schema change(s) failed, you can then retry the schema change.
 {{site.data.alerts.end}}

--- a/_includes/v22.1/sql/dev-schema-change-limits.md
+++ b/_includes/v22.1/sql/dev-schema-change-limits.md
@@ -1,3 +1,3 @@
-Review the [limitations of online schema changes](online-schema-changes.html#limitations). CockroachDB has [limited support for schema changes within the same explicit transaction](online-schema-changes.html#limited-support-for-schema-changes-within-transactions).
+Review the [limitations of online schema changes](online-schema-changes.html#limitations). CockroachDB [doesn't guarantee the atomicity of schema changes within transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions).
 
     Cockroach Labs recommends that you perform schema changes outside explicit transactions. When a database [schema management tool](third-party-database-tools.html#schema-migration-tools) manages transactions on your behalf, include one schema change operation per transaction.

--- a/_includes/v22.2/known-limitations/schema-changes-within-transactions.md
+++ b/_includes/v22.2/known-limitations/schema-changes-within-transactions.md
@@ -5,5 +5,5 @@ Within a single [transaction](transactions.html):
 - [`DROP COLUMN`](alter-table.html#drop-column) can result in data loss if one of the other schema changes in the transaction fails or is canceled. To work around this, move the `DROP COLUMN` statement to its own explicit transaction or run it in a single statement outside the existing transaction.
 
 {{site.data.alerts.callout_info}}
-If a schema change within a transaction fails, manual intervention may be needed to determine which has failed. After determining which schema change(s) failed, you can then retry the schema changes.
+If a schema change within a transaction fails, manual intervention may be needed to determine which statement has failed. After determining which schema change(s) failed, you can then retry the schema change.
 {{site.data.alerts.end}}

--- a/_includes/v22.2/sql/dev-schema-change-limits.md
+++ b/_includes/v22.2/sql/dev-schema-change-limits.md
@@ -1,3 +1,3 @@
-Review the [limitations of online schema changes](online-schema-changes.html#limitations). CockroachDB has [limited support for schema changes within the same explicit transaction](online-schema-changes.html#limited-support-for-schema-changes-within-transactions).
+Review the [limitations of online schema changes](online-schema-changes.html#limitations). CockroachDB [doesn't guarantee the atomicity of schema changes within transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions).
 
     Cockroach Labs recommends that you perform schema changes outside explicit transactions. When a database [schema management tool](third-party-database-tools.html#schema-migration-tools) manages transactions on your behalf, include one schema change operation per transaction.

--- a/_includes/v23.1/known-limitations/schema-changes-within-transactions.md
+++ b/_includes/v23.1/known-limitations/schema-changes-within-transactions.md
@@ -5,5 +5,5 @@ Within a single [transaction](transactions.html):
 - [`DROP COLUMN`](alter-table.html#drop-column) can result in data loss if one of the other schema changes in the transaction fails or is canceled. To work around this, move the `DROP COLUMN` statement to its own explicit transaction or run it in a single statement outside the existing transaction.
 
 {{site.data.alerts.callout_info}}
-If a schema change within a transaction fails, manual intervention may be needed to determine which has failed. After determining which schema change(s) failed, you can then retry the schema changes.
+If a schema change within a transaction fails, manual intervention may be needed to determine which statement has failed. After determining which schema change(s) failed, you can then retry the schema change.
 {{site.data.alerts.end}}

--- a/_includes/v23.1/sql/dev-schema-change-limits.md
+++ b/_includes/v23.1/sql/dev-schema-change-limits.md
@@ -1,3 +1,3 @@
-Review the [limitations of online schema changes](online-schema-changes.html#limitations). CockroachDB has [limited support for schema changes within the same explicit transaction](online-schema-changes.html#limited-support-for-schema-changes-within-transactions).
+Review the [limitations of online schema changes](online-schema-changes.html#limitations). CockroachDB [doesn't guarantee the atomicity of schema changes within transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions).
 
     Cockroach Labs recommends that you perform schema changes outside explicit transactions. When a database [schema management tool](third-party-database-tools.html#schema-migration-tools) manages transactions on your behalf, include one schema change operation per transaction.

--- a/v22.1/liquibase.md
+++ b/v22.1/liquibase.md
@@ -155,7 +155,7 @@ Let's define a changelog with the [XML format](https://docs.liquibase.com/concep
     This first changeset uses [the `sqlFile` tag](https://docs.liquibase.com/change-types/community/sql-file.html), which tells Liquibase that an external `.sql` file contains some [SQL statements](https://docs.liquibase.com/concepts/basic/sql-format.html) to execute.
 
     {{site.data.alerts.callout_success}}
-    CockroachDB has [limited support for online schema changes in transactions](online-schema-changes.html#limited-support-for-schema-changes-within-transactions). To avoid running into issues with incomplete transactions, we recommend setting the [`runInTransaction` attribute](https://docs.liquibase.com/concepts/basic/changeset.html#available-attributes) to `"false"` on all changesets.
+    CockroachDB [doesn't guarantee the atomicity of online schema changes in transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions). To avoid running into issues with incomplete transactions, we recommend setting the [`runInTransaction` attribute](https://docs.liquibase.com/concepts/basic/changeset.html#available-attributes) to `"false"` on all changesets.
     {{site.data.alerts.end}}
 
 
@@ -481,7 +481,7 @@ You can also query the `account` table directly to see the latest changes reflec
 
 By default, Liquibase wraps each changeset within a single transaction. If the transaction fails to successfully commit, Liquibase rolls back the transaction.
 
-CockroachDB has [limited support for online schema changes within transactions](online-schema-changes.html#limited-support-for-schema-changes-within-transactions). If a schema change fails, automatic rollbacks can lead to unexpected results. To avoid running into issues with incomplete transactions, we recommend setting the `runInTransaction` attribute on each of your changesets to `"false"`, as demonstrated throughout this tutorial.
+CockroachDB [doesn't guarantee the atomicity of online schema changes within transactions](online-schema-changes.html#schema-changes-within-transactions). If a schema change fails, automatic rollbacks can lead to unexpected results. To avoid running into issues with incomplete transactions, we recommend setting the `runInTransaction` attribute on each of your changesets to `"false"`, as demonstrated throughout this tutorial.
 
 {{site.data.alerts.callout_info}}
 If `runInTransaction="false"` for a changeset, and an error occurs while Liquid is running the changeset, the `databasechangelog` table might be left in an invalid state and need to be fixed manually.

--- a/v22.1/online-schema-changes.md
+++ b/v22.1/online-schema-changes.md
@@ -19,7 +19,7 @@ Schema changes consume additional resources, and if they are run when the cluste
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
-Support for schema changes within [transactions][txns] is [limited](#limitations). We recommend doing schema changes outside transactions where possible. When a schema management tool uses transactions on your behalf, we recommend only doing one schema change operation per transaction.
+CockroachDB [does not support schema changes](#limitations) within explicit [transactions][txns] with full atomicity guarantees. CockroachDB only supports DDL changes within implicit transactions (individual statements). If a schema management tool uses transactions on your behalf, it should only execute one schema change operation per transaction.
 {{site.data.alerts.end}}
 
 ## How online schema changes work
@@ -62,7 +62,7 @@ If a schema change fails, the schema change job will be cleaned up automatically
 
 ## Declarative schema changer
 
-{% include_cached new-in.html version="v22.1" %} The declarative schema changer is the next iteration of how schema changes will be performed in CockroachDB. By planning schema change operations in a more principled manner, the declarative schema changer will ultimately make transactional schema changes more stable. You can identify jobs that are using the declarative schema changer by running [`SHOW JOBS`](show-jobs.html) and finding jobs with a `job_type` of `NEW SCHEMA CHANGE`.
+{% include_cached new-in.html version="v22.1" %} CockroachDB only guarantees atomicity for schema changes within single statement transactions, either implicit transactions or in an explicit transaction with a single schema change statement. The declarative schema changer is the next iteration of how schema changes will be performed in CockroachDB. By planning schema change operations in a more principled manner, the declarative schema changer will ultimately make transactional schema changes possible. You can identify jobs that are using the declarative schema changer by running [`SHOW JOBS`](show-jobs.html) and finding jobs with a `job_type` of `NEW SCHEMA CHANGE`.
 
 The following statements use the declarative schema changer by default:
 
@@ -165,7 +165,9 @@ For more long-term recovery solutions, consider taking either a [full or increme
 
 ## Limitations
 
-### Limited support for schema changes within transactions
+### Schema changes within transactions
+
+Schema changes should not be performed within an explicit transaction with multiple statements, as they do not have the same atomicity guarantees as other SQL statements. Execute schema changes either as single statements (as an implicit transaction), or in an explicit transaction consisting of the single schema change statement.
 
 Schema changes keep your data consistent at all times, but they do not run inside [transactions][txns] in the general case. Making schema changes transactional would mean requiring a given schema change to propagate across all the nodes of a cluster. This would block all user-initiated transactions being run by your application, since the schema change would have to commit before any other transactions could make progress. This would prevent the cluster from servicing reads and writes during the schema change, requiring application downtime.
 
@@ -182,79 +184,6 @@ You cannot start an online schema change on a table if a [primary key change](al
 ### No online schema changes between executions of prepared statements
 
 {% include {{ page.version.version }}/known-limitations/schema-changes-between-prepared-statements.md %}
-
-### Examples of statements that fail
-
-The following statements fail due to [limited support for schema changes within transactions](#limited-support-for-schema-changes-within-transactions).
-
-#### Create an index and then run a select against that index inside a transaction
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE TABLE foo (id INT PRIMARY KEY, name VARCHAR);
-  BEGIN;
-  SAVEPOINT cockroach_restart;
-  CREATE INDEX foo_idx ON foo (id, name);
-  SELECT * from foo@foo_idx;
-  RELEASE SAVEPOINT cockroach_restart;
-  COMMIT;
-~~~
-
-~~~
-CREATE TABLE
-BEGIN
-SAVEPOINT
-CREATE INDEX
-ERROR:  relation "foo_idx" does not exist
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
-ROLLBACK
-~~~
-
-#### Add a column and then add a constraint against that column inside a transaction
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE TABLE foo ();
-  BEGIN;
-  SAVEPOINT cockroach_restart;
-  ALTER TABLE foo ADD COLUMN bar VARCHAR;
-  ALTER TABLE foo ADD CONSTRAINT bar CHECK (foo IN ('a', 'b', 'c', 'd'));
-  RELEASE SAVEPOINT cockroach_restart;
-  COMMIT;
-~~~
-
-~~~
-CREATE TABLE
-BEGIN
-SAVEPOINT
-ALTER TABLE
-ERROR:  column "foo" not found for constraint "foo"
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
-ROLLBACK
-~~~
-
-#### Add a column and then select against that column inside a transaction
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE TABLE foo ();
-  BEGIN;
-  SAVEPOINT cockroach_restart;
-  ALTER TABLE foo ADD COLUMN bar VARCHAR;
-  SELECT bar FROM foo;
-  RELEASE SAVEPOINT cockroach_restart;
-  COMMIT;
-~~~
-
-~~~
-CREATE TABLE
-BEGIN
-SAVEPOINT
-ALTER TABLE
-ERROR:  column name "bar" not found
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
-ROLLBACK
-~~~
 
 ### `ALTER TYPE` schema changes cannot be cancelled
 

--- a/v22.1/schema-design-indexes.md
+++ b/v22.1/schema-design-indexes.md
@@ -283,8 +283,8 @@ It's likely that you will need to update your database schema at some point. For
 
 - [Change and Remove Objects in a Database Schema](schema-design-update.html)
 - [Online Schema Changes](online-schema-changes.html)
-- [Insert Data](schema-design-indexes.html)
-- [Query Data](online-schema-changes.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
 
 You might also be interested in the following pages:
 

--- a/v22.2/liquibase.md
+++ b/v22.2/liquibase.md
@@ -155,7 +155,7 @@ Let's define a changelog with the [XML format](https://docs.liquibase.com/concep
     This first changeset uses [the `sqlFile` tag](https://docs.liquibase.com/change-types/community/sql-file.html), which tells Liquibase that an external `.sql` file contains some [SQL statements](https://docs.liquibase.com/concepts/basic/sql-format.html) to execute.
 
     {{site.data.alerts.callout_success}}
-    CockroachDB has [limited support for online schema changes in transactions](online-schema-changes.html#limited-support-for-schema-changes-within-transactions). To avoid running into issues with incomplete transactions, we recommend setting the [`runInTransaction` attribute](https://docs.liquibase.com/concepts/basic/changeset.html#available-attributes) to `"false"` on all changesets.
+    CockroachDB [doesn't guarantee the atomicity of online schema changes in transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions). To avoid running into issues with incomplete transactions, we recommend setting the [`runInTransaction` attribute](https://docs.liquibase.com/concepts/basic/changeset.html#available-attributes) to `"false"` on all changesets.
     {{site.data.alerts.end}}
 
 
@@ -481,7 +481,7 @@ You can also query the `account` table directly to see the latest changes reflec
 
 By default, Liquibase wraps each changeset within a single transaction. If the transaction fails to successfully commit, Liquibase rolls back the transaction.
 
-CockroachDB has [limited support for online schema changes within transactions](online-schema-changes.html#limited-support-for-schema-changes-within-transactions). If a schema change fails, automatic rollbacks can lead to unexpected results. To avoid running into issues with incomplete transactions, we recommend setting the `runInTransaction` attribute on each of your changesets to `"false"`, as demonstrated throughout this tutorial.
+CockroachDB has [doesn't guarantee the atomicity of schema changes within transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions). If a schema change fails, automatic rollbacks can lead to unexpected results. To avoid running into issues with incomplete transactions, we recommend setting the `runInTransaction` attribute on each of your changesets to `"false"`, as demonstrated throughout this tutorial.
 
 {{site.data.alerts.callout_info}}
 If `runInTransaction="false"` for a changeset, and an error occurs while Liquid is running the changeset, the `databasechangelog` table might be left in an invalid state and need to be fixed manually.

--- a/v22.2/schema-design-indexes.md
+++ b/v22.2/schema-design-indexes.md
@@ -285,8 +285,8 @@ It's likely that you will need to update your database schema at some point. For
 
 - [Change and Remove Objects in a Database Schema](schema-design-update.html)
 - [Online Schema Changes](online-schema-changes.html)
-- [Insert Data](schema-design-indexes.html)
-- [Query Data](online-schema-changes.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
 
 You might also be interested in the following pages:
 

--- a/v23.1/liquibase.md
+++ b/v23.1/liquibase.md
@@ -155,7 +155,7 @@ Let's define a changelog with the [XML format](https://docs.liquibase.com/concep
     This first changeset uses [the `sqlFile` tag](https://docs.liquibase.com/change-types/community/sql-file.html), which tells Liquibase that an external `.sql` file contains some [SQL statements](https://docs.liquibase.com/concepts/basic/sql-format.html) to execute.
 
     {{site.data.alerts.callout_success}}
-    CockroachDB has [limited support for online schema changes in transactions](online-schema-changes.html#limited-support-for-schema-changes-within-transactions). To avoid running into issues with incomplete transactions, we recommend setting the [`runInTransaction` attribute](https://docs.liquibase.com/concepts/basic/changeset.html#available-attributes) to `"false"` on all changesets.
+    CockroachDB [doesn't guarantee the atomicity of online schema changes in transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions). To avoid running into issues with incomplete transactions, we recommend setting the [`runInTransaction` attribute](https://docs.liquibase.com/concepts/basic/changeset.html#available-attributes) to `"false"` on all changesets.
     {{site.data.alerts.end}}
 
 
@@ -481,7 +481,7 @@ You can also query the `account` table directly to see the latest changes reflec
 
 By default, Liquibase wraps each changeset within a single transaction. If the transaction fails to successfully commit, Liquibase rolls back the transaction.
 
-CockroachDB has [limited support for online schema changes within transactions](online-schema-changes.html#limited-support-for-schema-changes-within-transactions). If a schema change fails, automatic rollbacks can lead to unexpected results. To avoid running into issues with incomplete transactions, we recommend setting the `runInTransaction` attribute on each of your changesets to `"false"`, as demonstrated throughout this tutorial.
+CockroachDB has [doesn't guarantee the atomicity of schema changes within transactions with multiple statements](online-schema-changes.html#schema-changes-within-transactions). If a schema change fails, automatic rollbacks can lead to unexpected results. To avoid running into issues with incomplete transactions, we recommend setting the `runInTransaction` attribute on each of your changesets to `"false"`, as demonstrated throughout this tutorial.
 
 {{site.data.alerts.callout_info}}
 If `runInTransaction="false"` for a changeset, and an error occurs while Liquid is running the changeset, the `databasechangelog` table might be left in an invalid state and need to be fixed manually.

--- a/v23.1/schema-design-indexes.md
+++ b/v23.1/schema-design-indexes.md
@@ -285,8 +285,8 @@ It's likely that you will need to update your database schema at some point. For
 
 - [Change and Remove Objects in a Database Schema](schema-design-update.html)
 - [Online Schema Changes](online-schema-changes.html)
-- [Insert Data](schema-design-indexes.html)
-- [Query Data](online-schema-changes.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
 
 You might also be interested in the following pages:
 


### PR DESCRIPTION
This PR clarifies that CockroachDB doesn't support fully atomic multi-DDL statements within transactions, and that users should use single-statement transactions when executing schema changes.

It also removes the examples of failing multi-statement transactions.

Fixes DOC-6948.
Fixes DOC-6949.