### PR TITLE
DOC-6534 click to stick

### DIFF
--- a/_includes/v22.1/ui/ui-metrics-navigation.md
+++ b/_includes/v22.1/ui/ui-metrics-navigation.md
@@ -6,3 +6,5 @@ Use the **Graph** menu to display metrics for your entire cluster or for a speci
 - When set to **Graph: {node}**, only data for the specific selected node is shown.
 
 To the right of the Graph and Dashboard menus, a time interval selector allows you to filter the view for a predefined or custom time interval. Use the navigation buttons to move to the previous, next, or current time interval. When you select a time interval, the same interval is selected in the [SQL Activity](ui-overview.html#sql-activity) pages. However, if you select 10 or 30 minutes, the interval defaults to 1 hour in SQL Activity pages.
+
+When viewing graphs, a tooltip will appear at your mouse cursor providing further insight into the data under the mouse cursor. Click anywhere within the graph to pin the tooltip in place, decoupling the tooltip from your mouse movements. Click anywhere within the graph to cause the tooltip to follow your mouse once more.

--- a/_includes/v22.2/ui/ui-metrics-navigation.md
+++ b/_includes/v22.2/ui/ui-metrics-navigation.md
@@ -3,3 +3,5 @@
 Use the **Graph** menu to display metrics for your entire cluster or for a specific node.
 
 To the right of the Graph and Dashboard menus, a time interval selector allows you to filter the view for a predefined or custom time interval. Use the navigation buttons to move to the previous, next, or current time interval. When you select a time interval, the same interval is selected in the [SQL Activity](ui-overview.html#sql-activity) pages. However, if you select 10 or 30 minutes, the interval defaults to 1 hour in SQL Activity pages.
+
+When viewing graphs, a tooltip will appear at your mouse cursor providing further insight into the data under the mouse cursor. Click anywhere within the graph to pin the tooltip in place, decoupling the tooltip from your mouse movements. Click anywhere within the graph to cause the tooltip to follow your mouse once more.

--- a/_includes/v23.1/ui/ui-metrics-navigation.md
+++ b/_includes/v23.1/ui/ui-metrics-navigation.md
@@ -3,3 +3,5 @@
 Use the **Graph** menu to display metrics for your entire cluster or for a specific node.
 
 To the right of the Graph and Dashboard menus, a time interval selector allows you to filter the view for a predefined or custom time interval. Use the navigation buttons to move to the previous, next, or current time interval. When you select a time interval, the same interval is selected in the [SQL Activity](ui-overview.html#sql-activity) pages. However, if you select 10 or 30 minutes, the interval defaults to 1 hour in SQL Activity pages.
+
+When viewing graphs, a tooltip will appear at your mouse cursor providing further insight into the data under the mouse cursor. Click anywhere within the graph to pin the tooltip in place, decoupling the tooltip from your mouse movements. Click anywhere within the graph to cause the tooltip to follow your mouse once more.


### PR DESCRIPTION
Addresses: DOC-6534 (and its two backports, unticketed)

- Added mention of new click-to-stick functionality on include that appears on all metrics dashbaords (incl ui-overview).

Staging

[v23.1/ui-overview-dashboard.md](https://deploy-preview-16517--cockroachdb-docs.netlify.app/docs/dev/ui-overview-dashboard.html#dashboard-navigation) | [v22.2/ui-overview-dashboard.md](https://deploy-preview-16517--cockroachdb-docs.netlify.app/docs/stable/ui-overview-dashboard.html#dashboard-navigation) | [v22.1/ui-overview-dashboard.md](https://deploy-preview-16517--cockroachdb-docs.netlify.app/docs/v22.1/ui-overview-dashboard.html#dashboard-navigation)