### PR TITLE
SELECT FOR UPDATE uses unreplicated locks

### DIFF
--- a/_includes/v22.1/sql/select-for-update-limitations.md
+++ b/_includes/v22.1/sql/select-for-update-limitations.md
@@ -1,0 +1,10 @@
+Locks acquired using {% if page.name == "select-for-update.md" %} `SELECT ... FOR UPDATE` {% else %} [`SELECT ... FOR UPDATE`](select-for-update.html) {% endif %} are dropped on [lease transfers](architecture/replication-layer.html#epoch-based-leases-table-data) and [range splits and merges](architecture/distribution-layer.html#range-merges). `SELECT ... FOR UPDATE` locks should be thought of as best-effort, and should not be relied upon for correctness, as they are implemented as fast, in-memory [unreplicated locks](architecture/transaction-layer.html#unreplicated-locks).
+
+If a lease transfer or range split/merge occurs on a range held by an unreplicated lock, the lock is dropped, and the following behaviors can occur:
+
+- The desired ordering of concurrent accesses to one or more rows of a table expressed by your use of `SELECT ... FOR UPDATE` may not be preserved (that is, a transaction _B_ against some table _T_ that was supposed to wait behind another transaction _A_ operating on _T_ may not wait for transaction _A_).
+- The transaction that acquired the (now dropped) unreplicated lock may fail to commit, leading to [transaction retry errors with code `40001` and the `restart transaction` error message](common-errors.html#restart-transaction).
+
+We intend to improve the reliability of these locks. For details, see [cockroachdb/cockroach#75456](https://github.com/cockroachdb/cockroach/issues/75456).
+
+Note that [serializable isolation](transactions.html#serializable-isolation) is preserved despite this limitation.

--- a/_includes/v22.2/sql/select-for-update-limitations.md
+++ b/_includes/v22.2/sql/select-for-update-limitations.md
@@ -1,0 +1,10 @@
+Locks acquired using {% if page.name == "select-for-update.md" %} `SELECT ... FOR UPDATE` {% else %} [`SELECT ... FOR UPDATE`](select-for-update.html) {% endif %} are dropped on [lease transfers](architecture/replication-layer.html#epoch-based-leases-table-data) and [range splits and merges](architecture/distribution-layer.html#range-merges). `SELECT ... FOR UPDATE` locks should be thought of as best-effort, and should not be relied upon for correctness, as they are implemented as fast, in-memory [unreplicated locks](architecture/transaction-layer.html#unreplicated-locks).
+
+If a lease transfer or range split/merge occurs on a range held by an unreplicated lock, the lock is dropped, and the following behaviors can occur:
+
+- The desired ordering of concurrent accesses to one or more rows of a table expressed by your use of `SELECT ... FOR UPDATE` may not be preserved (that is, a transaction _B_ against some table _T_ that was supposed to wait behind another transaction _A_ operating on _T_ may not wait for transaction _A_).
+- The transaction that acquired the (now dropped) unreplicated lock may fail to commit, leading to [transaction retry errors with code `40001` and the `restart transaction` error message](common-errors.html#restart-transaction).
+
+We intend to improve the reliability of these locks. For details, see [cockroachdb/cockroach#75456](https://github.com/cockroachdb/cockroach/issues/75456).
+
+Note that [serializable isolation](transactions.html#serializable-isolation) is preserved despite this limitation.

--- a/v22.1/known-limitations.md
+++ b/v22.1/known-limitations.md
@@ -60,6 +60,10 @@ Change data capture (CDC) provides efficient, distributed, row-level changefeeds
 
 ## Unresolved limitations
 
+### `SELECT FOR UPDATE` locks are dropped on lease transfers  and range splits/merges
+
+{% include {{page.version.version}}/sql/select-for-update-limitations.md %}
+
 ### CockroachDB does not properly optimize some left and anti joins with GIN indexes
 
 [Left joins](joins.html#left-outer-joins) and anti joins involving [`JSONB`](jsonb.html), [`ARRAY`](array.html), or [spatial-typed](spatial-data.html) columns with a multi-column or [partitioned](partition-by.html) [GIN index](inverted-indexes.html) will not take advantage of the index if the prefix columns of the index are unconstrained, or if they are constrained to multiple, constant values.

--- a/v22.1/select-for-update.md
+++ b/v22.1/select-for-update.md
@@ -44,6 +44,10 @@ For documentation on all other parameters of a `SELECT` statement, see [Selectio
 
 The user must have the `SELECT` and `UPDATE` [privileges](security-reference/authorization.html#managing-privileges) on the tables used as operands.
 
+## Known limitations
+
+{% include {{page.version.version}}/sql/select-for-update-limitations.md %}
+
 ## Examples
 
 ### Enforce transaction order when updating the same rows

--- a/v22.2/known-limitations.md
+++ b/v22.2/known-limitations.md
@@ -84,6 +84,10 @@ If this is seen to happen, the behavior can be disabled by setting `kv.rangefeed
 
 ## Unresolved limitations
 
+### `SELECT FOR UPDATE` locks are dropped on lease transfers  and range splits/merges
+
+{% include {{page.version.version}}/sql/select-for-update-limitations.md %}
+
 ### Unsupported trigram syntax
 
 The following PostgreSQL syntax and features are currently unsupported for [trigrams](trigram-indexes.html):

--- a/v22.2/select-for-update.md
+++ b/v22.2/select-for-update.md
@@ -44,6 +44,10 @@ For documentation on all other parameters of a `SELECT` statement, see [Selectio
 
 The user must have the `SELECT` and `UPDATE` [privileges](security-reference/authorization.html#managing-privileges) on the tables used as operands.
 
+## Known limitations
+
+{% include {{page.version.version}}/sql/select-for-update-limitations.md %}
+
 ## Examples
 
 ### Enforce transaction order when updating the same rows


### PR DESCRIPTION
Followup to https://github.com/cockroachdb/docs/pull/16434 to backport that content to v22.1 and v22.2 (v21.2 is nearly out of support)

Addresses DOC-6276 and DOC-7124