### PR TITLE
DOC-5772 storage level metrics

### DIFF
--- a/_includes/v22.2/metric-names.md
+++ b/_includes/v22.2/metric-names.md
@@ -256,6 +256,20 @@ Name | Description
 `sql.txn.contended.count` | Number of SQL transactions that experienced contention
 `sql.txn.rollback.count` | Number of SQL transaction ROLLBACK statements
 `sql.update.count` | Number of SQL UPDATE statements
+`storage.l0-level-score` | Compaction score of level 0
+`storage.l1-level-score` | Compaction score of level 1
+`storage.l2-level-score` | Compaction score of level 2
+`storage.l3-level-score` | Compaction score of level 3
+`storage.l4-level-score` | Compaction score of level 4
+`storage.l5-level-score` | Compaction score of level 5
+`storage.l6-level-score` | Compaction score of level 6
+`storage.l0-level-size` | Size of the SSTables in level 0
+`storage.l1-level-size` | Size of the SSTables in level 1
+`storage.l2-level-size` | Size of the SSTables in level 2
+`storage.l3-level-size` | Size of the SSTables in level 3
+`storage.l4-level-size` | Size of the SSTables in level 4
+`storage.l5-level-size` | Size of the SSTables in level 5
+`storage.l6-level-size` | Size of the SSTables in level 6
 `storage.keys.range-key-set.count` | Approximate count of RangeKeySet internal keys across the storage engine.
 `storage.marked-for-compaction-files` | Count of SSTables marked for compaction
 `sys.cgo.allocbytes` | Current bytes of memory allocated by cgo

--- a/_includes/v23.1/metric-names.md
+++ b/_includes/v23.1/metric-names.md
@@ -258,6 +258,20 @@ Name | Description
 `sql.txn.contended.count` | Number of SQL transactions that experienced contention
 `sql.txn.rollback.count` | Number of SQL transaction ROLLBACK statements
 `sql.update.count` | Number of SQL UPDATE statements
+`storage.l0-level-score` | Compaction score of level 0
+`storage.l1-level-score` | Compaction score of level 1
+`storage.l2-level-score` | Compaction score of level 2
+`storage.l3-level-score` | Compaction score of level 3
+`storage.l4-level-score` | Compaction score of level 4
+`storage.l5-level-score` | Compaction score of level 5
+`storage.l6-level-score` | Compaction score of level 6
+`storage.l0-level-size` | Size of the SSTables in level 0
+`storage.l1-level-size` | Size of the SSTables in level 1
+`storage.l2-level-size` | Size of the SSTables in level 2
+`storage.l3-level-size` | Size of the SSTables in level 3
+`storage.l4-level-size` | Size of the SSTables in level 4
+`storage.l5-level-size` | Size of the SSTables in level 5
+`storage.l6-level-size` | Size of the SSTables in level 6
 `storage.keys.range-key-set.count` | Approximate count of RangeKeySet internal keys across the storage engine.
 `storage.marked-for-compaction-files` | Count of SSTables marked for compaction
 `sys.cgo.allocbytes` | Current bytes of memory allocated by cgo


### PR DESCRIPTION
Addresses: DOC-5772

- Adds 14 new metrics in form: `storage.$LEVEL-level-{size,score}` of $LEVEL `0` through `6`.
- If you disagree with a metric's description, please change it here: [pkg/kv/kvserver/metrics.go](https://github.com/cockroachdb/cockroach/pull/88504/files#diff-13de2cd5fd804cc3efbfb6f5d16ca58d33e1a9e297461d018b82dd087e662876).
- EDIT: just noticed that you [backported](https://github.com/cockroachdb/cockroach/pull/88592) this. Docs had no idea. I've backported the docs change now too.

Staging

- [v23.1/metrics.md](https://deploy-preview-16584--cockroachdb-docs.netlify.app/docs/dev/metrics.html)
- [v22.2/metrics.md](https://deploy-preview-16584--cockroachdb-docs.netlify.app/docs/stable/metrics.html)