### PR TITLE
[DOC-6519] Release notes for v23.1.0-alpha.9

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -140,12 +140,12 @@ release_info:
     start_time: 2023-03-23 12:47:11.032616 +0000 UTC
     version: v22.2.7
   v23.1:
-    build_time: 2023-03-27 00:00:00 (go1.19)
+    build_time: 2023-04-04 00:00:00 (go1.19)
     crdb_branch_name: release-23.1
     docker_image: cockroachdb/cockroach-unstable
-    name: v23.1.0-alpha.8
-    start_time: 2023-03-29 13:15:57.012641 +0000 UTC
-    version: v23.1.0-alpha.8
+    name: v23.1.0-alpha.9
+    start_time: 2023-04-04 10:24:39.246087 +0000 UTC
+    version: v23.1.0-alpha.9
 sass:
   quiet_deps: 'true'
   sass_dir: css

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -4065,3 +4065,22 @@
     docker_arm: true
   source: true
   previous_version: v23.1.0-alpha.7
+
+- version: v23.1.0-alpha.9
+  major_version: v23.1
+  release_date: '2023-04-04'
+  release_type: Testing
+  go_version: go1.19
+  sha: 7e72aae900c3ff4b44f1643c2d7ba55fbb2cbe23
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+  docker:
+    docker_image: cockroachdb/cockroach-unstable
+    docker_arm: true
+  source: true
+  previous_version: v23.1.0-alpha.8

--- a/_includes/releases/v23.1/v23.1.0-alpha.8.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.8.md
@@ -50,7 +50,7 @@ Release Date: March 27, 2023
 - Added badges for each selected filter on the [SQL Activity](../v23.1/ui-overview.html#sql-activity) and [Insights](../v23.1/ui-insights-page.html) pages. [#98988][#98988]
 - The default request sort for the [Statement Fingerprints Overview](../v23.1/ui-statements-page.html#statement-fingerprints-view) page is now `% of All Runtime`. [#99298][#99298]
 - Fixed a bug where the table's `CREATE` statement would not display correctly on the [Table Details](../v23.1/ui-databases-page.html#table-details) page. [#99434][#99434]
-- Added an assertion on the KV side to prevent other existing or future attempts of LeafTxn issuing locking requests. This ensures the KV API is used as agreed upon and can be helpful in debugging latency issues caused by holding locks. [#99412][#99412] 
+- Added an assertion on the KV side to prevent other existing or future attempts of LeafTxn issuing locking requests. This ensures the KV API is used as agreed upon and can be helpful in debugging latency issues caused by holding locks. [#99412][#99412]
 
 <h3 id="v23-1-0-alpha-8-bug-fixes">Bug fixes</h3>
 
@@ -82,9 +82,6 @@ This release includes 174 merged PRs by 65 authors.
 We would like to thank the following contributors from the CockroachDB community:
 
 - Eric.Yang
-- rharding6373
-- shralex
-- zachlite
 
 </div>
 

--- a/_includes/releases/v23.1/v23.1.0-alpha.9.md
+++ b/_includes/releases/v23.1/v23.1.0-alpha.9.md
@@ -1,0 +1,80 @@
+## v23.1.0-alpha.9
+
+Release Date: April 4, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-1-0-alpha-9-backward-incompatible-changes">Backward-incompatible changes</h3>
+
+- The output of the [`SHOW RANGES`](../v23.1/show-ranges.html) command for the `crdb_internal.ranges` and `crdb_internal.ranges_no_leases` tables has been updated, and the previous output is deprecated. To enable the new command output, set the `sql.show_ranges_deprecated_behavior.enabled` [cluster setting](../v23.1/cluster-settings.html) to `false`. The new output will become default in v23.2. [#99618][#99618]
+
+<h3 id="v23-1-0-alpha-9-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
+
+- The [`CREATE CHANGEFEED`](../v23.1/create-changefeed.html) statement now allows you to limit the nodes that can execute a changefeed by including a locality filter in the `WITH` clause. A node can execute the changefeed only if it was started with a matching [`--locality`](https://cockroachlabs.com/docs/v23.1/cockroach-start#locality) flag. Replace `{locality}` with a comma-separated list of key-value pairs. [#99935][#99935]
+
+<h3 id="v23-1-0-alpha-9-sql-language-changes">SQL language changes</h3>
+
+- The new `prepared_statements_cache_size` [cluster setting](../v23.1/cluster-settings.html) helps to prevent [prepared statement](../v23.1/savepoint.html#savepoints-and-prepared-statements) leaks by automatically deallocating the least-recently-used prepared statements when the cache reaches a given size. [#99254][#99254]
+
+<h3 id="v23-1-0-alpha-9-operational-changes">Operational changes</h3>
+
+- The new `COCKROACH_DISABLE_NODE_AND_TENANT_METRIC_LABELS` [environment variable](../v23.1/cockroach-commands.html#environment-variables) allows you to suppress metrics from a cluster's [Prometheus endpoint](../v23.1/monitoring-and-alerting.html#prometheus-endpoint) if they conflict with labels that are applied by external tools that collect metrics from the endpoint. Set the environment variable to a comma-separated list of key-value pairs. [#99820][#99820]
+
+<h3 id="v23-1-0-alpha-9-db-console-changes">DB Console changes</h3>
+
+- The [**Index Details**](../v23.1/ui-databases-page.html#index-details) section of the **Databases** page now displays the list of most-frequently-used index fingerprints to all users, rather than only to `admin` users, because the page now queries a view rather than a system table directly. [#99485][#99485]
+- When you search or filter within the [**Statements** page](../v23.1/ui-statements-page.html) or [**Transactions** page](../v23.1/ui-transactions-page.html), if you interactively sort the results using a column that was not part of the original query, a warning displays if you are viewing only a subset of the results, along with a suggestion to update the original query. [#99795][#99795]
+
+<h3 id="v23-1-0-alpha-9-miscellaneous">Miscellaneous</h3>
+
+- Several computed columns have been added to the `statement_statistics_persisted` and `transaction_statistics_persisted` views in the [`crdb_internal`](../v23.1/crdb-internal.html) system catalog and indexed in the corresponding system tables:
+
+    - `execution_count`
+    - `service_latency`
+    - `cpu_sql_nanos`
+    - `contention_time`
+    - `total_estimated_execution_time`
+    - `p99_latency`
+
+    [#99417][#99417]
+
+<h3 id="v23-1-0-alpha-9-bug-fixes">Bug fixes</h3>
+
+- Fixed pagination bugs when searching or filtering within the [**Databases** page](../v23.1/ui-databases-page.html) or viewing the details of a database. [#99513][#99513]
+- Fixed a rare bug introduced in v22.2.0 that could cause a node to crash with an `attempting to append refresh spans after the tracked timestamp has moved forward` error when querying virtual tables in the [`crdb_internal`](../v23.1/crdb-internal.html) or [`pg_catalog`](../v23.1/pg-catalog.html) system catalogs. If you are experiencing this bug, set the `sql.distsql.use_streamer.enabled` [cluster setting](../v23.1/cluster-settings.html) to `false` before upgrading a cluster to v23.1. [#99443][#99443]
+- Fixed a bug that could erroneously cause multiple garbage-collection jobs to be created when executing a [`DROP SCHEMA ... CASCADE`](../v23.1/drop-schema.html) command, one job for each table and one for the cascaded `DROP` itself. [#99706][#99706]
+- Fixed a bug in the [**Insights** page](../v23.1/ui-insights-page.html#schema-insights-view) page that prevented a recommendation to drop an index from being executed if the index's name contained a space. [#100023][#100023]
+- Fixed a rare bug that prevented the garbage-collection job for a [`TRUNCATE`](../v23.1/truncate.html) command from successfully finishing if the table descriptor had already been garbage-collected. The garbage-collection job now succeeds in this situation. [#100009][#100009]
+- Fixed a rare bug that could cause a query of a virtual table in the [`crdb_internal`](../v23.1/crdb-internal.html) or [`pg_catalog`](../v23.1/pg-catalog.html) system catalog to hang indefinitely if the query returned an error. [#99969][#99969]
+- Fixed a bug introduced prior to v21.2 that could cause the SQL gateway node to crash if you [created a view](../v23.1/create-view.html) with a circular or self-referencing dependencies. This situation no longer crashes the node, and a `cyclic view dependency for relation` error is now logged. [#100159][#100159]
+- Several rare bugs have been fixed that could cause corruption in the existing primary index when a rollback occurs concurrent to adding or removing a [column family](../v23.1/column-families.html). This could lead to subsequent unavailability of the table. [#100030][#100030]
+- Fixed a bug that could cause a node to crash with an out-of-memory (OOM) exception when viewing details in the [**Statements** page](../v23.1/ui-statements-page.html) or [**Transactions** page](../v23.1/ui-transactions-page.html). [#99550][#99550]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-0-alpha-9-contributors">Contributors</h3>
+
+This release includes 75 merged PRs by 41 authors.
+
+</div>
+
+[#100009]: https://github.com/cockroachdb/cockroach/pull/100009
+[#100011]: https://github.com/cockroachdb/cockroach/pull/100011
+[#100023]: https://github.com/cockroachdb/cockroach/pull/100023
+[#100030]: https://github.com/cockroachdb/cockroach/pull/100030
+[#100159]: https://github.com/cockroachdb/cockroach/pull/100159
+[#99254]: https://github.com/cockroachdb/cockroach/pull/99254
+[#99398]: https://github.com/cockroachdb/cockroach/pull/99398
+[#99417]: https://github.com/cockroachdb/cockroach/pull/99417
+[#99443]: https://github.com/cockroachdb/cockroach/pull/99443
+[#99485]: https://github.com/cockroachdb/cockroach/pull/99485
+[#99513]: https://github.com/cockroachdb/cockroach/pull/99513
+[#99550]: https://github.com/cockroachdb/cockroach/pull/99550
+[#99618]: https://github.com/cockroachdb/cockroach/pull/99618
+[#99706]: https://github.com/cockroachdb/cockroach/pull/99706
+[#99795]: https://github.com/cockroachdb/cockroach/pull/99795
+[#99820]: https://github.com/cockroachdb/cockroach/pull/99820
+[#99935]: https://github.com/cockroachdb/cockroach/pull/99935
+[#99969]: https://github.com/cockroachdb/cockroach/pull/99969
+[2dc0229e5]: https://github.com/cockroachdb/cockroach/commit/2dc0229e5
+[ebdec3c98]: https://github.com/cockroachdb/cockroach/commit/ebdec3c98


### PR DESCRIPTION
[DOC-6519]

- Also remove CRL employees from first-time contributors to v23.1.0-alpha.8

## Previews
[releases/v23.1.md](https://deploy-preview-16683--cockroachdb-docs.netlify.app/docs/releases/v23.1.html)

## Tests
- [x] Local build
- [x] Linkcheck 