### PR TITLE
[DOC-7103] Remove mention of external ID from AWS CMEK docs

### DIFF
--- a/cockroachcloud/cmek-ops-aws.md
+++ b/cockroachcloud/cmek-ops-aws.md
@@ -50,7 +50,6 @@ Here we will create a *cross-account IAM role*. This is a role in your AWS accou
 	1. For **Trusted entity type**, select **AWS account**.
 	1. Choose **Another AWS account**.
 		1. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found previously by querying your cluster's Cloud API.
-		1. Select the option to **Require external ID**, and for the value of **External ID**, provide your {{ site.data.products.dedicated }} Organization ID.
 	1. Finish creating the IAM role with a suitable name. You do not need to add any permissions.
 
 	{{site.data.alerts.callout_info}}

--- a/cockroachcloud/cmek-ops-aws.md
+++ b/cockroachcloud/cmek-ops-aws.md
@@ -48,7 +48,7 @@ Here we will create a *cross-account IAM role*. This is a role in your AWS accou
 	1. In the AWS console, visit the [IAM page](https://console.aws.amazon.com/iam/).
 	1. Select **Roles** and click **Create role**.
 	1. For **Trusted entity type**, select **AWS account**.
-	1. Choose **Another AWS account**. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found previously by querying your cluster's Cloud API.
+	1. Choose **Another AWS account**. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found [previously](#step-1-provision-the-cross-account-iam-role) by querying your cluster's Cloud API.
 	1. Finish creating the IAM role with a suitable name. You do not need to add any permissions.
 
 	{{site.data.alerts.callout_info}}

--- a/cockroachcloud/cmek-ops-aws.md
+++ b/cockroachcloud/cmek-ops-aws.md
@@ -48,8 +48,7 @@ Here we will create a *cross-account IAM role*. This is a role in your AWS accou
 	1. In the AWS console, visit the [IAM page](https://console.aws.amazon.com/iam/).
 	1. Select **Roles** and click **Create role**.
 	1. For **Trusted entity type**, select **AWS account**.
-	1. Choose **Another AWS account**.
-		1. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found previously by querying your cluster's Cloud API.
+	1. Choose **Another AWS account**. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found previously by querying your cluster's Cloud API.
 	1. Finish creating the IAM role with a suitable name. You do not need to add any permissions.
 
 	{{site.data.alerts.callout_info}}


### PR DESCRIPTION
[DOC-7103] Remove mention of external ID from AWS CMEK docs

This is a temporary change and I'll prepare a revert as soon as it is merged.

## Previews
[cockroachcloud/cmek-ops-aws.md](https://deploy-preview-16398--cockroachdb-docs.netlify.app/docs/cockroachcloud/cmek-ops-aws.html)

## Tests
- [x] Local build
- [x] Linkcheck