### PR TITLE
TA 97932

### DIFF
--- a/advisories/a97932.md
+++ b/advisories/a97932.md
@@ -4,7 +4,7 @@ advisory: A-97932
 summary: The SCRAM protocol had a high default hash count causing connection latency spikes for clients running on limited CPU. 
 toc: true
 affected_versions: v22.2.0 to v22.2.6
-advisory_date: 2023-03-28
+advisory_date: 2023-03-29
 docs_area: releases
 ---
 
@@ -24,7 +24,7 @@ The public issue is tracked by [97932](https://github.com/cockroachdb/cockroach/
 
 Users of CockroachDB v22.2.0 to v22.2.6, should set the value of the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256` to `10610`. You will also need to run [`ALTER USER ... WITH PASSWORD`](../{{site.versions["stable"]}}//alter-user.html#change-a-users-password) for every user in order to recompute the hash using the lower cost of `10610`.
 
-Alternatively, if your application is unaffected or you are not experiencing an increase in connection latency, the v22.2.7 release of CockroachDB will include the lower default hashing cost. This will be applied automatically during the upgrade without any user intervention.
+Alternatively, if your application is unaffected or you are not experiencing an increase in connection latency, the [22.2.7](../releases/v22.2.html#v22-2-7) release of CockroachDB will include the lower default hashing cost. This will be applied automatically during the upgrade without any user intervention.
 
 ## Impact
 

--- a/advisories/a97932.md
+++ b/advisories/a97932.md
@@ -1,0 +1,33 @@
+---
+title: Technical Advisory 97932
+advisory: A-97932
+summary: The SCRAM protocol had a high default hash count causing connection latency spikes for clients running on limited CPU. 
+toc: true
+affected_versions: v22.2.0 to v22.2.6
+advisory_date: 2023-03-16
+docs_area: releases
+---
+
+Publication date: {{ page.advisory_date | date: "%B %e, %Y" }}
+
+## Description
+
+Starting in CockroachDB v22.2.0 and above, CockroachDB switched to using the [SCRAM](../{{site.versions["stable"]}}/security-reference/scram-authentication.html) protocol for password authentication by default. The SCRAM protocol dictates that the password hash is computed on the client side and sent to the server instead of sending a cleartext password. After testing we determined the optimal default hash cost (iteration count) to be `119680`. However, this default hashing cost was high for certain clients running on a limited amount of CPU, which resulted in higher than normal connection latency after upgrading to CockroachDB v22.2.0 and above. 
+
+## Statement
+
+This is resolved in CockroachDB by PR [98254](https://github.com/cockroachdb/cockroach/pull/98254), which sets the default hash cost value to `10610` using the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256`. This fix has been released in 22.2.7. 
+
+The public issue is tracked by [97932](https://github.com/cockroachdb/cockroach/issues/97932).
+
+## Mitigation
+
+Users of CockroachDB v22.2.0 to v22.2.6, should set the value of the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256` to `10610`. You will also need to run [`ALTER USER ... WITH PASSWORD`](../{{site.versions["stable"]}}//alter-user.html#change-a-users-password) for every user in order to recompute the hash using the lower cost of `10610`.
+
+Alternatively, if your application is unaffected or you are not experiencing an increase in connection latency, the v22.2.7 release of CockroachDB will include the lower default hashing cost. This will be applied automatically during the upgrade without any user intervention.
+
+## Impact
+
+Customers upgrading their CockroachDB versions to 22.2.0 and above may see an increase in connection latency after upgrade. Versions affected include all versions of CockroachDB v22.2.0 to v22.2.6.
+
+Questions about any technical alert can be directed to our [support team](https://support.cockroachlabs.com/).

--- a/advisories/a97932.md
+++ b/advisories/a97932.md
@@ -4,7 +4,7 @@ advisory: A-97932
 summary: The SCRAM protocol had a high default hash count causing connection latency spikes for clients running on limited CPU. 
 toc: true
 affected_versions: v22.2.0 to v22.2.6
-advisory_date: 2023-03-16
+advisory_date: 2023-03-27
 docs_area: releases
 ---
 

--- a/advisories/a97932.md
+++ b/advisories/a97932.md
@@ -16,7 +16,7 @@ Starting in CockroachDB v22.2.0 and above, CockroachDB switched to using the [SC
 
 ## Statement
 
-This is resolved in CockroachDB by PR [98254](https://github.com/cockroachdb/cockroach/pull/98254), which sets the default hash cost value to `10610` using the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256`. This fix has been released in [22.2.7](../releases/v22.2.html#v22-2-7. 
+This is resolved in CockroachDB by PR [98254](https://github.com/cockroachdb/cockroach/pull/98254), which sets the default hash cost value to `10610` using the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256`. This fix has been released in [22.2.7](../releases/v22.2.html#v22-2-7). 
 
 The public issue is tracked by [97932](https://github.com/cockroachdb/cockroach/issues/97932).
 

--- a/advisories/a97932.md
+++ b/advisories/a97932.md
@@ -4,7 +4,7 @@ advisory: A-97932
 summary: The SCRAM protocol had a high default hash count causing connection latency spikes for clients running on limited CPU. 
 toc: true
 affected_versions: v22.2.0 to v22.2.6
-advisory_date: 2023-03-27
+advisory_date: 2023-03-28
 docs_area: releases
 ---
 
@@ -16,7 +16,7 @@ Starting in CockroachDB v22.2.0 and above, CockroachDB switched to using the [SC
 
 ## Statement
 
-This is resolved in CockroachDB by PR [98254](https://github.com/cockroachdb/cockroach/pull/98254), which sets the default hash cost value to `10610` using the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256`. This fix has been released in 22.2.7. 
+This is resolved in CockroachDB by PR [98254](https://github.com/cockroachdb/cockroach/pull/98254), which sets the default hash cost value to `10610` using the cluster setting `server.user_login.password_hashes.default_cost.scram_sha_256`. This fix has been released in [22.2.7](../releases/v22.2.html#v22-2-7. 
 
 The public issue is tracked by [97932](https://github.com/cockroachdb/cockroach/issues/97932).
 

--- a/v22.2/security-reference/scram-authentication.md
+++ b/v22.2/security-reference/scram-authentication.md
@@ -53,7 +53,7 @@ SCRAM authentication imposes additional computational load on your application s
 
 {% include_cached {{page.version.version}}/scram-authentication-recommendations.md %}
 
-In clusters running v22.2.0 to v22.2.6, the default hashing cost was high for certain clients that are running on a limited amount of CPU, which may cause higher than normal connection latency. See the [Technical Advisory](../../advisories/a97932.html) for mitigation steps. 
+In clusters running v22.2.0 to v22.2.6, the default hashing cost was too high for certain clients running on a limited amount of CPU, causing connection latency. See the [Technical Advisory](../../advisories/a97932.html) for mitigation steps. 
 
 For more details, refer to [Troubleshoot SQL client application problems](../error-handling-and-troubleshooting.html#troubleshoot-sql-client-application-problems)
 {{site.data.alerts.end}}

--- a/v22.2/security-reference/scram-authentication.md
+++ b/v22.2/security-reference/scram-authentication.md
@@ -53,6 +53,8 @@ SCRAM authentication imposes additional computational load on your application s
 
 {% include_cached {{page.version.version}}/scram-authentication-recommendations.md %}
 
+In clusters running v22.2.0 to v22.2.6, the default hashing cost was high for certain clients that are running on a limited amount of CPU, which may cause higher than normal connection latency. See the [Technical Advisory](../../advisories/a97932.html) for mitigation steps. 
+
 For more details, refer to [Troubleshoot SQL client application problems](../error-handling-and-troubleshooting.html#troubleshoot-sql-client-application-problems)
 {{site.data.alerts.end}}
 


### PR DESCRIPTION
This PR includes the TA and a draft update for the SCRAM docs.

Fixed release not yet published to link on release.

## Preview

https://deploy-preview-16515--cockroachdb-docs.netlify.app/docs/advisories/a97932