### PR TITLE
DOC-6775 support arbitrarily long incremental backups

### DIFF
--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -159,7 +159,7 @@ Incremental backups form chains between full backups. Each incremental backup co
 
 Cockroach Labs recommends taking incremental backups every 10 minutes. CockroachDB supports up to 400 incremental backups between full backups. This may vary based on your specific use-case, so we recommend testing within your own environment and workloads. This can look like:
 
-- A full backup taken daily with incrementals taken every hour for a total of 24 incremental backups
+- A full backup taken daily with incrementals taken every hour for a total of 24 incremental backups.
 - A full backup taken daily with incrementals taken every 10 minutes for a total of 144 incremental backups.
 - A full backup taken daily with incrementals taken every 5 minutes for a total of 288 incremental backups.
 - A full backup taken weekly with incrementals taken every hour for a total of 168 incremental backups.

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -149,19 +149,22 @@ To view the available backup subdirectories, use [`SHOW BACKUPS`](show-backup.ht
 To take incremental backups, you need an [Enterprise license](enterprise-licensing.html).
 {{site.data.alerts.end}}
 
+If your cluster grows too large for daily [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with daily incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
+
+If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups.
+
+### Recommendations
+
 Incremental backups are chains between full backups and contain only the data that has changed since a base set of backups (which must include one full backup, and can include many incremental backups). Incremental backups are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
 
-CockroachDB recommends taking incremental backups every 10 minutes. We support up to 400 incremental backups between full backups. This can look like:
+CockroachDB recommends taking incremental backups every 10 minutes. We support up to 400 incremental backups between full backups. This may vary based on your specific use-case, so we recommend testing within your own environment and workloads. This can look like:
 <ul>
   <li>A full backup taken daily with incrementals taken every hour for a total of 24 incremental backups.</li>
   <li>A full backup taken daily with incrementals taken every 10 minutes for a total of 144 incremental backups.</li>
+  <li>A full backup taken daily with incrementals taken every 5 minutes for a total of 288 incremental backups.</li>
   <li>A full backup taken weekly with incrementals taken every hour for a total of 168 incremental backups.</li>
   <li>A full backup taken weekly with incrementals taken every 30 minutes for a total of 336 incremental backups.</li>
 </ul>
-
-If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
-
-If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup.html#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>Incremental backup schedule <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>Incremental backup schedule <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
 
 ### Garbage collection and backups
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -161,7 +161,7 @@ CockroachDB recommends taking incremental backups every 10 minutes. We support u
 
 If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
-If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup.html#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>`RECURRING` <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>`RECURRING` <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
+If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup.html#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>Incremental backup frequency <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>Incremental backup frequency <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
 
 ### Garbage collection and backups
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -149,9 +149,11 @@ To view the available backup subdirectories, use [`SHOW BACKUPS`](show-backup.ht
 To take incremental backups, you need an [Enterprise license](enterprise-licensing.html).
 {{site.data.alerts.end}}
 
-If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
+Incremental backups are chains between full backups and contain only the data that has changed since a base set of backups (which must include one full backup, and can include many incremental backups). Incremental backups are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
 
-Incremental backups are smaller and faster to produce than full backups because they contain only the data that has changed since a base set of backups you specify (which must include one full backup, and can include many incremental backups). You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
+CockroachDB recommends taking incremental backups every 10 minutes. We support up to 400 incremental backups between full backups. 
+
+If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
 If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups.
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -155,7 +155,7 @@ If you are taking backups on a regular cadence, we recommend [creating a schedul
 
 ### Recommendations for incremental backup frequency
 
-Incremental backups form chains between full backups. Each incremental backup only contains only the data that has changed since a base set of backups, which must include one full backup, and can include many incremental backups. Incremental backups are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
+Incremental backups form chains between full backups. Each incremental backup contains only the data that has changed since a base set of backups. This base set of backups must include one full backup and can include many incremental backups, which are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
 
 Cockroach Labs recommends taking incremental backups every 10 minutes. CockroachDB supports up to 400 incremental backups between full backups. This may vary based on your specific use-case, so we recommend testing within your own environment and workloads. This can look like:
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -153,18 +153,17 @@ If your cluster grows too large for daily [full backups](#full-backups), you can
 
 If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups.
 
-### Recommendations
+### Recommendations for incremental backup frequency
 
-Incremental backups are chains between full backups and contain only the data that has changed since a base set of backups (which must include one full backup, and can include many incremental backups). Incremental backups are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
+Incremental backups form chains between full backups. Each incremental backup only contains only the data that has changed since a base set of backups, which must include one full backup, and can include many incremental backups. Incremental backups are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
 
-CockroachDB recommends taking incremental backups every 10 minutes. We support up to 400 incremental backups between full backups. This may vary based on your specific use-case, so we recommend testing within your own environment and workloads. This can look like:
-<ul>
-  <li>A full backup taken daily with incrementals taken every hour for a total of 24 incremental backups.</li>
-  <li>A full backup taken daily with incrementals taken every 10 minutes for a total of 144 incremental backups.</li>
-  <li>A full backup taken daily with incrementals taken every 5 minutes for a total of 288 incremental backups.</li>
-  <li>A full backup taken weekly with incrementals taken every hour for a total of 168 incremental backups.</li>
-  <li>A full backup taken weekly with incrementals taken every 30 minutes for a total of 336 incremental backups.</li>
-</ul>
+Cockroach Labs recommends taking incremental backups every 10 minutes. CockroachDB supports up to 400 incremental backups between full backups. This may vary based on your specific use-case, so we recommend testing within your own environment and workloads. This can look like:
+
+- A full backup taken daily with incrementals taken every hour for a total of 24 incremental backups
+- A full backup taken daily with incrementals taken every 10 minutes for a total of 144 incremental backups.
+- A full backup taken daily with incrementals taken every 5 minutes for a total of 288 incremental backups.
+- A full backup taken weekly with incrementals taken every hour for a total of 168 incremental backups.
+- A full backup taken weekly with incrementals taken every 30 minutes for a total of 336 incremental backups.
 
 ### Garbage collection and backups
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -151,11 +151,17 @@ To take incremental backups, you need an [Enterprise license](enterprise-licensi
 
 Incremental backups are chains between full backups and contain only the data that has changed since a base set of backups (which must include one full backup, and can include many incremental backups). Incremental backups are smaller and faster to produce than full backups. You can take incremental backups either as of a given timestamp or with full [revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
 
-CockroachDB recommends taking incremental backups every 10 minutes. We support up to 400 incremental backups between full backups. 
+CockroachDB recommends taking incremental backups every 10 minutes. We support up to 400 incremental backups between full backups. This can look like:
+<ul>
+  <li>A full backup taken daily with incrementals taken every hour for a total of 24 incremental backups.</li>
+  <li>A full backup taken daily with incrementals taken every 10 minutes for a total of 144 incremental backups.</li>
+  <li>A full backup taken weekly with incrementals taken every hour for a total of 168 incremental backups.</li>
+  <li>A full backup taken weekly with incrementals taken every 30 minutes for a total of 336 incremental backups.</li>
+</ul>
 
 If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
-If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups.
+If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>`RECURRING` <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>`RECURRING` <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
 
 ### Garbage collection and backups
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -161,7 +161,7 @@ CockroachDB recommends taking incremental backups every 10 minutes. We support u
 
 If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
-If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup.html#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>Incremental backup frequency <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>Incremental backup frequency <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
+If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup.html#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>Incremental backup schedule <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>Incremental backup schedule <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
 
 ### Garbage collection and backups
 

--- a/v23.1/take-full-and-incremental-backups.md
+++ b/v23.1/take-full-and-incremental-backups.md
@@ -161,7 +161,7 @@ CockroachDB recommends taking incremental backups every 10 minutes. We support u
 
 If your cluster grows too large for nightly [full backups](#full-backups), you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
-If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>`RECURRING` <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>`RECURRING` <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
+If you are taking backups on a regular cadence, we recommend [creating a schedule](create-schedule-for-backup.html) for your backups. When scheduling backups, if the [`FULL BACKUP`](create-schedule-for-backup.html#full-backup-clause) clause is omitted, CockroachDB will default to the following full backup schedule: <ul><li>`RECURRING` <= 1 hour: Default to `FULL BACKUP '@daily'`.</li><li>`RECURRING` <= 1 day: Default to `FULL BACKUP '@weekly'`.</li><li>Otherwise: Default to `FULL BACKUP ALWAYS` and all backups triggered by the `RECURRING` clause will be full backups.</li></ul>
 
 ### Garbage collection and backups
 


### PR DESCRIPTION
Addresses DOC-6775:
- Arbitrarily long incremental backup chain are now available for users who wish to do incremental backups with increasing frequency, up to 400 incremental backups
- Docs provide guidance on the range available for customers to take incremental backups 

Preview:
- [Take Incremental Backups](https://deploy-preview-16839--cockroachdb-docs.netlify.app/docs/dev/take-full-and-incremental-backups.html#incremental-backups)