### PR TITLE
DOC-6987 log export GTM limited access

### DIFF
--- a/_includes/feature-phases/limited-access.md
+++ b/_includes/feature-phases/limited-access.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+**This feature is in limited access** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
+{{site.data.alerts.end}}

--- a/cockroachcloud/export-logs.md
+++ b/cockroachcloud/export-logs.md
@@ -11,7 +11,7 @@ docs_area: manage
 The {{ site.data.products.dedicated }} log export feature is only available on clusters created after August 11, 2022 (AWS) or September 9, 2022 (GCP).
 {{site.data.alerts.end}}
 
-{% include feature-phases/preview-opt-in.md %}
+{% include feature-phases/limited-access.md %}
 
 ## The `logexport` endpoint
 


### PR DESCRIPTION
Addresses: DOC-6987

- Created new "limited access" include, similar to existing "private preview" include.
- Directed log export docs to use this new "limited access" include.

Staging

[export-logs.md](https://deploy-preview-16318--cockroachdb-docs.netlify.app/docs/cockroachcloud/export-logs.html)