### PR TITLE
Accept upper/lowercase "serverless" in Vale

### DIFF
--- a/vale/Vocab/CockroachDB/accept.txt
+++ b/vale/Vocab/CockroachDB/accept.txt
@@ -333,7 +333,7 @@ seeked
 [sS][eE][lL]inux
 Sequelize
 serializab(ility|le)
-serverless
+[sS]erverless
 servlet
 severities
 shapefiles?


### PR DESCRIPTION
Fixes Vale to allow upper and lowercase serverless/Serverless.