### PR TITLE
update IMPORT/COPY guidance

### DIFF
--- a/_includes/cockroachcloud/migration/sct-self-hosted.md
+++ b/_includes/cockroachcloud/migration/sct-self-hosted.md
@@ -1,0 +1,1 @@
+If you are migrating to a {{ site.data.products.core }} database, you can export the converted schema and execute the statements in [`cockroach sql`](cockroach-sql.html), or use a third-party schema migration tool such as [Alembic](alembic.html), [Flyway](flyway.html), or [Liquibase](liquibase.html).

--- a/_includes/cockroachcloud/migration/sct-self-hosted.md
+++ b/_includes/cockroachcloud/migration/sct-self-hosted.md
@@ -1,1 +1,5 @@
+{% if page.cloud != true %}
 If you are migrating to a {{ site.data.products.core }} database, you can export the converted schema and execute the statements in [`cockroach sql`](cockroach-sql.html), or use a third-party schema migration tool such as [Alembic](alembic.html), [Flyway](flyway.html), or [Liquibase](liquibase.html).
+{% else %}
+If you are migrating to a {{ site.data.products.core }} database, you can export the converted schema and execute the statements in [`cockroach sql`](../{{version_prefix}}cockroach-sql.html), or use a third-party schema migration tool such as [Alembic](../{{version_prefix}}alembic.html), [Flyway](../{{version_prefix}}flyway.html), or [Liquibase](../{{version_prefix}}liquibase.html).
+{% endif %}

--- a/_includes/v22.2/known-limitations/copy-syntax.md
+++ b/_includes/v22.2/known-limitations/copy-syntax.md
@@ -4,12 +4,12 @@ CockroachDB does not yet support the following `COPY` syntax:
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85571)
 
-- Various unsupported `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc.)
+- Various `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc).
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85572)
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85573)
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85574)
 
-- `COPY ... FROM ... WHERE <expr>`
+- `COPY ... FROM ... WHERE <expr>`.
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/54580)

--- a/_includes/v22.2/known-limitations/copy-syntax.md
+++ b/_includes/v22.2/known-limitations/copy-syntax.md
@@ -4,7 +4,7 @@ CockroachDB does not yet support the following `COPY` syntax:
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85571)
 
-- Various `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc).
+- Various `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc.).
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85572)
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85573)

--- a/_includes/v23.1/known-limitations/copy-syntax.md
+++ b/_includes/v23.1/known-limitations/copy-syntax.md
@@ -4,12 +4,12 @@ CockroachDB does not yet support the following `COPY` syntax:
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85571)
 
-- Various unsupported `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc.)
+- Various `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc).
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85572)
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85573)
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85574)
 
-- `COPY ... FROM ... WHERE <expr>`
+- `COPY ... FROM ... WHERE <expr>`.
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/54580)

--- a/_includes/v23.1/known-limitations/copy-syntax.md
+++ b/_includes/v23.1/known-limitations/copy-syntax.md
@@ -4,7 +4,7 @@ CockroachDB does not yet support the following `COPY` syntax:
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85571)
 
-- Various `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc).
+- Various `COPY` options (`FORMAT`, `FREEZE`, `QUOTE`, etc.).
 
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85572)
   - [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/85573)

--- a/cockroachcloud/migrations-page.md
+++ b/cockroachcloud/migrations-page.md
@@ -11,10 +11,7 @@ docs_area: migrate
 The **Migrations** page on the {{ site.data.products.db }} Console features a **Schema Conversion Tool** that helps you:
 
 - Convert a schema from a PostgreSQL, MySQL, Oracle, or Microsoft SQL Server database for use with CockroachDB.
-- Create a new {{ site.data.products.serverless }} database that uses the converted schema. You specify the target database and database owner when [finalizing the schema](#finalize-the-schema).
-    {{site.data.alerts.callout_success}}
-    {% include cockroachcloud/migration/sct-self-hosted.md %}
-    {{site.data.alerts.end}}
+- Create a new {{ site.data.products.serverless }} database that uses the converted schema. You specify the target database and database owner when [finalizing the schema](#finalize-the-schema). {% include cockroachcloud/migration/sct-self-hosted.md %}
 
 {{site.data.alerts.callout_info}}
 On the **Migrations** page, a *migration* refers to converting a schema for use with CockroachDB and creating a new database that uses the schema. It does not include moving data to the new database. For details on all steps required to complete a database migration, see [Migrate Your Database to CockroachDB](../{{version_prefix}}migration-overview.html).
@@ -221,11 +218,7 @@ To finalize the schema, click **Finalize Schema** when viewing the **Summary Rep
 
 1. In the **Success** tab, click **Next**.
 
-1. In the **Create Schema** tab, name the new database and select a user to own the database. Optionally click **Download SQL export** to download your schema file. 
-
-    {{site.data.alerts.callout_success}}
-    {% include cockroachcloud/migration/sct-self-hosted.md %}
-    {{site.data.alerts.end}}
+1. In the **Create Schema** tab, name the new database and select a user to own the database. Optionally click **Download SQL export** to download your schema file. {% include cockroachcloud/migration/sct-self-hosted.md %}
 
 1. Click **Finalize** to create the new database.
 

--- a/cockroachcloud/migrations-page.md
+++ b/cockroachcloud/migrations-page.md
@@ -11,7 +11,10 @@ docs_area: migrate
 The **Migrations** page on the {{ site.data.products.db }} Console features a **Schema Conversion Tool** that helps you:
 
 - Convert a schema from a PostgreSQL, MySQL, Oracle, or Microsoft SQL Server database for use with CockroachDB.
-- Create a new database that uses the converted schema. You specify the target database and database owner when [finalizing the schema](#finalize-the-schema).
+- Create a new {{ site.data.products.serverless }} database that uses the converted schema. You specify the target database and database owner when [finalizing the schema](#finalize-the-schema).
+    {{site.data.alerts.callout_success}}
+    {% include cockroachcloud/migration/sct-self-hosted.md %}
+    {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
 On the **Migrations** page, a *migration* refers to converting a schema for use with CockroachDB and creating a new database that uses the schema. It does not include moving data to the new database. For details on all steps required to complete a database migration, see [Migrate Your Database to CockroachDB](../{{version_prefix}}migration-overview.html).
@@ -218,11 +221,15 @@ To finalize the schema, click **Finalize Schema** when viewing the **Summary Rep
 
 1. In the **Success** tab, click **Next**.
 
-1. In the **Create Schema** tab, name the new database and select a user to own the database. Optionally click **Download SQL export** to download your schema file. This is useful for migrating your database to a different cluster. Then click **Finalize** to create the new database.
+1. In the **Create Schema** tab, name the new database and select a user to own the database. Optionally click **Download SQL export** to download your schema file. 
 
-{{site.data.alerts.callout_success}}
+    {{site.data.alerts.callout_success}}
+    {% include cockroachcloud/migration/sct-self-hosted.md %}
+    {{site.data.alerts.end}}
+
+1. Click **Finalize** to create the new database.
+
 After finalizing the schema and creating the new database, [move data into the database](../{{version_prefix}}migration-overview.html#step-2-move-your-data-to-cockroachdb) and [test your application](../{{version_prefix}}migration-overview.html#step-3-test-and-update-your-application).
-{{site.data.alerts.end}}
 
 ## See also
 

--- a/cockroachcloud/migrations-page.md
+++ b/cockroachcloud/migrations-page.md
@@ -60,7 +60,7 @@ The dump file must be smaller than 4 MB. `INSERT` and `COPY` statements will be 
 
 <ul>
 <section class="filter-content" markdown="1" data-scope="postgres">
-<li><b>INT type conversion</b>: On CockroachDB, <code>INT</code> is an alias for <code>INT8</code>, which creates 64-bit signed integers. On PostgreSQL, <code>INT</code> defaults to <code>INT4</code>. For details, see <a href="../{{version_prefix}}migration-overview.html#differences-from-other-databases">Differences from other databases</a>.</li> 
+<li><b>INT type conversion</b>: On CockroachDB, <code>INT</code> is an alias for <code>INT8</code>, which creates 64-bit signed integers. On PostgreSQL, <code>INT</code> defaults to <code>INT4</code>. For details, see <a href="../{{version_prefix}}migration-overview.html#schema-design-best-practices">Schema design best practices</a>.</li> 
 </section>
 
 <section class="filter-content" markdown="1" data-scope="mysql oracle mssql">
@@ -68,16 +68,16 @@ The dump file must be smaller than 4 MB. `INSERT` and `COPY` statements will be 
 </section>
 
 <section class="filter-content" markdown="1" data-scope="mysql">
-<li><b>AUTO_INCREMENT Conversion Option:</b> We do not recommend using a sequence to define a primary key column. For details, see <a href="../{{version_prefix}}migration-overview.html#differences-from-other-databases">Differences from other databases</a>. To understand the differences between the <code><b>UUID</b></code> and <code><b>unique_rowid()</b></code></b> options, see the <a href="../{{version_prefix}}sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid">SQL FAQs</a>.</li>
+<li><b>AUTO_INCREMENT Conversion Option:</b> We do not recommend using a sequence to define a primary key column. For details, see <a href="../{{version_prefix}}migration-overview.html#schema-design-best-practices">Schema design best practices</a>. To understand the differences between the <code><b>UUID</b></code> and <code><b>unique_rowid()</b></code></b> options, see the <a href="../{{version_prefix}}sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid">SQL FAQs</a>.</li>
 <li><b>Enum Preferences:</b> On CockroachDB, <a href="../{{version_prefix}}enum.html"><code>ENUMS</code></a> are a standalone type. On MySQL, they are part of column definitions. You can select to either deduplicate the <code>ENUM</code> definitions or create a separate type for each column.</li>
 </section>
 
 <section class="filter-content" markdown="1" data-scope="oracle">
-<li><b>GENERATED AS IDENTITY Conversion Option:</b> We do not recommend using a sequence to define a primary key column. For details, see <a href="../{{version_prefix}}migration-overview.html#differences-from-other-databases">Differences from other databases</a>. To understand the differences between the <code><b>UUID</b></code> and <code><b>unique_rowid()</b></code></b> options, see the <a href="../{{version_prefix}}sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid">SQL FAQs</a>.</li>
+<li><b>GENERATED AS IDENTITY Conversion Option:</b> We do not recommend using a sequence to define a primary key column. For details, see <a href="../{{version_prefix}}migration-overview.html#schema-design-best-practices">Schema design best practices</a>. To understand the differences between the <code><b>UUID</b></code> and <code><b>unique_rowid()</b></code></b> options, see the <a href="../{{version_prefix}}sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid">SQL FAQs</a>.</li>
 </section>
 
 <section class="filter-content" markdown="1" data-scope="mssql">
-<li><b>IDENTITY Conversion Option:</b> We do not recommend using a sequence to define a primary key column. For details, see <a href="../{{version_prefix}}migration-overview.html#differences-from-other-databases">Differences from other databases</a>. To understand the differences between the <code><b>UUID</b></code> and <code><b>unique_rowid()</b></code></b> options, see the <a href="../{{version_prefix}}sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid">SQL FAQs</a>.</li>
+<li><b>IDENTITY Conversion Option:</b> We do not recommend using a sequence to define a primary key column. For details, see <a href="../{{version_prefix}}migration-overview.html#schema-design-best-practices">Schema design best practices</a>. To understand the differences between the <code><b>UUID</b></code> and <code><b>unique_rowid()</b></code></b> options, see the <a href="../{{version_prefix}}sql-faqs.html#what-are-the-differences-between-uuid-sequences-and-unique_rowid">SQL FAQs</a>.</li>
 </section>
 </ul>
 
@@ -113,7 +113,7 @@ The **Summary Report** displays the results of the schema analysis:
 <li>The number of <b>Compatibility Notes</b> regarding differences in SQL syntax. Although these statements do not block finalization, you should [update](#update-the-schema) them before finalization.</li>
 </section>
 
-<li>The number of <b>Suggestions</b> regarding <a href="../{{version_prefix}}migration-overview.html#differences-from-other-databases">CockroachDB best practices</a>.</li>
+<li>The number of <b>Suggestions</b> regarding <a href="../{{version_prefix}}migration-overview.html#schema-design-best-practices">CockroachDB best practices</a>.</li>
 </ul>
 
 To review and [update the schema](#update-the-schema), click **View Statements** or the **Statements** tab to open the [**Statements** list](#statements-list).
@@ -147,7 +147,7 @@ The **Suggestions** graph displays the number of each suggestion type:
 - **Missing Primary Key** represents a statement that does not define an explicit primary key for a table. [Defining an explicit primary key on every table is recommended.](../{{version_prefix}}schema-design-table.html#select-primary-key-columns)
 
 {{site.data.alerts.callout_success}}
-For more details on why these suggestions are made, see [Differences from other databases](../{{version_prefix}}migration-overview.html#differences-from-other-databases).
+For more details on why these suggestions are made, see [Schema design best practices](../{{version_prefix}}migration-overview.html#schema-design-best-practices).
 {{site.data.alerts.end}}
 
 ## Statements list

--- a/v22.1/aws-dms.md
+++ b/v22.1/aws-dms.md
@@ -23,7 +23,7 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.14 or later.
+- Ensure you have a secure, publicly available CockroachDB cluster running the latest **{{ page.version.version }}** [production release](../releases/index.html).
     - If your CockroachDB cluster is running v22.1.14 or later, set the following session variable using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
         {% include_cached copy-clipboard.html %}

--- a/v22.2/aws-dms.md
+++ b/v22.2/aws-dms.md
@@ -21,7 +21,7 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.2.4 or later, and have created a [SQL user](security-reference/authorization.html#sql-users) that you can use for your AWS DMS [target endpoint](#step-1-create-a-target-endpoint-pointing-to-cockroachdb).
+- Ensure you have a secure, publicly available CockroachDB cluster running the latest **{{ page.version.version }}** [production release](../releases/index.html), and have created a [SQL user](security-reference/authorization.html#sql-users) that you can use for your AWS DMS [target endpoint](#step-1-create-a-target-endpoint-pointing-to-cockroachdb).
     - If your CockroachDB cluster is running v22.2.4 or later, set the following session variables using [`ALTER ROLE ... SET {session variable}`](alter-role.html#set-default-session-variable-values-for-a-role):
 
         {% include_cached copy-clipboard.html %}
@@ -47,7 +47,7 @@ Complete the following items before starting this tutorial:
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
     {{site.data.alerts.callout_info}}
-    All tables must have an explicitly defined primary key. For more guidance, see [Migrate Your Database to CockroachDB](migration-overview.html#step-1-test-and-update-your-schema).
+    All tables must have an explicitly defined primary key. For more guidance, see [Migrate Your Database to CockroachDB](migration-overview.html#step-1-convert-your-schema).
     {{site.data.alerts.end}}
 
 As of publishing, AWS DMS supports migrations from these relational databases (for a more accurate view of what is currently supported, see [Sources for AWS DMS](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.Sources.html)):

--- a/v22.2/copy-from.md
+++ b/v22.2/copy-from.md
@@ -51,58 +51,58 @@ cockroach demo
 
 ### Copy tab-delimited data to CockroachDB
 
-Start copying data to the `users` table:
+1. Start copying data to the `users` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY users FROM STDIN;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY users FROM STDIN;
+    ~~~
 
-You will see the following prompt:
+1. You will see the following prompt:
 
-~~~
-Enter data to be copied followed by a newline.
-End with a backslash and a period on a line by itself, or an EOF signal.
-~~~
+    ~~~
+    Enter data to be copied followed by a newline.
+    End with a backslash and a period on a line by itself, or an EOF signal.
+    ~~~
 
-Enter some tab-delimited data to copy to the table:
+1. Enter some tab-delimited data to copy to the table:
 
-{{site.data.alerts.callout_danger}}
-Before you input the following rows, ensure the delimiters are tab characters. They may have been converted to spaces by the browser.
-{{site.data.alerts.end}}
+    {{site.data.alerts.callout_danger}}
+    Before you input the following rows, ensure the delimiters are tab characters. They may have been converted to spaces by the browser.
+    {{site.data.alerts.end}}
 
-~~~
-8a3d70a3-d70a-4000-8000-00000000001d	seattle	Hannah	'400 Broad St'	0987654321
-~~~
+    ~~~
+    8a3d70a3-d70a-4000-8000-00000000001d	seattle	Hannah	'400 Broad St'	0987654321
+    ~~~
 
-~~~
-9eb851eb-851e-4800-8000-00000000001e	new york	Carl	'53 W 23rd St'	5678901234
-~~~
+    ~~~
+    9eb851eb-851e-4800-8000-00000000001e	new york	Carl	'53 W 23rd St'	5678901234
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-~~~
-\.
-~~~
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 2
-~~~
+    ~~~
+    COPY 2
+    ~~~
 
-Query the `users` table for the rows that you just inserted:
+1. Query the `users` table for the rows that you just inserted:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851eb-851e-4800-8000-00000000001e');
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851eb-851e-4800-8000-00000000001e');
+    ~~~
 
-~~~
-                  id                  |   city   |  name  |    address     | credit_card
---------------------------------------+----------+--------+----------------+-------------
- 9eb851eb-851e-4800-8000-00000000001e | new york | Carl   | '53 W 23rd St' | 5678901234
- 8a3d70a3-d70a-4000-8000-00000000001d | seattle  | Hannah | '400 Broad St' | 0987654321
-(2 rows)
-~~~
+    ~~~
+                      id                  |   city   |  name  |    address     | credit_card
+    --------------------------------------+----------+--------+----------------+-------------
+     9eb851eb-851e-4800-8000-00000000001e | new york | Carl   | '53 W 23rd St' | 5678901234
+     8a3d70a3-d70a-4000-8000-00000000001d | seattle  | Hannah | '400 Broad St' | 0987654321
+    (2 rows)
+    ~~~
 
 ### Copy CSV-delimited data to CockroachDB
 
@@ -115,226 +115,226 @@ You can copy CSV data into CockroachDB using the following methods:
 
 #### Copy CSV-delimited data from `stdin`
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
+    ~~~
 
-Start copying data to the `setecastronomy` table:
+1. Start copying data to the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY setecastronomy FROM STDIN WITH CSV;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY setecastronomy FROM STDIN WITH CSV;
+    ~~~
 
-You will see the following prompt:
+    You will see the following prompt:
 
-~~~
-Enter data to be copied followed by a newline.
-End with a backslash and a period on a line by itself, or an EOF signal.
-~~~
+    ~~~
+    Enter data to be copied followed by a newline.
+    End with a backslash and a period on a line by itself, or an EOF signal.
+    ~~~
 
-Enter some CSV-delimited data to copy to the table:
+1. Enter some CSV-delimited data to copy to the table:
 
-{% include_cached copy-clipboard.html %}
-~~~
-"My name is Werner Brandes","My voice is my passport"
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    "My name is Werner Brandes","My voice is my passport"
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 1
-~~~
+    ~~~
+    COPY 1
+    ~~~
 
-View the data in the `setecastronomy` table:
+1. View the data in the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM setecastronomy;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM setecastronomy;
+    ~~~
 
-~~~
-            name            |              phrase
-----------------------------+------------------------------------
-  My name is Werner Brandes | My voice is my passport
-(1 row)
-~~~
+    ~~~
+                name            |              phrase
+    ----------------------------+------------------------------------
+      My name is Werner Brandes | My voice is my passport
+    (1 row)
+    ~~~
 
 #### Copy CSV-delimited data from `stdin` with an escape character
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
+    ~~~
 
-Start copying data to the `setecastronomy` table, specifying an escape character for quoting the fields:
+1. Start copying data to the `setecastronomy` table, specifying an escape character for quoting the fields:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY setecastronomy FROM STDIN WITH CSV DELIMITER ',' ESCAPE '\';
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY setecastronomy FROM STDIN WITH CSV DELIMITER ',' ESCAPE '\';
+    ~~~
 
-You will see the following prompt:
+    You will see the following prompt:
 
-~~~
-Enter data to be copied followed by a newline.
-End with a backslash and a period on a line by itself, or an EOF signal.
-~~~
+    ~~~
+    Enter data to be copied followed by a newline.
+    End with a backslash and a period on a line by itself, or an EOF signal.
+    ~~~
 
-Enter some CSV-delimited data to copy to the table:
+1. Enter some CSV-delimited data to copy to the table:
 
-{% include_cached copy-clipboard.html %}
-~~~
-"My name is Werner Brandes","\"My\" \"voice\" \"is\" \"my\" \"passport\""
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    "My name is Werner Brandes","\"My\" \"voice\" \"is\" \"my\" \"passport\""
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 1
-~~~
+    ~~~
+    COPY 1
+    ~~~
 
-View the data in the `setecastronomy` table:
+1. View the data in the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM setecastronomy;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM setecastronomy;
+    ~~~
 
-~~~
-            name            |              phrase
-----------------------------+------------------------------------
-  My name is Werner Brandes | My voice is my passport
-  My name is Werner Brandes | "My" "voice" "is" "my" "passport"
-(2 rows)
-~~~
+    ~~~
+                name            |              phrase
+    ----------------------------+------------------------------------
+      My name is Werner Brandes | My voice is my passport
+      My name is Werner Brandes | "My" "voice" "is" "my" "passport"
+    (2 rows)
+    ~~~
 
 #### Copy CSV-delimited data from `stdin` with a header
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
+    ~~~
 
-Start copying data to the `setecastronomy` table, specifying that CockroachDB should skip the header (first line of CSV input):
+1. Start copying data to the `setecastronomy` table, specifying that CockroachDB should skip the header (first line of CSV input):
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY setecastronomy FROM STDIN WITH CSV HEADER;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY setecastronomy FROM STDIN WITH CSV HEADER;
+    ~~~
 
-Enter the data, including the header line:
+1. Enter the data, including the header line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-"name","phrase"
-"Hi, my name is Werner Brandes","My voice is my passport; verify me"
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    "name","phrase"
+    "Hi, my name is Werner Brandes","My voice is my passport; verify me"
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 1
-~~~
+    ~~~
+    COPY 1
+    ~~~
 
-View the data in the `setecastronomy` table:
+1. View the data in the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM setecastronomy;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM setecastronomy;
+    ~~~
 
-~~~
-              name              |               phrase
---------------------------------+-------------------------------------
-  My name is Werner Brandes     | My voice is my passport
-  My name is Werner Brandes     | "My" "voice" "is" "my" "passport"
-  Hi, my name is Werner Brandes | My voice is my passport; verify me
-(3 rows)
-~~~
+    ~~~
+                  name              |               phrase
+    --------------------------------+-------------------------------------
+      My name is Werner Brandes     | My voice is my passport
+      My name is Werner Brandes     | "My" "voice" "is" "my" "passport"
+      Hi, my name is Werner Brandes | My voice is my passport; verify me
+    (3 rows)
+    ~~~
 
 #### Copy CSV-delimited data from `stdin` with hex-encoded byte array data
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS mybytes(a INT PRIMARY KEY, b BYTEA);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS mybytes(a INT PRIMARY KEY, b BYTEA);
+    ~~~
 
-Set the `bytea_output` [session variable](set-vars.html#supported-variables) to specify that CockroachDB should ingest hex-encoded byte array data:
+1. Set the `bytea_output` [session variable](set-vars.html#supported-variables) to specify that CockroachDB should ingest hex-encoded byte array data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SET bytea_output = 'escape';
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SET bytea_output = 'escape';
+    ~~~
 
-Start copying data to the `mybytes` table:
+1. Start copying data to the `mybytes` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY mybytes FROM STDIN WITH CSV;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY mybytes FROM STDIN WITH CSV;
+    ~~~
 
-Enter some CSV-delimited data to copy to the table:
+1. Enter some CSV-delimited data to copy to the table:
 
-{% include_cached copy-clipboard.html %}
-~~~
-1,X'6869
-2,x'6869
-3,"\x6869"
-4,\x6869
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    1,X'6869
+    2,x'6869
+    3,"\x6869"
+    4,\x6869
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 4
-~~~
+    ~~~
+    COPY 4
+    ~~~
 
-View the data in the `mybytes` table:
+1. View the data in the `mybytes` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM mybytes;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM mybytes;
+    ~~~
 
-~~~
-  a |   b
-----+---------
-  1 | X'6869
-  2 | x'6869
-  3 | hi
-  4 | hi
-(4 rows)
-~~~
+    ~~~
+      a |   b
+    ----+---------
+      1 | X'6869
+      2 | x'6869
+      3 | hi
+      4 | hi
+    (4 rows)
+    ~~~
 
 ## See also
 

--- a/v22.2/copy-from.md
+++ b/v22.2/copy-from.md
@@ -1,6 +1,6 @@
 ---
 title: COPY FROM
-summary: Copy data from a third-party client to CockroachDB.
+summary: Copy data from a third-party client to a CockroachDB table.
 toc: true
 docs_area: reference.sql
 ---
@@ -36,9 +36,7 @@ Option | Description
 
 Only members of the `admin` role can run `COPY` statements. By default, the `root` user belongs to the `admin` role.
 
-## Known limitations
-
-### `COPY` syntax not supported by CockroachDB
+## Unsupported syntax
 
 {% include {{ page.version.version }}/known-limitations/copy-syntax.md %}
 
@@ -51,26 +49,26 @@ To run the examples, use [`cockroach demo`](cockroach-demo.html) to start a temp
 cockroach demo
 ~~~
 
-### Copy tab delimited data
+### Copy tab-delimited data to CockroachDB
 
-In the SQL shell, run the following command to start copying data to the `users` table:
+Start copying data to the `users` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 COPY users FROM STDIN;
 ~~~
 
-The following prompt should appear:
+You will see the following prompt:
 
 ~~~
 Enter data to be copied followed by a newline.
 End with a backslash and a period on a line by itself, or an EOF signal.
 ~~~
 
-Enter some tab-delimited data that you want copied to the `users` table.
+Enter some tab-delimited data to copy to the table:
 
-{{site.data.alerts.callout_info}}
-You may need to edit the following rows after copying them to make sure the delimiters are tab characters.
+{{site.data.alerts.callout_danger}}
+Before you input the following rows, ensure the delimiters are tab characters. They may have been converted to spaces by the browser.
 {{site.data.alerts.end}}
 
 ~~~
@@ -81,6 +79,8 @@ You may need to edit the following rows after copying them to make sure the deli
 9eb851eb-851e-4800-8000-00000000001e	new york	Carl	'53 W 23rd St'	5678901234
 ~~~
 
+Mark the end of data with `\.` on its own line:
+
 ~~~
 \.
 ~~~
@@ -89,7 +89,7 @@ You may need to edit the following rows after copying them to make sure the deli
 COPY 2
 ~~~
 
-In the SQL shell, query the `users` table for the rows that you just inserted:
+Query the `users` table for the rows that you just inserted:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -104,25 +104,25 @@ SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851
 (2 rows)
 ~~~
 
-### Copy CSV delimited data
+### Copy CSV-delimited data to CockroachDB
 
 You can copy CSV data into CockroachDB using the following methods:
 
-- [Copy CSV delimited data from stdin](#copy-csv-delimited-data-from-stdin)
-- [Copy CSV delimited data from stdin with an escape character](#copy-csv-delimited-data-from-stdin-with-an-escape-character)
-- [Copy CSV delimited data from stdin with a header](#copy-csv-delimited-data-from-stdin-with-a-header)
-- [Copy CSV delimited data from stdin with hex encoded byte array data](#copy-csv-delimited-data-from-stdin-with-hex-encoded-byte-array-data)
+- [Copy CSV-delimited data from `stdin`](#copy-csv-delimited-data-from-stdin)
+- [Copy CSV-delimited data from `stdin` with an escape character](#copy-csv-delimited-data-from-stdin-with-an-escape-character)
+- [Copy CSV-delimited data from `stdin` with a header](#copy-csv-delimited-data-from-stdin-with-a-header)
+- [Copy CSV-delimited data from `stdin` with hex-encoded byte array data](#copy-csv-delimited-data-from-stdin-with-hex-encoded-byte-array-data)
 
-#### Copy CSV delimited data from stdin
+#### Copy CSV-delimited data from `stdin`
 
-Run the following SQL statement to create a new table that you will load with CSV formatted data:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
 ~~~
 
-Run the following command to start copying data to the table:
+Start copying data to the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -136,12 +136,14 @@ Enter data to be copied followed by a newline.
 End with a backslash and a period on a line by itself, or an EOF signal.
 ~~~
 
-Enter the data, followed by a backslash and period on a line by itself:
+Enter some CSV-delimited data to copy to the table:
 
 {% include_cached copy-clipboard.html %}
 ~~~
 "My name is Werner Brandes","My voice is my passport"
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -152,7 +154,7 @@ Enter the data, followed by a backslash and period on a line by itself:
 COPY 1
 ~~~
 
-To view the data, enter the following query:
+View the data in the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -166,16 +168,16 @@ SELECT * FROM setecastronomy;
 (1 row)
 ~~~
 
-#### Copy CSV delimited data from stdin with an escape character
+#### Copy CSV-delimited data from `stdin` with an escape character
 
-Run the following SQL statement to create a new table that you will load with CSV formatted data:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
 ~~~
 
-To copy CSV data into CockroachDB and specify an escape character for quoting the fields, enter the following statement:
+Start copying data to the `setecastronomy` table, specifying an escape character for quoting the fields:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -189,12 +191,14 @@ Enter data to be copied followed by a newline.
 End with a backslash and a period on a line by itself, or an EOF signal.
 ~~~
 
-Enter the data, followed by a backslash and period on a line by itself:
+Enter some CSV-delimited data to copy to the table:
 
 {% include_cached copy-clipboard.html %}
 ~~~
 "My name is Werner Brandes","\"My\" \"voice\" \"is\" \"my\" \"passport\""
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -205,7 +209,7 @@ Enter the data, followed by a backslash and period on a line by itself:
 COPY 1
 ~~~
 
-To view the data, enter the following query:
+View the data in the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -220,29 +224,31 @@ SELECT * FROM setecastronomy;
 (2 rows)
 ~~~
 
-#### Copy CSV delimited data from stdin with a header
+#### Copy CSV-delimited data from `stdin` with a header
 
-Run the following SQL statement to create a new table that you will load with CSV formatted data:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
 ~~~
 
-To copy CSV data into CockroachDB and specify that CockroachDB should skip the header (first line of CSV input), enter the following statement:
+Start copying data to the `setecastronomy` table, specifying that CockroachDB should skip the header (first line of CSV input):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 COPY setecastronomy FROM STDIN WITH CSV HEADER;
 ~~~
 
-Enter the data (including header line), followed by a backslash and period on a line by itself:
+Enter the data, including the header line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
 "name","phrase"
 "Hi, my name is Werner Brandes","My voice is my passport; verify me"
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -253,7 +259,7 @@ Enter the data (including header line), followed by a backslash and period on a 
 COPY 1
 ~~~
 
-To view the data, enter the following query:
+View the data in the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -269,28 +275,30 @@ SELECT * FROM setecastronomy;
 (3 rows)
 ~~~
 
-#### Copy CSV delimited data from stdin with hex encoded byte array data
+#### Copy CSV-delimited data from `stdin` with hex-encoded byte array data
 
-To copy CSV data into CockroachDB and specify that CockroachDB should ingest hex encoded byte array data, enter the following statements:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS mybytes(a INT PRIMARY KEY, b BYTEA);
 ~~~
 
+Set the `bytea_output` [session variable](set-vars.html#supported-variables) to specify that CockroachDB should ingest hex-encoded byte array data:
+
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-set bytea_output = 'escape';
+SET bytea_output = 'escape';
 ~~~
 
-To import the data, enter the following statement:
+Start copying data to the `mybytes` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 COPY mybytes FROM STDIN WITH CSV;
 ~~~
 
-Enter the data (including header line), followed by a backslash and period on a line by itself:
+Enter some CSV-delimited data to copy to the table:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -299,6 +307,8 @@ Enter the data (including header line), followed by a backslash and period on a 
 3,"\x6869"
 4,\x6869
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -309,7 +319,7 @@ Enter the data (including header line), followed by a backslash and period on a 
 COPY 4
 ~~~
 
-To view the data, enter the following query:
+View the data in the `mybytes` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -328,9 +338,10 @@ SELECT * FROM mybytes;
 
 ## See also
 
-- [`IMPORT`](import.html)
+- [Migration Overview](migration-overview.html)
 - [`IMPORT INTO`](import-into.html)
 - [`EXPORT`](export.html)
 - [Install a Driver or ORM Framework](install-client-drivers.html)
+{% comment %}
 - [Migrate from PostgreSQL](migrate-from-postgres.html)
-- [Migration Overview](migration-overview.html)
+{% endcomment %}

--- a/v22.2/import-into.md
+++ b/v22.2/import-into.md
@@ -41,8 +41,13 @@ Before using `IMPORT INTO`, you should have:
 
 - Constant `DEFAULT` expressions, which are expressions that return the same value in different statements. Examples include:
 
-    - Literals (booleans, strings, integers, decimals, dates)
+    - Literals (booleans, strings, integers, decimals, dates).
     - Functions where each argument is a constant expression and the functions themselves depend solely on their arguments (e.g., arithmetic operations, boolean logical operations, string operations).
+
+- `random()`
+- `gen_random_uuid()`
+- `unique_rowid()`
+- `nextval()`
 
 - Current [`TIMESTAMP`](timestamp.html) functions that record the transaction timestamp, which include:
 
@@ -53,11 +58,6 @@ Before using `IMPORT INTO`, you should have:
     - `statement_timestamp()`
     - `timeofday()`
     - `transaction_timestamp()`
-
-- `random()`
-- `gen_random_uuid()`
-- `unique_rowid()`
-- `nextval()`
 
 ### Available storage
 

--- a/v22.2/import-into.md
+++ b/v22.2/import-into.md
@@ -69,7 +69,7 @@ On [`cockroach start`](cockroach-start.html), if you set `--max-disk-temp-storag
 
 CockroachDB uses the URL provided to construct a secure API call to the service you specify. The URL structure depends on the type of file storage you are using. For more information, see the following:
 
-- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
+- [Use Cloud Storage](use-cloud-storage.html)
 - [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html)
 
 {% include {{ page.version.version }}/misc/external-connection-note.md %}

--- a/v22.2/import-into.md
+++ b/v22.2/import-into.md
@@ -5,125 +5,37 @@ toc: true
 docs_area: reference.sql
 ---
 
-The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimited data into an [existing table](create-table.html), by appending new rows into the table.
+The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimited data into an existing table by appending new rows to the table.
 
 ## Considerations
 
-- `IMPORT INTO` works for existing tables. To import data into new tables, read the following [Import into a new table from a CSV file](#import-into-a-new-table-from-a-csv-file) example.
-- `IMPORT INTO` takes the table **offline** before importing the data. The table will be online again once the job has completed successfully.
+- `IMPORT INTO` takes the table **offline** before importing the data. The table will be online again once the [job](#view-and-control-import-jobs) has completed successfully.
+- `IMPORT INTO` works with existing tables. To import data into a new table, see [Import into a new table from a CSV file](#import-into-a-new-table-from-a-csv-file).
 - `IMPORT INTO` cannot be used during a [rolling upgrade](upgrade-cockroach-version.html).
 - `IMPORT INTO` is a blocking statement. To run an `IMPORT INTO` job asynchronously, use the [`DETACHED`](#options-detached) option.
-- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](alter-table.html#validate-constraint) statement.
-- `IMPORT INTO` is an insert-only statement; it cannot be used to update existing rows—see [`UPDATE`](update.html). Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
-- `IMPORT INTO` does not offer `SELECT` or `WHERE` clauses to specify subsets of rows. To do this, use [`INSERT`](insert.html#insert-from-a-select-statement).
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`ALTER TABLE ... VALIDATE CONSTRAINT`](alter-table.html#validate-constraint) statement.
+- `IMPORT INTO` is an insert-only statement; it cannot be used to [update](update.html) existing rows. Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
+- `IMPORT INTO` does not offer `SELECT` or `WHERE` clauses to specify subsets of rows. To add a subset of rows to a table, use [`INSERT`](insert.html#insert-from-a-select-statement).
 - `IMPORT INTO` will cause any [changefeeds](change-data-capture-overview.html) running on the targeted table to fail.
 - `IMPORT INTO` supports importing into [`REGIONAL BY ROW`](alter-table.html#regional-by-row) tables.
-- See the [`IMPORT`](import.html) page for guidance on importing PostgreSQL and MySQL dump files.
 
-{{site.data.alerts.callout_info}}
+{{site.data.alerts.callout_success}}
 Optimize import operations in your applications by following our [Import Performance Best Practices](import-performance-best-practices.html).
 {{site.data.alerts.end}}
 
-## Required privileges
-
-### Table privileges
-
-The user must have the `INSERT` and `DROP` [privileges](security-reference/authorization.html#managing-privileges) on the specified table. (`DROP` is required because the table is taken offline during the `IMPORT INTO`.)
-
-### Source privileges
-
-{% include {{ page.version.version }}/misc/external-io-privilege.md %}
-
-Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege](security-reference/authorization.html#system-level-privileges) or the [`admin`](security-reference/authorization.html#admin-role) role is required for the following scenarios:
-
-- Interacting with a cloud storage resource using [`IMPLICIT` authentication](cloud-storage-authentication.html).
-- Using a [custom endpoint](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) on S3.
-- Using the [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) command.
-- Using [HTTP](use-a-local-file-server-for-bulk-operations.html) or HTTPS.
-
-No special privilege is required for: 
-
-- Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
-- Using [Userfile](use-userfile-for-bulk-operations.html) storage.
-
-{% include {{ page.version.version }}/misc/bulk-permission-note.md %}
-
-{% include {{ page.version.version }}/misc/s3-compatible-warning.md %}
-
-## Synopsis
-
-<div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/import_into.html %}
-</div>
-
-{{site.data.alerts.callout_info}}
-While importing into an existing table, the table is taken offline.
-{{site.data.alerts.end}}
-
-## Parameters
-
-Parameter | Description
-----------|------------
-`table_name` | The name of the table you want to import into.
-`column_name` | The table columns you want to import.<br><br>Note: Currently, target columns are not enforced.
-`file_location` | The [URL](#import-file-location) of a CSV or Avro file containing the table data. This can be a comma-separated list of URLs. For an example, see [Import into an existing table from multiple CSV files](#import-into-an-existing-table-from-multiple-csv-files) below.
-`<option> [= <value>]` | Control your import's behavior with [import options](#import-options).
-
-#### Delimited data files
-
-The `DELIMITED DATA` format can be used to import delimited data from any text file type, while ignoring characters that need to be escaped, like the following:
-
-- The file's delimiter (`\t` by default)
-- Double quotes (`"`)
-- Newline (`\n`)
-- Carriage return (`\r`)
-
-For examples showing how to use the `DELIMITED DATA` format, see the [Examples](#import-into-an-existing-table-from-a-delimited-data-file) section below.
-
-### Import options
-
-You can control the `IMPORT` process's behavior using any of the following key-value pairs as a `<option>  [= <value>]`.
-
-|                    Key                    |         <div style="width:130px">Context</div>         |                                                                                                                                                                                                                                                                                                                                                                                    Value                                                                                                                                                                                                                                                                                                                                                                                    |
-|-------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `allow_quoted_null`                       | `CSV DATA`                                             | **New in v22.2:** If included with `nullif`, both quoted and unquoted CSV input values can match the `nullif` setting.<br><br> Example: To interpret both empty columns and `""` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '', allow_quoted_null;`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `comment`                                 | `CSV DATA`                                             | The unicode character that identifies rows to skip. <br><br> Example: `IMPORT INTO ... CSV DATA ('file.csv') WITH comment = '#';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `data_as_binary_records`                  | `AVRO DATA`                                            | Use when [importing a binary file containing Avro records](migrate-from-avro.html#import-binary-or-json-records).  The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_binary_records, schema_uri='..';`                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `data_as_json_records`                    | `AVRO DATA`                                            | Use when [importing a JSON file containing Avro records](migrate-from-avro.html#import-binary-or-json-records). The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_json_records, schema='{ "type": "record",..}';`                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `decompress`                              | General                                                | The decompression codec to be used: `gzip`, `bzip`, `auto`, or `none`.  **Default: `'auto'`**, which guesses based on file extension (`.gz`, `.bz`, `.bz2`). `none` disables decompression. <br><br> Example: `IMPORT INTO ... WITH decompress = 'bzip';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `delimiter`                               | `CSV DATA`                                             | The unicode character that delimits columns in your rows. **Default: `,`**. <br><br> Example: To use tab-delimited values: `IMPORT INTO ... CSV DATA ('file.csv') WITH delimiter = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| <a name="options-detached"></a>`DETACHED` | N/A                                                    | When an import runs in `DETACHED` mode, it will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run an import within a [transaction](transactions.html), use the `DETACHED` option.                                                                                                                                                                                                                                                                                                                      |
-| `fields_enclosed_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character that encloses fields. **Default:** `"` <br><br> Example: `IMPORT INTO ... WITH fields_enclosed_by='"';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `fields_escaped_by`                       | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character, when preceding one of the above `DELIMITED DATA` options, to be interpreted literally. <br><br> Example: `IMPORT INTO ... WITH fields_escaped_by='\';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `fields_terminated_by`                    | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character used to separate fields in each input line. **Default:** `\t` <br><br> Example: `IMPORT INTO ... WITH fields_terminated_by='.';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `nullif`                                  | `CSV DATA`, [`DELIMITED DATA`](#delimited-data-files)  | Use `nullif` to specify a column value that should be interpreted as `NULL`.<br><br>Example: To interpret an empty column as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '';`<br><br>Example: To interpret `value` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = 'value';`<br><br>**Note:** When importing CSV files, `nullif` matches column values that are unquoted. Any CSV input value that is enclosed in double quotes, including an empty value, is interpreted as a string. To match both quoted and unquoted CSV input values to the `nullif` setting, include the `allow_quoted_null` option.<br><br>When importing from CSV without `nullif`, empty values are interpreted as `NULL` by default, unless enclosed in double quotes. When importing `DELIMITED DATA` files without `nullif`, empty values are interpreted as empty strings by default.</li></ul> |
-| `records_terminated_by`                   | `AVRO DATA`                                            | The unicode character to indicate new lines in the input binary or JSON file. This is not needed for Avro OCF. **Default:** `\n` <br><br> Example: To use tab-terminated records: `IMPORT INTO ... AVRO DATA ('file.csv') WITH records_terminated_by = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `row_limit`                               | General                                                | The number of rows to import. Useful for doing a test run of an import and finding errors quickly. This option will import the first *n* rows from each table in the dump file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `rows_terminated_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character to indicate new lines in the input file. **Default:** `\n` <br><br> Example: `IMPORT INTO ... WITH rows_terminated_by='\m';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `schema`                                  | `AVRO DATA`                                            | The schema of the Avro records included in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_json_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `schema_uri`                              | `AVRO DATA`                                            | The URI of the file containing the schema of the Avro records include in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_binary_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `skip`                                    | `CSV DATA `, [`DELIMITED DATA`](#delimited-data-files) | The number of rows to be skipped while importing a file. **Default: `'0'`**. <br><br> Example: To import CSV files with column headers: `IMPORT INTO ... CSV DATA ('file.csv') WITH skip = '1';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `strict_validation`                       | `AVRO DATA`                                            | Rejects Avro records that do not have a one-to-one mapping between Avro fields to the target CockroachDB schema. By default, CockroachDB ignores unknown Avro fields and sets missing SQL fields to `NULL`. CockroachDB will also attempt to convert the Avro field to the CockroachDB [data type][datatypes]; otherwise, it will report an error. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.avro') WITH strict_validation;`                                                                                                                                                                                                                                                                                                                                      |
-
-For examples showing how to use these options, see the [Examples section](import-into.html#examples).
-
-For instructions and working examples showing how to migrate data from other databases and formats, see the [Migration Overview](migration-overview.html).
-
-## Requirements
-
-### Before you begin
+## Before you begin
 
 Before using `IMPORT INTO`, you should have:
 
-- An existing table to import into (use [`CREATE TABLE`](create-table.html)).
+- An existing CockroachDB table to import into. `IMPORT INTO` supports [computed columns](computed-columns.html) and certain [`DEFAULT` expressions](#supported-default-expressions).
 
-     `IMPORT INTO` supports [computed columns](computed-columns.html) and the [`DEFAULT` expressions listed below](#supported-default-expressions).
+- Sufficient capacity in the [CockroachDB store](#available-storage) for the imported data.
 
-- The CSV or Avro data you want to import, preferably hosted on cloud storage. This location must be equally accessible to all nodes using the same import file location. This is necessary because the `IMPORT INTO` statement is issued once by the client, but is executed concurrently across all nodes of the cluster. For more information, see the [Import file location](#import-file-location) section below.
+- The CSV or Avro data you want to import, preferably hosted on cloud storage. The [import file location](#import-file-location) must be equally accessible to all nodes using the same import file location. This is necessary because the `IMPORT INTO` statement is issued once by the client, but is executed concurrently across all nodes of the cluster.
 
-#### Supported `DEFAULT` expressions
+### Supported `DEFAULT` expressions
 
-`IMPORT INTO` supports [computed columns](computed-columns.html) and the following [`DEFAULT`](default-value.html) expressions:
+`IMPORT INTO` supports the following [`DEFAULT`](default-value.html) expressions:
 
 - `DEFAULT` expressions with [user-defined types](enum.html).
 
@@ -157,22 +69,97 @@ On [`cockroach start`](cockroach-start.html), if you set `--max-disk-temp-storag
 
 CockroachDB uses the URL provided to construct a secure API call to the service you specify. The URL structure depends on the type of file storage you are using. For more information, see the following:
 
-- [Use Cloud Storage](use-cloud-storage.html)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
 - [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html)
 
 {% include {{ page.version.version }}/misc/external-connection-note.md %}
 
-## Performance
+## Required privileges
 
-- All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
-- To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
-- To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
-- An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
-- An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
+### Table privileges
 
-For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
+The user must have the `INSERT` and `DROP` [privileges](security-reference/authorization.html#managing-privileges) on the specified table. (`DROP` is required because the table is taken offline during the `IMPORT INTO`.)
 
-## Viewing and controlling import jobs
+### Source privileges
+
+{% include {{ page.version.version }}/misc/external-io-privilege.md %}
+
+Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege](security-reference/authorization.html#system-level-privileges) or the [`admin`](security-reference/authorization.html#admin-role) role is required for the following scenarios:
+
+- Interacting with a cloud storage resource using [`IMPLICIT` authentication](cloud-storage-authentication.html).
+- Using a [custom endpoint](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) on S3.
+- Using the [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) command.
+- Using [HTTP](use-a-local-file-server-for-bulk-operations.html) or HTTPS.
+
+No special privilege is required for: 
+
+- Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
+- Using [`userfile`](use-userfile-for-bulk-operations.html) storage.
+
+{% include {{ page.version.version }}/misc/bulk-permission-note.md %}
+
+{% include {{ page.version.version }}/misc/s3-compatible-warning.md %}
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/import_into.html %}
+</div>
+
+{{site.data.alerts.callout_info}}
+While importing into an existing table, the table is taken offline.
+{{site.data.alerts.end}}
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table you want to import into.
+`column_name` | The table columns you want to import.<br><br>**Note:** Currently, target columns are not enforced.
+`file_location` | The [URL](#import-file-location) of a CSV or Avro file containing the table data. This can be a comma-separated list of URLs. For an example, see [Import into an existing table from multiple CSV files](#import-into-an-existing-table-from-multiple-csv-files) below.
+`<option> [= <value>]` | Control your import's behavior with [import options](#import-options).
+
+#### Delimited data files
+
+The `DELIMITED DATA` format can be used to import delimited data from any text file type, while ignoring characters that need to be escaped, like the following:
+
+- The file's delimiter (`\t` by default).
+- Double quotes (`"`).
+- Newline (`\n`).
+- Carriage return (`\r`).
+
+For examples showing how to use the `DELIMITED DATA` format, see the [Examples](#import-into-an-existing-table-from-a-delimited-data-file) section below.
+
+### Import options
+
+You can control the `IMPORT` process's behavior using any of the following key-value pairs as a `<option>  [= <value>]`.
+
+|                    Key                    |         <div style="width:130px">Context</div>         |                                                                                                                                                                                                                                                                                                                                                                                    Value                                                                                                                                                                                                                                                                                                                                                                                    |
+|-------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allow_quoted_null`                       | `CSV DATA`                                             | **New in v22.2:** If included with `nullif`, both quoted and unquoted CSV input values can match the `nullif` setting.<br><br> Example: To interpret both empty columns and `""` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '', allow_quoted_null;`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `comment`                                 | `CSV DATA`                                             | The unicode character that identifies rows to skip. <br><br> Example: `IMPORT INTO ... CSV DATA ('file.csv') WITH comment = '#';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `data_as_binary_records`                  | `AVRO DATA`                                            | Use when [importing a binary file containing Avro records](migrate-from-avro.html#import-binary-or-json-records).  The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_binary_records, schema_uri='..';`                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `data_as_json_records`                    | `AVRO DATA`                                            | Use when [importing a JSON file containing Avro records](migrate-from-avro.html#import-binary-or-json-records). The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_json_records, schema='{ "type": "record",..}';`                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `decompress`                              | General                                                | The decompression codec to be used: `gzip`, `bzip`, `auto`, or `none`.  **Default: `'auto'`**, which guesses based on file extension (`.gz`, `.bz`, `.bz2`). `none` disables decompression. <br><br> Example: `IMPORT INTO ... WITH decompress = 'bzip';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `delimiter`                               | `CSV DATA`                                             | The unicode character that delimits columns in your rows. **Default: `,`**. <br><br> Example: To use tab-delimited values: `IMPORT INTO ... CSV DATA ('file.csv') WITH delimiter = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| <a name="options-detached"></a>`DETACHED` | N/A                                                    | When an import runs in `DETACHED` mode, it will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run an import within a [transaction](transactions.html), use the `DETACHED` option.                                                                                                                                                                                                                                                                                                                      |
+| `fields_enclosed_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character that encloses fields. **Default:** `"` <br><br> Example: `IMPORT INTO ... WITH fields_enclosed_by='"';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `fields_escaped_by`                       | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character, when preceding one of the above `DELIMITED DATA` options, to be interpreted literally. <br><br> Example: `IMPORT INTO ... WITH fields_escaped_by='\';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `fields_terminated_by`                    | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character used to separate fields in each input line. **Default:** `\t` <br><br> Example: `IMPORT INTO ... WITH fields_terminated_by='.';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `nullif`                                  | `CSV DATA`, [`DELIMITED DATA`](#delimited-data-files)  | Use `nullif` to specify a column value that should be interpreted as `NULL`.<br><br>Example: To interpret an empty column as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '';`<br><br>Example: To interpret `value` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = 'value';`<br><br>**Note:** When importing CSV files, `nullif` matches column values that are unquoted. Any CSV input value that is enclosed in double quotes, including an empty value, is interpreted as a string. To match both quoted and unquoted CSV input values to the `nullif` setting, include the `allow_quoted_null` option.<br><br>When importing from CSV without `nullif`, empty values are interpreted as `NULL` by default, unless enclosed in double quotes. When importing `DELIMITED DATA` files without `nullif`, empty values are interpreted as empty strings by default.</li></ul> |
+| `records_terminated_by`                   | `AVRO DATA`                                            | The unicode character to indicate new lines in the input binary or JSON file. This is not needed for Avro OCF. **Default:** `\n` <br><br> Example: To use tab-terminated records: `IMPORT INTO ... AVRO DATA ('file.csv') WITH records_terminated_by = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `row_limit`                               | General                                                | The number of rows to import. Useful for doing a test run of an import and finding errors quickly. This option will import the first *n* rows from each table in the dump file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `rows_terminated_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character to indicate new lines in the input file. **Default:** `\n` <br><br> Example: `IMPORT INTO ... WITH rows_terminated_by='\m';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `schema`                                  | `AVRO DATA`                                            | The schema of the Avro records included in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_json_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `schema_uri`                              | `AVRO DATA`                                            | The URI of the file containing the schema of the Avro records include in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_binary_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `skip`                                    | `CSV DATA `, [`DELIMITED DATA`](#delimited-data-files) | The number of rows to be skipped while importing a file. **Default: `'0'`**. <br><br> Example: To import CSV files with column headers: `IMPORT INTO ... CSV DATA ('file.csv') WITH skip = '1';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `strict_validation`                       | `AVRO DATA`                                            | Rejects Avro records that do not have a one-to-one mapping between Avro fields to the target CockroachDB schema. By default, CockroachDB ignores unknown Avro fields and sets missing SQL fields to `NULL`. CockroachDB will also attempt to convert the Avro field to the CockroachDB [data type][datatypes]; otherwise, it will report an error. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.avro') WITH strict_validation;`                                                                                                                                                                                                                                                                                                                                      |
+
+For examples showing how to use these options, see the [Examples section](import-into.html#examples).
+
+For instructions and working examples showing how to migrate data from other databases and formats, see the [Migration Overview](migration-overview.html).
+
+## View and control import jobs
 
 After CockroachDB successfully initiates an import into an existing table, it registers the import as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
 
@@ -309,7 +296,6 @@ For more information about importing data from Avro, including examples, see [Mi
 
 ## See also
 
-- [`IMPORT`](import.html)
 - [Migration Overview](migration-overview.html)
 - [Use Cloud Storage](use-cloud-storage.html)
 - [Import Performance Best Practices](import-performance-best-practices.html)

--- a/v22.2/import-performance-best-practices.md
+++ b/v22.2/import-performance-best-practices.md
@@ -16,14 +16,6 @@ Import speed primarily depends on the amount of data that you want to import. Ho
 If the import size is small, then you do not need to do anything to optimize performance. In this case, the import should run quickly, regardless of the settings.
 {{site.data.alerts.end}}
 
-## TK section from IMPORT INTO doc .. manage import jobs?
-
-- All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT INTO` task in addition to serving normal traffic.
-- To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
-- To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
-- An import job will pause if a node in the cluster runs out of disk space. See [View and control import jobs](import-into.html#view-and-control-import-jobs) for information on resuming and showing the progress of import jobs.
-- An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
-
 ## Split your data into multiple files
 
 Splitting the import data into multiple files can have a large impact on the import performance. The following formats support multi-file import using `IMPORT INTO`:
@@ -58,20 +50,16 @@ CockroachDB imports the files that you give it, and does not further split them.
 If you split the data into **more** files than you have nodes, it will not have a large impact on performance.
 {{site.data.alerts.end}}
 
-## Partition and sort your data
-
-TK
-
 ### File storage during import
 
-During migration, all of the features of [`IMPORT INTO`](import-into.html) that interact with external file storage assume that every node has the exact same view of that storage. In other words, in order to import from a file, every node needs to have the same access to that file.
+During migration, all of the features of [`IMPORT`](import-into.html) that interact with external file storage assume that every node has the exact same view of that storage. In other words, in order to import from a file, every node needs to have the same access to that file.
 
 ## Choose a performant import format
 
 Import formats do not have the same performance because of the way they are processed. Below, import formats are listed from fastest to slowest:
 
-1. [`CSV`](migrate-from-csv.html) or [`DELIMITED DATA`](import-into.html) (both have about the same import performance)
-1. [`AVRO`](migrate-from-avro.html)
+1. [`CSV`](migrate-from-csv.html) or [`DELIMITED DATA`](import-into.html) (both have about the same import performance).
+1. [`AVRO`](migrate-from-avro.html).
 
 We recommend formatting your import files as `CSV`, `DELIMITED DATA`, or `AVRO`. These formats can be processed in parallel by multiple threads, which increases performance. To import in these formats, use [`IMPORT INTO`](import-into.html).
 
@@ -81,19 +69,12 @@ We recommend formatting your import files as `CSV`, `DELIMITED DATA`, or `AVRO`.
 
 Split your dump data into two files:
 
-1. A SQL file containing the table schema (i.e., [data definition statements](sql-statements.html#data-definition-statements)).
-1. A CSV file containing the table data (i.e., tk).
+1. A SQL file containing the table schema.
+1. A CSV file containing the table data.
 
-<!-- Then, import the schema-only file:
+Convert the schema-only file using the [Schema Conversion Tool](../cockroachcloud/migrations-page.html). The Schema Conversion Tool automatically creates a new {{ site.data.products.serverless }} database with the converted schema. {% include cockroachcloud/migration/sct-self-hosted.md %}
 
-~~~ sql
-> IMPORT TABLE customers
-FROM PGDUMP
-    'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/employees-db/pg_dump/customers.sql' WITH ignore_unsupported_statements
-;
-~~~ -->
-
-And use the [`IMPORT INTO`](import-into.html) statement to import the CSV data into the newly created table:
+Then use the [`IMPORT INTO`](import-into.html) statement to import the CSV data into the newly created table:
 
 ~~~ sql
 > IMPORT INTO customers (id, name)
@@ -120,6 +101,7 @@ Above a certain size, many data types such as [`STRING`](string.html)s, [`DECIMA
 
 ## See also
 
+- [`IMPORT INTO`](import-into.html)
 - [Migration Overview](migration-overview.html)
 - [Migrate from Oracle](migrate-from-oracle.html)
 - [Migrate from PostgreSQL](migrate-from-postgres.html)

--- a/v22.2/import.md
+++ b/v22.2/import.md
@@ -6,6 +6,10 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 docs_area: reference.sql
 ---
 
+{{site.data.alerts.callout_danger}}
+The statements on this page are **deprecated** as of v23.1 and will be removed in a future release. To move data into CockroachDB, use [`IMPORT INTO`](import-into.html) or [`COPY FROM`](copy-from.html). For more details, see [Move your data to CockroachDB](migration-overview.html#step-2-move-your-data-to-cockroachdb).
+{{site.data.alerts.end}}
+
 The `IMPORT` [statement](sql-statements.html) imports the following types of data into CockroachDB:
 
 - [PostgreSQL dump files][postgres]

--- a/v22.2/migration-overview.md
+++ b/v22.2/migration-overview.md
@@ -64,9 +64,9 @@ For more details on the CockroachDB SQL implementation, see [SQL Feature Support
 
 To migrate data from another database to CockroachDB, use the source database's tooling to extract the data to a `.sql` file. Then use one of the following methods to migrate the data:
 
-- Use [AWS Database Migration Service (DMS)](aws-dms.html) to migrate data from any database, such as PostgreSQL, MySQL, or Oracle, to CockroachDB. This option is recommended for near-zero downtime migrations of large data sets, either with ongoing replication or as a one-time migration of a snapshot.
 - Use [`COPY FROM`](copy-from.html) to copy the data to your CockroachDB tables. This option behaves identically to the PostgreSQL syntax and is recommended if your tables must remain **online** and accessible during a migration or continuous bulk ingestion of data. However, it is slower than using [`IMPORT INTO`](import-into.html) because the statements are executed through a single node on the cluster. 
-- Use [`IMPORT INTO`](import-into.html) to migrate [CSV](migrate-from-csv.html) or [Avro](migrate-from-avro) data into pre-existing tables. This option is recommended if you can tolerate your tables being **offline**, such as during an initial migration to CockroachDB. It is faster than using [`COPY FROM`](copy-from.html) because the statements are distributed across multiple nodes.
+- Use [`IMPORT INTO`](import-into.html) to migrate [CSV](migrate-from-csv.html) or [Avro](migrate-from-avro.html) data into pre-existing tables. This option is recommended if you can tolerate your tables being **offline**, such as during an initial migration to CockroachDB. It is faster than using [`COPY FROM`](copy-from.html) because the statements are distributed across multiple nodes.
+- Use [AWS Database Migration Service (DMS)](aws-dms.html) to migrate data from any database, such as PostgreSQL, MySQL, or Oracle, to CockroachDB. This option is recommended for near-zero downtime migrations of large data sets, either with ongoing replication or as a one-time migration of a snapshot.
 	{% include {{ page.version.version }}/misc/import-perf.md %}
 
 ## Step 3. Test and update your application

--- a/v22.2/migration-overview.md
+++ b/v22.2/migration-overview.md
@@ -30,7 +30,7 @@ To begin a new migration to CockroachDB, convert your database schema to an equi
 1. Use the source database's tooling to extract the [data definition language (DDL)](sql-statements.html#data-definition-statements) to a `.sql` file.
 1. Upload the `.sql` file to the [**Schema Conversion Tool**](../cockroachcloud/migrations-page.html) on the {{ site.data.products.db }} Console. The tool will convert the syntax, identify [unimplemented features](#unimplemented-features) in the schema, and suggest edits according to CockroachDB [best practices](#schema-design-best-practices).
 	{{site.data.alerts.callout_info}}
-	The Schema Conversion Tool currently accepts `.sql` files from PostgreSQL, MySQL, Oracle, and Microsoft SQL Server.
+	The Schema Conversion Tool accepts `.sql` files from PostgreSQL, MySQL, Oracle, and Microsoft SQL Server.
 	{{site.data.alerts.end}}
 
 1. The Schema Conversion Tool automatically creates a new {{ site.data.products.serverless }} database with the converted schema. {% include cockroachcloud/migration/sct-self-hosted.md %}

--- a/v23.1/aws-dms.md
+++ b/v23.1/aws-dms.md
@@ -21,7 +21,7 @@ Complete the following items before starting this tutorial:
 
 - Configure a [replication instance](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Creating.html) in AWS.
 - Configure a [source endpoint](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.html) in AWS pointing to your source database.
-- Ensure you have a secure, publicly available CockroachDB cluster running v22.1.0 or later.
+- Ensure you have a secure, publicly available CockroachDB cluster running the latest **{{ page.version.version }}** [production release](../releases/index.html), and have created a [SQL user](security-reference/authorization.html#sql-users) that you can use for your AWS DMS [target endpoint](#step-1-create-a-target-endpoint-pointing-to-cockroachdb).
 - If you are migrating to a {{ site.data.products.db }} cluster and plan to [use replication as part of your migration strategy](#step-2-1-task-configuration), you must first **disable** [revision history for cluster backups](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
     {{site.data.alerts.callout_danger}}
     You will not be able to run a [point-in-time restore](take-backups-with-revision-history-and-restore-from-a-point-in-time.html#point-in-time-restore) as long as revision history for cluster backups is disabled. Once you [verify that the migration succeeded](#step-3-verify-the-migration), you should re-enable revision history.
@@ -33,7 +33,7 @@ Complete the following items before starting this tutorial:
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
     {{site.data.alerts.callout_info}}
-    All tables must have an explicitly defined primary key. For more guidance, see [Migrate Your Database to CockroachDB](migration-overview.html#step-1-test-and-update-your-schema).
+    All tables must have an explicitly defined primary key. For more guidance, see [Migrate Your Database to CockroachDB](migration-overview.html#step-1-convert-your-schema).
     {{site.data.alerts.end}}
 
 As of publishing, AWS DMS supports migrations from these relational databases (for a more accurate view of what is currently supported, see [Sources for AWS DMS](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.Sources.html)):

--- a/v23.1/copy-from.md
+++ b/v23.1/copy-from.md
@@ -51,58 +51,58 @@ cockroach demo
 
 ### Copy tab-delimited data to CockroachDB
 
-Start copying data to the `users` table:
+1. Start copying data to the `users` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY users FROM STDIN;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY users FROM STDIN;
+    ~~~
 
-You will see the following prompt:
+1. You will see the following prompt:
 
-~~~
-Enter data to be copied followed by a newline.
-End with a backslash and a period on a line by itself, or an EOF signal.
-~~~
+    ~~~
+    Enter data to be copied followed by a newline.
+    End with a backslash and a period on a line by itself, or an EOF signal.
+    ~~~
 
-Enter some tab-delimited data to copy to the table:
+1. Enter some tab-delimited data to copy to the table:
 
-{{site.data.alerts.callout_danger}}
-Before you input the following rows, ensure the delimiters are tab characters. They may have been converted to spaces by the browser.
-{{site.data.alerts.end}}
+    {{site.data.alerts.callout_danger}}
+    Before you input the following rows, ensure the delimiters are tab characters. They may have been converted to spaces by the browser.
+    {{site.data.alerts.end}}
 
-~~~
-8a3d70a3-d70a-4000-8000-00000000001d  seattle Hannah  '400 Broad St'  0987654321
-~~~
+    ~~~
+    8a3d70a3-d70a-4000-8000-00000000001d  seattle Hannah  '400 Broad St'  0987654321
+    ~~~
 
-~~~
-9eb851eb-851e-4800-8000-00000000001e  new york  Carl  '53 W 23rd St'  5678901234
-~~~
+    ~~~
+    9eb851eb-851e-4800-8000-00000000001e  new york  Carl  '53 W 23rd St'  5678901234
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-~~~
-\.
-~~~
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 2
-~~~
+    ~~~
+    COPY 2
+    ~~~
 
-Query the `users` table for the rows that you just inserted:
+1. Query the `users` table for the rows that you just inserted:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851eb-851e-4800-8000-00000000001e');
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851eb-851e-4800-8000-00000000001e');
+    ~~~
 
-~~~
-                  id                  |   city   |  name  |    address     | credit_card
---------------------------------------+----------+--------+----------------+-------------
- 9eb851eb-851e-4800-8000-00000000001e | new york | Carl   | '53 W 23rd St' | 5678901234
- 8a3d70a3-d70a-4000-8000-00000000001d | seattle  | Hannah | '400 Broad St' | 0987654321
-(2 rows)
-~~~
+    ~~~
+                      id                  |   city   |  name  |    address     | credit_card
+    --------------------------------------+----------+--------+----------------+-------------
+     9eb851eb-851e-4800-8000-00000000001e | new york | Carl   | '53 W 23rd St' | 5678901234
+     8a3d70a3-d70a-4000-8000-00000000001d | seattle  | Hannah | '400 Broad St' | 0987654321
+    (2 rows)
+    ~~~
 
 ### Copy CSV-delimited data to CockroachDB
 
@@ -115,226 +115,226 @@ You can copy CSV data into CockroachDB using the following methods:
 
 #### Copy CSV-delimited data from `stdin`
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
+    ~~~
 
-Start copying data to the `setecastronomy` table:
+1. Start copying data to the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY setecastronomy FROM STDIN WITH CSV;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY setecastronomy FROM STDIN WITH CSV;
+    ~~~
 
-You will see the following prompt:
+    You will see the following prompt:
 
-~~~
-Enter data to be copied followed by a newline.
-End with a backslash and a period on a line by itself, or an EOF signal.
-~~~
+    ~~~
+    Enter data to be copied followed by a newline.
+    End with a backslash and a period on a line by itself, or an EOF signal.
+    ~~~
 
-Enter some CSV-delimited data to copy to the table:
+1. Enter some CSV-delimited data to copy to the table:
 
-{% include_cached copy-clipboard.html %}
-~~~
-"My name is Werner Brandes","My voice is my passport"
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    "My name is Werner Brandes","My voice is my passport"
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 1
-~~~
+    ~~~
+    COPY 1
+    ~~~
 
-View the data in the `setecastronomy` table:
+1. View the data in the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM setecastronomy;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM setecastronomy;
+    ~~~
 
-~~~
-            name            |              phrase
-----------------------------+------------------------------------
-  My name is Werner Brandes | My voice is my passport
-(1 row)
-~~~
+    ~~~
+                name            |              phrase
+    ----------------------------+------------------------------------
+      My name is Werner Brandes | My voice is my passport
+    (1 row)
+    ~~~
 
 #### Copy CSV-delimited data from `stdin` with an escape character
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
+    ~~~
 
-Start copying data to the `setecastronomy` table, specifying an escape character for quoting the fields:
+1. Start copying data to the `setecastronomy` table, specifying an escape character for quoting the fields:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY setecastronomy FROM STDIN WITH CSV DELIMITER ',' ESCAPE '\';
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY setecastronomy FROM STDIN WITH CSV DELIMITER ',' ESCAPE '\';
+    ~~~
 
-You will see the following prompt:
+    You will see the following prompt:
 
-~~~
-Enter data to be copied followed by a newline.
-End with a backslash and a period on a line by itself, or an EOF signal.
-~~~
+    ~~~
+    Enter data to be copied followed by a newline.
+    End with a backslash and a period on a line by itself, or an EOF signal.
+    ~~~
 
-Enter some CSV-delimited data to copy to the table:
+1. Enter some CSV-delimited data to copy to the table:
 
-{% include_cached copy-clipboard.html %}
-~~~
-"My name is Werner Brandes","\"My\" \"voice\" \"is\" \"my\" \"passport\""
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    "My name is Werner Brandes","\"My\" \"voice\" \"is\" \"my\" \"passport\""
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 1
-~~~
+    ~~~
+    COPY 1
+    ~~~
 
-View the data in the `setecastronomy` table:
+1. View the data in the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM setecastronomy;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM setecastronomy;
+    ~~~
 
-~~~
-            name            |              phrase
-----------------------------+------------------------------------
-  My name is Werner Brandes | My voice is my passport
-  My name is Werner Brandes | "My" "voice" "is" "my" "passport"
-(2 rows)
-~~~
+    ~~~
+                name            |              phrase
+    ----------------------------+------------------------------------
+      My name is Werner Brandes | My voice is my passport
+      My name is Werner Brandes | "My" "voice" "is" "my" "passport"
+    (2 rows)
+    ~~~
 
 #### Copy CSV-delimited data from `stdin` with a header
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
+    ~~~
 
-Start copying data to the `setecastronomy` table, specifying that CockroachDB should skip the header (first line of CSV input):
+1. Start copying data to the `setecastronomy` table, specifying that CockroachDB should skip the header (first line of CSV input):
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY setecastronomy FROM STDIN WITH CSV HEADER;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY setecastronomy FROM STDIN WITH CSV HEADER;
+    ~~~
 
-Enter the data, including the header line:
+1. Enter the data, including the header line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-"name","phrase"
-"Hi, my name is Werner Brandes","My voice is my passport; verify me"
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    "name","phrase"
+    "Hi, my name is Werner Brandes","My voice is my passport; verify me"
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 1
-~~~
+    ~~~
+    COPY 1
+    ~~~
 
-View the data in the `setecastronomy` table:
+1. View the data in the `setecastronomy` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM setecastronomy;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM setecastronomy;
+    ~~~
 
-~~~
-              name              |               phrase
---------------------------------+-------------------------------------
-  My name is Werner Brandes     | My voice is my passport
-  My name is Werner Brandes     | "My" "voice" "is" "my" "passport"
-  Hi, my name is Werner Brandes | My voice is my passport; verify me
-(3 rows)
-~~~
+    ~~~
+                  name              |               phrase
+    --------------------------------+-------------------------------------
+      My name is Werner Brandes     | My voice is my passport
+      My name is Werner Brandes     | "My" "voice" "is" "my" "passport"
+      Hi, my name is Werner Brandes | My voice is my passport; verify me
+    (3 rows)
+    ~~~
 
 #### Copy CSV-delimited data from `stdin` with hex-encoded byte array data
 
-First, create a new table that you will load with CSV-formatted data:
+1. Create a new table that you will load with CSV-formatted data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE TABLE IF NOT EXISTS mybytes(a INT PRIMARY KEY, b BYTEA);
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE IF NOT EXISTS mybytes(a INT PRIMARY KEY, b BYTEA);
+    ~~~
 
-Set the `bytea_output` [session variable](set-vars.html#supported-variables) to specify that CockroachDB should ingest hex-encoded byte array data:
+1. Set the `bytea_output` [session variable](set-vars.html#supported-variables) to specify that CockroachDB should ingest hex-encoded byte array data:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SET bytea_output = 'escape';
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SET bytea_output = 'escape';
+    ~~~
 
-Start copying data to the `mybytes` table:
+1. Start copying data to the `mybytes` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-COPY mybytes FROM STDIN WITH CSV;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    COPY mybytes FROM STDIN WITH CSV;
+    ~~~
 
-Enter some CSV-delimited data to copy to the table:
+1. Enter some CSV-delimited data to copy to the table:
 
-{% include_cached copy-clipboard.html %}
-~~~
-1,X'6869
-2,x'6869
-3,"\x6869"
-4,\x6869
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    1,X'6869
+    2,x'6869
+    3,"\x6869"
+    4,\x6869
+    ~~~
 
-Mark the end of data with `\.` on its own line:
+1. Mark the end of data with `\.` on its own line:
 
-{% include_cached copy-clipboard.html %}
-~~~
-\.
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    \.
+    ~~~
 
-~~~
-COPY 4
-~~~
+    ~~~
+    COPY 4
+    ~~~
 
-View the data in the `mybytes` table:
+1. View the data in the `mybytes` table:
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT * FROM mybytes;
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    SELECT * FROM mybytes;
+    ~~~
 
-~~~
-  a |   b
-----+---------
-  1 | X'6869
-  2 | x'6869
-  3 | hi
-  4 | hi
-(4 rows)
-~~~
+    ~~~
+      a |   b
+    ----+---------
+      1 | X'6869
+      2 | x'6869
+      3 | hi
+      4 | hi
+    (4 rows)
+    ~~~
 
 ## See also
 

--- a/v23.1/copy-from.md
+++ b/v23.1/copy-from.md
@@ -1,6 +1,6 @@
 ---
 title: COPY FROM
-summary: Copy data from a third-party client to CockroachDB.
+summary: Copy data from a third-party client to a CockroachDB table.
 toc: true
 docs_area: reference.sql
 ---
@@ -36,9 +36,7 @@ Option | Description
 
 Only members of the `admin` role can run `COPY` statements. By default, the `root` user belongs to the `admin` role.
 
-## Known limitations
-
-### `COPY` syntax not supported by CockroachDB
+## Unsupported syntax
 
 {% include {{ page.version.version }}/known-limitations/copy-syntax.md %}
 
@@ -51,35 +49,37 @@ To run the examples, use [`cockroach demo`](cockroach-demo.html) to start a temp
 cockroach demo
 ~~~
 
-### Copy tab delimited data
+### Copy tab-delimited data to CockroachDB
 
-In the SQL shell, run the following command to start copying data to the `users` table:
+Start copying data to the `users` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 COPY users FROM STDIN;
 ~~~
 
-The following prompt should appear:
+You will see the following prompt:
 
 ~~~
 Enter data to be copied followed by a newline.
 End with a backslash and a period on a line by itself, or an EOF signal.
 ~~~
 
-Enter some tab-delimited data that you want copied to the `users` table.
+Enter some tab-delimited data to copy to the table:
 
-{{site.data.alerts.callout_info}}
-You may need to edit the following rows after copying them to make sure the delimiters are tab characters.
+{{site.data.alerts.callout_danger}}
+Before you input the following rows, ensure the delimiters are tab characters. They may have been converted to spaces by the browser.
 {{site.data.alerts.end}}
 
 ~~~
-8a3d70a3-d70a-4000-8000-00000000001d	seattle	Hannah	'400 Broad St'	0987654321
+8a3d70a3-d70a-4000-8000-00000000001d  seattle Hannah  '400 Broad St'  0987654321
 ~~~
 
 ~~~
-9eb851eb-851e-4800-8000-00000000001e	new york	Carl	'53 W 23rd St'	5678901234
+9eb851eb-851e-4800-8000-00000000001e  new york  Carl  '53 W 23rd St'  5678901234
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 ~~~
 \.
@@ -89,7 +89,7 @@ You may need to edit the following rows after copying them to make sure the deli
 COPY 2
 ~~~
 
-In the SQL shell, query the `users` table for the rows that you just inserted:
+Query the `users` table for the rows that you just inserted:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -104,25 +104,25 @@ SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851
 (2 rows)
 ~~~
 
-### Copy CSV delimited data
+### Copy CSV-delimited data to CockroachDB
 
 You can copy CSV data into CockroachDB using the following methods:
 
-- [Copy CSV delimited data from stdin](#copy-csv-delimited-data-from-stdin)
-- [Copy CSV delimited data from stdin with an escape character](#copy-csv-delimited-data-from-stdin-with-an-escape-character)
-- [Copy CSV delimited data from stdin with a header](#copy-csv-delimited-data-from-stdin-with-a-header)
-- [Copy CSV delimited data from stdin with hex encoded byte array data](#copy-csv-delimited-data-from-stdin-with-hex-encoded-byte-array-data)
+- [Copy CSV-delimited data from `stdin`](#copy-csv-delimited-data-from-stdin)
+- [Copy CSV-delimited data from `stdin` with an escape character](#copy-csv-delimited-data-from-stdin-with-an-escape-character)
+- [Copy CSV-delimited data from `stdin` with a header](#copy-csv-delimited-data-from-stdin-with-a-header)
+- [Copy CSV-delimited data from `stdin` with hex-encoded byte array data](#copy-csv-delimited-data-from-stdin-with-hex-encoded-byte-array-data)
 
-#### Copy CSV delimited data from stdin
+#### Copy CSV-delimited data from `stdin`
 
-Run the following SQL statement to create a new table that you will load with CSV formatted data:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
 ~~~
 
-Run the following command to start copying data to the table:
+Start copying data to the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -136,12 +136,14 @@ Enter data to be copied followed by a newline.
 End with a backslash and a period on a line by itself, or an EOF signal.
 ~~~
 
-Enter the data, followed by a backslash and period on a line by itself:
+Enter some CSV-delimited data to copy to the table:
 
 {% include_cached copy-clipboard.html %}
 ~~~
 "My name is Werner Brandes","My voice is my passport"
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -152,7 +154,7 @@ Enter the data, followed by a backslash and period on a line by itself:
 COPY 1
 ~~~
 
-To view the data, enter the following query:
+View the data in the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -166,16 +168,16 @@ SELECT * FROM setecastronomy;
 (1 row)
 ~~~
 
-#### Copy CSV delimited data from stdin with an escape character
+#### Copy CSV-delimited data from `stdin` with an escape character
 
-Run the following SQL statement to create a new table that you will load with CSV formatted data:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
 ~~~
 
-To copy CSV data into CockroachDB and specify an escape character for quoting the fields, enter the following statement:
+Start copying data to the `setecastronomy` table, specifying an escape character for quoting the fields:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -189,12 +191,14 @@ Enter data to be copied followed by a newline.
 End with a backslash and a period on a line by itself, or an EOF signal.
 ~~~
 
-Enter the data, followed by a backslash and period on a line by itself:
+Enter some CSV-delimited data to copy to the table:
 
 {% include_cached copy-clipboard.html %}
 ~~~
 "My name is Werner Brandes","\"My\" \"voice\" \"is\" \"my\" \"passport\""
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -205,7 +209,7 @@ Enter the data, followed by a backslash and period on a line by itself:
 COPY 1
 ~~~
 
-To view the data, enter the following query:
+View the data in the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -220,29 +224,31 @@ SELECT * FROM setecastronomy;
 (2 rows)
 ~~~
 
-#### Copy CSV delimited data from stdin with a header
+#### Copy CSV-delimited data from `stdin` with a header
 
-Run the following SQL statement to create a new table that you will load with CSV formatted data:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS setecastronomy (name STRING, phrase STRING);
 ~~~
 
-To copy CSV data into CockroachDB and specify that CockroachDB should skip the header (first line of CSV input), enter the following statement:
+Start copying data to the `setecastronomy` table, specifying that CockroachDB should skip the header (first line of CSV input):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 COPY setecastronomy FROM STDIN WITH CSV HEADER;
 ~~~
 
-Enter the data (including header line), followed by a backslash and period on a line by itself:
+Enter the data, including the header line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
 "name","phrase"
 "Hi, my name is Werner Brandes","My voice is my passport; verify me"
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -253,7 +259,7 @@ Enter the data (including header line), followed by a backslash and period on a 
 COPY 1
 ~~~
 
-To view the data, enter the following query:
+View the data in the `setecastronomy` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -269,28 +275,30 @@ SELECT * FROM setecastronomy;
 (3 rows)
 ~~~
 
-#### Copy CSV delimited data from stdin with hex encoded byte array data
+#### Copy CSV-delimited data from `stdin` with hex-encoded byte array data
 
-To copy CSV data into CockroachDB and specify that CockroachDB should ingest hex encoded byte array data, enter the following statements:
+First, create a new table that you will load with CSV-formatted data:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE IF NOT EXISTS mybytes(a INT PRIMARY KEY, b BYTEA);
 ~~~
 
+Set the `bytea_output` [session variable](set-vars.html#supported-variables) to specify that CockroachDB should ingest hex-encoded byte array data:
+
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-set bytea_output = 'escape';
+SET bytea_output = 'escape';
 ~~~
 
-To import the data, enter the following statement:
+Start copying data to the `mybytes` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 COPY mybytes FROM STDIN WITH CSV;
 ~~~
 
-Enter the data (including header line), followed by a backslash and period on a line by itself:
+Enter some CSV-delimited data to copy to the table:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -299,6 +307,8 @@ Enter the data (including header line), followed by a backslash and period on a 
 3,"\x6869"
 4,\x6869
 ~~~
+
+Mark the end of data with `\.` on its own line:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -309,7 +319,7 @@ Enter the data (including header line), followed by a backslash and period on a 
 COPY 4
 ~~~
 
-To view the data, enter the following query:
+View the data in the `mybytes` table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -328,9 +338,10 @@ SELECT * FROM mybytes;
 
 ## See also
 
-- [`IMPORT`](import.html)
+- [Migration Overview](migration-overview.html)
 - [`IMPORT INTO`](import-into.html)
 - [`EXPORT`](export.html)
 - [Install a Driver or ORM Framework](install-client-drivers.html)
+{% comment %}
 - [Migrate from PostgreSQL](migrate-from-postgres.html)
-- [Migration Overview](migration-overview.html)
+{% endcomment %}

--- a/v23.1/import-into.md
+++ b/v23.1/import-into.md
@@ -41,8 +41,13 @@ Before using `IMPORT INTO`, you should have:
 
 - Constant `DEFAULT` expressions, which are expressions that return the same value in different statements. Examples include:
 
-    - Literals (booleans, strings, integers, decimals, dates)
+    - Literals (booleans, strings, integers, decimals, dates).
     - Functions where each argument is a constant expression and the functions themselves depend solely on their arguments (e.g., arithmetic operations, boolean logical operations, string operations).
+
+- `random()`
+- `gen_random_uuid()`
+- `unique_rowid()`
+- `nextval()`
 
 - Current [`TIMESTAMP`](timestamp.html) functions that record the transaction timestamp, which include:
 
@@ -53,11 +58,6 @@ Before using `IMPORT INTO`, you should have:
     - `statement_timestamp()`
     - `timeofday()`
     - `transaction_timestamp()`
-
-- `random()`
-- `gen_random_uuid()`
-- `unique_rowid()`
-- `nextval()`
 
 ### Available storage
 

--- a/v23.1/import-into.md
+++ b/v23.1/import-into.md
@@ -5,125 +5,37 @@ toc: true
 docs_area: reference.sql
 ---
 
-The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimited data into an [existing table](create-table.html), by appending new rows into the table.
+The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimited data into an existing table by appending new rows to the table.
 
 ## Considerations
 
-- `IMPORT INTO` works for existing tables. To import data into new tables, read the following [Import into a new table from a CSV file](#import-into-a-new-table-from-a-csv-file) example.
-- `IMPORT INTO` takes the table **offline** before importing the data. The table will be online again once the job has completed successfully.
+- `IMPORT INTO` takes the table **offline** before importing the data. The table will be online again once the [job](#view-and-control-import-jobs) has completed successfully.
+- `IMPORT INTO` works with existing tables. To import data into a new table, see [Import into a new table from a CSV file](#import-into-a-new-table-from-a-csv-file).
 - `IMPORT INTO` cannot be used during a [rolling upgrade](upgrade-cockroach-version.html).
 - `IMPORT INTO` is a blocking statement. To run an `IMPORT INTO` job asynchronously, use the [`DETACHED`](#options-detached) option.
-- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](alter-table.html#validate-constraint) statement.
-- `IMPORT INTO` is an insert-only statement; it cannot be used to update existing rows—see [`UPDATE`](update.html). Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
-- `IMPORT INTO` does not offer `SELECT` or `WHERE` clauses to specify subsets of rows. To do this, use [`INSERT`](insert.html#insert-from-a-select-statement).
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`ALTER TABLE ... VALIDATE CONSTRAINT`](alter-table.html#validate-constraint) statement.
+- `IMPORT INTO` is an insert-only statement; it cannot be used to [update](update.html) existing rows. Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
+- `IMPORT INTO` does not offer `SELECT` or `WHERE` clauses to specify subsets of rows. To add a subset of rows to a table, use [`INSERT`](insert.html#insert-from-a-select-statement).
 - `IMPORT INTO` will cause any [changefeeds](change-data-capture-overview.html) running on the targeted table to fail.
 - `IMPORT INTO` supports importing into [`REGIONAL BY ROW`](alter-table.html#regional-by-row) tables.
-- See the [`IMPORT`](import.html) page for guidance on importing PostgreSQL and MySQL dump files.
 
-{{site.data.alerts.callout_info}}
+{{site.data.alerts.callout_success}}
 Optimize import operations in your applications by following our [Import Performance Best Practices](import-performance-best-practices.html).
 {{site.data.alerts.end}}
 
-## Required privileges
-
-### Table privileges
-
-The user must have the `INSERT` and `DROP` [privileges](security-reference/authorization.html#managing-privileges) on the specified table. (`DROP` is required because the table is taken offline during the `IMPORT INTO`.)
-
-### Source privileges
-
-{% include {{ page.version.version }}/misc/external-io-privilege.md %}
-
-Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege](security-reference/authorization.html#system-level-privileges) or the [`admin`](security-reference/authorization.html#admin-role) role is required for the following scenarios:
-
-- Interacting with a cloud storage resource using [`IMPLICIT` authentication](cloud-storage-authentication.html).
-- Using a [custom endpoint](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) on S3.
-- Using the [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) command.
-- Using [HTTP](use-a-local-file-server-for-bulk-operations.html) or HTTPS.
-
-No special privilege is required for: 
-
-- Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
-- Using [Userfile](use-userfile-for-bulk-operations.html) storage.
-
-{% include {{ page.version.version }}/misc/bulk-permission-note.md %}
-
-{% include {{ page.version.version }}/misc/s3-compatible-warning.md %}
-
-## Synopsis
-
-<div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/import_into.html %}
-</div>
-
-{{site.data.alerts.callout_info}}
-While importing into an existing table, the table is taken offline.
-{{site.data.alerts.end}}
-
-## Parameters
-
-Parameter | Description
-----------|------------
-`table_name` | The name of the table you want to import into.
-`column_name` | The table columns you want to import.<br><br>Note: Currently, target columns are not enforced.
-`file_location` | The [URL](#import-file-location) of a CSV or Avro file containing the table data. This can be a comma-separated list of URLs. For an example, see [Import into an existing table from multiple CSV files](#import-into-an-existing-table-from-multiple-csv-files) below.
-`<option> [= <value>]` | Control your import's behavior with [import options](#import-options).
-
-#### Delimited data files
-
-The `DELIMITED DATA` format can be used to import delimited data from any text file type, while ignoring characters that need to be escaped, like the following:
-
-- The file's delimiter (`\t` by default)
-- Double quotes (`"`)
-- Newline (`\n`)
-- Carriage return (`\r`)
-
-For examples showing how to use the `DELIMITED DATA` format, see the [Examples](#import-into-an-existing-table-from-a-delimited-data-file) section below.
-
-### Import options
-
-You can control the `IMPORT` process's behavior using any of the following key-value pairs as a `<option>  [= <value>]`.
-
-|                    Key                    |         <div style="width:130px">Context</div>         |                                                                                                                                                                                                                                                                                                                                                                                    Value                                                                                                                                                                                                                                                                                                                                                                                    |
-|-------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `allow_quoted_null`                       | `CSV DATA`                                             | If included with `nullif`, both quoted and unquoted CSV input values can match the `nullif` setting.<br><br> Example: To interpret both empty columns and `""` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '', allow_quoted_null;`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `comment`                                 | `CSV DATA`                                             | The unicode character that identifies rows to skip. <br><br> Example: `IMPORT INTO ... CSV DATA ('file.csv') WITH comment = '#';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `data_as_binary_records`                  | `AVRO DATA`                                            | Use when [importing a binary file containing Avro records](migrate-from-avro.html#import-binary-or-json-records).  The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_binary_records, schema_uri='..';`                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `data_as_json_records`                    | `AVRO DATA`                                            | Use when [importing a JSON file containing Avro records](migrate-from-avro.html#import-binary-or-json-records). The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_json_records, schema='{ "type": "record",..}';`                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `decompress`                              | General                                                | The decompression codec to be used: `gzip`, `bzip`, `auto`, or `none`.  **Default: `'auto'`**, which guesses based on file extension (`.gz`, `.bz`, `.bz2`). `none` disables decompression. <br><br> Example: `IMPORT INTO ... WITH decompress = 'bzip';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `delimiter`                               | `CSV DATA`                                             | The unicode character that delimits columns in your rows. **Default: `,`**. <br><br> Example: To use tab-delimited values: `IMPORT INTO ... CSV DATA ('file.csv') WITH delimiter = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| <a name="options-detached"></a>`DETACHED` | N/A                                                    | When an import runs in `DETACHED` mode, it will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run an import within a [transaction](transactions.html), use the `DETACHED` option.                                                                                                                                                                                                                                                                                                                      |
-| `fields_enclosed_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character that encloses fields. **Default:** `"` <br><br> Example: `IMPORT INTO ... WITH fields_enclosed_by='"';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `fields_escaped_by`                       | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character, when preceding one of the above `DELIMITED DATA` options, to be interpreted literally. <br><br> Example: `IMPORT INTO ... WITH fields_escaped_by='\';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `fields_terminated_by`                    | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character used to separate fields in each input line. **Default:** `\t` <br><br> Example: `IMPORT INTO ... WITH fields_terminated_by='.';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `nullif`                                  | `CSV DATA`, [`DELIMITED DATA`](#delimited-data-files)  | Use `nullif` to specify a column value that should be interpreted as `NULL`.<br><br>Example: To interpret an empty column as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '';`<br><br>Example: To interpret `value` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = 'value';`<br><br>**Note:** When importing CSV files, `nullif` matches column values that are unquoted. Any CSV input value that is enclosed in double quotes, including an empty value, is interpreted as a string. To match both quoted and unquoted CSV input values to the `nullif` setting, include the `allow_quoted_null` option.<br><br>When importing from CSV without `nullif`, empty values are interpreted as `NULL` by default, unless enclosed in double quotes. When importing `DELIMITED DATA` files without `nullif`, empty values are interpreted as empty strings by default.</li></ul> |
-| `records_terminated_by`                   | `AVRO DATA`                                            | The unicode character to indicate new lines in the input binary or JSON file. This is not needed for Avro OCF. **Default:** `\n` <br><br> Example: To use tab-terminated records: `IMPORT INTO ... AVRO DATA ('file.csv') WITH records_terminated_by = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `row_limit`                               | General                                                | The number of rows to import. Useful for doing a test run of an import and finding errors quickly. This option will import the first *n* rows from each table in the dump file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `rows_terminated_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character to indicate new lines in the input file. **Default:** `\n` <br><br> Example: `IMPORT INTO ... WITH rows_terminated_by='\m';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `schema`                                  | `AVRO DATA`                                            | The schema of the Avro records included in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_json_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `schema_uri`                              | `AVRO DATA`                                            | The URI of the file containing the schema of the Avro records include in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_binary_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `skip`                                    | `CSV DATA `, [`DELIMITED DATA`](#delimited-data-files) | The number of rows to be skipped while importing a file. **Default: `'0'`**. <br><br> Example: To import CSV files with column headers: `IMPORT INTO ... CSV DATA ('file.csv') WITH skip = '1';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `strict_validation`                       | `AVRO DATA`                                            | Rejects Avro records that do not have a one-to-one mapping between Avro fields to the target CockroachDB schema. By default, CockroachDB ignores unknown Avro fields and sets missing SQL fields to `NULL`. CockroachDB will also attempt to convert the Avro field to the CockroachDB [data type][datatypes]; otherwise, it will report an error. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.avro') WITH strict_validation;`                                                                                                                                                                                                                                                                                                                                      |
-
-For examples showing how to use these options, see the [Examples section](import-into.html#examples).
-
-For instructions and working examples showing how to migrate data from other databases and formats, see the [Migration Overview](migration-overview.html).
-
-## Requirements
-
-### Before you begin
+## Before you begin
 
 Before using `IMPORT INTO`, you should have:
 
-- An existing table to import into (use [`CREATE TABLE`](create-table.html)).
+- An existing CockroachDB table to import into. `IMPORT INTO` supports [computed columns](computed-columns.html) and certain [`DEFAULT` expressions](#supported-default-expressions).
 
-     `IMPORT INTO` supports [computed columns](computed-columns.html) and the [`DEFAULT` expressions listed below](#supported-default-expressions).
+- Sufficient capacity in the [CockroachDB store](#available-storage) for the imported data.
 
-- The CSV or Avro data you want to import, preferably hosted on cloud storage. This location must be equally accessible to all nodes using the same import file location. This is necessary because the `IMPORT INTO` statement is issued once by the client, but is executed concurrently across all nodes of the cluster. For more information, see the [Import file location](#import-file-location) section below.
+- The CSV or Avro data you want to import, preferably hosted on cloud storage. The [import file location](#import-file-location) must be equally accessible to all nodes using the same import file location. This is necessary because the `IMPORT INTO` statement is issued once by the client, but is executed concurrently across all nodes of the cluster.
 
-#### Supported `DEFAULT` expressions
+### Supported `DEFAULT` expressions
 
-`IMPORT INTO` supports [computed columns](computed-columns.html) and the following [`DEFAULT`](default-value.html) expressions:
+`IMPORT INTO` supports the following [`DEFAULT`](default-value.html) expressions:
 
 - `DEFAULT` expressions with [user-defined types](enum.html).
 
@@ -157,22 +69,97 @@ On [`cockroach start`](cockroach-start.html), if you set `--max-disk-temp-storag
 
 CockroachDB uses the URL provided to construct a secure API call to the service you specify. The URL structure depends on the type of file storage you are using. For more information, see the following:
 
-- [Use Cloud Storage](use-cloud-storage.html)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
 - [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html)
 
 {% include {{ page.version.version }}/misc/external-connection-note.md %}
 
-## Performance
+## Required privileges
 
-- All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
-- To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
-- To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
-- An import job will pause if a node in the cluster runs out of disk space. See [Viewing and controlling import jobs](#viewing-and-controlling-import-jobs) for information on resuming and showing the progress of import jobs.
-- An import job will [pause](pause-job.html) instead of entering a `failed` state if it continues to encounter transient errors once it has retried a maximum number of times. Once the import has paused, you can either [resume](resume-job.html) or [cancel](cancel-job.html) it.
+### Table privileges
 
-For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
+The user must have the `INSERT` and `DROP` [privileges](security-reference/authorization.html#managing-privileges) on the specified table. (`DROP` is required because the table is taken offline during the `IMPORT INTO`.)
 
-## Viewing and controlling import jobs
+### Source privileges
+
+{% include {{ page.version.version }}/misc/external-io-privilege.md %}
+
+Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege](security-reference/authorization.html#system-level-privileges) or the [`admin`](security-reference/authorization.html#admin-role) role is required for the following scenarios:
+
+- Interacting with a cloud storage resource using [`IMPLICIT` authentication](cloud-storage-authentication.html).
+- Using a [custom endpoint](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) on S3.
+- Using the [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) command.
+- Using [HTTP](use-a-local-file-server-for-bulk-operations.html) or HTTPS.
+
+No special privilege is required for: 
+
+- Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
+- Using [`userfile`](use-userfile-for-bulk-operations.html) storage.
+
+{% include {{ page.version.version }}/misc/bulk-permission-note.md %}
+
+{% include {{ page.version.version }}/misc/s3-compatible-warning.md %}
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/import_into.html %}
+</div>
+
+{{site.data.alerts.callout_info}}
+While importing into an existing table, the table is taken offline.
+{{site.data.alerts.end}}
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table you want to import into.
+`column_name` | The table columns you want to import.<br><br>**Note:** Currently, target columns are not enforced.
+`file_location` | The [URL](#import-file-location) of a CSV or Avro file containing the table data. This can be a comma-separated list of URLs. For an example, see [Import into an existing table from multiple CSV files](#import-into-an-existing-table-from-multiple-csv-files) below.
+`<option> [= <value>]` | Control your import's behavior with [import options](#import-options).
+
+#### Delimited data files
+
+The `DELIMITED DATA` format can be used to import delimited data from any text file type, while ignoring characters that need to be escaped, like the following:
+
+- The file's delimiter (`\t` by default).
+- Double quotes (`"`).
+- Newline (`\n`).
+- Carriage return (`\r`).
+
+For examples showing how to use the `DELIMITED DATA` format, see the [Examples](#import-into-an-existing-table-from-a-delimited-data-file) section below.
+
+### Import options
+
+You can control the `IMPORT` process's behavior using any of the following key-value pairs as a `<option>  [= <value>]`.
+
+|                    Key                    |         <div style="width:130px">Context</div>         |                                                                                                                                                                                                                                                                                                                                                                                    Value                                                                                                                                                                                                                                                                                                                                                                                    |
+|-------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allow_quoted_null`                       | `CSV DATA`                                             | If included with `nullif`, both quoted and unquoted CSV input values can match the `nullif` setting.<br><br> Example: To interpret both empty columns and `""` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '', allow_quoted_null;`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `comment`                                 | `CSV DATA`                                             | The unicode character that identifies rows to skip. <br><br> Example: `IMPORT INTO ... CSV DATA ('file.csv') WITH comment = '#';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `data_as_binary_records`                  | `AVRO DATA`                                            | Use when [importing a binary file containing Avro records](migrate-from-avro.html#import-binary-or-json-records).  The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_binary_records, schema_uri='..';`                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `data_as_json_records`                    | `AVRO DATA`                                            | Use when [importing a JSON file containing Avro records](migrate-from-avro.html#import-binary-or-json-records). The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.bjson') WITH data_as_json_records, schema='{ "type": "record",..}';`                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `decompress`                              | General                                                | The decompression codec to be used: `gzip`, `bzip`, `auto`, or `none`.  **Default: `'auto'`**, which guesses based on file extension (`.gz`, `.bz`, `.bz2`). `none` disables decompression. <br><br> Example: `IMPORT INTO ... WITH decompress = 'bzip';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `delimiter`                               | `CSV DATA`                                             | The unicode character that delimits columns in your rows. **Default: `,`**. <br><br> Example: To use tab-delimited values: `IMPORT INTO ... CSV DATA ('file.csv') WITH delimiter = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| <a name="options-detached"></a>`DETACHED` | N/A                                                    | When an import runs in `DETACHED` mode, it will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run an import within a [transaction](transactions.html), use the `DETACHED` option.                                                                                                                                                                                                                                                                                                                      |
+| `fields_enclosed_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character that encloses fields. **Default:** `"` <br><br> Example: `IMPORT INTO ... WITH fields_enclosed_by='"';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `fields_escaped_by`                       | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character, when preceding one of the above `DELIMITED DATA` options, to be interpreted literally. <br><br> Example: `IMPORT INTO ... WITH fields_escaped_by='\';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `fields_terminated_by`                    | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character used to separate fields in each input line. **Default:** `\t` <br><br> Example: `IMPORT INTO ... WITH fields_terminated_by='.';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `nullif`                                  | `CSV DATA`, [`DELIMITED DATA`](#delimited-data-files)  | Use `nullif` to specify a column value that should be interpreted as `NULL`.<br><br>Example: To interpret an empty column as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = '';`<br><br>Example: To interpret `value` as `NULL`: `IMPORT INTO ... CSV DATA ('file.csv') WITH nullif = 'value';`<br><br>**Note:** When importing CSV files, `nullif` matches column values that are unquoted. Any CSV input value that is enclosed in double quotes, including an empty value, is interpreted as a string. To match both quoted and unquoted CSV input values to the `nullif` setting, include the `allow_quoted_null` option.<br><br>When importing from CSV without `nullif`, empty values are interpreted as `NULL` by default, unless enclosed in double quotes. When importing `DELIMITED DATA` files without `nullif`, empty values are interpreted as empty strings by default.</li></ul> |
+| `records_terminated_by`                   | `AVRO DATA`                                            | The unicode character to indicate new lines in the input binary or JSON file. This is not needed for Avro OCF. **Default:** `\n` <br><br> Example: To use tab-terminated records: `IMPORT INTO ... AVRO DATA ('file.csv') WITH records_terminated_by = e'\t';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `row_limit`                               | General                                                | The number of rows to import. Useful for doing a test run of an import and finding errors quickly. This option will import the first *n* rows from each table in the dump file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `rows_terminated_by`                      | [`DELIMITED DATA`](#delimited-data-files)              | The unicode character to indicate new lines in the input file. **Default:** `\n` <br><br> Example: `IMPORT INTO ... WITH rows_terminated_by='\m';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `schema`                                  | `AVRO DATA`                                            | The schema of the Avro records included in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_json_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `schema_uri`                              | `AVRO DATA`                                            | The URI of the file containing the schema of the Avro records include in the binary or JSON file. This is not needed for Avro OCF. <br> See `data_as_binary_records` example above.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `skip`                                    | `CSV DATA `, [`DELIMITED DATA`](#delimited-data-files) | The number of rows to be skipped while importing a file. **Default: `'0'`**. <br><br> Example: To import CSV files with column headers: `IMPORT INTO ... CSV DATA ('file.csv') WITH skip = '1';`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `strict_validation`                       | `AVRO DATA`                                            | Rejects Avro records that do not have a one-to-one mapping between Avro fields to the target CockroachDB schema. By default, CockroachDB ignores unknown Avro fields and sets missing SQL fields to `NULL`. CockroachDB will also attempt to convert the Avro field to the CockroachDB [data type][datatypes]; otherwise, it will report an error. <br><br> Example: `IMPORT INTO ... AVRO DATA ('file.avro') WITH strict_validation;`                                                                                                                                                                                                                                                                                                                                      |
+
+For examples showing how to use these options, see the [Examples section](import-into.html#examples).
+
+For instructions and working examples showing how to migrate data from other databases and formats, see the [Migration Overview](migration-overview.html).
+
+## View and control import jobs
 
 After CockroachDB successfully initiates an import into an existing table, it registers the import as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
 
@@ -309,7 +296,6 @@ For more information about importing data from Avro, including examples, see [Mi
 
 ## See also
 
-- [`IMPORT`](import.html)
 - [Migration Overview](migration-overview.html)
 - [Use Cloud Storage](use-cloud-storage.html)
 - [Import Performance Best Practices](import-performance-best-practices.html)

--- a/v23.1/import-into.md
+++ b/v23.1/import-into.md
@@ -69,7 +69,7 @@ On [`cockroach start`](cockroach-start.html), if you set `--max-disk-temp-storag
 
 CockroachDB uses the URL provided to construct a secure API call to the service you specify. The URL structure depends on the type of file storage you are using. For more information, see the following:
 
-- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
+- [Use Cloud Storage](use-cloud-storage.html)
 - [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html)
 
 {% include {{ page.version.version }}/misc/external-connection-note.md %}

--- a/v23.1/import-performance-best-practices.md
+++ b/v23.1/import-performance-best-practices.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: migrate
 ---
 
-This page provides best practices for optimizing [import](import.html) performance in CockroachDB.
+This page provides best practices for optimizing [import](import-into.html) performance in CockroachDB.
 
 Import speed primarily depends on the amount of data that you want to import. However, there are two main factors that have can have a large impact on the amount of time it will take to run an import:
 
@@ -52,42 +52,29 @@ If you split the data into **more** files than you have nodes, it will not have 
 
 ### File storage during import
 
-During migration, all of the features of [`IMPORT`](import.html) that interact with external file storage assume that every node has the exact same view of that storage. In other words, in order to import from a file, every node needs to have the same access to that file.
+During migration, all of the features of [`IMPORT`](import-into.html) that interact with external file storage assume that every node has the exact same view of that storage. In other words, in order to import from a file, every node needs to have the same access to that file.
 
 ## Choose a performant import format
 
 Import formats do not have the same performance because of the way they are processed. Below, import formats are listed from fastest to slowest:
 
-1. [`CSV`](migrate-from-csv.html) or [`DELIMITED DATA`](import-into.html) (both have about the same import performance)
-1. [`AVRO`](migrate-from-avro.html)
-1. [`MYSQLDUMP`](migrate-from-mysql.html)
-1. [`PGDUMP`](migrate-from-postgres.html)
+1. [`CSV`](migrate-from-csv.html) or [`DELIMITED DATA`](import-into.html) (both have about the same import performance).
+1. [`AVRO`](migrate-from-avro.html).
 
 We recommend formatting your import files as `CSV`, `DELIMITED DATA`, or `AVRO`. These formats can be processed in parallel by multiple threads, which increases performance. To import in these formats, use [`IMPORT INTO`](import-into.html).
-
-`MYSQLDUMP` and `PGDUMP` run a single thread to parse their data, and therefore have substantially slower performance.
-
-`MYSQLDUMP` and `PGDUMP` are two examples of "bundled" data. This means that the dump file contains both the table schema and the data to import. These formats are the slowest to import, with `PGDUMP` being the slower of the two. This is because CockroachDB has to first load the whole file, read the whole file to get the schema, create the table with that schema, and then import the data. While these formats are slow, see [Import the schema separately from the data](#import-the-schema-separately-from-the-data) for guidance on speeding up bundled-data imports.
 
 {% include {{ page.version.version }}/import-table-deprecate.md %}
 
 ### Import the schema separately from the data
 
-For single-table `MYSQLDUMP` or `PGDUMP` imports, split your dump data into two files:
+Split your dump data into two files:
 
-1. A SQL file containing the table schema
-1. A CSV file containing the table data
+1. A SQL file containing the table schema.
+1. A CSV file containing the table data.
 
-Then, import the schema-only file:
+Convert the schema-only file using the [Schema Conversion Tool](../cockroachcloud/migrations-page.html). The Schema Conversion Tool automatically creates a new {{ site.data.products.serverless }} database with the converted schema. {% include cockroachcloud/migration/sct-self-hosted.md %}
 
-~~~ sql
-> IMPORT TABLE customers
-FROM PGDUMP
-    'https://s3-us-west-1.amazonaws.com/cockroachdb-movr/datasets/employees-db/pg_dump/customers.sql' WITH ignore_unsupported_statements
-;
-~~~
-
-And use the [`IMPORT INTO`](import-into.html) statement to import the CSV data into the newly created table:
+Then use the [`IMPORT INTO`](import-into.html) statement to import the CSV data into the newly created table:
 
 ~~~ sql
 > IMPORT INTO customers (id, name)
@@ -114,7 +101,7 @@ Above a certain size, many data types such as [`STRING`](string.html)s, [`DECIMA
 
 ## See also
 
-- [`IMPORT`](import.html)
+- [`IMPORT INTO`](import-into.html)
 - [Migration Overview](migration-overview.html)
 - [Migrate from Oracle](migrate-from-oracle.html)
 - [Migrate from PostgreSQL](migrate-from-postgres.html)

--- a/v23.1/import.md
+++ b/v23.1/import.md
@@ -6,6 +6,10 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 docs_area: reference.sql
 ---
 
+{{site.data.alerts.callout_danger}}
+The statements on this page are **deprecated** as of v23.1 and will be removed in a future release. To move data into CockroachDB, use [`IMPORT INTO`](import-into.html) or [`COPY FROM`](copy-from.html). For more details, see [Move your data to CockroachDB](migration-overview.html#step-2-move-your-data-to-cockroachdb).
+{{site.data.alerts.end}}
+
 The `IMPORT` [statement](sql-statements.html) imports the following types of data into CockroachDB:
 
 - [PostgreSQL dump files][postgres]

--- a/v23.1/migration-overview.md
+++ b/v23.1/migration-overview.md
@@ -64,9 +64,9 @@ For more details on the CockroachDB SQL implementation, see [SQL Feature Support
 
 To migrate data from another database to CockroachDB, use the source database's tooling to extract the data to a `.sql` file. Then use one of the following methods to migrate the data:
 
-- Use [AWS Database Migration Service (DMS)](aws-dms.html) to migrate data from any database, such as PostgreSQL, MySQL, or Oracle, to CockroachDB. This option is recommended for near-zero downtime migrations of large data sets, either with ongoing replication or as a one-time migration of a snapshot.
 - Use [`COPY FROM`](copy-from.html) to copy the data to your CockroachDB tables. This option behaves identically to the PostgreSQL syntax and is recommended if your tables must remain **online** and accessible during a migration or continuous bulk ingestion of data. However, it is slower than using [`IMPORT INTO`](import-into.html) because the statements are executed through a single node on the cluster. 
-- Use [`IMPORT INTO`](import-into.html) to migrate [CSV](migrate-from-csv.html) or [Avro](migrate-from-avro) data into pre-existing tables. This option is recommended if you can tolerate your tables being **offline**, such as during an initial migration to CockroachDB. It is faster than using [`COPY FROM`](copy-from.html) because the statements are distributed across multiple nodes.
+- Use [`IMPORT INTO`](import-into.html) to migrate [CSV](migrate-from-csv.html) or [Avro](migrate-from-avro.html) data into pre-existing tables. This option is recommended if you can tolerate your tables being **offline**, such as during an initial migration to CockroachDB. It is faster than using [`COPY FROM`](copy-from.html) because the statements are distributed across multiple nodes.
+- Use [AWS Database Migration Service (DMS)](aws-dms.html) to migrate data from any database, such as PostgreSQL, MySQL, or Oracle, to CockroachDB. This option is recommended for near-zero downtime migrations of large data sets, either with ongoing replication or as a one-time migration of a snapshot.
 	{% include {{ page.version.version }}/misc/import-perf.md %}
 
 ## Step 3. Test and update your application

--- a/v23.1/migration-overview.md
+++ b/v23.1/migration-overview.md
@@ -30,7 +30,7 @@ To begin a new migration to CockroachDB, convert your database schema to an equi
 1. Use the source database's tooling to extract the [data definition language (DDL)](sql-statements.html#data-definition-statements) to a `.sql` file.
 1. Upload the `.sql` file to the [**Schema Conversion Tool**](../cockroachcloud/migrations-page.html) on the {{ site.data.products.db }} Console. The tool will convert the syntax, identify [unimplemented features](#unimplemented-features) in the schema, and suggest edits according to CockroachDB [best practices](#schema-design-best-practices).
 	{{site.data.alerts.callout_info}}
-	The Schema Conversion Tool currently accepts `.sql` files from PostgreSQL, MySQL, Oracle, and Microsoft SQL Server.
+	The Schema Conversion Tool accepts `.sql` files from PostgreSQL, MySQL, Oracle, and Microsoft SQL Server.
 	{{site.data.alerts.end}}
 
 1. The Schema Conversion Tool automatically creates a new {{ site.data.products.serverless }} database with the converted schema. {% include cockroachcloud/migration/sct-self-hosted.md %}


### PR DESCRIPTION
DOC-6723
DOC-6887

This is an interim update to get our migration docs up to date on the data ingestion options.

- Added deprecation notice to `IMPORT` docs (23.1 and 22.2, specifying "as of v23.1" in both).
- Updated & lightly restructured Migration Overview to recommend `COPY FROM`, `IMPORT INTO`, and AWS DMS with some considerations for each. (**Reviewers:** I'd like to enhance these considerations with more detail, if possible.)
- Lightly updated & restructured `COPY FROM` and `IMPORT INTO` reference docs for usability.
- Clarified that schema can be exported from SCT for use with self-hosted cluster.
- Added recommendation for "latest production release" on DMS docs while I'm here.