### PR TITLE
Add example of using dates in ttl expressions

### DIFF
--- a/v23.1/row-level-ttl.md
+++ b/v23.1/row-level-ttl.md
@@ -212,7 +212,7 @@ CREATE TABLE events (
 );
 ~~~
 
-A `ttl_expiration_expression` that uses an existing `TIMESTAMPTZ` column.
+A `ttl_expiration_expression` that uses an existing `TIMESTAMPTZ` column:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -226,7 +226,7 @@ CREATE TABLE events (
 );
 ~~~
 
-When using a `ttl_expiration_expression` on a `DATE` or `TIMESTAMPTTZ` column use `AT TIME ZONE` to explicitly set the timezone for the expression. By setting the timezone to UTC in the expression, you set an exact time when the delete should be performed, regardless of the local timezone of the node.
+When using a `ttl_expiration_expression` on a `DATE` or `TIMESTAMPTTZ` column, use `AT TIME ZONE` to explicitly set the time zone for the expression. By setting the time zone to UTC in the expression, you set an exact time when the delete should be performed, regardless of the local time zone of the node.
 
 ### Create a table with `ttl_expire_after`
 

--- a/v23.1/row-level-ttl.md
+++ b/v23.1/row-level-ttl.md
@@ -194,9 +194,11 @@ The `ttl_expiration_expression` parameter has the following requirements:
 - Any column it references cannot be [dropped](alter-table.html#drop-column) or have its [type altered](alter-type.html).
 - Finally, if the [column is renamed](alter-table.html#rename-column), the value of `ttl_expiration_expression` is automatically updated.
 
-### Use a `ttl_expiration_expression` on a `DATE` column
+### Use a `ttl_expiration_expression` on a `DATE` or `TIMESTAMPTZ` column
 
 Use the SQL syntax shown below to create a new table with rows that expire 30 days after an event ends using a `ttl_expiration_expression`.
+
+A `ttl_expiration_expression` that uses an existing `DATE` column:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -207,6 +209,20 @@ CREATE TABLE events (
   end_date DATE NOT NULL
 ) WITH (
   ttl_expiration_expression = '((end_date::TIMESTAMP) + INTERVAL ''30 days'') AT TIME ZONE ''UTC'''
+);
+~~~
+
+A `ttl_expiration_expression` that uses an existing `TIMESTAMPTZ` column.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  description TEXT,
+  start_date TIMESTAMPTZ DEFAULT now() NOT NULL,
+  end_date TIMESTAMPTZ NOT NULL
+) WITH (
+  ttl_expiration_expression = '((end_date AT TIME ZONE ''UTC'') + INTERVAL ''30 days'') AT TIME ZONE ''UTC'''
 );
 ~~~
 

--- a/v23.1/row-level-ttl.md
+++ b/v23.1/row-level-ttl.md
@@ -194,6 +194,24 @@ The `ttl_expiration_expression` parameter has the following requirements:
 - Any column it references cannot be [dropped](alter-table.html#drop-column) or have its [type altered](alter-type.html).
 - Finally, if the [column is renamed](alter-table.html#rename-column), the value of `ttl_expiration_expression` is automatically updated.
 
+### Use a `ttl_expiration_expression` on a `DATE` column
+
+Use the SQL syntax shown below to create a new table with rows that expire 30 days after an event ends using a `ttl_expiration_expression`.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  description TEXT,
+  start_date DATE DEFAULT now() NOT NULL,
+  end_date DATE NOT NULL
+) WITH (
+  ttl_expiration_expression = '((end_date::TIMESTAMP) + INTERVAL ''30 days'') AT TIME ZONE ''UTC'''
+);
+~~~
+
+When using a `ttl_expiration_expression` on a `DATE` or `TIMESTAMPTTZ` column use `AT TIME ZONE` to explicitly set the timezone for the expression. By setting the timezone to UTC in the expression, you set an exact time when the delete should be performed, regardless of the local timezone of the node.
+
 ### Create a table with `ttl_expire_after`
 
 Use the SQL syntax shown below to create a new table with rows that expire after a 3 month [interval](interval.html), execute a statement like the following:


### PR DESCRIPTION
Adds an example of using `ttl_expiration_expression` with a `DATE` column and explicitly setting the timezone.

Closes DOC-6918.