### PR TITLE
DOC-6988 metrics export GTM preview

### DIFF
--- a/cockroachcloud/export-metrics.md
+++ b/cockroachcloud/export-metrics.md
@@ -9,7 +9,7 @@ docs_area: manage
 
 Exporting metrics to AWS CloudWatch is only available on {{ site.data.products.dedicated }} clusters which are hosted on AWS, and were created after August 11, 2022. Metrics export to Datadog is supported on all {{ site.data.products.dedicated }} clusters regardless of creation date.
 
-{% include feature-phases/preview-opt-in.md %}
+{% include feature-phases/preview.md %}
 
 ## The `metricexport` endpoint
 


### PR DESCRIPTION
Addresses: DOC-6988

- Switches GTM include from `preview-opt-in.md` to `preview.md`, removing "enroll" language.

Staging

[export-metrics.md](https://deploy-preview-16319--cockroachdb-docs.netlify.app/docs/cockroachcloud/export-metrics.html)