### PR TITLE
Silence deprecation warnings for SASS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :jekyll_plugins do
     gem 'jekyll-remote-include', github: 'ianjevans/jekyll-remote-include', tag: 'v1.1.7'
     gem "jekyll-last-modified-at"
     gem "jekyll-get-json"
+    gem 'jekyll-sass-converter', '~> 3.0'
   end

--- a/_config_base.yml
+++ b/_config_base.yml
@@ -147,6 +147,7 @@ release_info:
     start_time: 2023-03-06 10:55:32.149776 +0000 UTC
     version: v23.1.0-alpha.5
 sass:
+  quiet_deps: true
   sass_dir: css
   style: compressed
 site_title: CockroachDB Docs


### PR DESCRIPTION
Also add a locked-in version for the jekyll-sass-converter