### PR TITLE
DOC-6649, DOC-6650 show grants column names fix

### DIFF
--- a/v22.2/show-grants.md
+++ b/v22.2/show-grants.md
@@ -52,7 +52,7 @@ Field            | Description
 `schema_name`    | The name of the schema.
 `table_name`     | The name of the table.
 `type_name`      | The name of the user-defined type.
-`name`           | The name of the external connection.
+`connection_name`| The name of the external connection.
 `grantee`        | The name of the user or role that was granted the [privilege](security-reference/authorization.html#managing-privileges).
 `privilege_type` | The name of the privilege.
 `is_grantable`   | `TRUE` if the grantee has the grant option on the object; `FALSE` if not.
@@ -359,13 +359,13 @@ SHOW GRANTS ON EXTERNAL CONNECTION my_backup_bucket;
 ~~~
 
 ~~~
-  name              |  grantee  | privilege | grantable
---------------------+-----------+-----------+------------
-  my_backup_bucket  | alice     | DROP      |     t
-  my_backup_bucket  | alice     | USAGE     |     t
-  my_backup_bucket  | max       | DROP      |     f
-  my_backup_bucket  | max       | USAGE     |     f
-  my_backup_bucket  | root      | ALL       |     f
+  connection_name   |  grantee  | privilege_type | is_grantable
+--------------------+-----------+----------------+-------------
+  my_backup_bucket  | alice     | DROP           |     t
+  my_backup_bucket  | alice     | USAGE          |     t
+  my_backup_bucket  | max       | DROP           |     f
+  my_backup_bucket  | max       | USAGE          |     f
+  my_backup_bucket  | root      | ALL            |     f
 (5 rows)
 ~~~
 
@@ -379,10 +379,10 @@ SHOW GRANTS ON EXTERNAL CONNECTION my_backup_bucket FOR alice;
 ~~~
 
 ~~~
-  name              |  grantee  | privilege | grantable
---------------------+-----------+-----------+------------
-  my_backup_bucket  | alice     | DROP      |     t
-  my_backup_bucket  | alice     | USAGE     |     t
+  connection_name   |  grantee  | privilege_type | is_grantable
+--------------------+-----------+----------------+-------------
+  my_backup_bucket  | alice     | DROP           |     t
+  my_backup_bucket  | alice     | USAGE          |     t
 (2 rows)
 ~~~
 

--- a/v22.2/show-system-grants.md
+++ b/v22.2/show-system-grants.md
@@ -31,7 +31,7 @@ The `SHOW SYSTEM GRANTS` statement returns the following fields:
 Field            | Description
 -----------------|-----------------------------------------------------------------------------------------------------
 `grantee`  | The name of the user.
-`privilege`  | The name of the [system privilege](security-reference/authorization.html#supported-privileges) granted to the user.
+`privilege_type`  | The name of the [system privilege](security-reference/authorization.html#supported-privileges) granted to the user.
 `is_grantable`   | `t` (true) if the user has the grant option on the object; `f` (false) if not.
 
 ## Required privileges
@@ -50,7 +50,7 @@ To list all system grants for all users and roles:
 ~~~
 
 ~~~
-  grantee |      privilege       | is_grantable
+  grantee |    privilege_type    | is_grantable
 ----------+----------------------+---------------
   max     | VIEWACTIVITY         |      t
   max     | VIEWCLUSTERMETADATA  |      t
@@ -80,9 +80,9 @@ To list all system grants for a specific user or role:
 ~~~
 
 ~~~
-  grantee | privilege | is_grantable
-----------+-----------+---------------
-  max     | ALL       |      t
+  grantee | privilege_type | is_grantable
+----------+----------------+---------------
+  max     | ALL            |      t
 (1 row)
 ~~~
 

--- a/v23.1/show-grants.md
+++ b/v23.1/show-grants.md
@@ -52,7 +52,7 @@ Field            | Description
 `schema_name`    | The name of the schema.
 `table_name`     | The name of the table.
 `type_name`      | The name of the user-defined type.
-`name`           | The name of the external connection.
+`connection_name`| The name of the external connection.
 `grantee`        | The name of the user or role that was granted the [privilege](security-reference/authorization.html#managing-privileges).
 `privilege_type` | The name of the privilege.
 `is_grantable`   | `TRUE` if the grantee has the grant option on the object; `FALSE` if not.
@@ -359,13 +359,13 @@ SHOW GRANTS ON EXTERNAL CONNECTION my_backup_bucket;
 ~~~
 
 ~~~
-  name              |  grantee  | privilege | grantable
---------------------+-----------+-----------+------------
-  my_backup_bucket  | alice     | DROP      |     t
-  my_backup_bucket  | alice     | USAGE     |     t
-  my_backup_bucket  | max       | DROP      |     f
-  my_backup_bucket  | max       | USAGE     |     f
-  my_backup_bucket  | root      | ALL       |     f
+  connection_name   |  grantee  | privilege_type | is_grantable
+--------------------+-----------+----------------+-------------
+  my_backup_bucket  | alice     | DROP           |     t
+  my_backup_bucket  | alice     | USAGE          |     t
+  my_backup_bucket  | max       | DROP           |     f
+  my_backup_bucket  | max       | USAGE          |     f
+  my_backup_bucket  | root      | ALL            |     f
 (5 rows)
 ~~~
 
@@ -379,10 +379,10 @@ SHOW GRANTS ON EXTERNAL CONNECTION my_backup_bucket FOR alice;
 ~~~
 
 ~~~
-  name              |  grantee  | privilege | grantable
---------------------+-----------+-----------+------------
-  my_backup_bucket  | alice     | DROP      |     t
-  my_backup_bucket  | alice     | USAGE     |     t
+  connection_name   |  grantee  | privilege_type | is_grantable
+--------------------+-----------+----------------+-------------
+  my_backup_bucket  | alice     | DROP           |     t
+  my_backup_bucket  | alice     | USAGE          |     t
 (2 rows)
 ~~~
 

--- a/v23.1/show-system-grants.md
+++ b/v23.1/show-system-grants.md
@@ -31,7 +31,7 @@ The `SHOW SYSTEM GRANTS` statement returns the following fields:
 Field            | Description
 -----------------|-----------------------------------------------------------------------------------------------------
 `grantee`  | The name of the user.
-`privilege`  | The name of the [system privilege](security-reference/authorization.html#supported-privileges) granted to the user.
+`privilege_type`  | The name of the [system privilege](security-reference/authorization.html#supported-privileges) granted to the user.
 `is_grantable`   | `t` (true) if the user has the grant option on the object; `f` (false) if not.
 
 ## Required privileges
@@ -50,7 +50,7 @@ To list all system grants for all users and roles:
 ~~~
 
 ~~~
-  grantee |      privilege       | is_grantable
+  grantee |    privilege_type    | is_grantable
 ----------+----------------------+---------------
   max     | VIEWACTIVITY         |      t
   max     | VIEWCLUSTERMETADATA  |      t
@@ -80,9 +80,9 @@ To list all system grants for a specific user or role:
 ~~~
 
 ~~~
-  grantee | privilege | is_grantable
-----------+-----------+---------------
-  max     | ALL       |      t
+  grantee | privilege_type | is_grantable
+----------+----------------+---------------
+  max     | ALL            |      t
 (1 row)
 ~~~
 


### PR DESCRIPTION
Addresses: DOC-6649, DOC-6650

- Adjusts column names for `SHOW GRANTS ON EXTERNAL CONNECTION` for v23.1 and v22.2 as follows:
	- `name` --> `connection_name`
	- `privilege` --> `privilege_type`
	- `grantable` --> `is_grantable`
- Adjusts column name for `SHOW SYSTEM GRANTS` for v23.1 and v22.2 as follows:
	- `privilege` --> `privilege_type`

Staging

- [v23.1/show-system-grants.md](https://deploy-preview-16461--cockroachdb-docs.netlify.app/docs/dev/show-system-grants.html#privilege-grants) | [v22.2/show-system-grants.md](https://deploy-preview-16461--cockroachdb-docs.netlify.app/docs/stable/show-system-grants.html#privilege-grants)
- [v23.1/show-grants.md ](https://deploy-preview-16461--cockroachdb-docs.netlify.app/docs/dev/show-grants.html#privilege-grants)| [v22.2/show-grants.md](https://deploy-preview-16461--cockroachdb-docs.netlify.app/docs/stable/show-grants.html#privilege-grants)