### PR TITLE
DOC-6404 updated restore section for manage Dedicated cluster page

### DIFF
--- a/cockroachcloud/cluster-management.md
+++ b/cockroachcloud/cluster-management.md
@@ -171,9 +171,9 @@ You can use the [**Databases** page](databases-page.html) to create a new databa
 
 ## Restore data from a backup
 
-Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days and incremental backups for 7 days. Use the [Managed-Service Backups](use-managed-service-backups.html?filters=dedicated#ways-to-restore-data) to restore from automatic backups in the Console. 
+Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. Full backups are retained for 30 days and incremental backups for 7 days. See the [Use Managed-Service Backups](use-managed-service-backups.html?filters=dedicated#ways-to-restore-data) page for ways to restore data from your cluster's automatic backups in the Console. 
 
-Additionally, you can [backup and restore](take-and-restore-customer-owned-backups.html) your {{ site.data.products.dedicated }} cluster manually. You can take backups locally to [`userfile`](../{{site.current_cloud_version}}/use-userfile-storage.html) or backup to [cloud storage](take-and-restore-customer-owned-backups.html?filters=cloud#back-up-data).
+Additionally, you can [backup and restore](take-and-restore-customer-owned-backups.html) your {{ site.data.products.dedicated }} cluster manually. For detail on taking backups to your cloud storage, see [Take and Restore Customer-Owned Backups](take-and-restore-customer-owned-backups.html?filters=cloud#back-up-data).
 
 {{site.data.alerts.callout_info}}
 All databases are not backed up at the same time. Each database is backed up every hour based on the time of creation. For larger databases, you might see an hourly CPU spike while the database is being backed up.

--- a/cockroachcloud/cluster-management.md
+++ b/cockroachcloud/cluster-management.md
@@ -173,7 +173,7 @@ You can use the [**Databases** page](databases-page.html) to create a new databa
 
 Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. Full backups are retained for 30 days and incremental backups for 7 days. See the [Use Managed-Service Backups](use-managed-service-backups.html?filters=dedicated#ways-to-restore-data) page for ways to restore data from your cluster's automatic backups in the Console. 
 
-Additionally, you can [backup and restore](take-and-restore-customer-owned-backups.html) your {{ site.data.products.dedicated }} cluster manually. For detail on taking backups to your cloud storage, see [Take and Restore Customer-Owned Backups](take-and-restore-customer-owned-backups.html?filters=cloud#back-up-data).
+Additionally, you can [back up and restore](take-and-restore-customer-owned-backups.html) your {{ site.data.products.dedicated }} cluster manually. For detail on taking backups to your cloud storage, see [Take and Restore Customer-Owned Backups](take-and-restore-customer-owned-backups.html?filters=cloud#back-up-data).
 
 {{site.data.alerts.callout_info}}
 All databases are not backed up at the same time. Each database is backed up every hour based on the time of creation. For larger databases, you might see an hourly CPU spike while the database is being backed up.

--- a/cockroachcloud/cluster-management.md
+++ b/cockroachcloud/cluster-management.md
@@ -171,15 +171,13 @@ You can use the [**Databases** page](databases-page.html) to create a new databa
 
 ## Restore data from a backup
 
-Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days and incremental backups for 7 days.
+Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days and incremental backups for 7 days. To restore your data, use the [Managed-Service Backups](use-managed-service-backups.html?filters=dedicated#ways-to-restore-data) to restore from automatic backups. 
+
+Additionally, you can [backup and restore](take-and-restore-customer-owned-backups.html) your {{ site.data.products.dedicated }} cluster manually. You can take backups locally to [`userfile`](../{{site.current_cloud_version}}/use-userfile-storage.html) or backup to [cloud storage](take-and-restore-customer-owned-backups.html?filters=cloud#back-up-data).
 
 {{site.data.alerts.callout_info}}
 All databases are not backed up at the same time. Each database is backed up every hour based on the time of creation. For larger databases, you might see an hourly CPU spike while the database is being backed up.
 {{site.data.alerts.end}}
-
-To restore your data, [contact us](https://support.cockroachlabs.com).
-
-Additionally, you can [backup and restore](../{{site.current_cloud_version}}/take-full-and-incremental-backups.html) data on your own.
 
 ## Configure PCI ready features (Dedicated advanced)
 

--- a/cockroachcloud/cluster-management.md
+++ b/cockroachcloud/cluster-management.md
@@ -171,7 +171,7 @@ You can use the [**Databases** page](databases-page.html) to create a new databa
 
 ## Restore data from a backup
 
-Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days and incremental backups for 7 days. To restore your data, use the [Managed-Service Backups](use-managed-service-backups.html?filters=dedicated#ways-to-restore-data) to restore from automatic backups. 
+Cockroach Labs runs full backups daily and incremental backups hourly for every {{ site.data.products.dedicated }} cluster. The full backups are retained for 30 days and incremental backups for 7 days. Use the [Managed-Service Backups](use-managed-service-backups.html?filters=dedicated#ways-to-restore-data) to restore from automatic backups in the Console. 
 
 Additionally, you can [backup and restore](take-and-restore-customer-owned-backups.html) your {{ site.data.products.dedicated }} cluster manually. You can take backups locally to [`userfile`](../{{site.current_cloud_version}}/use-userfile-storage.html) or backup to [cloud storage](take-and-restore-customer-owned-backups.html?filters=cloud#back-up-data).
 


### PR DESCRIPTION
Addresses DOC-6404:
- Updated the restore section on the Dedicated Cluster Management page
- Linked out to the relevant pages for Console restores and manual backups and restores

Questions:
- Should we include the 'Note' section? Is this still applicable?
- Do we care about the URL naming convention for the page? For Serverless, the URL is `serverless-cluster-management.html` while this page is `cluster-management.html`. We could change it to `dedicated-cluster-management.html` for consistency. 

Preview:
- [Manage Dedicated Cluster](https://deploy-preview-16806--cockroachdb-docs.netlify.app/docs/cockroachcloud/cluster-management.html#restore-data-from-a-backup)