### PR TITLE
Include grant statement for drop ext connection

### DIFF
--- a/v22.2/create-external-connection.md
+++ b/v22.2/create-external-connection.md
@@ -26,6 +26,7 @@ To create an external connection, a user must have the `EXTERNALCONNECTION` [sys
 
 For example: 
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
 GRANT SYSTEM EXTERNALCONNECTION TO user;
 ~~~
@@ -34,6 +35,7 @@ To use a specific external connection during an operation, the user must also ha
 
 For example:
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
 GRANT USAGE ON EXTERNAL CONNECTION backup_bucket TO user;
 ~~~

--- a/v22.2/drop-external-connection.md
+++ b/v22.2/drop-external-connection.md
@@ -19,6 +19,13 @@ You can also use the following SQL statements to work with external connections:
 
 Users must have the [`DROP` privilege](security-reference/authorization.html#supported-privileges) or be a member of the [`admin` role](security-reference/authorization.html#admin-role) to drop an external connection.
 
+For example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+GRANT DROP ON EXTERNAL CONNECTION backup_bucket TO user;
+~~~
+
 ## Synopsis
 
 <div>

--- a/v23.1/create-external-connection.md
+++ b/v23.1/create-external-connection.md
@@ -22,6 +22,7 @@ To create an external connection, a user must have the `EXTERNALCONNECTION` [sys
 
 For example: 
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
 GRANT SYSTEM EXTERNALCONNECTION TO user;
 ~~~
@@ -30,6 +31,7 @@ To use a specific external connection during an operation, the user must also ha
 
 For example:
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
 GRANT USAGE ON EXTERNAL CONNECTION backup_bucket TO user;
 ~~~

--- a/v23.1/drop-external-connection.md
+++ b/v23.1/drop-external-connection.md
@@ -20,6 +20,13 @@ You can also use the following SQL statements to work with external connections:
 
 Users must have the [`DROP` privilege](security-reference/authorization.html#supported-privileges) or be a member of the [`admin` role](security-reference/authorization.html#admin-role) to drop an external connection.
 
+For example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+GRANT DROP ON EXTERNAL CONNECTION backup_bucket TO user;
+~~~
+
 ## Synopsis
 
 <div>


### PR DESCRIPTION
Fixes DOC-5781

This is a small addition to the `DROP EXTERNAL CONNECTION` page to add a `GRANT` statement to match the `CREATE EXTERNAL CONNECTION` page.