### PR TITLE
DOC-7137 Release notes for v23.1.0-alpha.5

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -140,12 +140,12 @@ release_info:
     start_time: 2023-02-28 13:49:22.362179 +0000 UTC
     version: v22.2.6
   v23.1:
-    build_time: 2023-02-27 00:00:00 (go1.19)
+    build_time: 2023-03-06 00:00:00 (go1.19)
     crdb_branch_name: master
     docker_image: cockroachdb/cockroach-unstable
-    name: v23.1.0-alpha.4
-    start_time: 2023-02-27 13:07:19.837040 +0000 UTC
-    version: v23.1.0-alpha.4
+    name: v23.1.0-alpha.5
+    start_time: 2023-03-06 10:55:32.149776 +0000 UTC
+    version: v23.1.0-alpha.5
 sass:
   sass_dir: css
   style: compressed

--- a/_data/releases.csv
+++ b/_data/releases.csv
@@ -325,3 +325,4 @@ v23.1.0-alpha.3,v23.1,2023-02-21,false,False,Testing,False,go1.19,51ed100a464183
 v23.1.0-alpha.4,v23.1,2023-02-27,false,False,Testing,False,go1.19,286b3e235171a39b8f9910555affcc7ce310741a,cockroachdb/cockroach-unstable,true,true,true,true,true
 v22.2.6,v22.2,2023-03-03,false,False,Production,False,go1.19,d5a076f2953c0712193b8cbe08bbb682563c5675,cockroachdb/cockroach,true,true,true,true,true
 v22.1.16,v22.1,2023-03-03,false,False,Production,False,go1.19,1dfbda1a87bc8866a0a54b5b53617f80ff1441e0,cockroachdb/cockroach,true,false,false,false,true
+v23.1.0-alpha.5,v23.1,2023-03-06,false,False,Testing,False,go1.19,21786aa112e6b822858f281c1cc59608987c5c0a,cockroachdb/cockroach-unstable,true,true,true,true,true

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -11,7 +11,7 @@ Release Date: March 6, 2023
 <h3 id="v23-1-0-alpha-5-general-changes">General changes</h3>
 
 - Users with the `CONTROLJOB` role option can now view jobs owned by admins (ex. via `SHOW JOBS`). [#96382][#96382]
-- Users with the the `VIEWJOB` role option can now view all jobs, such as by using the `SHOW JOBS` command. This role can be revoked by granting the `NOVIEWJOB` role. [#96382][#96382]
+- Users with the `VIEWJOB` role option can now view all jobs, such as by using the `SHOW JOBS` command. This role can be revoked by granting the `NOVIEWJOB` role. [#96382][#96382]
 
 <h3 id="v23-1-0-alpha-5-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
 

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -22,7 +22,7 @@ Release Date: March 6, 2023
 <h3 id="v23-1-0-alpha-5-sql-language-changes">SQL language changes</h3>
 
 - String literals are now allowed for region names in DDL syntax, in addition to quoted syntax. [#97021][#97021]
-- It is now possible to use `*` inside a [`CREATE VIEW`](create-view.htm) statement. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as in PostgreSQL. [#97515][#97515]
+- It is now possible to use `*` inside a [`CREATE VIEW`](create-view.html) statement. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as in PostgreSQL. [#97515][#97515]
 - The default value of `sql.stats.cleanup.rows_to_delete_per_txn` has been increased to `10000` to increase efficiency of the cleanup job for SQL statistics. [#97642][#97642]
 - The new [session setting](set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
 - Builtins have been added for `tsvector`, `to_tsquery`, `phraseto_tsquery`, and `plainto_tsquery`, which parse input documents into tsvectors and tsqueries, respectively. The new `ts_parse` builtin is used to debug the text search parser. [#92966][#92966]

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -34,7 +34,6 @@ Release Date: March 6, 2023
 - The following [cluster settings](/docs/v23.1/cluster-settings.html), which control rebalancing and upreplication behavior in the face of IO-overloaded storage, have been deprecated:
   - `kv.allocator.l0_sublevels_threshold`
   - `kv.allocator.l0_sublevels_threshold_enforce`
-  -
   These cluster settings have been replaced by internal mechanisms. [#97142][#97142]
 
 - Max timeout-to-intent resolution has been added to prevent intent resolution from becoming stuck indefinitely and blocking other ranges attempting to resolve intents. [#91815][#91815]
@@ -72,7 +71,7 @@ Release Date: March 6, 2023
 
     [#97590][#97590]
 
-- Active execution information is now shown on the SQL Activity page even when there is a max size limit error. [#97662][#97662]
+- Active execution information is now shown on the [Statements page](/docs/v23.1/ui-statements-page.html) even when there is a max size limit error. [#97662][#97662]
 - "Retrying" is no longer a status shown in the [Jobs](/docs/v23.1/ui-jobs-page.html) page. [#97505][#97505]
 
 <h3 id="v23-1-0-alpha-5-bug-fixes">Bug fixes</h3>

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -79,37 +79,35 @@ Release Date: March 6, 2023
 
 - Transaction uncertainty intervals are now correctly configured for reverse scans, to prevent reverse scans from serving stale reads when clocks in a cluster are skewed. [#97443][#97443]
 - The formatting of uniqueness violation errors now matches the corresponding errors from PostgreSQL. [#96914][#96914]
-- Fixed a bug in `ALTER TABLE ... ADD COLUMN` when the new column name requires quoting due to mixed case or special characters and the statement is not run in an explicit or multi-statement transaction. [#97514][#97514]
-- Fixed a bug when formatting `CREATE` statements for user-defined types which require quoting which might prevent those statements from round-tripping. [#97514][#97514]
+- Previously, when a new column name would require quoting due to mixed-case or special characters, [`ALTER TABLE ... ADD COLUMN`](alter-table.html#add-column) would not run in an explicit or multi-statement transaction. This is now fixed. [#97514][#97514]
+- Fixed a bug when formatting [`CREATE TYPE` statements for user-defined types](create-type.html) which require quoting which might prevent those statements from round-tripping. [#97514][#97514]
 - Using subqueries in UDFs without an `AS` clause is now supported, for consistency with the syntax supported outside of UDFs. [#97515][#97515]
 - Fixed a rare bug existing since before v22.1.x that could cause a projected expression to replace column references with the wrong values. [#97554][#97554]
-- Cross-descriptor validation on lease renewal is now disabled, because it can starve schema changes when there are many descriptors with many foreign key references [#97630][#97630]
-- Fixed a bug with pagination on the Schema Insights page. [#97640][#97640]
-- Columns referenced in partial index predicates and partial unique constraint predicates can no longer be dropped. The `ALTER TABLE .. DROP COLUMN` statement now returns an error with a suggestion to drop the indexes and constraints first. This is a temporary safe-guard to prevent users from hitting [#96924][#96924]. This restriction will be lifted when that bug is fixed. [#97372][#97372]
-- Jobs page properly shows error state when we receive an error during data fetching. [#97486][#97486]
-- Fixed a bug introduced in v22.1 that caused the internal error "no bytes in account to release ...". [#97750][#97750]
-- The `COPY FROM` command now respects the `statement_timeout` and `transaction_timeout` cluster settings. [#97808][#97808]
-- `COPY FROM` commands now appears in the output of the `SHOW QUERIES` command. [#97808][#97808]
+- Cross-descriptor validation on lease renewal is now disabled, because it can starve [online schema changes](online-schema-changes.html) when there are many descriptors with many foreign key references. [#97630][#97630]
+- Fixed a bug with pagination on the [Insights](ui-insights-page.html) page. [#97640][#97640]
+- Columns referenced in partial index predicates and partial unique constraint predicates can no longer be dropped. The [`ALTER TABLE .. DROP COLUMN`](alter-table.html#drop-column) statement now returns an error with a suggestion to drop the indexes and constraints first. This is a temporary safeguard to prevent users from hitting [#96924][#96924]. This restriction will be lifted when that bug is fixed. [#97372][#97372]
+- The [Jobs](/ui-jobs-page.html) page now displays an error state when an error is encountered during data fetching. [#97486][#97486]
+- Fixed a bug introduced in v22.1 that caused the internal error `no bytes in account to release ...`. [#97750][#97750]
+- The [`COPY FROM`](copy-from.html) command now respects the `statement_timeout` and `transaction_timeout` [cluster settings](cluster-settings.html). [#97808][#97808]
+- [`COPY FROM`](copy-from.html) commands now appear in the output of the [`SHOW STATEMENTS`](show-statements.html) command. [#97808][#97808]
 - Fixed an error where querying a `pg_catalog` table included information about a temporary table created in another session. [#97727][#97727]
 
 <h3 id="v23-1-0-alpha-5-performance-improvements">Performance improvements</h3>
 
-- If the session setting `optimizer_use_improved_split_disjunction_for_joins` is `true`, the optimizer now creates a better query plan in some cases where an inner, semi, or anti join contains a join predicate with a disjuction (`OR` condition). [#97696][#97696]
+- If the [session setting](set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` is `true`, the optimizer now creates a better query plan in some cases where an inner, semi, or anti join contains a join predicate with a disjuction (`OR` condition). [#97696][#97696]
 
 <h3 id="v23-1-0-alpha-5-miscellaneous">Miscellaneous</h3>
 
 - UDFs can now return the `RECORD` result type, which represents any tuple. For example, `CREATE FUNCTION f() RETURNS RECORD AS 'SELECT * FROM t' LANGUAGE SQL;` is equivalent to `CREATE FUNCTION f() RETURNS t AS 'SELECT * FROM t' LANGUAGE SQL;`. [#97199][#97199]
-- The parameters for delegated snapshots have been marked as non-public. [#97408][#97408]
-- Fixed an error when calling `CREATE OR REPLACE FUNCTION` with a user-defined return type if the UDT was modified after the original UDF was created. The command now succeeds as long as the function body returns output that matches the modified UDT. [#97274][#97274]
+- The parameters for [delegated snapshots](replication-layer.html#snapshots) have been marked as internal. [#97408][#97408]
+- Fixed an error when calling [`CREATE OR REPLACE FUNCTION`](create-function.html) with a [user-defined return type](create-type.html) if the user-defined type was modified after the original [user-defined function](create-function.html) was created. The command now succeeds as long as the function body returns output that matches the modified user-defined type. [#97274][#97274]
 
 <h4 id="v23-1-0-alpha-5-changes-without-release-note-annotation">Changes without release note annotation</h4>
 
 - Columns with referenced constraints can now be dropped. [#97579][#97579]
 - Index cascades with a dependent inbound foreign key can now be dropped. [#97065][#97065]
 
-<h3 id="v23-1-0-alpha-5-doc-updates">Doc updates</h3>
 
-{% comment %}Docs team: Please add these manually.{% endcomment %}
 
 <div class="release-note-contributors" markdown="1">
 

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -1,0 +1,166 @@
+## v23.1.0-alpha.5
+
+Release Date: March 6, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-1-0-alpha-5-security-updates">Security updates</h3>
+
+- The new cluster setting `server.user_login.downgrade_scram_stored_passwords_to_bcrypt.enabled`, which allows you to migrate passwords from SCRAM to bcrypt during user authentication, defaults to true. If it is true and if `server.user_login.password_encryption` is `crdb-bcrypt`, then during login, the stored hashed password will be migrated from SCRAM to bcrypt. [#97429][#97429]
+
+<h3 id="v23-1-0-alpha-5-general-changes">General changes</h3>
+
+- Users with the `CONTROLJOB` role option can now view jobs owned by admins (ex. via `SHOW JOBS`). [#96382][#96382]
+- Users with the the `VIEWJOB` role option can now view all jobs, such as by using the `SHOW JOBS` command. This role can be revoked by granting the `NOVIEWJOB` role. [#96382][#96382]
+
+<h3 id="v23-1-0-alpha-5-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
+
+- Jobs that utilize protected timestamp system (such as `BACKUP`, `CHANGEFEED`, or `IMPORT` now produce metrics that can be monitored to detect cases when a job leaves a stale protected timestamp that will prevent garbage collection from occurring. [#97148][#97148]
+- Changefeeds now automatically expire PTS records for paused jobs if the changefeed is configured with the `gc_protect_expires_after` option. [#97148][#97148]
+- UDFs can now be referenced from column DEFAULT expressions when creating a new table or issuing the `SET DEFAULT` command. Backup and restore operations also back up and restore UDF IDs that are referenced in a column's DEFAULT expression. If UDF dependencies are missing and the `skip_missing_udfs` flag is provided, the DEFAULT expressions are dropped during a restore operation. [#97501][#97501]
+- Error messages related to `initial_scan_only`, such as "cannot specify both initial_scan_only and resolved", n0.ow substitute in "initial_scan='only'".[#97487][#97487]
+
+<h3 id="v23-1-0-alpha-5-sql-language-changes">SQL language changes</h3>
+
+- String literals are now allowed for region names in DDL syntax, in addition to quoted syntax. [#97021][#97021]
+- It is now possible to use `*` inside `CREATE VIEW`. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as PostgreSQL. [#97515][#97515]
+- The default value of `sql.stats.cleanup.rows_to_delete_per_txn` has been increased to 10k to increase efficiency of the cleanup job for SQL statistics. [#97642][#97642]
+- The new new session setting `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s` will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
+- Builtins have been added for `tsvector`, `to_tsquery`, `phraseto_tsquery`, `plainto_tsquery`, which parse input documents into tsvectors and tsqueries respectively. The new `ts_parse` builtin is used to debug the text search parser. [#92966][#92966]
+- The new session variable `inject_retry_errors_on_commit_enabled` returns a transaction retry error if it is run inside of an explicit transaction when it is set to `true`. The transaction retry error continues to be returned until `inject_retry_errors_on_commit_enabled` is set to `false`. This setting allows developers to test their transaction retry logic. [#97226][#97226]
+- Previously, `ADD PRIMARY KEY NOT VALID` ignored the `NOT VALID` qualifier. This behavior was not compatible with PostgreSQL. CockroachDB now throws the error `PRIMARY KEY constraints cannot be marked NOT VALID`. [#97746][#97746]
+
+<h3 id="v23-1-0-alpha-5-operational-changes">Operational changes</h3>
+
+- The following cluster settings, which control rebalancing and upreplication behavior in the face of IO-overloaded storage, have been deprecated:
+  - `kv.allocator.l0_sublevels_threshold`
+  - `kv.allocator.l0_sublevels_threshold_enforce`
+  -
+  These cluster settings have been replaced by internal mechanisms. [#97142][#97142]
+
+- Max timeout-to-intent resolution has been added to prevent intent resolution from becoming stuck indefinitely and blocking other ranges attempting to resolve intents. [#91815][#91815]
+- Nodes are now considered suspect when re-joining a cluster and cannot accept lease transfers for one `server.time_after_store_suspect` window, which defaults to 30 seconds. [#97532][#97532]
+
+<h3 id="v23-1-0-alpha-5-command-line-changes">Command-line changes</h3>
+
+- The SQL shell (`cockroach sql`, `demo`) now supports the client-side commands `\l`, `\dn`, `\d`, `\di`, `\dm`, `\ds`, `\dt`, `\dv`, `\dC`, `\dT`, `\dd`, `\dg`, `\du` and `\dd` in a similar manner to PostgreSQL, including the modifier flags `S` and `+`, for convenience for users migrating from PostgreSQL. A notable difference is that when a pattern argument is specified, it should use the SQL `LIKE` syntax (with `%` representing the wildcard character) instead of PostgreSQL's glob-like syntax (with `*` representing wildcards). [#88061][#88061]
+
+<h3 id="v23-1-0-alpha-5-db-console-changes">DB Console changes</h3>
+
+- The following new metrics track memory usage of prepared statements in sessions:
+  - `sql.mem.internal.session.prepared.current`
+  - `sql.mem.internal.session.prepared.max-avg`
+  - `sql.mem.internal.session.prepared.max-count`
+  - `sql.mem.internal.session.prepared.max-max`
+  - `sql.mem.internal.session.prepared.max-p50`
+  - `sql.mem.internal.session.prepared.max-p75`
+  - `sql.mem.internal.session.prepared.max-p90`
+  - `sql.mem.internal.session.prepared.max-p99`
+  - `sql.mem.internal.session.prepared.max-p99.9`
+  - `sql.mem.internal.session.prepared.max-p99.99`
+  - `sql.mem.internal.session.prepared.max-p99.999`
+  - `sql.mem.sql.session.prepared.current`
+  - `sql.mem.sql.session.prepared.max-avg`
+  - `sql.mem.sql.session.prepared.max-count`
+  - `sql.mem.sql.session.prepared.max-max`
+  - `sql.mem.sql.session.prepared.max-p50`
+  - `sql.mem.sql.session.prepared.max-p75`
+  - `sql.mem.sql.session.prepared.max-p90`
+  - `sql.mem.sql.session.prepared.max-p99`
+  - `sql.mem.sql.session.prepared.max-p99.9`
+  - `sql.mem.sql.session.prepared.max-p99.99`
+  - `sql.mem.sql.session.prepared.max-p99.999`
+
+    [#97590][#97590]
+
+- Active execution information is now shown even when there is a max size limit error. [#97662][#97662]
+- "Retrying" is no longer a status shown in the Jobs page. [#97505][#97505]
+
+<h3 id="v23-1-0-alpha-5-bug-fixes">Bug fixes</h3>
+
+- Transaction uncertainty intervals are now correctly configured for reverse scans, to prevent reverse scans from serving stale reads when clocks in a cluster are skewed. [#97443][#97443]
+- The formatting of uniqueness violation errors now matches the corresponding errors from PostgreSQL. [#96914][#96914]
+- Fixed a bug in `ALTER TABLE ... ADD COLUMN` when the new column name requires quoting due to mixed case or special characters and the statement is not run in an explicit or multi-statement transaction. [#97514][#97514]
+- Fixed a bug when formatting `CREATE` statements for user-defined types which require quoting which might prevent those statements from round-tripping. [#97514][#97514]
+- Using subqueries in UDFs without an `AS` clause is now supported, for consistency with the syntax supported outside of UDFs. [#97515][#97515]
+- Fixed a rare bug existing since before v22.1.x that could cause a projected expression to replace column references with the wrong values. [#97554][#97554]
+- Cross-descriptor validation on lease renewal is now disabled, because it can starve schema changes when there are many descriptors with many foreign key references [#97630][#97630]
+- Fixed a bug with pagination on the Schema Insights page. [#97640][#97640]
+- Columns referenced in partial index predicates and partial unique constraint predicates can no longer be dropped. The `ALTER TABLE .. DROP COLUMN` statement now returns an error with a suggestion to drop the indexes and constraints first. This is a temporary safe-guard to prevent users from hitting [#96924][#96924]. This restriction will be lifted when that bug is fixed. [#97372][#97372]
+- Jobs page properly shows error state when we receive an error during data fetching. [#97486][#97486]
+- Fixed a bug introduced in v22.1 that caused the internal error "no bytes in account to release ...". [#97750][#97750]
+- The `COPY FROM` command now respects the `statement_timeout` and `transaction_timeout` cluster settings. [#97808][#97808]
+- `COPY FROM` commands now appears in the output of the `SHOW QUERIES` command. [#97808][#97808]
+- Fixed an error where querying a `pg_catalog` table included information about a temporary table created in another session. [#97727][#97727]
+
+<h3 id="v23-1-0-alpha-5-performance-improvements">Performance improvements</h3>
+
+- If the session setting `optimizer_use_improved_split_disjunction_for_joins` is `true`, the optimizer now creates a better query plan in some cases where an inner, semi, or anti join contains a join predicate with a disjuction (`OR` condition). [#97696][#97696]
+
+<h3 id="v23-1-0-alpha-5-miscellaneous">Miscellaneous</h3>
+
+- UDFs can now return the `RECORD` result type, which represents any tuple. For example, `CREATE FUNCTION f() RETURNS RECORD AS 'SELECT * FROM t' LANGUAGE SQL;` is equivalent to `CREATE FUNCTION f() RETURNS t AS 'SELECT * FROM t' LANGUAGE SQL;`. [#97199][#97199]
+- The parameters for delegated snapshots have been marked as non-public. [#97408][#97408]
+- Fixed an error when calling `CREATE OR REPLACE FUNCTION` with a user-defined return type if the UDT was modified after the original UDF was created. The command now succeeds as long as the function body returns output that matches the modified UDT. [#97274][#97274]
+
+<h4 id="v23-1-0-alpha-5-changes-without-release-note-annotation">Changes without release note annotation</h4>
+
+- Columns with referenced constraints can now be dropped. [#97579][#97579]
+- Index cascades with a dependent inbound foreign key can now be dropped. [#97065][#97065]
+
+<h3 id="v23-1-0-alpha-5-doc-updates">Doc updates</h3>
+
+{% comment %}Docs team: Please add these manually.{% endcomment %}
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-0-alpha-5-contributors">Contributors</h3>
+
+This release includes 120 merged PRs by 51 authors.
+We would like to thank the following contributors from the CockroachDB community:
+
+- Eric.Yang (first-time contributor)
+
+</div>
+
+[#88061]: https://github.com/cockroachdb/cockroach/pull/88061
+[#91815]: https://github.com/cockroachdb/cockroach/pull/91815
+[#92966]: https://github.com/cockroachdb/cockroach/pull/92966
+[#96350]: https://github.com/cockroachdb/cockroach/pull/96350
+[#96382]: https://github.com/cockroachdb/cockroach/pull/96382
+[#96914]: https://github.com/cockroachdb/cockroach/pull/96914
+[#97021]: https://github.com/cockroachdb/cockroach/pull/97021
+[#97065]: https://github.com/cockroachdb/cockroach/pull/97065
+[#97142]: https://github.com/cockroachdb/cockroach/pull/97142
+[#97148]: https://github.com/cockroachdb/cockroach/pull/97148
+[#97199]: https://github.com/cockroachdb/cockroach/pull/97199
+[#97226]: https://github.com/cockroachdb/cockroach/pull/97226
+[#97274]: https://github.com/cockroachdb/cockroach/pull/97274
+[#97372]: https://github.com/cockroachdb/cockroach/pull/97372
+[#97408]: https://github.com/cockroachdb/cockroach/pull/97408
+[#97429]: https://github.com/cockroachdb/cockroach/pull/97429
+[#97443]: https://github.com/cockroachdb/cockroach/pull/97443
+[#97486]: https://github.com/cockroachdb/cockroach/pull/97486
+[#97487]: https://github.com/cockroachdb/cockroach/pull/97487
+[#97501]: https://github.com/cockroachdb/cockroach/pull/97501
+[#97505]: https://github.com/cockroachdb/cockroach/pull/97505
+[#97514]: https://github.com/cockroachdb/cockroach/pull/97514
+[#97515]: https://github.com/cockroachdb/cockroach/pull/97515
+[#97532]: https://github.com/cockroachdb/cockroach/pull/97532
+[#97554]: https://github.com/cockroachdb/cockroach/pull/97554
+[#97579]: https://github.com/cockroachdb/cockroach/pull/97579
+[#97590]: https://github.com/cockroachdb/cockroach/pull/97590
+[#97630]: https://github.com/cockroachdb/cockroach/pull/97630
+[#97640]: https://github.com/cockroachdb/cockroach/pull/97640
+[#97642]: https://github.com/cockroachdb/cockroach/pull/97642
+[#97656]: https://github.com/cockroachdb/cockroach/pull/97656
+[#97662]: https://github.com/cockroachdb/cockroach/pull/97662
+[#97696]: https://github.com/cockroachdb/cockroach/pull/97696
+[#97727]: https://github.com/cockroachdb/cockroach/pull/97727
+[#97746]: https://github.com/cockroachdb/cockroach/pull/97746
+[#97750]: https://github.com/cockroachdb/cockroach/pull/97750
+[#97808]: https://github.com/cockroachdb/cockroach/pull/97808
+[8c6cf2877]: https://github.com/cockroachdb/cockroach/commit/8c6cf2877
+[a53a8d354]: https://github.com/cockroachdb/cockroach/commit/a53a8d354
+[f84bd02ae]: https://github.com/cockroachdb/cockroach/commit/f84bd02ae
+[#96924]: https://github.com/cockroachdb/cockroach/issue/97808

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -6,24 +6,23 @@ Release Date: March 6, 2023
 
 <h3 id="v23-1-0-alpha-5-security-updates">Security updates</h3>
 
-- The new cluster setting `server.user_login.downgrade_scram_stored_passwords_to_bcrypt.enabled`, which allows you to migrate passwords from SCRAM to bcrypt during user authentication, defaults to true. If it is true and if `server.user_login.password_encryption` is `crdb-bcrypt`, then during login, the stored hashed password will be migrated from SCRAM to bcrypt. [#97429][#97429]
+- The new [cluster setting](cluster-settings.html) `server.user_login.downgrade_scram_stored_passwords_to_bcrypt.enabled`, which allows you to migrate passwords from SCRAM to bcrypt during user authentication, defaults to `true`. If it is `true` and if `server.user_login.password_encryption` is `crdb-bcrypt`, then during login, the stored hashed password will be migrated from SCRAM to bcrypt. [#97429][#97429]
 
 <h3 id="v23-1-0-alpha-5-general-changes">General changes</h3>
 
-- Users with the `CONTROLJOB` role option can now view jobs owned by admins (ex. via `SHOW JOBS`). [#96382][#96382]
-- Users with the `VIEWJOB` role option can now view all jobs, such as by using the `SHOW JOBS` command. This role can be revoked by granting the `NOVIEWJOB` role. [#96382][#96382]
+- Users with the `CONTROLJOB` [role option](create-role.html#role-options) can now [view jobs](show-jobs.html) owned by admins. [#96382][#96382]
+- Users with the `VIEWJOB` [role option](create-role.html#role-options) can now [view all jobs](show-jobs.html). This role can be revoked by granting the `NOVIEWJOB` role option. [#96382][#96382]
 
 <h3 id="v23-1-0-alpha-5-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
 
-- Jobs that utilize protected timestamp system (such as `BACKUP`, `CHANGEFEED`, or `IMPORT` now produce metrics that can be monitored to detect cases when a job leaves a stale protected timestamp that will prevent garbage collection from occurring. [#97148][#97148]
-- Changefeeds now automatically expire PTS records for paused jobs if the changefeed is configured with the `gc_protect_expires_after` option. [#97148][#97148]
-- UDFs can now be referenced from column DEFAULT expressions when creating a new table or issuing the `SET DEFAULT` command. Backup and restore operations also back up and restore UDF IDs that are referenced in a column's DEFAULT expression. If UDF dependencies are missing and the `skip_missing_udfs` flag is provided, the DEFAULT expressions are dropped during a restore operation. [#97501][#97501]
-- Error messages related to `initial_scan_only`, such as "cannot specify both initial_scan_only and resolved", n0.ow substitute in "initial_scan='only'".[#97487][#97487]
+- Jobs that utilize a protected timestamp system (such as `BACKUP`, `CHANGEFEED`, or `IMPORT`) now produce metrics that can be monitored to detect cases when a job leaves a stale protected timestamp that will prevent garbage collection from occurring. [#97148][#97148]
+- [Changefeeds](create-changefeed.html) now automatically expire protected timestamp records for paused jobs if the changefeed is configured with the `gc_protect_expires_after` option. [#97148][#97148]
+- User-defined functions (UDFs) can now be referenced from column [`DEFAULT`](default-value.html) expressions when creating a new table or issuing the `SET DEFAULT` command. Backup and restore operations also back up and restore UDF IDs that are referenced in a column's DEFAULT expression. If UDF dependencies are missing and the `skip_missing_udfs` flag is provided, the `DEFAULT` expressions are dropped during a restore operation. [#97501][#97501]
 
 <h3 id="v23-1-0-alpha-5-sql-language-changes">SQL language changes</h3>
 
 - String literals are now allowed for region names in DDL syntax, in addition to quoted syntax. [#97021][#97021]
-- It is now possible to use `*` inside `CREATE VIEW`. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as PostgreSQL. [#97515][#97515]
+- It is now possible to use `*` inside a [`CREATE VIEW`](create-view.htm) statement. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as in PostgreSQL. [#97515][#97515]
 - The default value of `sql.stats.cleanup.rows_to_delete_per_txn` has been increased to 10k to increase efficiency of the cleanup job for SQL statistics. [#97642][#97642]
 - The new new session setting `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s` will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
 - Builtins have been added for `tsvector`, `to_tsquery`, `phraseto_tsquery`, `plainto_tsquery`, which parse input documents into tsvectors and tsqueries respectively. The new `ts_parse` builtin is used to debug the text search parser. [#92966][#92966]

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -6,32 +6,32 @@ Release Date: March 6, 2023
 
 <h3 id="v23-1-0-alpha-5-security-updates">Security updates</h3>
 
-- The new [cluster setting](cluster-settings.html) `server.user_login.downgrade_scram_stored_passwords_to_bcrypt.enabled`, which allows you to migrate passwords from SCRAM to bcrypt during user authentication, defaults to `true`. If it is `true` and if `server.user_login.password_encryption` is `crdb-bcrypt`, then during login, the stored hashed password will be migrated from SCRAM to bcrypt. [#97429][#97429]
+- The new [cluster setting](/docs/v23.1/cluster-settings.html) `server.user_login.downgrade_scram_stored_passwords_to_bcrypt.enabled`, which allows you to migrate passwords from SCRAM to bcrypt during user authentication, defaults to `true`. If it is `true` and if `server.user_login.password_encryption` is `crdb-bcrypt`, then during login, the stored hashed password will be migrated from SCRAM to bcrypt. [#97429][#97429]
 
 <h3 id="v23-1-0-alpha-5-general-changes">General changes</h3>
 
-- Users with the `CONTROLJOB` [role option](create-role.html#role-options) can now [view jobs](show-jobs.html) owned by admins. [#96382][#96382]
-- Users with the `VIEWJOB` [role option](create-role.html#role-options) can now [view all jobs](show-jobs.html). This role can be revoked by granting the `NOVIEWJOB` role option. [#96382][#96382]
+- Users with the `CONTROLJOB` [role option](/docs/v23.1/create-role.html#role-options) can now [view jobs](/docs/v23.1/show-jobs.html) owned by admins. [#96382][#96382]
+- Users with the `VIEWJOB` [role option](/docs/v23.1/create-role.html#role-options) can now [view all jobs](/docs/v23.1/show-jobs.html). This role can be revoked by granting the `NOVIEWJOB` role option. [#96382][#96382]
 
 <h3 id="v23-1-0-alpha-5-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
 
 - Jobs that utilize a protected timestamp system (such as `BACKUP`, `CHANGEFEED`, or `IMPORT`) now produce metrics that can be monitored to detect cases when a job leaves a stale protected timestamp that will prevent garbage collection from occurring. [#97148][#97148]
-- [Changefeeds](create-changefeed.html) now automatically expire protected timestamp records for paused jobs if the changefeed is configured with the `gc_protect_expires_after` option. [#97148][#97148]
-- User-defined functions (UDFs) can now be referenced from column [`DEFAULT`](default-value.html) expressions when creating a new table or issuing the `SET DEFAULT` command. Backup and restore operations also back up and restore UDF IDs that are referenced in a column's DEFAULT expression. If UDF dependencies are missing and the `skip_missing_udfs` flag is provided, the `DEFAULT` expressions are dropped during a restore operation. [#97501][#97501]
+- [Changefeeds](/docs/v23.1/create-changefeed.html) now automatically expire protected timestamp records for paused jobs if the changefeed is configured with the `gc_protect_expires_after` option. [#97148][#97148]
+- User-defined functions (UDFs) can now be referenced from column [`DEFAULT`](/docs/v23.1/default-value.html) expressions when creating a new table or issuing the `SET DEFAULT` command. Backup and restore operations also back up and restore UDF IDs that are referenced in a column's DEFAULT expression. If UDF dependencies are missing and the `skip_missing_udfs` flag is provided, the `DEFAULT` expressions are dropped during a restore operation. [#97501][#97501]
 
 <h3 id="v23-1-0-alpha-5-sql-language-changes">SQL language changes</h3>
 
 - String literals are now allowed for region names in DDL syntax, in addition to quoted syntax. [#97021][#97021]
-- It is now possible to use `*` inside a [`CREATE VIEW`](create-view.html) statement. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as in PostgreSQL. [#97515][#97515]
+- It is now possible to use `*` inside a [`CREATE VIEW`](/docs/v23.1/create-view.html) statement. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as in PostgreSQL. [#97515][#97515]
 - The default value of `sql.stats.cleanup.rows_to_delete_per_txn` has been increased to `10000` to increase efficiency of the cleanup job for SQL statistics. [#97642][#97642]
-- The new [session setting](set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
+- The new [session setting](/docs/v23.1/set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
 - Builtins have been added for `tsvector`, `to_tsquery`, `phraseto_tsquery`, and `plainto_tsquery`, which parse input documents into tsvectors and tsqueries, respectively. The new `ts_parse` builtin is used to debug the text search parser. [#92966][#92966]
-- The new [session variable](set-vars.html) `inject_retry_errors_on_commit_enabled` returns a [transaction retry error](transaction-retry-error-reference.html) if it is run inside of an explicit transaction when it is set to `true`. The transaction retry error continues to be returned until `inject_retry_errors_on_commit_enabled` is set to `false`. This setting allows you to test your transaction retry logic. [#97226][#97226]
-- Previously, [`ADD PRIMARY KEY NOT VALID`](primary-key.html) ignored the `NOT VALID` qualifier. This behavior was not compatible with PostgreSQL. CockroachDB now throws the error `PRIMARY KEY constraints cannot be marked NOT VALID`. [#97746][#97746]
+- The new [session variable](/docs/v23.1/set-vars.html) `inject_retry_errors_on_commit_enabled` returns a [transaction retry error](/docs/v23.1/transaction-retry-error-reference.html) if it is run inside of an explicit transaction when it is set to `true`. The transaction retry error continues to be returned until `inject_retry_errors_on_commit_enabled` is set to `false`. This setting allows you to test your transaction retry logic. [#97226][#97226]
+- Previously, [`ADD PRIMARY KEY NOT VALID`](/docs/v23.1/primary-key.html) ignored the `NOT VALID` qualifier. This behavior was not compatible with PostgreSQL. CockroachDB now throws the error `PRIMARY KEY constraints cannot be marked NOT VALID`. [#97746][#97746]
 
 <h3 id="v23-1-0-alpha-5-operational-changes">Operational changes</h3>
 
-- The following [cluster settings](cluster-settings.html), which control rebalancing and upreplication behavior in the face of IO-overloaded storage, have been deprecated:
+- The following [cluster settings](/docs/v23.1/cluster-settings.html), which control rebalancing and upreplication behavior in the face of IO-overloaded storage, have been deprecated:
   - `kv.allocator.l0_sublevels_threshold`
   - `kv.allocator.l0_sublevels_threshold_enforce`
   -
@@ -42,7 +42,7 @@ Release Date: March 6, 2023
 
 <h3 id="v23-1-0-alpha-5-command-line-changes">Command-line changes</h3>
 
-- The SQL shell ([`cockroach sql`](cockroach-sql.html), [`cockroach demo`](cockroach-demo.html)) now supports the client-side commands `\l`, `\dn`, `\d`, `\di`, `\dm`, `\ds`, `\dt`, `\dv`, `\dC`, `\dT`, `\dd`, `\dg`, `\du` and `\dd` in a similar manner to PostgreSQL, including the modifier flags `S` and `+`, for convenience for users migrating from PostgreSQL. A notable difference is that when a pattern argument is specified, it should use the SQL `LIKE` syntax (with `%` representing the wildcard character) instead of PostgreSQL's glob-like syntax (with `*` representing wildcards). [#88061][#88061]
+- The SQL shell ([`cockroach sql`](/docs/v23.1/cockroach-sql.html), [`cockroach demo`](/docs/v23.1/cockroach-demo.html)) now supports the client-side commands `\l`, `\dn`, `\d`, `\di`, `\dm`, `\ds`, `\dt`, `\dv`, `\dC`, `\dT`, `\dd`, `\dg`, `\du` and `\dd` in a similar manner to PostgreSQL, including the modifier flags `S` and `+`, for convenience for users migrating from PostgreSQL. A notable difference is that when a pattern argument is specified, it should use the SQL `LIKE` syntax (with `%` representing the wildcard character) instead of PostgreSQL's glob-like syntax (with `*` representing wildcards). [#88061][#88061]
 
 <h3 id="v23-1-0-alpha-5-db-console-changes">DB Console changes</h3>
 
@@ -73,41 +73,36 @@ Release Date: March 6, 2023
     [#97590][#97590]
 
 - Active execution information is now shown on the SQL Activity page even when there is a max size limit error. [#97662][#97662]
-- "Retrying" is no longer a status shown in the [Jobs](ui-jobs-page.html) page. [#97505][#97505]
+- "Retrying" is no longer a status shown in the [Jobs](/docs/v23.1/ui-jobs-page.html) page. [#97505][#97505]
 
 <h3 id="v23-1-0-alpha-5-bug-fixes">Bug fixes</h3>
 
 - Transaction uncertainty intervals are now correctly configured for reverse scans, to prevent reverse scans from serving stale reads when clocks in a cluster are skewed. [#97443][#97443]
 - The formatting of uniqueness violation errors now matches the corresponding errors from PostgreSQL. [#96914][#96914]
-- Previously, when a new column name would require quoting due to mixed-case or special characters, [`ALTER TABLE ... ADD COLUMN`](alter-table.html#add-column) would not run in an explicit or multi-statement transaction. This is now fixed. [#97514][#97514]
-- Fixed a bug when formatting [`CREATE TYPE` statements for user-defined types](create-type.html) which require quoting which might prevent those statements from round-tripping. [#97514][#97514]
-- Using subqueries in UDFs without an `AS` clause is now supported, for consistency with the syntax supported outside of UDFs. [#97515][#97515]
-- Fixed a rare bug existing since before v22.1.x that could cause a projected expression to replace column references with the wrong values. [#97554][#97554]
-- Cross-descriptor validation on lease renewal is now disabled, because it can starve [online schema changes](online-schema-changes.html) when there are many descriptors with many foreign key references. [#97630][#97630]
-- Fixed a bug with pagination on the [Insights](ui-insights-page.html) page. [#97640][#97640]
-- Columns referenced in partial index predicates and partial unique constraint predicates can no longer be dropped. The [`ALTER TABLE .. DROP COLUMN`](alter-table.html#drop-column) statement now returns an error with a suggestion to drop the indexes and constraints first. This is a temporary safeguard to prevent users from hitting [#96924][#96924]. This restriction will be lifted when that bug is fixed. [#97372][#97372]
-- The [Jobs](/ui-jobs-page.html) page now displays an error state when an error is encountered during data fetching. [#97486][#97486]
+- Previously, when a new column name would require quoting due to mixed-case or special characters, [`ALTER TABLE ... ADD COLUMN`](/docs/v23.1/alter-table.html#add-column) would not run in an explicit or multi-statement transaction. This is now fixed. [#97514][#97514]
+- Fixed a bug when formatting [`CREATE TYPE` statements for user-defined types](/docs/v23.1/create-type.html) which require quoting which might prevent those statements from round-tripping. [#97514][#97514]
+- Using subqueries in user-defined functions without an `AS` clause is now supported, for consistency with the syntax supported outside of user-defined functions. [#97515][#97515]
+- Fixed a rare bug introduced before v22.1.x that could cause a projected expression to replace column references with the wrong values. [#97554][#97554]
+- Cross-descriptor validation on lease renewal is now disabled, because it can starve [online schema changes](/docs/v23.1/online-schema-changes.html) when there are many descriptors with many foreign key references. [#97630][#97630]
+- Fixed a bug with pagination on the [Insights](/docs/v23.1/ui-insights-page.html) page. [#97640][#97640]
+- Columns referenced in partial index predicates and partial unique constraint predicates can no longer be dropped. The [`ALTER TABLE .. DROP COLUMN`](/docs/v23.1/alter-table.html#drop-column) statement now returns an error with a suggestion to drop the indexes and constraints first. This is a temporary safeguard to prevent users from hitting [#96924][#96924]. This restriction will be lifted when that bug is fixed. [#97372][#97372]
+- The [Jobs](/docs/v23.1/ui-jobs-page.html) page now displays an error state when an error is encountered during data fetching. [#97486][#97486]
 - Fixed a bug introduced in v22.1 that caused the internal error `no bytes in account to release ...`. [#97750][#97750]
-- The [`COPY FROM`](copy-from.html) command now respects the `statement_timeout` and `transaction_timeout` [cluster settings](cluster-settings.html). [#97808][#97808]
-- [`COPY FROM`](copy-from.html) commands now appear in the output of the [`SHOW STATEMENTS`](show-statements.html) command. [#97808][#97808]
+- The [`COPY FROM`](/docs/v23.1/copy-from.html) command now respects the `statement_timeout` and `transaction_timeout` [cluster settings](/docs/v23.1/cluster-settings.html). [#97808][#97808]
+- [`COPY FROM`](/docs/v23.1/copy-from.html) commands now appear in the output of the [`SHOW STATEMENTS`](/docs/v23.1/show-statements.html) command. [#97808][#97808]
 - Fixed an error where querying a `pg_catalog` table included information about a temporary table created in another session. [#97727][#97727]
 
 <h3 id="v23-1-0-alpha-5-performance-improvements">Performance improvements</h3>
 
-- If the [session setting](set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` is `true`, the optimizer now creates a better query plan in some cases where an inner, semi, or anti join contains a join predicate with a disjuction (`OR` condition). [#97696][#97696]
+- If the [session setting](/docs/v23.1/set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` is `true`, the optimizer now creates a better query plan in some cases where an inner, semi, or anti join contains a join predicate with a disjuction (`OR` condition). [#97696][#97696]
 
 <h3 id="v23-1-0-alpha-5-miscellaneous">Miscellaneous</h3>
 
 - UDFs can now return the `RECORD` result type, which represents any tuple. For example, `CREATE FUNCTION f() RETURNS RECORD AS 'SELECT * FROM t' LANGUAGE SQL;` is equivalent to `CREATE FUNCTION f() RETURNS t AS 'SELECT * FROM t' LANGUAGE SQL;`. [#97199][#97199]
-- The parameters for [delegated snapshots](replication-layer.html#snapshots) have been marked as internal. [#97408][#97408]
-- Fixed an error when calling [`CREATE OR REPLACE FUNCTION`](create-function.html) with a [user-defined return type](create-type.html) if the user-defined type was modified after the original [user-defined function](create-function.html) was created. The command now succeeds as long as the function body returns output that matches the modified user-defined type. [#97274][#97274]
-
-<h4 id="v23-1-0-alpha-5-changes-without-release-note-annotation">Changes without release note annotation</h4>
-
+- The parameters for [delegated snapshots](/docs/v23.1/architecture/replication-layer.html#snapshots) have been marked as internal. [#97408][#97408]
+- Fixed an error when calling [`CREATE OR REPLACE FUNCTION`](/docs/v23.1/create-function.html) with a [user-defined return type](/docs/v23.1/create-type.html) if the user-defined type was modified after the original [user-defined function](/docs/v23.1/create-function.html) was created. The command now succeeds as long as the function body returns output that matches the modified user-defined type. [#97274][#97274]
 - Columns with referenced constraints can now be dropped. [#97579][#97579]
 - Index cascades with a dependent inbound foreign key can now be dropped. [#97065][#97065]
-
-
 
 <div class="release-note-contributors" markdown="1">
 

--- a/_includes/releases/v23.1/v23.1.0-alpha.5.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.5.md
@@ -23,26 +23,26 @@ Release Date: March 6, 2023
 
 - String literals are now allowed for region names in DDL syntax, in addition to quoted syntax. [#97021][#97021]
 - It is now possible to use `*` inside a [`CREATE VIEW`](create-view.htm) statement. The list of columns is expanded at the time the view is created, so that new columns added after the view was defined are not included in the view. This behavior is the same as in PostgreSQL. [#97515][#97515]
-- The default value of `sql.stats.cleanup.rows_to_delete_per_txn` has been increased to 10k to increase efficiency of the cleanup job for SQL statistics. [#97642][#97642]
-- The new new session setting `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s` will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
-- Builtins have been added for `tsvector`, `to_tsquery`, `phraseto_tsquery`, `plainto_tsquery`, which parse input documents into tsvectors and tsqueries respectively. The new `ts_parse` builtin is used to debug the text search parser. [#92966][#92966]
-- The new session variable `inject_retry_errors_on_commit_enabled` returns a transaction retry error if it is run inside of an explicit transaction when it is set to `true`. The transaction retry error continues to be returned until `inject_retry_errors_on_commit_enabled` is set to `false`. This setting allows developers to test their transaction retry logic. [#97226][#97226]
-- Previously, `ADD PRIMARY KEY NOT VALID` ignored the `NOT VALID` qualifier. This behavior was not compatible with PostgreSQL. CockroachDB now throws the error `PRIMARY KEY constraints cannot be marked NOT VALID`. [#97746][#97746]
+- The default value of `sql.stats.cleanup.rows_to_delete_per_txn` has been increased to `10000` to increase efficiency of the cleanup job for SQL statistics. [#97642][#97642]
+- The new [session setting](set-vars.html) `optimizer_use_improved_split_disjunction_for_joins` allows the optimizer to split disjunctions (`OR` expressions) in more `JOIN` conditions by building a `UNION` of two `JOIN` expressions. If this setting is true, all disjunctions in inner, semi, and anti `JOIN`s will be split. Otherwise, only disjunctions that potentially contain an equijoin condition will be split. [#97696][#97696]
+- Builtins have been added for `tsvector`, `to_tsquery`, `phraseto_tsquery`, and `plainto_tsquery`, which parse input documents into tsvectors and tsqueries, respectively. The new `ts_parse` builtin is used to debug the text search parser. [#92966][#92966]
+- The new [session variable](set-vars.html) `inject_retry_errors_on_commit_enabled` returns a [transaction retry error](transaction-retry-error-reference.html) if it is run inside of an explicit transaction when it is set to `true`. The transaction retry error continues to be returned until `inject_retry_errors_on_commit_enabled` is set to `false`. This setting allows you to test your transaction retry logic. [#97226][#97226]
+- Previously, [`ADD PRIMARY KEY NOT VALID`](primary-key.html) ignored the `NOT VALID` qualifier. This behavior was not compatible with PostgreSQL. CockroachDB now throws the error `PRIMARY KEY constraints cannot be marked NOT VALID`. [#97746][#97746]
 
 <h3 id="v23-1-0-alpha-5-operational-changes">Operational changes</h3>
 
-- The following cluster settings, which control rebalancing and upreplication behavior in the face of IO-overloaded storage, have been deprecated:
+- The following [cluster settings](cluster-settings.html), which control rebalancing and upreplication behavior in the face of IO-overloaded storage, have been deprecated:
   - `kv.allocator.l0_sublevels_threshold`
   - `kv.allocator.l0_sublevels_threshold_enforce`
   -
   These cluster settings have been replaced by internal mechanisms. [#97142][#97142]
 
 - Max timeout-to-intent resolution has been added to prevent intent resolution from becoming stuck indefinitely and blocking other ranges attempting to resolve intents. [#91815][#91815]
-- Nodes are now considered suspect when re-joining a cluster and cannot accept lease transfers for one `server.time_after_store_suspect` window, which defaults to 30 seconds. [#97532][#97532]
+- Nodes are now considered suspect when rejoining a cluster and cannot accept lease transfers for one `server.time_after_store_suspect` window, which defaults to 30 seconds. [#97532][#97532]
 
 <h3 id="v23-1-0-alpha-5-command-line-changes">Command-line changes</h3>
 
-- The SQL shell (`cockroach sql`, `demo`) now supports the client-side commands `\l`, `\dn`, `\d`, `\di`, `\dm`, `\ds`, `\dt`, `\dv`, `\dC`, `\dT`, `\dd`, `\dg`, `\du` and `\dd` in a similar manner to PostgreSQL, including the modifier flags `S` and `+`, for convenience for users migrating from PostgreSQL. A notable difference is that when a pattern argument is specified, it should use the SQL `LIKE` syntax (with `%` representing the wildcard character) instead of PostgreSQL's glob-like syntax (with `*` representing wildcards). [#88061][#88061]
+- The SQL shell ([`cockroach sql`](cockroach-sql.html), [`cockroach demo`](cockroach-demo.html)) now supports the client-side commands `\l`, `\dn`, `\d`, `\di`, `\dm`, `\ds`, `\dt`, `\dv`, `\dC`, `\dT`, `\dd`, `\dg`, `\du` and `\dd` in a similar manner to PostgreSQL, including the modifier flags `S` and `+`, for convenience for users migrating from PostgreSQL. A notable difference is that when a pattern argument is specified, it should use the SQL `LIKE` syntax (with `%` representing the wildcard character) instead of PostgreSQL's glob-like syntax (with `*` representing wildcards). [#88061][#88061]
 
 <h3 id="v23-1-0-alpha-5-db-console-changes">DB Console changes</h3>
 
@@ -72,8 +72,8 @@ Release Date: March 6, 2023
 
     [#97590][#97590]
 
-- Active execution information is now shown even when there is a max size limit error. [#97662][#97662]
-- "Retrying" is no longer a status shown in the Jobs page. [#97505][#97505]
+- Active execution information is now shown on the SQL Activity page even when there is a max size limit error. [#97662][#97662]
+- "Retrying" is no longer a status shown in the [Jobs](ui-jobs-page.html) page. [#97505][#97505]
 
 <h3 id="v23-1-0-alpha-5-bug-fixes">Bug fixes</h3>
 


### PR DESCRIPTION
[DOC-7137] Release notes for v23.1.0-alpha.5
Ref: https://cockroachlabs.slack.com/archives/C04E562A58F/p1677692194695609

## Previews
[releases/v23.1.md](https://deploy-preview-16422--cockroachdb-docs.netlify.app/docs/releases/v23.1.html#v23-1-0-alpha-5)

## Tests
- [x] Local build
- [x] Linkcheck 