### PR TITLE
adding miss "," in log configuration

### DIFF
--- a/cockroachcloud/export-logs.md
+++ b/cockroachcloud/export-logs.md
@@ -186,7 +186,7 @@ Perform the following steps to enable log export from your {{ site.data.products
                      },
                      {
                          log_name: "devops",
-                         channels: ["OPS", "HEALTH", "STORAGE"]
+                         channels: ["OPS", "HEALTH", "STORAGE"],
                          min_level: "WARNING"
                      },
              ]


### PR DESCRIPTION
The configuration is missing a "," before `min_level`
```
             log_name: "devops",
             channels: ["OPS", "HEALTH", "STORAGE"]
             min_level: "WARNING"
```