### PR TITLE
DOC-6692 index stmt fingerprint admin only

### DIFF
--- a/_includes/v23.1/ui/index-details.md
+++ b/_includes/v23.1/ui/index-details.md
@@ -14,7 +14,7 @@ The following information is displayed for each index:
 | Index Recommendations | A recommendation to drop the index if it is unused.                   |
 
 {% if page.cloud != true %}
-Click an **index name** to view index details. The index details page displays the query used to create the index, the number of times the index was read since index statistics were reset, the time the index was last read, and the reason for the index recommendation.
+Click an **index name** to view index details. The index details page displays the query used to create the index, the number of times the index was read since index statistics were reset, the time the index was last read, and the reason for the index recommendation. [Admin users](security-reference/authorization.html#admin-role) also see a list of executed statement fingerprints using the index.
 {% endif %}
 
 ## Grants view


### PR DESCRIPTION
Addresses: DOC-6692

- Adds new sentence to index details section on **Databases** page that appraises user of visibility into executed statement fingerprints which have used the selected index, and also that such visibility is limited to admin users only.

Staging

[v23.1/ui-databases-page](https://deploy-preview-16460--cockroachdb-docs.netlify.app/docs/v23.1/ui-databases-page#index-details)