### PR TITLE
[DOC-6974] Document Console observability's impact on cluster performance

### DIFF
--- a/_includes/v23.1/ui/admin-access.md
+++ b/_includes/v23.1/ui/admin-access.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_info}}
-On a [secure cluster](secure-a-cluster.html) you must be an `admin` user to access this area of the DB Console. See [DB Console security](ui-overview.html#db-console-access).
+On a [secure cluster](secure-a-cluster.html) you must be an `admin` user to access this area of the DB Console. Refer to [DB Console security](ui-overview.html#db-console-access).
 {{site.data.alerts.end}}

--- a/cockroachcloud/export-metrics.md
+++ b/cockroachcloud/export-metrics.md
@@ -8,13 +8,19 @@ cloud: true
 
 {{ site.data.products.dedicated }} users can use the [Cloud API](cloud-api.html) to configure metrics export to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/). Once the export is configured, metrics will flow from all nodes in all regions of your {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
 
+{{site.data.alerts.callout_success}}
+{{ site.data.products.dedicated }} clusters use Cloud Console instead of DB Console, and DB Console is disabled. To export metrics from a {{ site.data.products.core }} cluster, refer to [Monitoring and Alerting](/docs/{{site.versions["dev"]}}/monitoring-and-alerting.html) instead of this page.
+{{site.data.alerts.end}}
+
 Exporting metrics to AWS CloudWatch is only available on {{ site.data.products.dedicated }} clusters which are hosted on AWS, and were created after August 11, 2022. Metrics export to Datadog is supported on all {{ site.data.products.dedicated }} clusters regardless of creation date.
 
 {{site.data.alerts.callout_info}}
 {% include_cached feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-## The `metricexport` endpoint
+<a id="the-metricexport-endpoint"></a>
+
+## `metricexport` endpoint
 
 To configure and manage metrics export for your {{ site.data.products.dedicated }} cluster, use the `metricexport` endpoint appropriate for your desired cloud metrics sink:
 

--- a/v23.1/datadog.md
+++ b/v23.1/datadog.md
@@ -8,7 +8,7 @@ docs_area: manage
 [Datadog](https://www.datadoghq.com/) is a monitoring and security platform for cloud applications. The {{ site.data.products.core }} integration with Datadog enables data collection and alerting on selected [CockroachDB metrics](https://docs.datadoghq.com/integrations/cockroachdb/?tab=host#data-collected) using the Datadog platform.
 
 {{site.data.alerts.callout_success}}
-This tutorial explores the {{ site.data.products.core }} integration with Datadog. For the {{ site.data.products.dedicated }} integration with Datadog, see [Monitor CockroachDB Dedicated with Datadog](../cockroachcloud/tools-page.html#monitor-cockroachdb-dedicated-with-datadog)
+This tutorial explores the {{ site.data.products.core }} integration with Datadog. For the {{ site.data.products.dedicated }} integration with Datadog, refer to [Monitor CockroachDB Dedicated with Datadog](../cockroachcloud/tools-page.html#monitor-cockroachdb-dedicated-with-datadog) instead of this page.
 {{site.data.alerts.end}}
 
 The {{ site.data.products.core }} integration with Datadog is powered by the [Datadog Agent](https://app.datadoghq.com/account/settings#agent), and supported by Datadog directly:
@@ -170,6 +170,12 @@ The example alert below will trigger when [a node has less than 15% of storage c
 The timeseries graph at the top of the page indicates the configured metric and threshold:
 
 <img src="{{ 'images/v23.1/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
+
+## Step 7. Disable DB Console's local storage of metrics (optional)
+
+If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics](operational-faqs.html#disable-time-series-storage).
+
+When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint](monitoring-and-alerting.html#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
 
 ## Limitations
 

--- a/v23.1/kibana.md
+++ b/v23.1/kibana.md
@@ -5,7 +5,11 @@ toc: true
 docs_area: manage
 ---
 
-[Kibana](https://www.elastic.co/kibana/) is a platform that visualizes data on the [Elastic Stack](https://www.elastic.co/elastic-stack/). Using the [CockroachDB module for Metricbeat](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-cockroachdb.html), metrics exposed by the CockroachDB [Prometheus endpoint](monitoring-and-alerting.html#prometheus-endpoint) can be collected by Elasticsearch and visualized with Kibana.
+[Kibana](https://www.elastic.co/kibana/) is a platform that visualizes data on the [Elastic Stack](https://www.elastic.co/elastic-stack/). This page shows how to use the [CockroachDB module for Metricbeat](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-cockroachdb.html) to collect metrics exposed by your {{ site.data.products.core }} cluster's [Prometheus endpoint](monitoring-and-alerting.html#prometheus-endpoint) in Elasticsearch and how to visualize those metrics with Kibana.
+
+{{site.data.alerts.callout_success}}
+To export metrics from a {{ site.data.products.db }} cluster, refer to [Export Metrics From a {{ site.data.products.dedicated }} Cluster](/docs/cockroachcloud/export-metrics.html) instead of this page.
+{{site.data.alerts.end}}
 
 In this tutorial, you will enable the CockroachDB module for Metricbeat and visualize the data in Kibana.
 
@@ -106,6 +110,12 @@ cockroach workload run movr --duration=5m 'postgresql://root@localhost:26257?ssl
 Click **Refresh**. The query metrics will appear on the dashboard:
 
 <img src="{{ 'images/v23.1/kibana-crdb-dashboard-sql.png' | relative_url }}" alt="CockroachDB Overview dashboard for Metricbeat with SQL metrics" style="border:1px solid #eee;max-width:100%" />
+
+## Step 5. Disable DB Console's local storage of metrics (optional)
+
+If you rely on external tools such as Kibana for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics](operational-faqs.html#disable-time-series-storage).
+
+When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint](monitoring-and-alerting.html#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Kibana based on the data it is collecting from your cluster's Prometheus endpoint.
 
 ## See also
 

--- a/v23.1/monitor-cockroachdb-with-prometheus.md
+++ b/v23.1/monitor-cockroachdb-with-prometheus.md
@@ -198,6 +198,12 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
 1. [Add the dashboards to Grafana](http://docs.grafana.org/reference/export_import/#importing-a-dashboard).
 
+## Step 6. Disable DB Console's local storage of metrics (optional)
+
++If you rely on external tools such as Prometheus for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics](operational-faqs.html#disable-time-series-storage).
++
++When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint](monitoring-and-alerting.html#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Prometheus and AlertManager based on the data Prometheus is collecting from your cluster's Prometheus endpoint.
+
 ## See also
 
 - [Monitoring and Alerting](monitoring-and-alerting.html)

--- a/v23.1/ui-overview-dashboard.md
+++ b/v23.1/ui-overview-dashboard.md
@@ -9,7 +9,7 @@ The **Overview** dashboard lets you monitor important SQL performance, replicati
 
 To view this dashboard, [access the DB Console](ui-overview.html#db-console-access) and click **Metrics** on the left-hand navigation bar. The **Overview** dashboard is displayed by default.
 
-The time-series data displayed in DB Console graphs is stored within the CockroachDB cluster and accumulates for 30 days before being truncated. For details about managing this process, see this [FAQ](operational-faqs.html#can-i-reduce-or-disable-the-storage-of-time-series-data). As a result, for the first 30 days or so of a cluster's life, you will see a steady increase in disk usage and the number of ranges even if you aren't writing data to the cluster.
+The time-series data displayed in DB Console graphs is stored within the CockroachDB cluster and steadily increases for the first several days of a cluster's life, before an automatic job begins to prune it. By default, time-series data is stored for at 10-second resolution for 10 days, and at 30-minute resolution for 90 days. For details about managing this process, see this [How Can I Reduce or Disable the Storage of Time-series Data?](operational-faqs.html#can-i-reduce-or-disable-the-storage-of-time-series-data). In a new cluster, you will observe a steady increase in disk usage and the number of ranges even if you aren't writing data to the cluster.
 
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 

--- a/v23.1/ui-sessions-page.md
+++ b/v23.1/ui-sessions-page.md
@@ -6,12 +6,10 @@ docs_area: reference.db_console
 ---
 
 {{site.data.alerts.callout_info}}
-On a secure cluster, this area of the DB Console can only be accessed by users belonging to the `admin` role or a SQL user with the `VIEWACTIVITY` [system privilege](security-reference/authorization.html#supported-privileges) (or the legacy `VIEWACTIVITY` [role option](security-reference/authorization.html#role-options)) defined. Non-`admin` users will see only their own sessions, while `admin` users see sessions for all users.
+On a secure cluster, you must be an `admin` user or a SQL user with the `VIEWACTIVITY` [system privilege](security-reference/authorization.html#supported-privileges) (or the legacy `VIEWACTIVITY` [role option](security-reference/authorization.html#role-options)). Other users will see only their own sessions. Refer to [DB Console security](ui-overview.html#db-console-access).
 {{site.data.alerts.end}}
 
-The **Sessions** page  of the DB Console provides details of all open sessions in the cluster.
-
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. Click the **Sessions** tab.
+The **Sessions** page provides information about open SQL sessions in your cluster, using data in the cluster's [`crdb_internal` system catalog](monitoring-and-alerting.html#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Sessions**.
 
 {% include common/ui/sessions-page.md %}
 

--- a/v23.1/ui-statements-page.md
+++ b/v23.1/ui-statements-page.md
@@ -7,7 +7,12 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/admin-access.md %}
 
-The **Statements** page offers two views on statements: **Statement Fingerprints**, which represents one or more completed SQL statements; and **Active Executions**, which represents individual statement executions in progress.
+The **Statements** page provides information about the execution of SQL statements in your cluster, using data in the cluster's [`crdb_internal` system catalog](monitoring-and-alerting.html#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Statements**.
+
+It offers two views:
+
+- **Statement Fingerprints** show information about completed SQL statements.
+- **Active Executions** show information about SQL statements which are currently executing.
 
 Choose a view by selecting the **Statement Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
 

--- a/v23.1/ui-transactions-page.md
+++ b/v23.1/ui-transactions-page.md
@@ -7,7 +7,12 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/admin-access.md %}
 
-The **Transactions** page offers two views on transactions: **Transaction Fingerprints**, which represents one or more completed SQL transactions; and **Active Executions**, which represents individual transaction executions in progress.
+The **Transactions** page provides information about the execution of SQL transactions in your cluster, using data in the cluster's [`crdb_internal` system catalog](monitoring-and-alerting.html#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Transactions**.
+
+It offers two views:
+
+- **Transaction Fingerprints** show information about completed SQL transactions.
+- **Active Executions**, show information about SQL transactions which are currently executing.
 
 Choose a view by selecting the **Transaction Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
 


### PR DESCRIPTION
[DOC-6974] Document Console observability's impact on cluster performance

- Primarily add advice about disabling DB Console metric persistence if you use the Prometheus endpoint with a third-party tool
- Light copyedit
- Done for 23.1 and Cloud. Will backport to 22.2 and 22.1 after technical agreement is reached
- Out of scope: Mention of visus, which will happen in a follow-up PR against the same JIRA.

## Previews
[cockroachcloud/export-metrics.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/cockroachcloud/export-metrics.html)
[v23.1/datadog.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/datadog.html)
[v23.1/kibana.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/kibana.html)
[v23.1/monitor-cockroachdb-with-prometheus.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/monitor-cockroachdb-with-prometheus.html)
[v23.1/monitoring-and-alerting.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/monitoring-and-alerting.html)
[v23.1/operational-faqs.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/operational-faqs.html)
[v23.1/ui-overview-dashboard.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/ui-overview-dashboard.html)
[v23.1/ui-sessions-page.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/ui-sessions-page.html)
[v23.1/ui-statements-page.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/ui-statements-page.html)
[v23.1/ui-transactions-page.md](https://deploy-preview-16520--cockroachdb-docs.netlify.app/docs/v23.1/ui-transactions-page.html)

## Tests
- [x] Local build
- [x] Linkcheck 