### PR TITLE
add SCT as search synonym

### DIFF
--- a/jekyll-algolia-dev/lib/jekyll/algolia/indexer.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/indexer.rb
@@ -331,7 +331,13 @@ module Jekyll
           objectID: 'not visible',
           type: 'synonym',
           synonyms: ['not visible', 'invisible']
-        }, false)        
+        }, false)
+        
+        index.save_synonym('schema conversion tool', {
+          objectID: 'schema conversion tool',
+          type: 'synonym',
+          synonyms: ['schema conversion tool', 'sct']
+        }, false)
         
         return
       end


### PR DESCRIPTION
DOC-6143

Add `SCT` as a search synonym for `schema conversion tool`.