### PR TITLE
Fix structured content in page header

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -50,9 +50,9 @@
   {
     "@context": "https://schema.org",
     "@type": "Article",
-    "headline": "{{ page.title }}",
+    "headline": "{{ page.title | replace: '"', '\"' }}",
     "image": "{% if page.image_url %}{{ page.image_url }}{% else %}https://www.cockroachlabs.com/img/crl-socialpost-default-2020-2.jpg?auto=format,compress{% endif %}",
-    {% if page.summary %}"description": "{{ page.summary | strip_html | strip_newlines | truncate: 160 }}",{% endif %}
+    {% if page.summary %}"description": "{{ page.summary | strip_html | strip_newlines | truncate: 160 | replace: '"', '\"' }}",{% endif %}
     "author": {
         "@type": "Organization",
         "name": "Cockroach Labs Documentation Team",


### PR DESCRIPTION
We were getting an error because the summary in one page had unescaped double quotes. This should fix that.

![image](https://user-images.githubusercontent.com/13631471/223169940-1c84f65b-4a69-451e-8304-4c8be81417a4.png)
