### PR TITLE
Remove the preview label from changefeed webhook sink

### DIFF
--- a/v23.1/changefeed-examples.md
+++ b/v23.1/changefeed-examples.md
@@ -539,10 +539,6 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 [`CREATE CHANGEFEED`](create-changefeed.html) is an [{{ site.data.products.enterprise }}-only](enterprise-licensing.html) feature. For the Core version, see [the `CHANGEFEED FOR` example](#create-a-core-changefeed).
 {{site.data.alerts.end}}
 
-{{site.data.alerts.callout_info}}
-{% include feature-phases/preview.md %}
-{{site.data.alerts.end}}
-
  In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
 
 1. If you do not already have one, [request a trial {{ site.data.products.enterprise }} license](enterprise-licensing.html).

--- a/v23.1/changefeed-sinks.md
+++ b/v23.1/changefeed-sinks.md
@@ -376,10 +376,6 @@ The following shows the default JSON messages for a changefeed emitting to a clo
 
 ## Webhook sink
 
-{{site.data.alerts.callout_info}}
-{% include feature-phases/preview.md %}
-{{site.data.alerts.end}}
-
 Use a webhook sink to deliver changefeed messages to an arbitrary HTTP endpoint.
 
 Example of a webhook sink URL:

--- a/v23.1/cockroachdb-feature-availability.md
+++ b/v23.1/cockroachdb-feature-availability.md
@@ -173,10 +173,6 @@ For usage details, see the [Monitor and Debug Changefeeds](monitor-and-debug-cha
 
 Changefeeds can deliver messages to a [Google Cloud Pub/Sub sink](changefeed-sinks.html#google-cloud-pub-sub), which is integrated with Google Cloud Platform.
 
-### Webhook sink for changefeeds
-
-Use a [webhook sink](changefeed-sinks.html#webhook-sink) to deliver changefeed messages to an arbitrary HTTP endpoint.
-
 ### Multiple active portals
 
 The multiple active portals feature of the Postgres wire protocol (pgwire) is available, with limitations.  For more information, see [Multiple active portals](postgresql-compatibility.html#multiple-active-portals).

--- a/v23.1/create-changefeed.md
+++ b/v23.1/create-changefeed.md
@@ -83,7 +83,7 @@ Example of a Kafka sink URI:
 #### Google Cloud Pub/Sub
 
 {{site.data.alerts.callout_info}}
-The Google Cloud Pub/Sub sink is currently in **beta**.
+{% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
 Example of a Google Cloud Pub/Sub sink URI:
@@ -108,10 +108,6 @@ HTTP         | `'http://localhost:8080/{PATH}'`
 [Use Cloud Storage](use-cloud-storage.html) explains the requirements for authentication and encryption for each supported cloud storage sink. See [Changefeed Sinks](changefeed-sinks.html#cloud-storage-sink) for considerations when using cloud storage.
 
 #### Webhook
-
-{{site.data.alerts.callout_info}}
-The webhook sink is currently in **beta**.
-{{site.data.alerts.end}}
 
 Example of a webhook URI:
 
@@ -316,7 +312,7 @@ CREATE CHANGEFEED FOR TABLE name INTO 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY
 ### Create a changefeed connected to a Google Cloud Pub/Sub
 
 {{site.data.alerts.callout_info}}
-The Google Cloud Pub/Sub sink is currently in **beta**.
+{% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
 {% include_cached copy-clipboard.html %}
@@ -337,8 +333,6 @@ The Google Cloud Pub/Sub sink is currently in **beta**.
 For step-by-step guidance on creating a changefeed connected to a Google Cloud Pub/Sub, see the [Changefeed Examples](changefeed-examples.html#create-a-changefeed-connected-to-a-google-cloud-pub-sub-sink) page. The parameters table on the [Changefeed Sinks](changefeed-sinks.html#pub-sub-parameters) page provides a list of the available Google Cloud Pub/Sub parameters.
 
 ### Create a changefeed connected to a webhook sink
-
-{% include {{ page.version.version }}/cdc/webhook-beta.md %}
 
 {% include_cached copy-clipboard.html %}
 ~~~sql


### PR DESCRIPTION
Fixes DOC-7149

Removed the preview label from webhook sink across the changefeed docs.
Updated the "beta" label on Pub/Sub to "Preview" that was missed on one of the pages.