### PR TITLE
Fix the v20.1 Change Data Capture page version dropdown

### DIFF
--- a/v20.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v20.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -2,6 +2,7 @@
 title: Stream Data Out of CockroachDB Using Changefeeds
 summary: Stream data out of CockroachDB with efficient, distributed, row-level change subscriptions (changefeeds).
 toc: true
+key: change-data-capture.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level change feeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.
@@ -20,7 +21,6 @@ The main feature of CDC is the changefeed, which targets an allowlist of tables,
 | Create with [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html). | Create with [`CREATE CHANGEFEED`](create-changefeed.html). |
 | Watches one or multiple tables in a comma-separated list. Emits every change to a "watched" row as a record. | Watches one or multiple tables in a comma-separated list. Emits every change to a "watched" row as a record in a <br> configurable format (`JSON` or Avro) to a configurable sink  ([Kafka](https://kafka.apache.org/)). |
 | [`CREATE`](#create-a-changefeed-core) changefeed and cancel by closing the connection. | Manage changefeed with [`CREATE`](#create), [`PAUSE`](#pause), [`RESUME`](#resume), and [`CANCEL`](#cancel), as well as [monitor](#monitor-a-changefeed) and [debug](#debug-a-changefeed). |
-
 
 ## Enable rangefeeds
 

--- a/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -2,6 +2,7 @@
 title: Stream Data Out of CockroachDB Using Changefeeds
 summary: Stream data out of CockroachDB with efficient, distributed, row-level change subscriptions (changefeeds).
 toc: true
+key: change-data-capture.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level change feeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.

--- a/v21.2/change-data-capture-overview.md
+++ b/v21.2/change-data-capture-overview.md
@@ -4,6 +4,7 @@ summary: Stream data out of CockroachDB with efficient, distributed, row-level c
 toc: true
 docs_area: stream_data
 key: stream-data-out-of-cockroachdb-using-changefeeds.html
+key: change-data-capture.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level changefeeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.

--- a/v22.1/change-data-capture-overview.md
+++ b/v22.1/change-data-capture-overview.md
@@ -4,6 +4,7 @@ summary: Stream data out of CockroachDB with efficient, distributed, row-level c
 toc: true
 docs_area: stream_data
 key: stream-data-out-of-cockroachdb-using-changefeeds.html
+key: change-data-capture.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level changefeeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.

--- a/v22.2/change-data-capture-overview.md
+++ b/v22.2/change-data-capture-overview.md
@@ -4,6 +4,7 @@ summary: Stream data out of CockroachDB with efficient, distributed, row-level c
 toc: true
 docs_area: stream_data
 key: stream-data-out-of-cockroachdb-using-changefeeds.html
+key: change-data-capture.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level changefeeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.

--- a/v23.1/change-data-capture-overview.md
+++ b/v23.1/change-data-capture-overview.md
@@ -4,6 +4,7 @@ summary: Stream data out of CockroachDB with efficient, distributed, row-level c
 toc: true
 docs_area: stream_data
 key: stream-data-out-of-cockroachdb-using-changefeeds.html
+key: change-data-capture.html
 ---
 
 Change data capture (CDC) provides efficient, distributed, row-level changefeeds into a configurable sink for downstream processing such as reporting, caching, or full-text indexing.


### PR DESCRIPTION
Fixes DOC-7590

Right now, users who search for "cockroachdb cdc" on Google will run into the Change Data Capture Overview page (good), but the second result will be the very old Change Data Capture page (bad). And it's particularly bad, since over the last few years the `key` element hasn't been added to frontmatters to control where v20.1 visitors on that page will end up. They cannot select the newer versions, and so end up stuck.