### PR TITLE
Correction to duplicate See also Statements Page

### DIFF
--- a/_includes/v22.2/ui/statement-details.md
+++ b/_includes/v22.2/ui/statement-details.md
@@ -135,12 +135,3 @@ Although fingerprints are periodically cleared from the Statements page, all dia
 {% endif %}
 
 Click <img src="{{ 'images/v22.2/ui-download-button.png' | relative_url }}" alt="Down arrow" /> **Bundle (.zip)** to download any diagnostics bundle.
-
-## See also
-
-- [Troubleshoot Query Behavior]({{ link_prefix }}query-behavior-troubleshooting.html)
-- [Transaction retries]({{ link_prefix }}transactions.html#transaction-retries)
-- [Optimize Statement Performance]({{ link_prefix }}make-queries-fast.html)
-- [Support Resources]({{ link_prefix }}support-resources.html)
-- [Raw Status Endpoints]({{ link_prefix }}monitoring-and-alerting.html#raw-status-endpoints)
-- [Transactions Page]({{ page_prefix }}transactions-page.html)

--- a/_includes/v23.1/ui/statement-details.md
+++ b/_includes/v23.1/ui/statement-details.md
@@ -135,12 +135,3 @@ Although fingerprints are periodically cleared from the Statements page, all dia
 {% endif %}
 
 Click <img src="{{ 'images/v23.1/ui-download-button.png' | relative_url }}" alt="Down arrow" /> **Bundle (.zip)** to download any diagnostics bundle.
-
-## See also
-
-- [Troubleshoot Query Behavior]({{ link_prefix }}query-behavior-troubleshooting.html)
-- [Transaction retries]({{ link_prefix }}transactions.html#transaction-retries)
-- [Optimize Statement Performance]({{ link_prefix }}make-queries-fast.html)
-- [Support Resources]({{ link_prefix }}support-resources.html)
-- [Raw Status Endpoints]({{ link_prefix }}monitoring-and-alerting.html#raw-status-endpoints)
-- [Transactions Page]({{ page_prefix }}transactions-page.html)


### PR DESCRIPTION
Quick fix to the DB Console Statements Page Docs --> duplicate See Also section hidden in an include was causing issues on the sidebar TOC, and wasn't necessary.