### PR TITLE
Link fix

### DIFF
--- a/cockroachcloud/serverless-cluster-management.md
+++ b/cockroachcloud/serverless-cluster-management.md
@@ -53,7 +53,7 @@ The monthly cost estimate is calculated using simple extrapolation that assumes 
 
 ## Edit your spend limit
 
-You can edit your spend limit from the **Overview** page. The change in your spend limit will affect current and upcoming billing cycles. See [Planning your cluster](plan-your-cluster.html) for more information on resource usage.
+You can edit your spend limit from the **Overview** page. The change in your spend limit will affect current and upcoming billing cycles. See [Learn about {{ site.data.products.serverless }} Pricing](learn-about-pricing.html) for more information on resource usage.
 
 1. Navigate to the **Overview** page for the cluster you want to edit.
 1. Click the pencil icon (or **Add a spend limit** if you haven't set one before) next to your **Spend limit** in the **Usage this month** section.


### PR DESCRIPTION
DOC-7167
"Planning your cluster" was for dedicated, not serverless. updated to correct page.