### PR TITLE
Add docs for decommissioning pre-flight checks

### DIFF
--- a/_includes/v23.1/prod-deployment/decommission-pre-flight-checks.md
+++ b/_includes/v23.1/prod-deployment/decommission-pre-flight-checks.md
@@ -1,0 +1,18 @@
+By default, CockroachDB will perform a set of "decommissioning pre-flight checks". That is, decommission pre-checks look over the ranges with replicas on the to-be-decommissioned node, and check that each replica can be moved to some other node in the cluster. If errors are detected that would result in the inability to complete node decommissioning, they will be printed to `STDERR` and the command will exit *without attempting to perform node decommissioning*. For example, ranges that require a certain number of voting replicas in a region but do not have any available nodes in the region not already containing a replica will block the decommissioning process.
+
+The error format is shown below:
+
+~~~
+ranges blocking decommission detected
+n1 has 44 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); likely not enough nodes in cluster"
+n2 has 27 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); likely not enough nodes in cluster"
+
+ERROR: Cannot decommission nodes.
+Failed running "node decommission"
+~~~
+
+These checks can be skipped by [passing the flag `--checks=skip` to `cockroach node decommission`](cockroach-node.html#decommission-checks).
+
+{{site.data.alerts.callout_info}}
+Remaining disk space on other nodes in the cluster is not yet considered as part of the decommissioning pre-flight checks. For more information, see [cockroachdb/cockroach#71757](https://github.com/cockroachdb/cockroach/issues/71757)
+{{site.data.alerts.end}}

--- a/_includes/v23.1/prod-deployment/decommission-pre-flight-checks.md
+++ b/_includes/v23.1/prod-deployment/decommission-pre-flight-checks.md
@@ -14,5 +14,5 @@ Failed running "node decommission"
 These checks can be skipped by [passing the flag `--checks=skip` to `cockroach node decommission`](cockroach-node.html#decommission-checks).
 
 {{site.data.alerts.callout_info}}
-Remaining disk space on other nodes in the cluster is not yet considered as part of the decommissioning pre-flight checks. For more information, see [cockroachdb/cockroach#71757](https://github.com/cockroachdb/cockroach/issues/71757)
+The amount of remaining disk space on other nodes in the cluster is not yet considered as part of the decommissioning pre-flight checks. For more information, see [cockroachdb/cockroach#71757](https://github.com/cockroachdb/cockroach/issues/71757)
 {{site.data.alerts.end}}

--- a/v23.1/cockroach-node.md
+++ b/v23.1/cockroach-node.md
@@ -16,7 +16,7 @@ Subcommand | Usage
 -----------|------
 `ls` | List the ID of each node in the cluster, excluding those that have been decommissioned and are offline.
 `status` | View the status of one or all nodes, excluding nodes that have been decommissioned and taken offline. Depending on flags used, this can include details about range/replicas, disk usage, and decommissioning progress.
-`decommission` | Decommission nodes for removal from the cluster. For details, see [Node Shutdown](node-shutdown.html?filters=decommission).
+`decommission` | Decommission nodes for removal from the cluster. For more information, see [Decommission nodes](#decommission-nodes).
 `recommission` | Recommission nodes that are decommissioning. If the decommissioning node has already reached the [draining stage](node-shutdown.html?filters=decommission#draining), you may need to restart the node after it is recommissioned. For details, see [Node Shutdown](node-shutdown.html#recommission-nodes).
 `drain` | Drain nodes in preparation for process termination. Draining always occurs when sending a termination signal or decommissioning a node. The `drain` subcommand is used to drain nodes without also decommissioning or shutting them down. For details, see [Node Shutdown](node-shutdown.html).
 
@@ -117,10 +117,12 @@ Flag | Description
 `--stats` | Show node disk usage details.
 `--timeout` | Set the duration of time that the subcommand is allowed to run before it returns an error and prints partial information. The timeout is specified with a suffix of `s` for seconds, `m` for minutes, and `h` for hours. If this flag is not set, the subcommand may hang.
 
-The `node decommission` subcommand also supports the following general flags:
+The `node decommission` subcommand also supports the following general flags. For more information, see `cockroach node decommission --help`.
 
 Flag | Description
 -----|------------
+`--checks` | <a name="decommission-checks"></a> Whether to perform a set of "decommissioning pre-flight checks". Possible values: `enabled`, `strict`, or `skip`. If `enabled`, CockroachDB will check if a node can successfully complete decommissioning given the current state of the cluster. If errors are detected that would result in the inability to complete node decommissioning, they will be printed to `STDERR` and the command will exit *without attempting to perform node decommissioning*. For more information, see [Remove nodes](node-shutdown.html?filters=decommission#remove-nodes).<br/><br/>**Default:** `enabled`
+`--dry-run` | Performs the same decommissioning checks as the `--checks` flag, but without attempting to decommission the node. When `cockroach node decommission {nodeID} --dry-run` is executed, it runs the checks, prints the status of those checks, and exits.
 `--wait` | When to return to the client. Possible values: `all`, `none`.<br><br>If `all`, the command returns to the client only after all replicas on all specified nodes have been transferred to other nodes. If any specified nodes are offline, the command will not return to the client until those nodes are back online.<br><br>If `none`, the command does not wait for the decommissioning process to complete; it returns to the client after starting the decommissioning process on all specified nodes that are online. Any specified nodes that are offline will automatically be marked as decommissioning; if they come back online, the cluster will recognize this status and will not rebalance data to the nodes.<br><br>**Default:** `all`
 `--self` | **Deprecated.** Instead, specify a node ID explicitly in addition to the `--host` flag.
 

--- a/v23.1/node-shutdown.md
+++ b/v23.1/node-shutdown.md
@@ -345,6 +345,8 @@ If the rebalancing stalls during decommissioning, replicas that have yet to move
 Do **not** terminate the node process, delete the storage volume, or remove the VM before a `decommissioning` node has [changed its membership status](#status-change) to `decommissioned`. Prematurely terminating the process will prevent the node from rebalancing all of its range replicas onto other nodes gracefully, cause transient query errors in client applications, and leave the remaining ranges under-replicated and vulnerable to loss of [quorum](architecture/replication-layer.html#overview) if another node goes down.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/prod-deployment/decommission-pre-flight-checks.md %}
+
 ### Terminate the node process
 </section>
 
@@ -577,6 +579,15 @@ You can use [`cockroach node drain`](cockroach-node.html) to drain a node separa
 <section class="filter-content" markdown="1" data-scope="decommission">
 ### Remove nodes
 
+- [Prerequisites](#prerequisites)
+- [Step 1. Get the IDs of the nodes to decommission](#step-1-get-the-ids-of-the-nodes-to-decommission)
+- [Step 2. Drain the nodes manually](#step-2-drain-the-nodes-manually)
+- [Step 3. Decommission the nodes](#step-3-decommission-the-nodes)
+- [Step 4. Confirm the nodes are decommissioned](#step-4-confirm-the-nodes-are-decommissioned)
+- [Step 5. Terminate the process on decommissioned nodes](#step-5-terminate-the-process-on-decommissioned-nodes)
+
+#### Prerequisites
+
 In addition to the [graceful node shutdown](#prepare-for-graceful-shutdown) requirements, observe the following guidelines:
 
 - Before decommissioning nodes, verify that there are no [under-replicated or unavailable ranges](ui-cluster-overview-page.html#cluster-overview-panel) on the cluster.
@@ -652,6 +663,8 @@ The `is_decommissioning` field remains `true` after all replicas have been remov
 {{site.data.alerts.callout_danger}}
 Do **not** terminate the node process, delete the storage volume, or remove the VM before a `decommissioning` node has [changed its membership status](#status-change) to `decommissioned`. Prematurely terminating the process will prevent the node from rebalancing all of its range replicas onto other nodes gracefully, cause transient query errors in client applications, and leave the remaining ranges under-replicated and vulnerable to loss of [quorum](architecture/replication-layer.html#overview) if another node goes down.
 {{site.data.alerts.end}}
+
+{% include {{page.version.version}}/prod-deployment/decommission-pre-flight-checks.md %}
 
 #### Step 4. Confirm the nodes are decommissioned
 


### PR DESCRIPTION
Fixes DOC-6744

Summary of changes:

- Update 'Node Shutdown' page with information about the new decommissioning pre-flight checks, including how they work at a high level, and with an example of the error message format

  - Since this page mentions decommissioning in several places, we share the info across those places using an include

  - Small opportunistic edit to add a sub-TOC to make the node removal process a little easier to follow

- Update `cockroach node decommission` docs with the new `--checks` flag