### PR TITLE
DOC-6840 DB Console stale capacity

### DIFF
--- a/v23.1/ui-cluster-overview-page.md
+++ b/v23.1/ui-cluster-overview-page.md
@@ -37,6 +37,8 @@ Usable disk space is constrained by the following:
 
 The DB Console thus calculates **usable** disk space as the sum of empty disk space, up to the value of the maximum store size, and disk space that is already being **used** by CockroachDB data.
 
+If a node is currently unavailable, the last-known capacity usage will be shown, and noted as stale.
+
 {{site.data.alerts.callout_info}}
 {% include {{ page.version.version }}/misc/available-capacity-metric.md %}
 {{site.data.alerts.end}}


### PR DESCRIPTION
Addresses: DOC-6840

- Adds brief mention that unavailable nodes will show stale (last-known) values for capacity on the **Cluster Overview** page.

Staging

[ui-cluster-overview-page.md](https://deploy-preview-16442--cockroachdb-docs.netlify.app/docs/dev/ui-cluster-overview-page.html#capacity-metrics)