### PR TITLE
Correct changefeed from system priv v22.2

### DIFF
--- a/_includes/v22.2/sql/privileges.md
+++ b/_includes/v22.2/sql/privileges.md
@@ -1,26 +1,27 @@
 Privilege | Levels
 ----------|------------
 `ALL` | Database, Schema, Table, Sequence, Type
+`BACKUP` | System, Database, Table
+`CANCELQUERY` | System
+`CHANGEFEED` | Table
+`CONNECT` | Database
 `CREATE` | Database, Schema, Table, Sequence
+`DELETE` | Table, Sequence
 `DROP` | Database, Table, Sequence
 `EXECUTE` | Function
+`EXTERNALCONNECTION` | System
+`EXTERNALIOIMPLICITACCESS` | System
 `GRANT` | Database, Function, Schema, Table, Sequence, Type
-`CONNECT` | Database
-`SELECT` | Table, Sequence
 `INSERT` | Table, Sequence
-`DELETE` | Table, Sequence
+`MODIFYCLUSTERSETTING` | System
+`NOSQLLOGIN` | System
+`RESTORE` | System, Database
+`SELECT` | Table, Sequence
 `UPDATE` | Table, Sequence
 `USAGE`  | Function, Schema, Sequence, Type
-`ZONECONFIG` | Database, Table, Sequence
-`EXTERNALCONNECTION` | System
-`BACKUP` | System, Database, Table
-`RESTORE` | System, Database
-`EXTERNALIOIMPLICITACCESS` | System
-`MODIFYCLUSTERSETTING` | System
 `VIEWACTIVITY` | System
 `VIEWACTIVITYREDACTED` | System
 `VIEWCLUSTERMETADATA` | System
 `VIEWCLUSTERSETTING` | System
 `VIEWDEBUG` | System
-`CANCELQUERY` | System
-`NOSQLLOGIN` | System
+`ZONECONFIG` | Database, Table, Sequence

--- a/v22.2/security-reference/authorization.md
+++ b/v22.2/security-reference/authorization.md
@@ -138,7 +138,7 @@ Roles and users can be granted the following privileges:
 
 ### System-level privileges 
 
-<span class="version-tag">New in v22.2:</span> System-level privileges offer more granular control over a user's actions when working with CockroachDB, compared to the [role options authorization model](#role-options).
+<span class="version-tag">New in v22.2:</span> System-level privileges (also known as global privileges) offer more granular control over a user's actions when working with CockroachDB, compared to the [role options authorization model](#role-options).
 
 System-level privileges are a special kind of privilege that apply cluster-wide, meaning that the privilege is not tied to any specific object in the database.
 
@@ -160,7 +160,6 @@ New System-level Privilege  | Replaces Legacy Role Option
 `BACKUP`                    | No, new in v22.2
 `RESTORE`                   | No, new in v22.2
 `EXTERNALIOIMPLICITACCESS`  | No, new in v22.2
-`CHANGEFEED`                | No, new in v22.2
 
 If a system-level privilege exists with the same name as a role option, the system-level privilege should be used. Some role options do not have a corresponding system-level privilege, since they configure per-user attributes. For those system-level privileges that replace legacy role options (such as `VIEWACTIVITY`), if both the system-level privilege and its legacy role option are specified for a user/role, the system-level privilege will take precedence and the legacy role option will be ignored.
 


### PR DESCRIPTION
Fixes DOC-7574

Removed `CHANGEFEED` priv from system-level privilege table in v22.2 and added to supported privilege table.