### PR TITLE
Recommend changefeeds for exporting data over `EXPORT`

### DIFF
--- a/v22.2/export-data-with-changefeeds.md
+++ b/v22.2/export-data-with-changefeeds.md
@@ -7,7 +7,7 @@ docs_area: stream_data
 
 When you create an {{ site.data.products.enterprise }} changefeed, you can include the [`initial_scan = 'only'`](create-changefeed.html#initial-scan) option to specify that the changefeed should only complete a table scan. The changefeed emits messages for the table scan and then the job completes with a `succeeded` status. As a result, you can create a changefeed with `initial_scan = 'only'` to [export](export.html) data out of your database.  
 
-The benefits of using changefeeds for this function compared to an [export](export.html), include:
+The benefits of using changefeeds for this function instead of [export](export.html), include:
 
 - Changefeeds are jobs, which can be [paused](pause-job.html), [resumed](resume-job.html), and [cancelled](cancel-job.html).
 - There is observability into a changefeed job using [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs) and the [Changefeeds Dashboard](ui-cdc-dashboard.html) in the DB Console.

--- a/v22.2/export-data-with-changefeeds.md
+++ b/v22.2/export-data-with-changefeeds.md
@@ -7,11 +7,12 @@ docs_area: stream_data
 
 When you create an {{ site.data.products.enterprise }} changefeed, you can include the [`initial_scan = 'only'`](create-changefeed.html#initial-scan) option to specify that the changefeed should only complete a table scan. The changefeed emits messages for the table scan and then the job completes with a `succeeded` status. As a result, you can create a changefeed with `initial_scan = 'only'` to [export](export.html) data out of your database.  
 
-The benefits of using changefeeds for this function compared to an export, include:
+The benefits of using changefeeds for this function compared to an [export](export.html), include:
 
 - Changefeeds are jobs, which can be [paused](pause-job.html), [resumed](resume-job.html), and [cancelled](cancel-job.html).
 - There is observability into a changefeed job using [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs) and the [Changefeeds Dashboard](ui-cdc-dashboard.html) in the DB Console.
-- [Changefeed sinks](changefeed-sinks.html) provide additional endpoints to send your data.
+- Changefeed jobs have built-in [checkpointing](change-data-capture-overview.html#how-does-an-enterprise-changefeed-work) and [retries](monitor-and-debug-changefeeds.html#changefeed-retry-errors).
+- [Changefeed sinks](changefeed-sinks.html) provide additional endpoints for your data.
 - You can use the [`format=csv`](create-changefeed.html#format) option with `initial_scan= 'only'` to emit messages in CSV format.
 
 {% include {{ page.version.version }}/cdc/csv-changefeed-format.md %}

--- a/v22.2/export.md
+++ b/v22.2/export.md
@@ -5,6 +5,10 @@ toc: true
 docs_area: reference.sql
 ---
 
+{{site.data.alerts.callout_info}}
+`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
+{{site.data.alerts.end}}
+
 The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to the following:
 
 - CSV files
@@ -15,7 +19,7 @@ Using the [CockroachDB distributed execution engine](architecture/sql-layer.html
 If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
+**Cockroach Labs recommends using [changefeeds to export data](export-data-with-changefeeds.html)** because they provide better performance for growing workloads. Additionally, changefeeds operate as jobs, which offer [observability](monitor-and-debug-changefeeds.html) and [job management](create-and-configure-changefeeds.html).
 {{site.data.alerts.end}}
 
 ## Cancelling export

--- a/v22.2/export.md
+++ b/v22.2/export.md
@@ -6,7 +6,7 @@ docs_area: reference.sql
 ---
 
 {{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
+**Cockroach Labs recommends using [changefeeds to export data](export-data-with-changefeeds.html)** because they provide better performance for growing workloads. Additionally, changefeeds operate as jobs, which offer [observability](monitor-and-debug-changefeeds.html) and [job management](create-and-configure-changefeeds.html).
 {{site.data.alerts.end}}
 
 The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to the following:
@@ -19,7 +19,7 @@ Using the [CockroachDB distributed execution engine](architecture/sql-layer.html
 If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
-**Cockroach Labs recommends using [changefeeds to export data](export-data-with-changefeeds.html)** because they provide better performance for growing workloads. Additionally, changefeeds operate as jobs, which offer [observability](monitor-and-debug-changefeeds.html) and [job management](create-and-configure-changefeeds.html).
+`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
 {{site.data.alerts.end}}
 
 ## Cancelling export

--- a/v23.1/export-data-with-changefeeds.md
+++ b/v23.1/export-data-with-changefeeds.md
@@ -9,7 +9,7 @@ When you create an {{ site.data.products.enterprise }} changefeed, you can inclu
 
 {% include_cached new-in.html version="v23.1" %} You can also [schedule a changefeed](#create-a-scheduled-changefeed-to-export-filtered-data) to use a changefeed initial scan for exporting data on a regular cadence. 
 
-The benefits of using changefeeds for this use case compared to an [export](export.html), include:
+The benefits of using changefeeds for this use case instead of [export](export.html), include:
 
 - Changefeeds are jobs, which can be [paused](pause-job.html), [resumed](resume-job.html), [cancelled](cancel-job.html), [scheduled](create-schedule-for-changefeed.html), and [altered](alter-changefeed.html).
 - There is observability into a changefeed job using [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs) and the [Changefeeds Dashboard](ui-cdc-dashboard.html) in the DB Console.

--- a/v23.1/export-data-with-changefeeds.md
+++ b/v23.1/export-data-with-changefeeds.md
@@ -9,11 +9,12 @@ When you create an {{ site.data.products.enterprise }} changefeed, you can inclu
 
 {% include_cached new-in.html version="v23.1" %} You can also [schedule a changefeed](#create-a-scheduled-changefeed-to-export-filtered-data) to use a changefeed initial scan for exporting data on a regular cadence. 
 
-The benefits of using changefeeds for this use case compared to an export, include:
+The benefits of using changefeeds for this use case compared to an [export](export.html), include:
 
-- Changefeeds are jobs, which can be [paused](pause-job.html), [resumed](resume-job.html), and [cancelled](cancel-job.html).
+- Changefeeds are jobs, which can be [paused](pause-job.html), [resumed](resume-job.html), [cancelled](cancel-job.html), [scheduled](create-schedule-for-changefeed.html), and [altered](alter-changefeed.html).
 - There is observability into a changefeed job using [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs) and the [Changefeeds Dashboard](ui-cdc-dashboard.html) in the DB Console.
-- [Changefeed sinks](changefeed-sinks.html) provide additional endpoints to send your data.
+- Changefeed jobs have built-in [checkpointing](change-data-capture-overview.html#how-does-an-enterprise-changefeed-work) and [retries](monitor-and-debug-changefeeds.html#changefeed-retry-errors).
+- [Changefeed sinks](changefeed-sinks.html) provide additional endpoints for your data.
 - You can use the [`format=csv`](create-changefeed.html#format) option with `initial_scan= 'only'` to emit messages in CSV format.
 
 {% include {{ page.version.version }}/cdc/csv-changefeed-format.md %}

--- a/v23.1/export.md
+++ b/v23.1/export.md
@@ -5,6 +5,10 @@ toc: true
 docs_area: reference.sql
 ---
 
+{{site.data.alerts.callout_info}}
+`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
+{{site.data.alerts.end}}
+
 The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to the following:
 
 - CSV files
@@ -15,7 +19,7 @@ Using the [CockroachDB distributed execution engine](architecture/sql-layer.html
 If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
+**Cockroach Labs recommends using [changefeeds to export data](export-data-with-changefeeds.html)** because they provide better performance for growing workloads. Additionally, changefeeds operate as jobs, which offer [observability](monitor-and-debug-changefeeds.html), [scheduling](export-data-with-changefeeds.html#create-a-scheduled-changefeed-to-export-filtered-data), and [job management](create-and-configure-changefeeds.html).
 {{site.data.alerts.end}}
 
 ## Cancelling export

--- a/v23.1/export.md
+++ b/v23.1/export.md
@@ -6,7 +6,7 @@ docs_area: reference.sql
 ---
 
 {{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
+**Cockroach Labs recommends using [changefeeds to export data](export-data-with-changefeeds.html)** because they provide better performance for growing workloads. Additionally, changefeeds operate as jobs, which offer [observability](monitor-and-debug-changefeeds.html), [scheduling](export-data-with-changefeeds.html#create-a-scheduled-changefeed-to-export-filtered-data), and [job management](create-and-configure-changefeeds.html).
 {{site.data.alerts.end}}
 
 The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to the following:
@@ -19,7 +19,7 @@ Using the [CockroachDB distributed execution engine](architecture/sql-layer.html
 If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
-**Cockroach Labs recommends using [changefeeds to export data](export-data-with-changefeeds.html)** because they provide better performance for growing workloads. Additionally, changefeeds operate as jobs, which offer [observability](monitor-and-debug-changefeeds.html), [scheduling](export-data-with-changefeeds.html#create-a-scheduled-changefeed-to-export-filtered-data), and [job management](create-and-configure-changefeeds.html).
+`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
 {{site.data.alerts.end}}
 
 ## Cancelling export


### PR DESCRIPTION
Fixes DOC-7323

This PR adds the following to encourage users to create changefeeds for data export over `EXPORT`:

- Note to the top of the `EXPORT` page 
- Additional benefits of changefeeds to Export Data with Changefeeds page