### PR TITLE
[skip ci] Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ vale:
 vendor:
 	gem install bundler
 	bundle install
-	go install github.com/wjdp/htmltest@master
 
 bootstrap: Gemfile | vendor
 	touch $@


### PR DESCRIPTION
We advise people to install htmltest via brew, and using go get/install to install htmltest is not the supported way in the htmltest docs.