### PR TITLE
Update SHOW DATABASES example output

### DIFF
--- a/_includes/v22.2/sql/preloaded-databases.md
+++ b/_includes/v22.2/sql/preloaded-databases.md
@@ -1,9 +1,8 @@
 New clusters and existing clusters [upgraded](upgrade-cockroach-version.html) to {{ page.version.version }} or later will include auto-generated databases, with the following purposes:
 
 - The empty `defaultdb` database is used if a client does not specify a database in the [connection parameters](connection-parameters.html).
-- The `movr` database contains data about users, vehicles, and rides for the vehicle-sharing app [MovR](movr.html).
+- The `movr` database contains data about users, vehicles, and rides for the vehicle-sharing app [MovR](movr.html) (only when the cluster is started using the [`demo` command](cockroach-demo.html)).
 - The empty `postgres` database is provided for compatibility with PostgreSQL client applications that require it.
-- The `startrek` database contains quotes from episodes.
 - The `system` database contains CockroachDB metadata and is read-only.
 
 All databases except for the `system` database can be [deleted](drop-database.html) if they are not needed.

--- a/_includes/v23.1/sql/preloaded-databases.md
+++ b/_includes/v23.1/sql/preloaded-databases.md
@@ -1,9 +1,8 @@
 New clusters and existing clusters [upgraded](upgrade-cockroach-version.html) to {{ page.version.version }} or later will include auto-generated databases, with the following purposes:
 
 - The empty `defaultdb` database is used if a client does not specify a database in the [connection parameters](connection-parameters.html).
-- The `movr` database contains data about users, vehicles, and rides for the vehicle-sharing app [MovR](movr.html).
+- The `movr` database contains data about users, vehicles, and rides for the vehicle-sharing app [MovR](movr.html) (only when the cluster is started using the [`demo` command](cockroach-demo.html)).
 - The empty `postgres` database is provided for compatibility with PostgreSQL client applications that require it.
-- The `startrek` database contains quotes from episodes.
 - The `system` database contains CockroachDB metadata and is read-only.
 
 All databases except for the `system` database can be [deleted](drop-database.html) if they are not needed.

--- a/v22.2/show-databases.md
+++ b/v22.2/show-databases.md
@@ -28,14 +28,13 @@ The user must be granted the `CONNECT` [privilege](security-reference/authorizat
 ~~~
 
 ~~~
-  database_name
-+---------------+
-  defaultdb
-  movr
-  postgres
-  startrek
-  system
-(5 rows)
+  database_name | owner | primary_region | secondary_region | regions | survival_goal
+----------------+-------+----------------+------------------+---------+----------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL
+  postgres      | root  | NULL           | NULL             | {}      | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL
+(4 rows)
 ~~~
 
 Alternatively, within the built-in SQL shell, you can use the `\l` [shell command](cockroach-sql.html#commands) to list all databases:
@@ -46,14 +45,13 @@ Alternatively, within the built-in SQL shell, you can use the `\l` [shell comman
 ~~~
 
 ~~~
-  database_name
-+---------------+
-  defaultdb
-  movr
-  postgres
-  startrek
-  system
-(5 rows)
+  database_name | owner | primary_region | secondary_region | regions | survival_goal
+----------------+-------+----------------+------------------+---------+----------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL
+  postgres      | root  | NULL           | NULL             | {}      | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL
+(4 rows)
 ~~~
 
 ### Show databases with comments
@@ -62,7 +60,7 @@ You can use [`COMMENT ON`](comment-on.html) to add comments on a database.
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> COMMENT ON DATABASE movr IS 'This database holds information about users, vehicles, and rides.';
+COMMENT ON DATABASE movr IS 'This database holds information about users, vehicles, and rides.';
 ~~~
 
 To view a database's comments:
@@ -73,14 +71,13 @@ To view a database's comments:
 ~~~
 
 ~~~
-  database_name |                              comment
-+---------------+-------------------------------------------------------------------+
-  defaultdb     | NULL
-  movr          | This database holds information about users, vehicles, and rides.
-  postgres      | NULL
-  startrek      | NULL
-  system        | NULL
-(5 rows)
+   database_name | owner | primary_region | secondary_region | regions | survival_goal |                              comment
+----------------+-------+----------------+------------------+---------+---------------+--------------------------------------------------------------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL          | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL          | This database holds information about users, vehicles, and rides.
+  postgres      | root  | NULL           | NULL             | {}      | NULL          | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL          | NULL
+(4 rows)
 ~~~
 
 For more information, see [`COMMENT ON`](comment-on.html).

--- a/v23.1/show-databases.md
+++ b/v23.1/show-databases.md
@@ -28,14 +28,13 @@ The user must be granted the `CONNECT` [privilege](security-reference/authorizat
 ~~~
 
 ~~~
-  database_name
-+---------------+
-  defaultdb
-  movr
-  postgres
-  startrek
-  system
-(5 rows)
+  database_name | owner | primary_region | secondary_region | regions | survival_goal
+----------------+-------+----------------+------------------+---------+----------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL
+  postgres      | root  | NULL           | NULL             | {}      | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL
+(4 rows)
 ~~~
 
 Alternatively, within the built-in SQL shell, you can use the `\l` [shell command](cockroach-sql.html#commands) to list all databases:
@@ -46,14 +45,13 @@ Alternatively, within the built-in SQL shell, you can use the `\l` [shell comman
 ~~~
 
 ~~~
-  database_name
-+---------------+
-  defaultdb
-  movr
-  postgres
-  startrek
-  system
-(5 rows)
+  database_name | owner | primary_region | secondary_region | regions | survival_goal
+----------------+-------+----------------+------------------+---------+----------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL
+  postgres      | root  | NULL           | NULL             | {}      | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL
+(4 rows)
 ~~~
 
 ### Show databases with comments
@@ -62,7 +60,7 @@ You can use [`COMMENT ON`](comment-on.html) to add comments on a database.
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> COMMENT ON DATABASE movr IS 'This database holds information about users, vehicles, and rides.';
+COMMENT ON DATABASE movr IS 'This database holds information about users, vehicles, and rides.';
 ~~~
 
 To view a database's comments:
@@ -73,14 +71,13 @@ To view a database's comments:
 ~~~
 
 ~~~
-  database_name |                              comment
-+---------------+-------------------------------------------------------------------+
-  defaultdb     | NULL
-  movr          | This database holds information about users, vehicles, and rides.
-  postgres      | NULL
-  startrek      | NULL
-  system        | NULL
-(5 rows)
+   database_name | owner | primary_region | secondary_region | regions | survival_goal |                              comment
+----------------+-------+----------------+------------------+---------+---------------+--------------------------------------------------------------------
+  defaultdb     | root  | NULL           | NULL             | {}      | NULL          | NULL
+  movr          | demo  | NULL           | NULL             | {}      | NULL          | This database holds information about users, vehicles, and rides.
+  postgres      | root  | NULL           | NULL             | {}      | NULL          | NULL
+  system        | node  | NULL           | NULL             | {}      | NULL          | NULL
+(4 rows)
 ~~~
 
 For more information, see [`COMMENT ON`](comment-on.html).


### PR DESCRIPTION
This PR fixes the example output of `SHOW DATABASES` to match the current output, and fixes the incorrect list of default database.

Fixes DOC-7511.
Fixes DOC-7374.