### PR TITLE
[DOC-3566] added example for locality aware show backup

### DIFF
--- a/v22.2/show-backup.md
+++ b/v22.2/show-backup.md
@@ -195,7 +195,7 @@ movr          | public             | vehicles                   | table       | 
 To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
 
 {{site.data.alerts.callout_info}}
-`SHOW BACKUP` can display backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option **or** for locality-aware backups, but not for locality-aware backups taken with the `incremental_location` option.
+`SHOW BACKUP` cannot display metadata for locality-aware backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option.
 {{site.data.alerts.end}}
 
 {% include_cached copy-clipboard.html %}

--- a/v22.2/show-backup.md
+++ b/v22.2/show-backup.md
@@ -192,15 +192,15 @@ movr          | public             | vehicles                   | table       | 
 
 ### Show a locality-aware backup
 
-To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
-
 {{site.data.alerts.callout_info}}
 `SHOW BACKUP` cannot display metadata for locality-aware backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option.
 {{site.data.alerts.end}}
 
+To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
+
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUP FROM LATEST in ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');
+> SHOW BACKUP FROM LATEST IN ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');
 ~~~
 
 ~~~

--- a/v22.2/show-backup.md
+++ b/v22.2/show-backup.md
@@ -194,6 +194,10 @@ movr          | public             | vehicles                   | table       | 
 
 To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
 
+{{site.data.alerts.callout_info}}
+`SHOW BACKUP` can display backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option **or** for locality-aware backups, but not for locality-aware backups taken with the `incremental_location` option.
+{{site.data.alerts.end}}
+
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW BACKUP FROM LATEST in ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');

--- a/v22.2/show-backup.md
+++ b/v22.2/show-backup.md
@@ -190,6 +190,29 @@ movr          | public             | vehicles                   | table       | 
 . . .
 ~~~
 
+### Show a locality-aware backup
+
+To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW BACKUP FROM LATEST in ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');
+~~~
+
+~~~
+  database_name | parent_schema_name |        object_name         | object_type | backup_type | start_time |          end_time          | size_bytes | rows | is_full_cluster
+----------------+--------------------+----------------------------+-------------+-------------+------------+----------------------------+------------+------+------------------
+  NULL          | NULL               | movr                       | database    | full        | NULL       | 2023-02-23 15:09:25.625777 |       NULL | NULL |        f
+  movr          | NULL               | public                     | schema      | full        | NULL       | 2023-02-23 15:09:25.625777 |       NULL | NULL |        f
+  movr          | public             | users                      | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |       5633 |   58 |        f
+  movr          | public             | vehicles                   | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |       3617 |   17 |        f
+  movr          | public             | rides                      | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |     159269 |  511 |        f
+  movr          | public             | vehicle_location_histories | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |      79963 | 1092 |        f
+  movr          | public             | promo_codes                | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |     221763 | 1003 |        f
+  movr          | public             | user_promo_codes           | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |        927 |   11 |        f
+(8 rows)
+~~~
+
 ### Show a backup with schemas
 
 {% include_cached copy-clipboard.html %}

--- a/v23.1/known-limitations.md
+++ b/v23.1/known-limitations.md
@@ -412,10 +412,6 @@ As a workaround, take a cluster backup instead, as the `system.comments` table i
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/44396)
 
-### `SHOW BACKUP` does not work with locality-aware backups and the `incremental_location` option
-
-{% include {{ page.version.version }}/known-limitations/show-backup-locality-incremental-location.md %}
-
 ### DB Console may become inaccessible for secure clusters
 
 Accessing the DB Console for a secure cluster now requires login information (i.e., username and password). This login information is stored in a system table that is replicated like other data in the cluster. If a majority of the nodes with the replicas of the system table data go down, users will be locked out of the DB Console.

--- a/v23.1/show-backup.md
+++ b/v23.1/show-backup.md
@@ -157,10 +157,6 @@ system        | public             | role_members               | table       | 
 
 To view an incremental backup that was taken with the `incremental_location` option, run `SHOW BACKUP` with the full backup and incremental backup location following the original `BACKUP` statement.
 
-{{site.data.alerts.callout_info}}
-`SHOW BACKUP` can display metadata for locality-aware backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option.
-{{site.data.alerts.end}}
-
 You can use the option to show the most recent backup where `incremental_location` has stored the backup:
 
 {% include_cached copy-clipboard.html %}
@@ -193,11 +189,6 @@ movr          | public             | vehicles                   | table       | 
 ### Show a locality-aware backup
 
 To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
-
-{% include_cached new-in.html version="v23.1.0" %}
-{{site.data.alerts.callout_info}}
-`SHOW BACKUP` can display metadata for locality-aware backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option.
-{{site.data.alerts.end}}
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -408,10 +399,6 @@ WITH x AS (SHOW BACKUP FROM '/2021/11/15-150703.21' IN 's3://{bucket name}?AWS_A
   data/710798326337404929.sst
   data/710798326337404929.sst
 ~~~
-
-## Known limitations
-
-- {% include {{ page.version.version }}/known-limitations/show-backup-locality-incremental-location.md %}
 
 ## See also
 

--- a/v23.1/show-backup.md
+++ b/v23.1/show-backup.md
@@ -158,7 +158,7 @@ system        | public             | role_members               | table       | 
 To view an incremental backup that was taken with the `incremental_location` option, run `SHOW BACKUP` with the full backup and incremental backup location following the original `BACKUP` statement.
 
 {{site.data.alerts.callout_info}}
-`SHOW BACKUP` can display backups taken with the `incremental_location` option **or** for [locality-aware backups](take-and-restore-locality-aware-backups.html), but not for locality-aware backups taken with the `incremental_location` option.
+`SHOW BACKUP` can display metadata for locality-aware backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option.
 {{site.data.alerts.end}}
 
 You can use the option to show the most recent backup where `incremental_location` has stored the backup:
@@ -194,8 +194,9 @@ movr          | public             | vehicles                   | table       | 
 
 To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
 
+{% include_cached new-in.html version="v23.1.0" %}
 {{site.data.alerts.callout_info}}
-`SHOW BACKUP` can display backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option **or** for locality-aware backups, but not for locality-aware backups taken with the `incremental_location` option.
+`SHOW BACKUP` can display metadata for locality-aware backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option.
 {{site.data.alerts.end}}
 
 {% include_cached copy-clipboard.html %}

--- a/v23.1/show-backup.md
+++ b/v23.1/show-backup.md
@@ -192,7 +192,7 @@ To view a [locality-aware backup](take-and-restore-locality-aware-backups.html),
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUP FROM LATEST in ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');
+> SHOW BACKUP FROM LATEST IN ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');
 ~~~
 
 ~~~

--- a/v23.1/show-backup.md
+++ b/v23.1/show-backup.md
@@ -194,6 +194,10 @@ movr          | public             | vehicles                   | table       | 
 
 To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
 
+{{site.data.alerts.callout_info}}
+`SHOW BACKUP` can display backups taken with the [`incremental_location`](show-backup.html#show-a-backup-taken-with-the-incremental-location-option) option **or** for locality-aware backups, but not for locality-aware backups taken with the `incremental_location` option.
+{{site.data.alerts.end}}
+
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW BACKUP FROM LATEST in ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');

--- a/v23.1/show-backup.md
+++ b/v23.1/show-backup.md
@@ -190,6 +190,29 @@ movr          | public             | vehicles                   | table       | 
 . . .
 ~~~
 
+### Show a locality-aware backup
+
+To view a [locality-aware backup](take-and-restore-locality-aware-backups.html), pass locality-aware backup URIs to `SHOW BACKUP`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW BACKUP FROM LATEST in ('s3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=default', 's3://{bucket name}/locality?AWS_ACCESS_KEY_ID={placeholder}&AWS_SECRET_ACCESS_KEY={placeholder}&COCKROACH_LOCALITY=region%3Dus-west');
+~~~
+
+~~~
+  database_name | parent_schema_name |        object_name         | object_type | backup_type | start_time |          end_time          | size_bytes | rows | is_full_cluster
+----------------+--------------------+----------------------------+-------------+-------------+------------+----------------------------+------------+------+------------------
+  NULL          | NULL               | movr                       | database    | full        | NULL       | 2023-02-23 15:09:25.625777 |       NULL | NULL |        f
+  movr          | NULL               | public                     | schema      | full        | NULL       | 2023-02-23 15:09:25.625777 |       NULL | NULL |        f
+  movr          | public             | users                      | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |       5633 |   58 |        f
+  movr          | public             | vehicles                   | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |       3617 |   17 |        f
+  movr          | public             | rides                      | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |     159269 |  511 |        f
+  movr          | public             | vehicle_location_histories | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |      79963 | 1092 |        f
+  movr          | public             | promo_codes                | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |     221763 | 1003 |        f
+  movr          | public             | user_promo_codes           | table       | full        | NULL       | 2023-02-23 15:09:25.625777 |        927 |   11 |        f
+(8 rows)
+~~~
+
 ### Show a backup with schemas
 
 {% include_cached copy-clipboard.html %}


### PR DESCRIPTION
Addresses DOC-3566:
- Users can now pass locality-aware backup URIs to SHOW BACKUP
- Users can not yet run SHOW BACKUP for locality aware backups created using the
incremental_location parameter

Preview:
- [22.2 Show a locality-aware backup](https://deploy-preview-16341--cockroachdb-docs.netlify.app/docs/stable/show-backup.html#show-a-locality-aware-backup)
- [23.1 Show a locality-aware backup](https://deploy-preview-16341--cockroachdb-docs.netlify.app/docs/dev/show-backup.html#show-a-locality-aware-backup)