### PR TITLE
DOC-6520 v23.1.0-beta.1 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -140,12 +140,12 @@ release_info:
     start_time: 2023-03-23 12:47:11.032616 +0000 UTC
     version: v22.2.7
   v23.1:
-    build_time: 2023-04-04 00:00:00 (go1.19)
+    build_time: 2023-04-10 00:00:00 (go1.19)
     crdb_branch_name: release-23.1
     docker_image: cockroachdb/cockroach-unstable
-    name: v23.1.0-alpha.9
-    start_time: 2023-04-04 10:24:39.246087 +0000 UTC
-    version: v23.1.0-alpha.9
+    name: v23.1.0-beta.1
+    start_time: 2023-04-10 10:45:33.467860 +0000 UTC
+    version: v23.1.0-beta.1
 sass:
   quiet_deps: 'true'
   sass_dir: css

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -4146,3 +4146,24 @@
     docker_arm: true
   source: true
   previous_version: v23.1.0-alpha.8
+
+- version: v23.1.0-beta.1
+  major_version: v23.1
+  release_date: '2023-04-13'
+  release_type: Testing
+  go_version: go1.19
+  sha: aa1c57b36fab87222c82a4ca027b2275654401af
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_intel_fips: false
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach-unstable
+    docker_arm: true
+  source: true
+  previous_version: v23.1.0-alpha.9

--- a/_includes/releases/v23.1/v23.1.0-beta.1.md
+++ b/_includes/releases/v23.1/v23.1.0-beta.1.md
@@ -1,0 +1,80 @@
+## v23.1.0-beta.1
+
+Release Date: April 13, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-1-0-beta-1-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
+
+- The [Avro](../v23.1/changefeed-messages.html#avro) schema registry URI now allows an additional `timeout=T` query parameter, which allows you to change the default timeout for contacting the schema registry. [#99300][#99300]
+
+<h3 id="v23-1-0-beta-1-sql-language-changes">SQL language changes</h3>
+
+- Changed the [GC TTL](../v23.1/configure-replication-zones.html#gc-ttlseconds) on the SQL Stats table to 1h on {{ site.data.products.dedicated }} and Self-Hosted clusters. This change is not applicable to {{ site.data.products.serverless }} clusters or clusters running CockroachDB v23.1 with secondary tenants. [#100359][#100359]
+- When there is no data persisted, show the in-memory data. [#100505][#100505]
+- Added two new [cluster settings](../v23.1/cluster-settings.html) that enable users to change the number of histogram samples and buckets collected when building histograms as part of table statistics collection. While the default values should work for most cases, it may be beneficial to increase the number of samples and buckets for very large tables to avoid creating a histogram that misses important values: [#100662][#100662]
+   - `sql.stats.histogram_samples.count`
+   - `sql.stats.histogram_buckets.count`
+- Added two new table storage parameters, `sql_stats_histogram_buckets_count` and `sql_stats_histogram_samples_count`. These parameters can be used to override the [cluster settings](../v23.1/cluster-settings.html) `sql.stats.histogram_buckets.count` and `sql.stats.histogram_samples.count` at the table level, allowing you to change the number of histogram samples and buckets collected when building histograms as part of table statistics collection. While the default values should work for most cases, it may be beneficial to increase the number of samples and buckets for very large tables to avoid creating a histogram that misses important values. [#100662][#100662]
+
+<h3 id="v23-1-0-beta-1-operational-changes">Operational changes</h3>
+
+- Introduced seven new timeseries [metrics](../v23.1/metrics.html) for better visibility into the behavior of storage engine iterators and their internals. [#100445][#100445]
+- Added a new [metric](../v23.1/metrics.html) `range.snapshots.delegate.in-progress` and renamed two metrics:
+   - `range.snapshot.delegate.successes` -> `range.snapshots.delegate.successes`
+   - `range.snapshot.delegate.failures` -> `range.snapshots.delegate.failures` [#100421][#100421]
+- Added two new timeseries [metrics](../v23.1/metrics.html), providing some observability into the volume of keys preserved by open LSM snapshots: [#100878][#100878]
+   - `storage.compactions.keys.pinned.count`
+   - `storage.compactions.keys.pinned.bytes`
+
+<h3 id="v23-1-0-beta-1-db-console-changes">DB Console changes</h3>
+
+- Fixed an issue with properly rendering placeholders on the **Node Map** view for [insecure](../v23.1/start-a-local-cluster.html) clusters. [#100214][#100214]
+
+<h3 id="v23-1-0-beta-1-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug which could cause [`SHOW CLUSTER SETTING version`](../v23.1/show-cluster-setting.html) to hang and return an opaque error while cluster finalization is ongoing. [#100259][#100259]
+- Fixed a bug that could cause internal errors and corrupt partial indexes when deleting rows with the `DELETE FROM .. USING` syntax. This bug is only present in alpha versions of v23.1.0. [#100307][#100307]
+- The [**Hot Ranges** page](../v23.1/ui-hot-ranges-page.html) DB Console page would show hot ranges by CPU and not QPS (queries per second), depending on the value of the `kv.allocator.load_based_rebalancing.objective` [cluster setting](../v23.1/cluster-settings.html) (default `cpu`). Now the page will always collect statistics based on QPS. [#100211][#100211]
+- In rare cases involving overload and schema changes, users could sometimes, transiently, see errors of the form `deadline below read timestamp is nonsensical; txn has would have no chance to commit`. These errors carried and internal pgcode and could not be retried. This form of error is now classified as a retriable error and will be retried automatically either by the client or internally. [#100256][#100256]
+- Fixed a bug in the declarative schema changer in v23.1 where unique without index can be incorrectly added in tables with duplicate values if it was added with a [`ALTER TABLE ... ADD/DROP COLUMN`](/docs/v23.1/alter-table.html in one `ALTER TABLE` statement. [#100535][#100535]
+- Fixed an issue where the `enforce_home_region` [session setting](../v23.1/set-vars.html) did not prevent a locality-optimized anti-join from looking up rows in remote regions. This bug is only present in alpha versions of v23.1.0. [#100735][#100735]
+
+<h3 id="v23-1-0-beta-1-performance-improvements">Performance improvements</h3>
+
+- Audit logging should no longer incur extra latency when resolving table/view/sequence names. [#99548][#99548]
+- The webhook sink is now able to handle a drastically higher maximum throughput by enabling the `changefeed.new_webhook_sink_enabled` [cluster setting](../v23.1/cluster-settings.html). [#100639][#100639]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-0-beta-1-contributors">Contributors</h3>
+
+This release includes 116 merged PRs by 44 authors.
+
+</div>
+
+[#100162]: https://github.com/cockroachdb/cockroach/pull/100162
+[#100211]: https://github.com/cockroachdb/cockroach/pull/100211
+[#100214]: https://github.com/cockroachdb/cockroach/pull/100214
+[#100256]: https://github.com/cockroachdb/cockroach/pull/100256
+[#100259]: https://github.com/cockroachdb/cockroach/pull/100259
+[#100307]: https://github.com/cockroachdb/cockroach/pull/100307
+[#100359]: https://github.com/cockroachdb/cockroach/pull/100359
+[#100421]: https://github.com/cockroachdb/cockroach/pull/100421
+[#100424]: https://github.com/cockroachdb/cockroach/pull/100424
+[#100445]: https://github.com/cockroachdb/cockroach/pull/100445
+[#100505]: https://github.com/cockroachdb/cockroach/pull/100505
+[#100535]: https://github.com/cockroachdb/cockroach/pull/100535
+[#100604]: https://github.com/cockroachdb/cockroach/pull/100604
+[#100628]: https://github.com/cockroachdb/cockroach/pull/100628
+[#100639]: https://github.com/cockroachdb/cockroach/pull/100639
+[#100662]: https://github.com/cockroachdb/cockroach/pull/100662
+[#100720]: https://github.com/cockroachdb/cockroach/pull/100720
+[#100735]: https://github.com/cockroachdb/cockroach/pull/100735
+[#100878]: https://github.com/cockroachdb/cockroach/pull/100878
+[#99300]: https://github.com/cockroachdb/cockroach/pull/99300
+[#99548]: https://github.com/cockroachdb/cockroach/pull/99548
+[43306383f]: https://github.com/cockroachdb/cockroach/commit/43306383f
+[4fd02898c]: https://github.com/cockroachdb/cockroach/commit/4fd02898c
+[925e1600a]: https://github.com/cockroachdb/cockroach/commit/925e1600a
+[f27e6b2eb]: https://github.com/cockroachdb/cockroach/commit/f27e6b2eb


### PR DESCRIPTION
Addresses: DOC-6520

- Release notes for v23.1.0-beta.1

Staging

[v23.1.md](https://deploy-preview-16710--cockroachdb-docs.netlify.app/docs/releases/v23.1.html#v23-1-0-beta-1)