### PR TITLE
Free tier early changes

### DIFF
--- a/_includes/cockroachcloud/quickstart/create-a-free-cluster.md
+++ b/_includes/cockroachcloud/quickstart/create-a-free-cluster.md
@@ -3,7 +3,7 @@
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select **Serverless**.
 
-    Unless you change your monthly budget, this cluster will be free forever.
+    Unless you change your monthly budget, this cluster will be free.
 
 1. Click **Create cluster**.
 

--- a/_includes/v21.2/setup/create-a-free-cluster.md
+++ b/_includes/v21.2/setup/create-a-free-cluster.md
@@ -3,7 +3,7 @@
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select **Serverless**.
 
-    Unless you change your monthly budget, this cluster will be free forever.
+    Unless you change your monthly budget, this cluster will be free.
 
 1. Click **Create cluster**.
 

--- a/_includes/v22.1/setup/create-a-free-cluster.md
+++ b/_includes/v22.1/setup/create-a-free-cluster.md
@@ -3,7 +3,7 @@
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select **Serverless**.
 
-    Unless you change your monthly budget, this cluster will be free forever.
+    Unless you change your monthly budget, this cluster will be free.
 
 1. Click **Create cluster**.
 

--- a/_includes/v22.2/setup/create-a-free-cluster.md
+++ b/_includes/v22.2/setup/create-a-free-cluster.md
@@ -3,7 +3,7 @@
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select **Serverless**.
 
-    Unless you change your monthly budget, this cluster will be free forever.
+    Unless you change your monthly budget, this cluster will be free.
 
 1. Click **Create cluster**.
 

--- a/_includes/v23.1/setup/create-a-free-cluster.md
+++ b/_includes/v23.1/setup/create-a-free-cluster.md
@@ -3,7 +3,7 @@
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select **Serverless**.
 
-    Unless you change your monthly budget, this cluster will be free forever.
+    Unless you change your monthly budget, this cluster will be free.
 
 1. Click **Create cluster**.
 

--- a/cockroachcloud/architecture.md
+++ b/cockroachcloud/architecture.md
@@ -62,7 +62,7 @@ Finally, the SQL pods communicate with the KV layer to access data managed by th
 
 #### Baseline
 
-Baseline performance for a Serverless cluster is 100 [Request Units](learn-about-request-units.html), or RUs, per second, and any usage above that is called [burst performance](#cockroachdb-cloud-terms). Clusters start with 10M RUs of free burst capacity each month and earn 100 RUs per second up to a maximum of 250M free RUs per month. Earned RUs can be used immediately or accumulated as burst capacity. If you use all of your burst capacity, your cluster will revert to baseline performance.
+Baseline performance for a Serverless cluster is 100 [Request Units](learn-about-request-units.html), or RUs, per second, and any usage above that is called [burst performance](#cockroachdb-cloud-terms). Clusters start with 10M RUs of free burst capacity each month and earn 100 RUs per second up to a maximum of 50M free RUs per month. Earned RUs can be used immediately or accumulated as burst capacity. If you use all of your burst capacity, your cluster will revert to baseline performance.
 
 The following diagram shows how RUs are accumulated and consumed:
 

--- a/cockroachcloud/create-a-serverless-cluster.md
+++ b/cockroachcloud/create-a-serverless-cluster.md
@@ -34,15 +34,11 @@ You do not need an account with the cloud provider you choose in order to create
 
 ## Step 3. Enter a spend limit
 
-Every cluster starts with 10M RUs of free [burst capacity](architecture.html#cockroachdb-cloud-terms) each month and earns 100 RUs per second up to a maximum of 250M free RUs per month. Earned RUs can be used immediately or accumulated as burst capacity. If you use all of your burst capacity, your cluster will revert to baseline performance.
+Every cluster starts with 10M RUs of free [burst capacity](architecture.html#cockroachdb-cloud-terms) each month and earns 100 RUs per second up to a maximum of 50M free RUs per month. Earned RUs can be used immediately or accumulated as burst capacity. If you use all of your burst capacity, your cluster will revert to baseline performance.
 
 If you set a spend limit, your cluster will not be throttled to baseline performance once you use all of your free earned RUs. Instead, it will continue to use burst performance as needed until you reach your spend limit. You will only be charged for the resources you use up to your spend limit. If you reach your spend limit, your cluster will revert to the baseline performance of 100 RUs per second.
 
 {% include cockroachcloud/serverless-usage.md %} For more information, see [Planning your cluster](plan-your-cluster.html).
-
-{{site.data.alerts.callout_info}}
-Regardless of whether you set a spend limit, [adding billing information](billing-management.html) for your organization allows you to use [cloud storage for backups](take-and-restore-customer-owned-backups.html). Organizations without billing information are limited to [using `userfile` storage for bulk operations](take-and-restore-customer-owned-backups.html).
-{{site.data.alerts.end}}
 
 <div class="filters clearfix">
   <button class="filter-button page-level" data-scope="free">Free</button>

--- a/cockroachcloud/learn-about-pricing.md
+++ b/cockroachcloud/learn-about-pricing.md
@@ -15,8 +15,8 @@ RU and storage consumption is prorated at the following prices:
 
   Unit                    | Cost
   ------------------------|------
-  10M Request Units       | $1.00
-  1 GiB storage per month | $1.00
+  1M Request Units        | $0.20
+  1 GiB storage           | $0.50
 
 ## Choosing a spend limit
 
@@ -30,7 +30,7 @@ All [Console Admins](console-access-management.html#console-admin) will receive 
 
 ## Free vs. paid usage
 
-{{ site.data.products.serverless }} clusters scale based on your workload. Baseline performance for a Serverless cluster is 100 RUs per second, and any usage above that is called [burst performance](architecture.html#cockroachdb-cloud-terms). Clusters start with 10M RUs of free burst capacity each month and earn 100 RUs per second up to a maximum of 250M free RUs per month. Earned RUs can be used immediately or accumulated as burst capacity. If you use all of your burst capacity, your cluster will revert to baseline performance.
+{{ site.data.products.serverless }} clusters scale based on your workload. Baseline performance for a Serverless cluster is 100 RUs per second, and any usage above that is called [burst performance](architecture.html#cockroachdb-cloud-terms). Clusters start with 10M RUs of free burst capacity each month and earn 100 RUs per second up to a maximum of 50M free RUs per month. Earned RUs can be used immediately or accumulated as burst capacity. If you use all of your burst capacity, your cluster will revert to baseline performance.
 
 You can set your spend limit higher to maintain a high level of performance with larger workloads. If you have set a spend limit, you will get the equivalent number of RUs upfront each month as burst capacity, in addition to your free burst capacity. When you run out of all burst capacity, you will return to the baseline performance of 100 RUs per second.
 

--- a/cockroachcloud/serverless-faqs.md
+++ b/cockroachcloud/serverless-faqs.md
@@ -25,7 +25,7 @@ To get started with {{ site.data.products.serverless }}, <a href="https://cockro
 
 ### What are the usage limits of {{ site.data.products.serverless }}?
 
-Clusters start with 10M RUs of free burst capacity each month and earn 100 RUs per second up to a maximum of 250M free RUs per month. Earned RUs can be used immediately or accumulated. If you use all of your burst capacity and earned RUs, your cluster will revert to baseline performance.
+Clusters start with 10M RUs of free burst capacity each month and earn 100 RUs per second up to a maximum of 50M free RUs per month. Earned RUs can be used immediately or accumulated. If you use all of your burst capacity and earned RUs, your cluster will revert to baseline performance.
 
 If you set a spend limit, your cluster will not be throttled to baseline performance once you use all of your free earned RUs. Instead, it will continue to use burst performance as needed until you reach your spend limit. If you reach your spend limit, your cluster will revert to the baseline performance of 100 RUs per second.
 
@@ -37,7 +37,7 @@ With {{ site.data.products.serverless }}, you are charged for the storage and ac
 
 ### Do I have to pay for {{ site.data.products.serverless }}?
 
-No, you can create a {{ site.data.products.serverless }} cluster that is free forever. If you choose to set a spend limit for your cluster, you will only be charged for the resources you use up to your spend limit.
+No, you can create a {{ site.data.products.serverless }} cluster for free. If you choose to set a spend limit for your cluster, you will only be charged for the resources you use up to your spend limit.
 
 ### What regions are available for {{ site.data.products.serverless }} clusters?
 

--- a/cockroachcloud/take-and-restore-customer-owned-backups.md
+++ b/cockroachcloud/take-and-restore-customer-owned-backups.md
@@ -43,10 +43,6 @@ For information on `userfile` commands, visit the following pages:
 
 <section class="filter-content" markdown="1" data-scope="cloud">
 
-{{site.data.alerts.callout_info}}
-For {{ site.data.products.serverless }} clusters, you must have [billing information](billing-management.html) on file for your organization to have access to [cloud storage](../{{site.current_cloud_version}}/use-cloud-storage.html). If you don't have billing set up, [`userfile`](../{{site.current_cloud_version}}/use-userfile-storage.html) is your **only available storage option** for bulk operations. {{ site.data.products.dedicated }} users can run bulk operations with `userfile` or cloud storage.
-{{site.data.alerts.end}}
-
 The cloud storage examples on this page use Amazon S3 for demonstration purposes. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage](../{{site.current_cloud_version}}/use-cloud-storage.html).
 
 {% include cockroachcloud/backup-examples.md %}

--- a/cockroachcloud/use-managed-service-backups.md
+++ b/cockroachcloud/use-managed-service-backups.md
@@ -286,6 +286,6 @@ Find the cluster backup you want to restore, and click **Restore**.
 
 Performing a restore will cause your cluster to be unavailable for the duration of the restore. All current data is deleted, and the cluster will be restored to the state it was in at the time of the backup. There are no automatic incremental backups, and no automatic database or table level backups.
 
-You can [manage your own backups](take-and-restore-customer-owned-backups.html), including incremental, database, and table level backups. To perform manual backups, you must configure either a [`userfile`](take-and-restore-customer-owned-backups.html) location or a [cloud storage location](take-and-restore-customer-owned-backups.html?filters=cloud), which requires [billing information](billing-management.html) for your organization even if you don't set a spend limit. 
+You can [manage your own backups](take-and-restore-customer-owned-backups.html), including incremental, database, and table level backups. To perform manual backups, you must configure either a [`userfile`](take-and-restore-customer-owned-backups.html) location or a [cloud storage location](take-and-restore-customer-owned-backups.html?filters=cloud). 
 
 </section>

--- a/v21.2/choose-a-deployment-option.md
+++ b/v21.2/choose-a-deployment-option.md
@@ -27,7 +27,7 @@ Cockroach Labs offers three ways to deploy CockroachDB: two managed services&mda
         <li><b>Scale</b>: Automatic transactional capacity scaling (up and down) depending on database activity. Ability to scale down to zero and consume zero resources.</li>
         <li><b>Availability</b>: High availability. Data replication in triplicate within a single region. Ensures outage survival by spreading replicas across availability zones.</li>
         <li><b>Operations</b>: Cockroach Labs SRE team manages and maintains every cluster. Backups every three hours.</li>
-        <li><b>Cost</b>: Free for 5GiB of storage and 250M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
+        <li><b>Cost</b>: Free for 5GiB of storage and 50M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
         <li><b>Resource isolation</b>: Shared CockroachDB software and infrastructure. Data is protected and not shared between deployments.</li>
         <li><b>Support</b>: Provided by CockroachDB <a href="https://forum.cockroachlabs.com/">community forum</a> and public <a href="https://cockroachdb.slack.com/">Slack workspace</a>.</li>
       </ul></td>

--- a/v22.1/choose-a-deployment-option.md
+++ b/v22.1/choose-a-deployment-option.md
@@ -27,7 +27,7 @@ Cockroach Labs offers three ways to deploy CockroachDB: two managed services&mda
         <li><b>Scale</b>: Automatic transactional capacity scaling (up and down) depending on database activity. Ability to scale down to zero and consume zero resources.</li>
         <li><b>Availability</b>: High availability. Data replication in triplicate within a single region. Ensures outage survival by spreading replicas across availability zones.</li>
         <li><b>Operations</b>: Cockroach Labs SRE team manages and maintains every cluster. Backups every three hours.</li>
-        <li><b>Cost</b>: Free for 5GiB of storage and 250M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
+        <li><b>Cost</b>: Free for 5GiB of storage and 50M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
         <li><b>Resource isolation</b>: Shared CockroachDB software and infrastructure. Data is protected and not shared between deployments.</li>
         <li><b>Support</b>: Provided by CockroachDB <a href="https://forum.cockroachlabs.com/">community forum</a> and public <a href="https://cockroachdb.slack.com/">Slack workspace</a>.</li>
       </ul></td>

--- a/v22.2/choose-a-deployment-option.md
+++ b/v22.2/choose-a-deployment-option.md
@@ -27,7 +27,7 @@ Cockroach Labs offers three ways to deploy CockroachDB: two managed services&mda
         <li><b>Scale</b>: Automatic transactional capacity scaling (up and down) depending on database activity. Ability to scale down to zero and consume zero resources.</li>
         <li><b>Availability</b>: High availability. Data replication in triplicate within a single region. Ensures outage survival by spreading replicas across availability zones.</li>
         <li><b>Operations</b>: Cockroach Labs SRE team manages and maintains every cluster. Backups every three hours.</li>
-        <li><b>Cost</b>: Free for 5GiB of storage and 250M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
+        <li><b>Cost</b>: Free for 5GiB of storage and 50M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
         <li><b>Resource isolation</b>: Shared CockroachDB software and infrastructure. Data is protected and not shared between deployments.</li>
         <li><b>Support</b>: Provided by CockroachDB <a href="https://forum.cockroachlabs.com/">community forum</a> and public <a href="https://cockroachdb.slack.com/">Slack workspace</a>.</li>
       </ul></td>

--- a/v23.1/choose-a-deployment-option.md
+++ b/v23.1/choose-a-deployment-option.md
@@ -27,7 +27,7 @@ Cockroach Labs offers three ways to deploy CockroachDB: two managed services&mda
         <li><b>Scale</b>: Automatic transactional capacity scaling (up and down) depending on database activity. Ability to scale down to zero and consume zero resources.</li>
         <li><b>Availability</b>: High availability. Data replication in triplicate within a single region. Ensures outage survival by spreading replicas across availability zones.</li>
         <li><b>Operations</b>: Cockroach Labs SRE team manages and maintains every cluster. Backups every three hours.</li>
-        <li><b>Cost</b>: Free for 5GiB of storage and 250M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
+        <li><b>Cost</b>: Free for 5GiB of storage and 50M <a href="../cockroachcloud/serverless-faqs.html#what-is-a-request-unit">Request Units</a>. Consumption based billing and spend limits enforce budget requirements.</li>
         <li><b>Resource isolation</b>: Shared CockroachDB software and infrastructure. Data is protected and not shared between deployments.</li>
         <li><b>Support</b>: Provided by CockroachDB <a href="https://forum.cockroachlabs.com/">community forum</a> and public <a href="https://cockroachdb.slack.com/">Slack workspace</a>.</li>
       </ul></td>


### PR DESCRIPTION
Remove mentions of free forever and change 250M RUs to 50M. Holding off on all other changes.
Also removed leftover callouts about having a credit card for cloud storage; not sure how those got back in the docs.