### PR TITLE
Fix Algolia drift

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -6,6 +6,14 @@ algolia:
   - search.html
   index_name: cockroachcloud_docs
   search_api_key: 372a10456f4ed7042c531ff3a658771b
+  settings:                                                                      
+    attributesForFaceting:                                                       
+      - searchable(categories)                                                   
+      - searchable(collection)                                                   
+      - docs_area                                                                
+      - searchable(tags)                                                         
+      - searchable(title)                                                        
+      - type                                                                     
 defaults:
 - scope:
     path: ''


### PR DESCRIPTION
We've been getting the following warning in our production builds:

```
4:08:42 PM: [jekyll-algolia] Configuration mismatch:
4:08:42 PM: It seems that your index settings have been edited from outside of the
4:08:42 PM: jekyll-algolia plugin.
4:08:42 PM: This can happen if you manually edited them from the Algolia dashboard, for
4:08:42 PM: example. Don't worry, they will still be honored (for now).
4:08:42 PM: Still, we strongly encourage you to save any custom config inside the
4:08:42 PM: algolia.settings key of your _config.yml instead. Any value set there will
4:08:42 PM: always take precedence over anything you manually set in your dashboard.
4:08:42 PM: This is the best way to be sure your settings will not be lost in the future.
```

This PR fixes that drift.