### PR TITLE
You cannot drop a column ref'd in a partial index

### DIFF
--- a/v22.1/drop-column.md
+++ b/v22.1/drop-column.md
@@ -14,7 +14,7 @@ When used in an explicit transaction combined with other schema changes to the s
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
- By default, `DROP COLUMN` drops any [indexes](indexes.html) on the column being dropped, and any indexes that reference the column, including [partial indexes](partial-indexes.html) with predicates that reference the column and indexes with [`STORING` clauses](create-index.html#store-columns) that reference the column.
+ By default, `DROP COLUMN` drops any [indexes](indexes.html) on the column being dropped, and any indexes that reference the column, including indexes with [`STORING` clauses](create-index.html#store-columns) that reference the column.
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
@@ -39,6 +39,10 @@ The user must have the `CREATE` [privilege](security-reference/authorization.htm
 ## Viewing schema changes
 
 {% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
+## Known limitations
+
+- CockroachDB prevents a column from being dropped if it is referenced by a [partial index](partial-indexes.html) predicate. To drop such a column, the partial indexes need to be dropped first using [`DROP INDEX`](drop-index.html). See [tracking issue](https://github.com/cockroachdb/cockroach/issues/97813).
 
 ## Examples
 

--- a/v22.1/partial-indexes.md
+++ b/v22.1/partial-indexes.md
@@ -90,6 +90,8 @@ You can force queries [to use a specific partial index](table-expressions.html#f
 
 - CockroachDB does not currently support [`IMPORT`](import.html) statements on tables with partial indexes. See [tracking issue](https://github.com/cockroachdb/cockroach/issues/50225).
 - CockroachDB does not currently support multiple arbiter indexes for `INSERT ON CONFLICT DO UPDATE`, and will return an error if there are multiple unique or exclusion constraints matching the `ON CONFLICT DO UPDATE` specification. See [tracking issue](https://github.com/cockroachdb/cockroach/issues/53170).
+- CockroachDB prevents a column from being dropped using [`ALTER TABLE ... DROP COLUMN`](drop-column.html) if it is referenced by a partial index predicate. To drop such a column, the partial indexes need to be dropped first using [`DROP INDEX`](drop-index.html). See [tracking issue](https://github.com/cockroachdb/cockroach/issues/97813).
+
 
 ## Examples
 

--- a/v22.2/alter-table.md
+++ b/v22.2/alter-table.md
@@ -255,9 +255,13 @@ Use `ALTER TABLE ... DROP COLUMN` to remove columns from a table.
 When used in an explicit transaction combined with other schema changes to the same table, `DROP COLUMN` can result in data loss if one of the other schema changes fails or is canceled. To work around this, move the `DROP COLUMN` statement to its own explicit transaction or run it in a single statement outside the existing transaction.
 {{site.data.alerts.end}}
 
-By default, `DROP COLUMN` drops any [indexes](indexes.html) on the column being dropped, and any indexes that reference the column, including [partial indexes](partial-indexes.html) with predicates that reference the column and indexes with [`STORING` clauses](create-index.html#store-columns) that reference the column.
+By default, `DROP COLUMN` drops any [indexes](indexes.html) on the column being dropped, and any indexes that reference the column, including indexes with [`STORING` clauses](create-index.html#store-columns) that reference the column.
 
 For examples, see [Drop columns](#drop-columns).
+
+#### Known limitations
+
+- CockroachDB prevents a column from being dropped if it is referenced by a [partial index](partial-indexes.html) predicate. To drop such a column, the partial indexes need to be dropped first using [`DROP INDEX`](drop-index.html). See [tracking issue](https://github.com/cockroachdb/cockroach/issues/97813).
 
 #### Required privileges
 

--- a/v22.2/partial-indexes.md
+++ b/v22.2/partial-indexes.md
@@ -90,6 +90,7 @@ You can force queries [to use a specific partial index](table-expressions.html#f
 
 - CockroachDB does not currently support [`IMPORT`](import.html) statements on tables with partial indexes. See [tracking issue](https://github.com/cockroachdb/cockroach/issues/50225).
 - CockroachDB does not currently support multiple arbiter indexes for `INSERT ON CONFLICT DO UPDATE`, and will return an error if there are multiple unique or exclusion constraints matching the `ON CONFLICT DO UPDATE` specification. See [tracking issue](https://github.com/cockroachdb/cockroach/issues/53170).
+- CockroachDB prevents a column from being dropped using [`ALTER TABLE ... DROP COLUMN`](alter-table.html#drop-column) if it is referenced by a partial index predicate. To drop such a column, the partial indexes need to be dropped first using [`DROP INDEX`](drop-index.html). See [tracking issue](https://github.com/cockroachdb/cockroach/issues/97813).
 
 ## Examples
 

--- a/v23.1/alter-table.md
+++ b/v23.1/alter-table.md
@@ -255,9 +255,13 @@ Use `ALTER TABLE ... DROP COLUMN` to remove columns from a table.
 When used in an explicit transaction combined with other schema changes to the same table, `DROP COLUMN` can result in data loss if one of the other schema changes fails or is canceled. To work around this, move the `DROP COLUMN` statement to its own explicit transaction or run it in a single statement outside the existing transaction.
 {{site.data.alerts.end}}
 
-By default, `DROP COLUMN` drops any [indexes](indexes.html) on the column being dropped, and any indexes that reference the column, including [partial indexes](partial-indexes.html) with predicates that reference the column and indexes with [`STORING` clauses](create-index.html#store-columns) that reference the column.
+By default, `DROP COLUMN` drops any [indexes](indexes.html) on the column being dropped, and any indexes that reference the column, including indexes with [`STORING` clauses](create-index.html#store-columns) that reference the column.
 
 For examples, see [Drop columns](#drop-columns).
+
+#### Known limitations
+
+- CockroachDB prevents a column from being dropped if it is referenced by a [partial index](partial-indexes.html) predicate. To drop such a column, the partial indexes need to be dropped first using [`DROP INDEX`](drop-index.html). See [tracking issue](https://github.com/cockroachdb/cockroach/issues/97813).
 
 #### Required privileges
 

--- a/v23.1/partial-indexes.md
+++ b/v23.1/partial-indexes.md
@@ -90,6 +90,7 @@ You can force queries [to use a specific partial index](table-expressions.html#f
 
 - CockroachDB does not currently support [`IMPORT`](import.html) statements on tables with partial indexes. See [tracking issue](https://github.com/cockroachdb/cockroach/issues/50225).
 - CockroachDB does not currently support multiple arbiter indexes for `INSERT ON CONFLICT DO UPDATE`, and will return an error if there are multiple unique or exclusion constraints matching the `ON CONFLICT DO UPDATE` specification. See [tracking issue](https://github.com/cockroachdb/cockroach/issues/53170).
+- CockroachDB prevents a column from being dropped using [`ALTER TABLE ... DROP COLUMN`](alter-table.html#drop-column) if it is referenced by a partial index predicate. To drop such a column, the partial indexes need to be dropped first using [`DROP INDEX`](drop-index.html). See [tracking issue](https://github.com/cockroachdb/cockroach/issues/97813).
 
 ## Examples
 


### PR DESCRIPTION
Fixes DOC-7050

Relates to DOC-7029