### PR TITLE
Fix missing job_id from configure all resume/pause changefeeds

### DIFF
--- a/_includes/v22.1/cdc/configure-all-changefeed.md
+++ b/_includes/v22.1/cdc/configure-all-changefeed.md
@@ -4,7 +4,7 @@ To pause all running changefeeds:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
-PAUSE JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('running'));
+PAUSE JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT job_id FROM x WHERE status = ('running'));
 ~~~
 
 This will change the status for each of the running changefeeds to `paused`, which can be verified with [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs).
@@ -13,7 +13,7 @@ To resume all running changefeeds:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
-RESUME JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('paused'));
+RESUME JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT job_id FROM x WHERE status = ('paused'));
 ~~~
 
 This will resume the changefeeds and update the status for each of the changefeeds to `running`.

--- a/_includes/v22.2/cdc/configure-all-changefeed.md
+++ b/_includes/v22.2/cdc/configure-all-changefeed.md
@@ -4,7 +4,7 @@ To pause all running changefeeds:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
-PAUSE JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('running'));
+PAUSE JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT job_id FROM x WHERE status = ('running'));
 ~~~
 
 This will change the status for each of the running changefeeds to `paused`, which can be verified with [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs).
@@ -13,7 +13,7 @@ To resume all running changefeeds:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
-RESUME JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('paused'));
+RESUME JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT job_id FROM x WHERE status = ('paused'));
 ~~~
 
 This will resume the changefeeds and update the status for each of the changefeeds to `running`.

--- a/_includes/v23.1/cdc/configure-all-changefeed.md
+++ b/_includes/v23.1/cdc/configure-all-changefeed.md
@@ -4,7 +4,7 @@ To pause all running changefeeds:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
-PAUSE JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('running'));
+PAUSE JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT job_id FROM x WHERE status = ('running'));
 ~~~
 
 This will change the status for each of the running changefeeds to `paused`, which can be verified with [`SHOW CHANGEFEED JOBS`](show-jobs.html#show-changefeed-jobs).
@@ -13,7 +13,7 @@ To resume all running changefeeds:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
-RESUME JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('paused'));
+RESUME JOBS (WITH x AS (SHOW CHANGEFEED JOBS) SELECT job_id FROM x WHERE status = ('paused'));
 ~~~
 
 This will resume the changefeeds and update the status for each of the changefeeds to `running`.


### PR DESCRIPTION
Fixes DOC-7484

Fix a doc bug with configuring all changefeeds. The `job_id` needs to be included for this to run and pause or resume jobs successfully.