### PR TITLE
fix wrong format within table

### DIFF
--- a/v23.1/security-reference/security-overview.md
+++ b/v23.1/security-reference/security-overview.md
@@ -42,7 +42,7 @@ Cockroach Labs maintains <a href="https://github.com/cockroachdb/cockroach">Cock
     <th>Feature</th>
   </tr>
  <tr>
-   <td rowspan="7"><a href="authentication.html">Authentication</a></td>
+   <td rowspan="8"><a href="authentication.html">Authentication</a></td>
    <td>✓</td>
    <td>✓</td>
    <td>✓</td>


### PR DESCRIPTION
OCSP should be inclued in Authentication row, but is is not actually. So modify attribute rowspan from 7 to 8 in table row ```<td rowspan="8"><a href="authentication.html">Authentication</a></td>```.