### PR TITLE
updates to UDF functionality

### DIFF
--- a/v23.1/create-function.md
+++ b/v23.1/create-function.md
@@ -31,8 +31,8 @@ If you grant `EXECUTE` privilege as a default privilege at the database level, n
 Parameter | Description
 ----------|------------
 `func_create_name` | The name of the function.
-`func_arg` | A function argument.
-`func_arg_type` | The type returned by the function.
+`func_param` | A function argument.
+`func_param_type` | The type returned by the function. 
 `opt_routine_body` | The body of the function. For allowed contents, see [User-Defined Functions: Overview](user-defined-functions.html#overview).
 
 ## Example of a simple function
@@ -41,14 +41,14 @@ The following statement creates a function to compute the square of integers:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE OR REPLACE FUNCTION sq(a INT) RETURNS INT AS 'SELECT a*a' LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION sq(a INT) RETURNS INT AS 'SELECT a*a' LANGUAGE SQL;
 ~~~
 
 The following statement invokes the `sq` function:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT sq(2);
+SELECT sq(2);
 ~~~
 
 ~~~
@@ -68,12 +68,12 @@ The following statement defines a function that returns the total number of MovR
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE OR REPLACE FUNCTION num_users() RETURNS INT AS 'SELECT count(*) from users' LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION num_users() RETURNS INT AS 'SELECT COUNT(*) FROM users' LANGUAGE SQL;
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT num_users();
+SELECT num_users();
 ~~~
 
 ~~~
@@ -89,19 +89,73 @@ The following statement defines a function that returns the total revenue for ri
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> CREATE OR REPLACE FUNCTION total_euro_revenue() RETURNS DECIMAL LANGUAGE SQL AS $$
+CREATE OR REPLACE FUNCTION total_euro_revenue() RETURNS DECIMAL LANGUAGE SQL AS $$
   SELECT SUM(revenue) FROM rides WHERE city IN ('paris', 'rome', 'amsterdam')
-  $$;
+$$;
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SELECT total_euro_revenue();
+SELECT total_euro_revenue();
 ~~~
 ~~~
   total_euro_revenue
 ----------------------
              8468.00
+~~~
+
+### Create a function that returns a set of results
+
+The following statement defines a function that returns information for all vehicles not in use. The `SETOF` clause specifies that the function should return each row as the query executes to completion.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE OR REPLACE FUNCTION available_vehicles() RETURNS SETOF vehicles LANGUAGE SQL AS $$
+  SELECT * FROM vehicles WHERE status = 'available'
+$$;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT city,current_location,type FROM available_vehicles();
+~~~
+
+~~~
+      city      |      current_location       |    type
+----------------+-----------------------------+-------------
+  amsterdam     | 4102 Stout Flat Apt. 11     | skateboard
+  boston        | 30226 Logan Branch Suite 76 | skateboard
+  los angeles   | 25730 Crystal Terrace       | scooter
+  paris         | 9429 Joseph Neck Suite 52   | skateboard
+  san francisco | 43325 Jeffrey Wall Suite 26 | scooter
+(5 rows)
+~~~
+
+### Create a function that returns a `RECORD` type
+
+The following statement defines a function that returns the information for the user that most recently completed a ride. The information is returned as a record, which takes the structure of the row that is retrieved by the selection query.
+
+In the function subquery, the latest `end_time` timestamp is used to determine the most recently completed ride.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE OR REPLACE FUNCTION last_rider() RETURNS RECORD LANGUAGE SQL AS $$
+  SELECT * FROM users WHERE id = (
+    SELECT rider_id FROM rides WHERE end_time = (SELECT max(end_time) FROM rides)
+  )
+$$;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT last_rider();
+~~~
+
+~~~
+                                                last_rider
+----------------------------------------------------------------------------------------------------------
+  (70a3d70a-3d70-4400-8000-000000000016,seattle,"Mary Thomas","43322 Anthony Flats Suite 85",1141093639)
+(1 row)
 ~~~
 
 ## See also

--- a/v23.1/user-defined-functions.md
+++ b/v23.1/user-defined-functions.md
@@ -12,12 +12,15 @@ A user-defined function (UDF) is a named function defined at the database level 
 
 The basic components of a user-defined function are a name, list of arguments, return type, volatility, language, and function body.
 
-- An argument has a _mode_ and a _type_. CockroachDB supports the `IN` argument mode. The type can be a built-in type, [user-defined enum](enum.html), or implicit record type. CockroachDB **does not** support default values for arguments.
-- The return type can be a built-in type, user-defined enum, implicit record type, or `VOID`. `VOID` indicates that there is no return type and `NULL` will always be returned. If the return type of the function is not `VOID`, the last statement of a UDF must be a `SELECT`.
+- An argument has a _mode_ and a _type_. CockroachDB supports the `IN` argument mode. The type can be a built-in type, [user-defined `ENUM`](enum.html), or implicit record type. CockroachDB **does not** support default values for arguments.
+- The return type can be a built-in [type](data-types.html), user-defined [`ENUM`](enum.html), [`RECORD`](create-function.html#create-a-function-that-returns-a-record-type), implicit record type, or `VOID`.
+    - Preceding a type with `SETOF` indicates that a set, or multiple rows, should be returned. For an example, see [Create a function that returns a set of results](create-function.html#create-a-function-that-returns-a-set-of-results).
+    - `VOID` indicates that there is no return type and `NULL` will always be returned. If the return type of the function is not `VOID`, the last statement of a UDF must be a `SELECT`.
 - The [volatility](functions-and-operators.html#function-volatility) indicates whether the function has side effects. `VOLATILE` and `NOT LEAKPROOF` are the default.
   - Annotate a function with side effects with `VOLATILE`. This also prevents the [cost-based optimizer](cost-based-optimizer.html) from pre-evaluating the function.
   - A `STABLE` or `IMMUTABLE` function does not mutate data.
   - `LEAKPROOF` indicates that a function has no side effects and that it communicates nothing that depends on its arguments besides the return value (i.e., it cannot throw an error that depends on the value of its arguments). You must precede `LEAKPROOF` with `IMMUTABLE`, and only `IMMUTABLE` can be set to `LEAKPROOF`. `NOT LEAKPROOF` is allowed with any other volatility.
+  - Non-`VOLATILE` functions can be optimized through inlining. For more information, see [Create an inlined UDF](#create-an-inlined-udf).
 - The language specifies the language of the function body. CockroachDB supports the language `SQL`.
 - The function body:
   - Can reference arguments by name or by their ordinal in the function definition with the syntax `$1`.
@@ -26,8 +29,6 @@ The basic components of a user-defined function are a name, list of arguments, r
   - Can reference only the `SELECT` statement.
 
 ## Examples
-
-The following examples show how to create and invoke a simple UDF and view the definition of the UDF.
 
 ### Create a UDF
 
@@ -63,25 +64,11 @@ CREATE FUNCTION add(a INT, b INT) RETURNS INT LANGUAGE SQL AS $$
 $$;
 ~~~
 
-### Invoke a UDF
-
-You invoke the UDF like a [built-in function](functions-and-operators.html):
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT add(3,5) as sum;
-~~~
-
-~~~
-  sum
--------
-    8
-(1 row)
-~~~
+For more examples of UDF creation, see [`CREATE FUNCTION`](create-function.html).
 
 ### View a UDF definition
 
-To view the `add` function definition, run:
+To view the definition for the `add()` function:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -105,6 +92,192 @@ If you do not specify a schema for the function `add` when you create it, the de
 (1 row)
 ~~~
 
+### Invoke a UDF
+
+You invoke a UDF like a [built-in function](functions-and-operators.html).
+
+To invoke the `add()` function:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT add(3,5) as sum;
+~~~
+
+~~~
+  sum
+-------
+    8
+(1 row)
+~~~
+
+### Create an inlined UDF
+
+When possible, the [cost-based optimizer](cost-based-optimizer.html) will improve a function's performance by inlining the UDF within the query plan. The UDF must have the following attributes:
+
+- It is labeled as `IMMUTABLE`, `STABLE`, or `LEAKPROOF` (i.e., non-`VOLATILE`).
+- It has a single statement.
+- It is not a [set-returning function](create-function.html#create-a-function-that-returns-a-set-of-results).
+- Its arguments are only variable or constant expressions.
+- It is not a [record-returning function](create-function.html#create-a-function-that-returns-a-record-type).
+
+The following example demonstrates how inlining improves a UDF's performance.
+
+1. Create tables `a` and `b`:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE TABLE a (
+      a INT
+    );
+
+    CREATE TABLE b (
+      b INT PRIMARY KEY
+    );
+    ~~~
+
+1. Insert a value (`10`) into 1000 rows in `a` and 1 row in `b`:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    INSERT INTO a SELECT 10 FROM generate_series(1, 1000);
+    INSERT INTO b VALUES (10);
+    ~~~
+
+1. Create a `VOLATILE` function `foo_v()` and a `STABLE` function `foo_s()`:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    CREATE FUNCTION foo_v(x INT) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+      SELECT b FROM b WHERE b = x
+    $$;
+
+    CREATE FUNCTION foo_s(x INT) RETURNS INT STABLE LANGUAGE SQL AS $$
+      SELECT b FROM b WHERE b = x
+    $$;
+    ~~~
+
+    Each function returns a specified value from table `b`.
+
+1. View the query plan when `foo_v()` (the `VOLATILE` function) is used in a selection query to retrieve equal values from table `a`:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    EXPLAIN ANALYZE SELECT foo_v(a) FROM a WHERE a = 10;
+    ~~~
+
+    ~~~
+                                                info
+    --------------------------------------------------------------------------------------------
+      planning time: 2ms
+      execution time: 77ms
+      distribution: local
+      vectorized: true
+      rows read from KV: 1,000 (39 KiB, 1 gRPC calls)
+      cumulative time spent in KV: 330µs
+      maximum memory usage: 80 KiB
+      network usage: 0 B (0 messages)
+      sql cpu time: 75ms
+      estimated RUs consumed: 0
+
+      • render
+      │
+      └── • filter
+          │ nodes: n1
+          │ actual row count: 1,000
+          │ sql cpu time: 75ms
+          │ estimated row count: 1,000
+          │ filter: a = 10
+          │
+          └── • scan
+                nodes: n1
+                actual row count: 1,000
+                KV time: 330µs
+                KV contention time: 0µs
+                KV rows read: 1,000
+                KV bytes read: 39 KiB
+                KV gRPC calls: 1
+                estimated max memory allocated: 60 KiB
+                sql cpu time: 87µs
+                estimated row count: 1,000 (100% of the table; stats collected 19 seconds ago)
+                table: a@a_pkey
+                spans: FULL SCAN
+    (33 rows)
+    ~~~
+
+    The query takes `77ms` to execute because the function is evaluated for each row in `a`.
+
+1. View the query plan when using `foo_s()` (the `STABLE` function) instead:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    EXPLAIN ANALYZE SELECT foo_s(a) FROM a WHERE a = 10;
+    ~~~
+
+    ~~~
+                                                  info
+    ------------------------------------------------------------------------------------------------
+      planning time: 5ms
+      execution time: 4ms
+      distribution: local
+      vectorized: true
+      rows read from KV: 1,001 (39 KiB, 2 gRPC calls)
+      cumulative time spent in KV: 832µs
+      maximum memory usage: 420 KiB
+      network usage: 0 B (0 messages)
+      sql cpu time: 3ms
+      estimated RUs consumed: 0
+
+      • render
+      │
+      └── • merge join (left outer)
+          │ nodes: n1
+          │ actual row count: 1,000
+          │ estimated max memory allocated: 340 KiB
+          │ estimated max sql temp disk usage: 0 B
+          │ sql cpu time: 3ms
+          │ estimated row count: 1,000
+          │ equality: (a) = (b)
+          │ right cols are key
+          │
+          ├── • filter
+          │   │ nodes: n1
+          │   │ actual row count: 1,000
+          │   │ sql cpu time: 5µs
+          │   │ estimated row count: 1,000
+          │   │ filter: a = 10
+          │   │
+          │   └── • scan
+          │         nodes: n1
+          │         actual row count: 1,000
+          │         KV time: 722µs
+          │         KV contention time: 0µs
+          │         KV rows read: 1,000
+          │         KV bytes read: 39 KiB
+          │         KV gRPC calls: 1
+          │         estimated max memory allocated: 60 KiB
+          │         sql cpu time: 202µs
+          │         estimated row count: 1,000 (100% of the table; stats collected 42 seconds ago)
+          │         table: a@a_pkey
+          │         spans: FULL SCAN
+          │
+          └── • scan
+                nodes: n1
+                actual row count: 1
+                KV time: 110µs
+                KV contention time: 0µs
+                KV rows read: 1
+                KV bytes read: 30 B
+                KV gRPC calls: 1
+                estimated max memory allocated: 20 KiB
+                sql cpu time: 11µs
+                estimated row count: 1 (100% of the table; stats collected 42 seconds ago)
+                table: b@b_pkey
+                spans: FULL SCAN
+    (57 rows)
+    ~~~
+
+    The query takes only `4ms` to execute because the function is inlined as an equality comparison `(a) = (b)` with a much lower overhead.
+
 ## Known limitations
 
 ### Limitations on use of UDFs
@@ -127,17 +300,9 @@ User-defined functions are not currently supported in:
 
 The following are not currently allowed within the body of a UDF:
 
-- Subqueries in statements.
-
-    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87291)
-
 - Mutation statements such as `INSERT`, `UPDATE`, `DELETE`, and `UPSERT`.
 
     [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/87289)
-
-- Expressions with `*` such as `SELECT *`.
-
-    [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/90080)
 
 - CTEs (common table expressions).
 


### PR DESCRIPTION
DOC-6753

- Add example for `SETOF` type
- Add example for `RETURNS RECORD`
- Document UDF inlining
- Remove some features from unsupported UDF syntax list (i.e., they are supported now)