### PR TITLE
DOC-6442 queue.gc.info.clearrange metrics

### DIFF
--- a/_includes/v23.1/metric-names.md
+++ b/_includes/v23.1/metric-names.md
@@ -65,6 +65,8 @@ Name | Description
 `queue.gc.info.abortspanconsidered` | Number of AbortSpan entries eligible for removal based on their ages
 `queue.gc.info.abortspangcnum` | Number of AbortSpan entries fit for removal
 `queue.gc.info.abortspanscanned` | Number of transactions present in the AbortSpan scanned from the engine
+`queue.gc.info.clearrangefailed` | Number of failed ClearRange operations during GC
+`queue.gc.info.clearrangesuccess` | Number of successful ClearRange operations during GC
 `queue.gc.info.intentsconsidered` | Number of intents eligible to be considered because they are at least two hours old
 `queue.gc.info.intenttxns` | Number of associated distinct transactions
 `queue.gc.info.numkeysaffected` | Number of keys with GC'able data


### PR DESCRIPTION
Addresses: DOC-6442 (but also net-new adds these metrics, no ticket for that either)

- Updated description for (added in the first place) two existing (new) metrics:
	- `queue.gc.info.clearrangefailed`
	- `queue.gc.info.clearrangesuccess`

Staging

[metrics.md](https://deploy-preview-16518--cockroachdb-docs.netlify.app/docs/stable/metrics.html)