### PR TITLE
DOC-6211, DOC-6212 system log gc

### DIFF
--- a/v23.1/cockroach-auth-session.md
+++ b/v23.1/cockroach-auth-session.md
@@ -95,7 +95,8 @@ To run any of the `auth-session` subcommands, you must be a member of the [`admi
 
 - The `login` subcommand allows users with the [`admin` role](security-reference/authorization.html#admin-role) to create HTTP authentication tokens with an arbitrary duration. If operational policy requires stricter control of authentication sessions, you can:
 
-  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions.
+  - Monitor the `system.web_sessions` table for all current and recent HTTP sessions. If you monitor this table regularly, consider adjusting the `server.log_gc.period` and
+`server.log_gc.max_deletions_per_cycle` [cluster settings](cluster-settings.html) to fine tune garbage collection for this table.
   - Revoke HTTP authentication tokens as needed with the `logout` subcommand. See the [example](#terminate-all-active-sessions-for-a-user).
   - Set the `--expire-after` flag with a shorter duration. See the [example](#log-in-to-the-http-interface-with-a-custom-expiry).
 


### PR DESCRIPTION
Addresses: DOC-6211, DOC-6212

- Added one tiny sentence to the sole mention of `system.web_sessions` in the docs corpus to now advise of its GC tunability.
	- Remainder of docs corpus does not mention / describe any of  `system.eventlog`, `system.rangelog`, or `system.web_sessions` in a manner where GC tunability would be a relevant topic.
	
- The cluster settings themselves (deprecated or renamed), are automatically reflected, for now, in an upstream include, accessible here: `docs/generated/settings/settings.html`, which is exposed to the end user as copy [here](https://deploy-preview-16535--cockroachdb-docs.netlify.app/docs/dev/cluster-settings.html).

Alternative

- Also OK if you think we don't need any docs changes at all.

Staging

[v23.1/cockroach-auth-session.md](https://deploy-preview-16535--cockroachdb-docs.netlify.app/docs/dev/cockroach-auth-session.html#considerations)