### PR TITLE
Landing page cards can be in any docs section

### DIFF
--- a/_includes/landing-page.md
+++ b/_includes/landing-page.md
@@ -4,7 +4,7 @@
     <h1 class="m-0 text-white">{{ page.title }}</h1>
     <p class="mt-0 pb-4 text-white">{{ page.summary }}</p>
       <div class="row d-lg-flex mx-0">
-      {% for card in site.data.cards.[page.docs_area] %}
+      {% for card in site.data.cards.[page.cards_section] %}
         <div class="col-lg-4 mb-3 mb-lg-0 pb-5">
           <div class="card card-link h-100 d-flex">
           <a href="{{ card.link | replace: "PREFIX", page_version | relative_url }}" class="h-100">

--- a/v22.2/developer-guide-overview.md
+++ b/v22.2/developer-guide-overview.md
@@ -3,8 +3,8 @@ title: Develop with CockroachDB
 summary: An overview of common tasks that come up when you build an application using CockroachDB
 toc: false
 contribute: false
-landing_page: true
 docs_area: develop
+cards_section: develop
 ---
 
 {% include landing-page.md %}

--- a/v23.1/developer-guide-overview.md
+++ b/v23.1/developer-guide-overview.md
@@ -3,8 +3,8 @@ title: Develop with CockroachDB
 summary: An overview of common tasks that come up when you build an application using CockroachDB
 toc: false
 contribute: false
-landing_page: true
 docs_area: develop
+cards_section: develop
 ---
 
 {% include landing-page.md %}


### PR DESCRIPTION
This is a follow up PR to the new cards layout for landing pages. Instead of using the `docs_area` as the key for finding cards, use a new `cards_section` front matter variable.