### PR TITLE
Add setting to adjust grant lease options

### DIFF
--- a/_includes/v22.2/sql/grant-revoke-schema-changes.md
+++ b/_includes/v22.2/sql/grant-revoke-schema-changes.md
@@ -1,0 +1,5 @@
+`GRANT` and `REVOKE` operations are [schema changes](online-schema-changes.html).  As such they inherit the [limitations of schema changes](online-schema-changes.html#limitations).
+
+For example, schema changes wait for concurrent transactions using the same resources as the schema changes to complete. In the case of [role memberships](security-reference/authorization.html#roles) being modified by `GRANT` and `REVOKE` inside a transaction, most transactions need access to the set of role memberships.
+
+This means that [long-running transactions](query-behavior-troubleshooting.html#hanging-or-stuck-queries) elsewhere in the system can cause `GRANT` and `REVOKE` operations inside transactions to take several minutes to complete. This can have a cascading effect. When a `GRANT` or `REVOKE` operation inside a transaction takes a long time to complete, it can in turn block all user-initiated transactions being run by your application, since the `GRANT` operation in the transaction has to commit before any other transactions that access role memberships (i.e., most transactions) can make progress.

--- a/_includes/v23.1/sql/grant-revoke-schema-changes.md
+++ b/_includes/v23.1/sql/grant-revoke-schema-changes.md
@@ -1,0 +1,9 @@
+`GRANT` and `REVOKE` operations are [schema changes](online-schema-changes.html).  As such they inherit the [limitations of schema changes](online-schema-changes.html#limitations).
+
+For example, schema changes wait for concurrent transactions using the same resources as the schema changes to complete. In the case of [role memberships](security-reference/authorization.html#roles) being modified by `GRANT` and `REVOKE` inside a transaction, most transactions need access to the set of role memberships.
+
+This means that [long-running transactions](query-behavior-troubleshooting.html#hanging-or-stuck-queries) elsewhere in the system can cause `GRANT` and `REVOKE` operations inside transactions to take several minutes to complete. This can have a cascading effect. When a `GRANT` or `REVOKE` operation inside a transaction takes a long time to complete, it can in turn block all user-initiated transactions being run by your application, since the `GRANT` operation in the transaction has to commit before any other transactions that access role memberships (i.e., most transactions) can make progress.
+
+If you would prefer that grant and revoke operations finish rapidly, and do not care whether concurrent transactions will immediately see the side-effects of those operations, set the session variable `allow_role_memberships_to_change_during_transaction` to `true`.
+
+When enabled, this session variable means that the grant or revoke operations issued in the current session will only need to wait for the completion of statements in other sessions which do not have that session variable set. To accelerate grant and revoke operations across your entire application, you can set the session variable in all sessions by [passing it in the client connection string](connection-parameters.html#supported-options-parameters).

--- a/v22.2/grant.md
+++ b/v22.2/grant.md
@@ -65,6 +65,10 @@ For privileges required by specific statements, see the documentation for the re
 - All privileges of a role are inherited by all its members.
 - Membership loops are not allowed (direct: `A is a member of B is a member of A` or indirect: `A is a member of B is a member of C ... is a member of A`).
 
+## Limitations
+
+{% include {{page.version.version}}/sql/grant-revoke-schema-changes.md %}
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}

--- a/v22.2/revoke.md
+++ b/v22.2/revoke.md
@@ -47,6 +47,10 @@ The following privileges can be revoked:
 
 - The `root` user cannot be revoked from the `admin` role.
 
+## Limitations
+
+{% include {{page.version.version}}/sql/grant-revoke-schema-changes.md %}
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}

--- a/v23.1/grant.md
+++ b/v23.1/grant.md
@@ -65,6 +65,10 @@ For privileges required by specific statements, see the documentation for the re
 - All privileges of a role are inherited by all its members.
 - Membership loops are not allowed (direct: `A is a member of B is a member of A` or indirect: `A is a member of B is a member of C ... is a member of A`).
 
+## Limitations
+
+{% include {{page.version.version}}/sql/grant-revoke-schema-changes.md %}
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}

--- a/v23.1/revoke.md
+++ b/v23.1/revoke.md
@@ -47,6 +47,10 @@ The following privileges can be revoked:
 
 - The `root` user cannot be revoked from the `admin` role.
 
+## Limitations
+
+{% include {{page.version.version}}/sql/grant-revoke-schema-changes.md %}
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}


### PR DESCRIPTION
... as well as a note about GRANT operations inside transactions potentially blocking other transactions on the system, since they touch role memberships, which are used by most other transactions as well. Therefore the other concurrent transactions accessing the role information will be blocked and have to wait.

Unless they use the new cluster setting added in v23.1.

This change adds:

- The note about GRANT ops inside a transaction to the v22.2 and v23.1 docs

- The info about the new cluster setting to the v23.1 docs.

Fixes DOC-6345, DOC-6733, DOC-7205