### PR TITLE
Update docs on range inspection with SHOW RANGES

### DIFF
--- a/_includes/v23.1/sql/crdb-internal-is-not-supported-for-production-use.md
+++ b/_includes/v23.1/sql/crdb-internal-is-not-supported-for-production-use.md
@@ -1,0 +1,1 @@
+Many of the tables in the `crdb_internal` system catalog are **not supported for external use in production**.  This output is provided **as a debugging aid only**. The output of particular `crdb_internal` facilities may change from patch release to patch release without advance warning. For more information, see [the `crdb_internal` documentation](crdb-internal.html).

--- a/_includes/v23.1/sql/show-ranges-output-deprecation-notice.md
+++ b/_includes/v23.1/sql/show-ranges-output-deprecation-notice.md
@@ -1,0 +1,16 @@
+The statement syntax and output documented on this page use the updated `SHOW RANGES` that **will become the default in CockroachDB v23.2**. To enable this syntax and output, set the [cluster setting `sql.show_ranges_deprecated_behavior.enabled`](cluster-settings.html#setting-sql-show-ranges-deprecated-behavior-enabled)  to `false`:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SET CLUSTER SETTING sql.show_ranges_deprecated_behavior.enabled = false;
+~~~
+
+The pre-v23.1 output of `SHOW RANGES` is deprecated in v23.1 **and will be removed in v23.2**. To view the documentation for the deprecated version of the `SHOW RANGES` statement, see [`SHOW RANGES` (v22.2)](../v22.2/show-ranges.html).
+
+When you use the deprecated version of the `SHOW RANGES` statement, the following message will appear, reminding you to update [the cluster setting](cluster-settings.html#setting-sql-show-ranges-deprecated-behavior-enabled):
+
+~~~
+NOTICE: attention! the pre-23.1 behavior of SHOW RANGES and crdb_internal.ranges{,_no_leases} is deprecated!
+HINT: Consider enabling the new functionality by setting 'sql.show_ranges_deprecated_behavior.enabled' to 'false'.
+The new SHOW RANGES statement has more options. Refer to the online documentation or execute 'SHOW RANGES ??' for details.
+~~~

--- a/v23.1/alter-range.md
+++ b/v23.1/alter-range.md
@@ -115,7 +115,7 @@ SELECT store_id FROM crdb_internal.kv_store_status;
 
 #### Find range ID and leaseholder information
 
-To use `ALTER RANGE ... RELOCATE`, you need to know how to find the range ID, leaseholder, and other information for a [table](show-ranges.html#show-ranges-for-a-table-primary-index), [index](show-ranges.html#show-ranges-for-an-index), or [database](show-ranges.html#show-ranges-for-a-database). You can find this information using the [`SHOW RANGES`](show-ranges.html) statement.
+To use `ALTER RANGE ... RELOCATE`, you need to know how to find the range ID, leaseholder, and other information for a [table](show-ranges.html#show-ranges-for-a-table), [index](show-ranges.html#show-ranges-for-an-index), or [database](show-ranges.html#show-ranges-for-a-database). You can find this information using the [`SHOW RANGES`](show-ranges.html) statement.
 
 For example, to get all range IDs, leaseholder store IDs, and leaseholder localities for the [`movr.users`](movr.html) table, use the following query:
 

--- a/v23.1/crdb-internal.md
+++ b/v23.1/crdb-internal.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.sql
 ---
 
-The `crdb_internal` [system catalog](system-catalogs.html) is a schema that contains information about internal objects, processes, and metrics related to a specific database. `crdb_internal` tables are read-only.
+The `crdb_internal` [system catalog](system-catalogs.html) is a [schema](schema-design-overview.html#schemas) that contains information about internal objects, processes, and metrics related to a specific database. `crdb_internal` tables are read-only.
 
 <a id="data-exposed-by-crdb_internal"></a>
 
@@ -74,8 +74,8 @@ Table name | Description| Use in production
 `node_txn_stats` | Contains transaction statistics for nodes in your cluster.| ✗
 `partitions` | Contains information about [partitions](partitioning.html) in your cluster.| ✗
 `predefined_comments` | Contains predefined comments about your cluster.| ✗
-`ranges` | Contains information about ranges in your cluster.| ✗
-`ranges_no_leases` | Contains information about ranges in your cluster, without leases.| ✗
+`ranges` | Contains information about [ranges](architecture/overview.html#architecture-range) in your cluster.| ✗
+`ranges_no_leases` | Contains information about [ranges](architecture/overview.html#architecture-range) in your cluster, without [leases](architecture/replication-layer.html#leases).| ✗
 `regions` | Contains information about [cluster regions](multiregion-overview.html#cluster-regions).| ✗
 `schema_changes` | Contains information about schema changes in your cluster.| ✗
 `session_trace` | Contains session trace information for your cluster.| ✗

--- a/v23.1/show-ranges.md
+++ b/v23.1/show-ranges.md
@@ -5,9 +5,13 @@ toc: true
 docs_area: reference.sql
 ---
 
-The `SHOW RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#architecture-range) that comprise the data for a table, index, or entire database. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for ranges are located. If `SHOW RANGES` displays `NULL` for both the start and end keys of a range, the range is empty and has no splits.
+The `SHOW RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#architecture-range) that comprise the data for a table, index, database, or the current catalog. This information is useful for verifying how SQL data maps to underlying [ranges](architecture/overview.html#architecture-range), and where the [replicas](architecture/glossary.html#replica) for those ranges are located.
 
 {{site.data.alerts.callout_info}}
+{% include {{page.version.version}}/sql/show-ranges-output-deprecation-notice.md %}
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_success}}
 To show range information for a specific row in a table or index, use the [`SHOW RANGE ... FOR ROW`](show-range-for-row.html) statement.
 {{site.data.alerts.end}}
 
@@ -25,96 +29,388 @@ To use the `SHOW RANGES` statement, a user must either be a member of the [`admi
 
 Parameter | Description
 ----------|------------
-[`table_name`](sql-grammar.html#table_name) | The name of the table you want range information about.
-[`table_index_name`](sql-grammar.html#table_index_name) | The name of the index you want range information about.
-[`database_name`](sql-grammar.html#database_name) | The name of the database you want range information about.
+[`table_name`](sql-grammar.html#table_name) | The name of the [table](show-tables.html) you want [range](architecture/overview.html#architecture-range) information about.
+[`table_index_name`](sql-grammar.html#table_index_name) | The name of the [index](indexes.html) you want [range](architecture/overview.html#architecture-range) information about.
+[`database_name`](sql-grammar.html#database_name) | The name of the [database](show-databases.html) you want [range](architecture/overview.html#architecture-range) information about.
+[`opt_show_ranges_options`](sql-grammar.html#show_ranges_options) | The [options](#options) used to configure what fields appear in the [response](#response).
+
+## Options
+
+The following [options](sql-grammar.html#show_ranges_options) are available to affect the output. Multiple options can be passed at once, separated by commas.
+
+- `TABLES`:  List [tables](show-tables.html) contained per [range](architecture/overview.html#architecture-range).
+- `INDEXES`: List [indexes](indexes.html) contained per [range](architecture/overview.html#architecture-range).
+- `DETAILS`: Add [range](architecture/overview.html#architecture-range) size, [leaseholder](architecture/glossary.html#leaseholder) and other details. Note that this incurs a large computational overhead because it needs to fetch data across nodes.
+- `KEYS`:    Include binary [start and end keys](#start-key).
 
 ## Response
 
-The following fields are returned for each partition:
+The specific fields in the response vary depending on the values passed as [options](#options). The following fields may be returned:
 
-Field | Description
-------|------------
-`table_name` | The name of the table.
-`start_key` | The start key for the range.
-`end_key` | The end key for the range.
-`range_id` | The range ID.
-`range_size_mb` | The size of the range.
-`lease_holder` | The node that contains the range's [leaseholder](architecture/overview.html#architecture-range).
-`lease_holder_locality` | The [locality](cockroach-start.html#locality) of the leaseholder.
-`replicas` | The nodes that contain the range [replicas](architecture/overview.html#architecture-range).
-`replica_localities` | The [locality](cockroach-start.html#locality) of the range.
-
-{{site.data.alerts.callout_info}}
-If both `start_key` and `end_key` show `NULL`, the range is empty and has no splits.
-{{site.data.alerts.end}}
+Field | Description | Emitted for option(s)
+------|-------------|----------------------
+`start_key` | <a name="start-key"></a> The start key for the [range](architecture/overview.html#architecture-range). | Always emitted.
+`end_key` | The end key for the [range](architecture/overview.html#architecture-range). | Always emitted.
+`raw_start_key` | The start key for the [range](architecture/overview.html#architecture-range), displayed as a [hexadecimal byte value](sql-constants.html#string-literals-with-character-escapes). | `KEYS`
+`raw_end_key` | The end key for the [range](architecture/overview.html#architecture-range), displayed as a [hexadecimal byte value](sql-constants.html#string-literals-with-character-escapes). | `KEYS`
+`range_id` | The internal [range](architecture/overview.html#architecture-range) ID. | Always emitted.
+`voting_replicas` | The [nodes](architecture/glossary.html#node) that contain the range's voting replicas (that is, the replicas that participate in [Raft](architecture/replication-layer.html#raft) elections). | Always emitted.
+`non_voting_replicas` | The [nodes](architecture/glossary.html#node) that contain the range's [non-voting replicas](architecture/replication-layer.html#non-voting-replicas). | Always emitted.
+`replicas` | The [nodes](architecture/glossary.html#node) that contain the range's [replicas](architecture/glossary.html#replica). | Always emitted.
+`replica_localities` | The [localities](cockroach-start.html#locality) of the range's [replicas](architecture/glossary.html#replica). | Always emitted.
+`range_size` | The size of the [range](architecture/overview.html#architecture-range) in bytes. | `DETAILS`
+`range_size_mb` | The size of the [range](architecture/overview.html#architecture-range) in MiB. | `DETAILS`
+`lease_holder` | The  [node](architecture/glossary.html#node) that contains the range's [leaseholder](architecture/glossary.html#leaseholder). | `DETAILS`
+`lease_holder_locality` | The [locality](cockroach-start.html#locality) of the range's [leaseholder](architecture/glossary.html#leaseholder). | `DETAILS`
+`learner_replicas` | The _learner replicas_ of the range. A learner replica is a replica that has just been added to a range, and is thus in an interim state. It accepts messages but doesn't vote in [Raft](architecture/replication-layer.html#raft) elections. This means it doesn't affect quorum and thus doesn't affect the stability of the range, even if it's very far behind. | Always emitted.
+`split_enforced_until` | The time a [range split](architecture/distribution-layer.html#range-splits) is enforced until. This can be set using [`ALTER TABLE ... SPLIT AT`](alter-table.html#split-at) using the [`WITH EXPIRATION` clause](alter-table.html#set-the-expiration-on-a-split-enforcement). Example: `2262-04-11 23:47:16.854776` (this is a default value which means "never"). | Always emitted.
+`schema_name` | The name of the [schema](create-schema.html) this [range](architecture/overview.html#architecture-range) holds data for. | `TABLES`, `INDEXES`
+`table_name` | The name of the [table](create-table.html) this [range](architecture/overview.html#architecture-range) holds data for. | `TABLES`, `INDEXES`
+`table_id` | The internal ID of the [table](create-table.html) this [range](architecture/overview.html#architecture-range) holds data for. | `TABLES`, `INDEXES`
+`table_start_key` | The start key of the first [range](architecture/overview.html#architecture-range) that holds data for this table. | `TABLES`
+`table_end_key` | The end key of the last [range](architecture/overview.html#architecture-range) that holds data for this table. | `TABLES`
+`raw_table_start_key` | The start key of the first [range](architecture/overview.html#architecture-range) that holds data for this table, expressed as [`BYTES`](bytes.html). | `TABLES`, `KEYS`
+`raw_table_end_key` | The end key of the last [range](architecture/overview.html#architecture-range) that holds data for this table, expressed as [`BYTES`](bytes.html). | `TABLES`, `KEYS`
+`index_name` | The name of the [index](indexes.html) this [range](architecture/overview.html#architecture-range) holds data for. | `INDEXES`
+`index_id` | The internal ID of the [index](indexes.html) this [range](architecture/overview.html#architecture-range) holds data for. | `INDEXES`
+`index_start_key` | The start key of the first [range](architecture/overview.html#architecture-range) of [index](indexes.html) data. | `INDEXES`
+`index_end_key` | The end key of the last [range](architecture/overview.html#architecture-range) of [index](indexes.html) data. | `INDEXES`
+`raw_index_start_key` | The start key of the first [range](architecture/overview.html#architecture-range) of [index](indexes.html) data, expressed as [`BYTES`](bytes.html). | `INDEXES`, `KEYS`
+`raw_index_end_key` | The end key of the last [range](architecture/overview.html#architecture-range) of [index](indexes.html) data, expressed as [`BYTES`](bytes.html). | `INDEXES`, `KEYS`
 
 ## Examples
 
+{{site.data.alerts.callout_info}}
+{% include {{page.version.version}}/sql/show-ranges-output-deprecation-notice.md %}
+{{site.data.alerts.end}}
+
 {% include {{page.version.version}}/sql/movr-statements-geo-partitioned-replicas.md %}
 
-### Show ranges for a table (primary index)
+### Show ranges for a database
+
+- [Show ranges for a database (without options)](#show-ranges-for-a-database-without-options)
+- [Show ranges for a database (with tables, keys, details)](#show-ranges-for-a-database-with-tables-keys-details)
+- [Show ranges for a database (with tables)](#show-ranges-for-a-database-with-tables)
+- [Show ranges for a database (with indexes)](#show-ranges-for-a-database-with-indexes)
+- [Show ranges for a database (with details)](#show-ranges-for-a-database-with-details)
+- [Show ranges for a database (with keys)](#show-ranges-for-a-database-with-keys)
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> WITH x as (SHOW RANGES FROM TABLE vehicles) SELECT * FROM x WHERE "start_key" NOT LIKE '%Prefix%';
+SHOW DATABASES;
 ~~~
+
 ~~~
-     start_key     |          end_key           | range_id | range_size_mb | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities
-+------------------+----------------------------+----------+---------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+
-  /"new york"      | /"new york"/PrefixEnd      |       58 |      0.000304 |            2 | region=us-east1,az=c     | {1,2,5}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-west1,az=b"}
-  /"washington dc" | /"washington dc"/PrefixEnd |      102 |      0.000173 |            2 | region=us-east1,az=c     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  /"boston"        | /"boston"/PrefixEnd        |       63 |      0.000288 |            3 | region=us-east1,az=d     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  /"seattle"       | /"seattle"/PrefixEnd       |       97 |      0.000295 |            4 | region=us-west1,az=a     | {4,5,6}  | {"region=us-west1,az=a","region=us-west1,az=b","region=us-west1,az=c"}
-  /"los angeles"   | /"los angeles"/PrefixEnd   |       55 |      0.000156 |            5 | region=us-west1,az=b     | {4,5,6}  | {"region=us-west1,az=a","region=us-west1,az=b","region=us-west1,az=c"}
-  /"san francisco" | /"san francisco"/PrefixEnd |       71 |      0.000309 |            6 | region=us-west1,az=c     | {1,5,6}  | {"region=us-east1,az=b","region=us-west1,az=b","region=us-west1,az=c"}
-  /"amsterdam"     | /"amsterdam"/PrefixEnd     |       59 |      0.000305 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-  /"paris"         | /"paris"/PrefixEnd         |       62 |      0.000299 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-  /"rome"          | /"rome"/PrefixEnd          |       67 |      0.000168 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-(9 rows)
+  database_name | owner | primary_region | secondary_region | regions | survival_goal
+----------------+-------+----------------+------------------+---------+----------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL
+  postgres      | root  | NULL           | NULL             | {}      | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL
+(4 rows)
+~~~
+
+#### Show ranges for a database (without options)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM DATABASE movr;
+~~~
+
+~~~
+                                           start_key                                           |                                           end_key                                            | range_id | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+-----------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+----------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  /Table/106                                                                                   | /Table/106/1/"amsterdam"                                                                     |       70 | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  /Table/106/1/"amsterdam"                                                                     | /Table/106/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  /Table/111/1/"washington dc"/PrefixEnd                                                       | /Max                                                                                         |      309 | {3,5,9}  | {"region=us-east1,az=d","region=us-west1,az=b","region=europe-west1,az=d"}         | {3,5,9}         | {}                  | {}               | NULL
+(178 rows)
+~~~
+
+#### Show ranges for a database (with tables, keys, details)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM DATABASE movr WITH TABLES, KEYS, DETAILS;
+~~~
+
+~~~
+                                           start_key                                           |                                           end_key                                            |                                            raw_start_key                                             |                                             raw_end_key                                              | range_id | schema_name |         table_name         | table_id | table_start_key |    table_end_key     | raw_table_start_key | raw_table_end_key |       range_size_mb        | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until    | range_size
+-----------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+----------+-------------+----------------------------+----------+-----------------+----------------------+---------------------+-------------------+----------------------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+----------------------------+-------------
+  /Table/106                                                                                   | /Table/106/1/"amsterdam"                                                                     | \xf2                                                                                                 | \xf28912616d7374657264616d0001                                                                       |      174 | public      | users                      |      106 | /Table/106      | /Table/107           | \xf2                | \xf3              |                          0 |            3 | region=us-east1,az=d     | {3,6,9}  | {"region=us-east1,az=d","region=us-west1,az=c","region=europe-west1,az=d"}         | {3,9,6}         | {}                  | {}               | NULL                       |          0
+  /Table/106/1/"amsterdam"                                                                     | /Table/106/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       | \xf28912616d7374657264616d0001                                                                       | \xf28912616d7374657264616d000112b333333333334000ff8000ff00ff00ff00ff00ff00ff230001                   |      175 | public      | users                      |      106 | /Table/106      | /Table/107           | \xf2                | \xf3              |  0.00011900000000000000000 |            3 | region=us-east1,az=d     | {3,7,8}  | {"region=us-east1,az=d","region=europe-west1,az=b","region=europe-west1,az=c"}     | {3,7,8}         | {}                  | {}               | NULL                       |        119
+  ...
+  /Table/111/1/"washington dc"/PrefixEnd                                                       | /Max                                                                                         | \xf66f891277617368696e67746f6e2064630002                                                             | \xffff                                                                                               |      295 | public      | user_promo_codes           |      111 | /Table/111      | /Table/112           | \xf66f              | \xf670            |                          0 |            8 | region=europe-west1,az=c | {3,4,8}  | {"region=us-east1,az=d","region=us-west1,az=a","region=europe-west1,az=c"}         | {3,8,4}         | {}                  | {}               | NULL                       |          0
+(145 rows)
+~~~
+
+#### Show ranges for a database (with tables)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM DATABASE movr WITH TABLES;
+~~~
+
+~~~
+                                           start_key                                           |                                           end_key                                            | range_id | schema_name |         table_name         | table_id | table_start_key |    table_end_key     | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+-----------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+----------+-------------+----------------------------+----------+-----------------+----------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  /Table/106                                                                                   | /Table/106/1/"amsterdam"                                                                     |       67 | public      | users                      |      106 | /Table/106      | /Table/107           | {1,4,9}  | {"region=us-east1,az=b","region=us-west1,az=a","region=europe-west1,az=d"}         | {1,9,4}         | {}                  | {}               | NULL
+  /Table/106/1/"amsterdam"                                                                     | /Table/106/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       68 | public      | users                      |      106 | /Table/106      | /Table/107           | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {7,9,8}         | {}                  | {}               | NULL
+  ...
+  /Table/111/1/"washington dc"/PrefixEnd                                                       | /Max                                                                                         |      311 | public      | user_promo_codes           |      111 | /Table/111      | /Table/112           | {1,5,7}  | {"region=us-east1,az=b","region=us-west1,az=b","region=europe-west1,az=b"}         | {1,7,5}         | {}                  | {}               | NULL
+(178 rows)
+~~~
+
+#### Show ranges for a database (with indexes)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM DATABASE movr WITH INDEXES;
+~~~
+
+~~~
+                                           start_key                                           |                                           end_key                                            | range_id | schema_name |         table_name         | table_id |                  index_name                   | index_id | index_start_key | index_end_key | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+-----------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+----------+-------------+----------------------------+----------+-----------------------------------------------+----------+-----------------+---------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  /Table/106                                                                                   | /Table/106/1/"amsterdam"                                                                     |       70 | public      | users                      |      106 | users_pkey                                    |        1 | /Table/106/1    | /Table/106/2  | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  /Table/106/1/"amsterdam"                                                                     | /Table/106/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 | public      | users                      |      106 | users_pkey                                    |        1 | /Table/106/1    | /Table/106/2  | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  /Table/111/1/"washington dc"/PrefixEnd                                                       | /Max                                                                                         |      309 | public      | user_promo_codes           |      111 | user_promo_codes_pkey                         |        1 | /Table/111/1    | /Table/111/2  | {3,5,9}  | {"region=us-east1,az=d","region=us-west1,az=b","region=europe-west1,az=d"}         | {3,5,9}         | {}                  | {}               | NULL
+(179 rows)
+~~~
+
+#### Show ranges for a database (with details)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM DATABASE movr WITH DETAILS;
+~~~
+
+~~~
+                                           start_key                                           |                                           end_key                                            | range_id |       range_size_mb        | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until    | range_size
+-----------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+----------+----------------------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+----------------------------+-------------
+  /Table/106                                                                                   | /Table/106/1/"amsterdam"                                                                     |       70 |                          0 |            1 | region=us-east1,az=b     | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL                       |          0
+  /Table/106/1/"amsterdam"                                                                     | /Table/106/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 |  0.00011800000000000000000 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL                       |        118
+  ...
+  /Table/111/1/"washington dc"/PrefixEnd                                                       | /Max                                                                                         |      309 |                          0 |            9 | region=europe-west1,az=d | {3,5,9}  | {"region=us-east1,az=d","region=us-west1,az=b","region=europe-west1,az=d"}         | {3,5,9}         | {}                  | {}               | NULL                       |          0
+(178 rows)
+~~~
+
+#### Show ranges for a database (with keys)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM DATABASE movr WITH KEYS;
+~~~
+
+~~~
+                                           start_key                                           |                                           end_key                                            |                                            raw_start_key                                             |                                             raw_end_key                                              | range_id | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+-----------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+----------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  /Table/106                                                                                   | /Table/106/1/"amsterdam"                                                                     | \xf2                                                                                                 | \xf28912616d7374657264616d0001                                                                       |       70 | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  /Table/106/1/"amsterdam"                                                                     | /Table/106/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       | \xf28912616d7374657264616d0001                                                                       | \xf28912616d7374657264616d000112b333333333334000ff8000ff00ff00ff00ff00ff00ff230001                   |       71 | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  /Table/111/1/"washington dc"/PrefixEnd                                                       | /Max                                                                                         | \xf66f891277617368696e67746f6e2064630002                                                             | \xffff                                                                                               |      309 | {3,5,9}  | {"region=us-east1,az=d","region=us-west1,az=b","region=europe-west1,az=d"}         | {3,5,9}         | {}                  | {}               | NULL
+(178 rows)
+~~~
+
+### Show ranges for a table
+
+- [Show ranges for a table (without options)](#show-ranges-for-a-table-without-options)
+- [Show ranges for a table (with indexes, keys, details)](#show-ranges-for-a-table-with-indexes-keys-details)
+- [Show ranges for a table (with indexes)](#show-ranges-for-a-table-with-indexes)
+- [Show ranges for a table (with details)](#show-ranges-for-a-table-with-details)
+- [Show ranges for a table (with keys)](#show-ranges-for-a-table-with-keys)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TABLES;
+~~~
+
+~~~
+  schema_name |         table_name         | type  | owner | estimated_row_count | locality
+--------------+----------------------------+-------+-------+---------------------+-----------
+  public      | promo_codes                | table | demo  |                1000 | NULL
+  public      | rides                      | table | demo  |                 500 | NULL
+  public      | user_promo_codes           | table | demo  |                   5 | NULL
+  public      | users                      | table | demo  |                  50 | NULL
+  public      | vehicle_location_histories | table | demo  |                1000 | NULL
+  public      | vehicles                   | table | demo  |                  15 | NULL
+(6 rows)
+~~~
+
+#### Show ranges for a table (without options)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM TABLE movr.users;
+~~~
+
+~~~
+                                       start_key                                      |                                       end_key                                       | range_id | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+--------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+----------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  …/<TableMin>                                                                        | …/1/"amsterdam"                                                                     |       70 | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  …/1/"amsterdam"                                                                     | …/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  …/1/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                        |      154 | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL
+(27 rows)
+~~~
+
+#### Show ranges for a table (with indexes, keys, details)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM TABLE movr.users with INDEXES, KEYS, DETAILS;
+~~~
+
+~~~
+                                       start_key                                      |                                       end_key                                       |                                            raw_start_key                                             |                                             raw_end_key                                              | range_id | index_name | index_id | index_start_key | index_end_key | raw_index_start_key | raw_index_end_key |       range_size_mb       | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until    | range_size
+--------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+----------+------------+----------+-----------------+---------------+---------------------+-------------------+---------------------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+----------------------------+-------------
+  …/<TableMin>                                                                        | …/1/"amsterdam"                                                                     | \xf2                                                                                                 | \xf28912616d7374657264616d0001                                                                       |      174 | users_pkey |        1 | …/1             | …/2           | \xf289              | \xf28a            |                         0 |            3 | region=us-east1,az=d     | {3,6,9}  | {"region=us-east1,az=d","region=us-west1,az=c","region=europe-west1,az=d"}         | {3,9,6}         | {}                  | {}               | NULL                       |          0
+  …/1/"amsterdam"                                                                     | …/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       | \xf28912616d7374657264616d0001                                                                       | \xf28912616d7374657264616d000112b333333333334000ff8000ff00ff00ff00ff00ff00ff230001                   |      175 | users_pkey |        1 | …/1             | …/2           | \xf289              | \xf28a            | 0.00011900000000000000000 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL                       |        119
+  ...
+  …/1/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                        | \xf2891277617368696e67746f6e2064630002                                                               | \xf3                                                                                                 |      111 | users_pkey |        1 | …/1             | …/2           | \xf289              | \xf28a            |                         0 |            9 | region=europe-west1,az=d | {1,5,9}  | {"region=us-east1,az=b","region=us-west1,az=b","region=europe-west1,az=d"}         | {1,9,5}         | {}                  | {}               | NULL                       |          0
+(27 rows)
+~~~
+
+#### Show ranges for a table (with indexes)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM TABLE movr.users WITH INDEXES;
+~~~
+
+~~~
+                                       start_key                                      |                                       end_key                                       | range_id | index_name | index_id | index_start_key | index_end_key | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+--------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+----------+------------+----------+-----------------+---------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  …/<TableMin>                                                                        | …/1/"amsterdam"                                                                     |       70 | users_pkey |        1 | …/1             | …/2           | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  …/1/"amsterdam"                                                                     | …/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 | users_pkey |        1 | …/1             | …/2           | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  …/1/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                        |      154 | users_pkey |        1 | …/1             | …/2           | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL
+(27 rows)
+~~~
+
+#### Show ranges for a table (with details)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM TABLE movr.users WITH DETAILS;
+~~~
+
+~~~
+                                       start_key                                      |                                       end_key                                       | range_id |       range_size_mb        | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until    | range_size
+--------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+----------+----------------------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+----------------------------+-------------
+  …/<TableMin>                                                                        | …/1/"amsterdam"                                                                     |       70 |                          0 |            1 | region=us-east1,az=b     | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL                       |          0
+  …/1/"amsterdam"                                                                     | …/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 |  0.00011800000000000000000 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL                       |        118
+  ...
+  …/1/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                        |      154 |                          0 |            4 | region=us-west1,az=a     | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL                       |          0
+(27 rows)
+~~~
+
+#### Show ranges for a table (with keys)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM TABLE movr.users WITH KEYS;
+~~~
+
+~~~
+                                       start_key                                      |                                       end_key                                       |                                            raw_start_key                                             |                                             raw_end_key                                              | range_id | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+--------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+----------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  …/<TableMin>                                                                        | …/1/"amsterdam"                                                                     | \xf2                                                                                                 | \xf28912616d7374657264616d0001                                                                       |       70 | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  …/1/"amsterdam"                                                                     | …/1/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       | \xf28912616d7374657264616d0001                                                                       | \xf28912616d7374657264616d000112b333333333334000ff8000ff00ff00ff00ff00ff00ff230001                   |       71 | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  …/1/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                        | \xf2891277617368696e67746f6e2064630002                                                               | \xf3                                                                                                 |      154 | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL
+(27 rows)
 ~~~
 
 ### Show ranges for an index
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> WITH x AS (SHOW RANGES FROM INDEX vehicles_auto_index_fk_city_ref_users) SELECT * FROM x WHERE "start_key" NOT LIKE '%Prefix%';
-~~~
-~~~
-     start_key     |          end_key           | range_id | range_size_mb | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities
-+------------------+----------------------------+----------+---------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+
-  /"washington dc" | /"washington dc"/PrefixEnd |      188 |      0.000089 |            2 | region=us-east1,az=c     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  /"boston"        | /"boston"/PrefixEnd        |      141 |      0.000164 |            3 | region=us-east1,az=d     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  /"new york"      | /"new york"/PrefixEnd      |      168 |      0.000174 |            3 | region=us-east1,az=d     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  /"los angeles"   | /"los angeles"/PrefixEnd   |      165 |      0.000087 |            6 | region=us-west1,az=c     | {4,5,6}  | {"region=us-west1,az=a","region=us-west1,az=b","region=us-west1,az=c"}
-  /"san francisco" | /"san francisco"/PrefixEnd |      174 |      0.000183 |            6 | region=us-west1,az=c     | {4,5,6}  | {"region=us-west1,az=a","region=us-west1,az=b","region=us-west1,az=c"}
-  /"seattle"       | /"seattle"/PrefixEnd       |      186 |      0.000166 |            6 | region=us-west1,az=c     | {4,5,6}  | {"region=us-west1,az=a","region=us-west1,az=b","region=us-west1,az=c"}
-  /"amsterdam"     | /"amsterdam"/PrefixEnd     |      137 |       0.00017 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-  /"paris"         | /"paris"/PrefixEnd         |      170 |      0.000162 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-  /"rome"          | /"rome"/PrefixEnd          |      172 |       0.00008 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-(9 rows)
-~~~
-
-### Show ranges for a database
+- [Show ranges for an index (without options)](#show-ranges-for-an-index-without-options)
+- [Show ranges for an index (with keys, details)](#show-ranges-for-an-index-with-keys-details)
+- [Show ranges for an index (with details)](#show-ranges-for-an-index-with-details)
+- [Show ranges for an index (with keys)](#show-ranges-for-an-index-with-keys)
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> WITH x as (SHOW RANGES FROM database movr) SELECT * FROM x WHERE "start_key" NOT LIKE '%Prefix%';
+SHOW INDEXES FROM movr.users;
 ~~~
-~~~
-          table_name         |    start_key     |          end_key           | range_id | range_size_mb | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities
-+----------------------------+------------------+----------------------------+----------+---------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+
-  users                      | /"amsterdam"     | /"amsterdam"/PrefixEnd     |       47 |      0.000562 |            7 | region=europe-west1,az=b | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
-  users                      | /"boston"        | /"boston"/PrefixEnd        |       51 |      0.000665 |            3 | region=us-east1,az=d     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  users                      | /"chicago"       | /"los angeles"             |       83 |             0 |            4 | region=us-west1,az=a     | {2,4,8}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=c"}
-  users                      | /"los angeles"   | /"los angeles"/PrefixEnd   |       45 |      0.000697 |            4 | region=us-west1,az=a     | {4,5,6}  | {"region=us-west1,az=a","region=us-west1,az=b","region=us-west1,az=c"}
-  users                      | /"new york"      | /"new york"/PrefixEnd      |       48 |      0.000664 |            1 | region=us-east1,az=b     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-  users                      | /"paris"         | /"paris"/PrefixEnd         |       52 |      0.000628 |            8 | region=europe-west1,az=c | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"}
 
+~~~
+  table_name | index_name | non_unique | seq_in_index | column_name | definition  | direction | storing | implicit | visible
+-------------+------------+------------+--------------+-------------+-------------+-----------+---------+----------+----------
+  users      | users_pkey |     f      |            1 | city        | city        | ASC       |    f    |    f     |    t
+  users      | users_pkey |     f      |            2 | id          | id          | ASC       |    f    |    f     |    t
+  users      | users_pkey |     f      |            3 | name        | name        | N/A       |    t    |    f     |    t
+  users      | users_pkey |     f      |            4 | address     | address     | N/A       |    t    |    f     |    t
+  users      | users_pkey |     f      |            5 | credit_card | credit_card | N/A       |    t    |    f     |    t
+(5 rows)
+~~~
+
+#### Show ranges for an index (without options)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM INDEX movr.users_pkey;
+~~~
+
+~~~
+                                      start_key                                     |                                      end_key                                      | range_id | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+----------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  …/TableMin                                                                        | …/"amsterdam"                                                                     |       70 | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  …/"amsterdam"                                                                     | …/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
   ...
+  …/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                      |      154 | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL
+(27 rows)
+~~~
 
-  user_promo_codes           | /"washington dc" | /"washington dc"/PrefixEnd |      144 |             0 |            2 | region=us-east1,az=c     | {1,2,3}  | {"region=us-east1,az=b","region=us-east1,az=c","region=us-east1,az=d"}
-(73 rows)
+#### Show ranges for an index (with keys, details)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM INDEX movr.users_pkey WITH KEYS, DETAILS;
+~~~
+
+~~~
+                                      start_key                                     |                                      end_key                                      |                                            raw_start_key                                             |                                             raw_end_key                                              | range_id |       range_size_mb       | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until    | range_size
+------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+----------+---------------------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+----------------------------+-------------
+  …/TableMin                                                                        | …/"amsterdam"                                                                     | \xf2                                                                                                 | \xf28912616d7374657264616d0001                                                                       |      174 |                         0 |            3 | region=us-east1,az=d     | {3,6,9}  | {"region=us-east1,az=d","region=us-west1,az=c","region=europe-west1,az=d"}         | {3,9,6}         | {}                  | {}               | NULL                       |          0
+  …/"amsterdam"                                                                     | …/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       | \xf28912616d7374657264616d0001                                                                       | \xf28912616d7374657264616d000112b333333333334000ff8000ff00ff00ff00ff00ff00ff230001                   |      175 | 0.00011900000000000000000 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL                       |        119
+  ...
+  …/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                      | \xf2891277617368696e67746f6e2064630002                                                               | \xf3                                                                                                 |      111 |                         0 |            9 | region=europe-west1,az=d | {1,5,9}  | {"region=us-east1,az=b","region=us-west1,az=b","region=europe-west1,az=d"}         | {1,9,5}         | {}                  | {}               | NULL                       |          0
+(27 rows)
+~~~
+
+#### Show ranges for an index (with details)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM INDEX movr.users_pkey WITH DETAILS;
+~~~
+
+~~~
+                                      start_key                                     |                                      end_key                                      | range_id |       range_size_mb        | lease_holder |  lease_holder_locality   | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until    | range_size
+------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+----------+----------------------------+--------------+--------------------------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+----------------------------+-------------
+  …/TableMin                                                                        | …/"amsterdam"                                                                     |       70 |                          0 |            1 | region=us-east1,az=b     | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL                       |          0
+  …/"amsterdam"                                                                     | …/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       |       71 |  0.00011800000000000000000 |            9 | region=europe-west1,az=d | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL                       |        118
+  ...
+  …/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                      |      154 |                          0 |            4 | region=us-west1,az=a     | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL                       |          0
+(27 rows)
+~~~
+
+#### Show ranges for an index (with keys)
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW RANGES FROM INDEX movr.users_pkey WITH KEYS;
+~~~
+
+~~~
+                                      start_key                                     |                                      end_key                                      |                                            raw_start_key                                             |                                             raw_end_key                                              | range_id | replicas |                                 replica_localities                                 | voting_replicas | non_voting_replicas | learner_replicas |    split_enforced_until
+------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------+----------+----------+------------------------------------------------------------------------------------+-----------------+---------------------+------------------+-----------------------------
+  …/TableMin                                                                        | …/"amsterdam"                                                                     | \xf2                                                                                                 | \xf28912616d7374657264616d0001                                                                       |       70 | {1,6,8}  | {"region=us-east1,az=b","region=us-west1,az=c","region=europe-west1,az=c"}         | {1,6,8}         | {}                  | {}               | NULL
+  …/"amsterdam"                                                                     | …/"amsterdam"/"\xb333333@\x00\x80\x00\x00\x00\x00\x00\x00#"                       | \xf28912616d7374657264616d0001                                                                       | \xf28912616d7374657264616d000112b333333333334000ff8000ff00ff00ff00ff00ff00ff230001                   |       71 | {7,8,9}  | {"region=europe-west1,az=b","region=europe-west1,az=c","region=europe-west1,az=d"} | {9,7,8}         | {}                  | {}               | NULL
+  ...
+  …/"washington dc"/PrefixEnd                                                       | …/<TableMax>                                                                      | \xf2891277617368696e67746f6e2064630002                                                               | \xf3                                                                                                 |      154 | {2,4,7}  | {"region=us-east1,az=c","region=us-west1,az=a","region=europe-west1,az=b"}         | {2,4,7}         | {}                  | {}               | NULL
+(27 rows)
 ~~~
 
 ## See also


### PR DESCRIPTION
Fixes:

- DOC-6468
- DOC-6469
- DOC-6470
- DOC-6471
- DOC-6472
- DOC-6473
- DOC-6732
- DOC-6839
- DOC-7311
- DOC-7327

Summary of changes:

- Update `SHOW RANGES` docs to use the new syntax and output, and note the deprecation of the old output.

- Also, let users know that the updated `SHOW RANGES` is the place to get detailed information about leaseholders, etc., *not*  `crdb_internal.ranges*`