### PR TITLE
Online schema change best practices

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Get changed files
       id: changed_files
-      uses: tj-actions/changed-files@main
+      uses: tj-actions/changed-files@v35.9.2
 
     - name: Calculate changed files to pass to Vale
       id: calc_changed_files

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@main
+      uses: actions/checkout@v3
 
     - name: Get changed files
       id: changed_files

--- a/v22.2/online-schema-changes.md
+++ b/v22.2/online-schema-changes.md
@@ -87,7 +87,7 @@ Declarative schema changer statements and legacy schema changer statements opera
 
 ### Estimate your storage capacity before performing online schema changes
 
-Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming at least three times the storage space of the range size while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
+Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming up to three times the storage space of the range size while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
 
 To find the range size of the indexes in your table, use the following query:
 

--- a/v22.2/online-schema-changes.md
+++ b/v22.2/online-schema-changes.md
@@ -85,6 +85,93 @@ Declarative schema changer statements and legacy schema changer statements opera
 
 ## Best practices for online schema changes
 
+### Estimate your storage capacity before performing online schema changes
+
+Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming at least three times the storage space of the range size while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
+
+To find the range size of the indexes in your table, use the following query:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+WITH x AS (
+            SELECT *, row_number() OVER ()
+              FROM (
+                    SELECT DISTINCT index_name
+                      FROM [SHOW INDEXES FROM {table name}]
+                   )
+         )
+SELECT x.index_name,
+       round(l.range_size / 1048576, 4) AS range_size_mb
+  FROM crdb_internal.ranges AS l, x
+ WHERE     start_key
+           < (
+                (crdb_internal.index_span((SELECT id FROM system.namespace WHERE name = '{table name}'), x.row_number)::STRING[])[2]
+            )::BYTES
+       AND end_key
+           > (
+                (crdb_internal.index_span((SELECT id FROM system.namespace WHERE name = '{table name}'), x.row_number)::STRING[])[1]
+            )::BYTES;
+~~~
+
+Where `{table name}` is the name of the table.
+
+The output includes a `range_size_mb` column that shows the size of the range in megabytes for each index.
+
+In many cases this range size is trivial, but when the range size is many gigabytes or terabytes, you will need at least three times that amount of free storage space to successfully apply an online schema change.
+
+#### Example of finding the range size of an index
+
+1. Start a 3 node [`cockroach demo`](cockroach-demo.html) cluster with the MovR dataset.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    cockroach demo --nodes 3
+    ~~~
+
+1. Find the range size of the indexes in the `movr.vehicles` table:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    WITH x AS (
+                SELECT *, row_number() OVER ()
+                  FROM (
+                        SELECT DISTINCT index_name
+                          FROM [SHOW INDEXES FROM vehicles]
+                      )
+            )
+    SELECT x.index_name,
+          round(l.range_size / 1048576, 4) AS range_size_mb
+      FROM crdb_internal.ranges AS l, x
+    WHERE     start_key
+              < (
+                    (crdb_internal.index_span((SELECT id FROM system.namespace WHERE name = 'vehicles'), x.row_number)::STRING[])[2]
+                )::BYTES
+          AND end_key
+              > (
+                    (crdb_internal.index_span((SELECT id FROM system.namespace WHERE name = 'vehicles'), x.row_number)::STRING[])[1]
+                )::BYTES;
+    ~~~
+
+    ~~~
+                  index_name               | range_size_mb
+    ----------------------------------------+----------------
+      vehicles_pkey                         |        0.0003
+      vehicles_pkey                         |        0.0001
+      vehicles_pkey                         |        0.0004
+      vehicles_pkey                         |        0.0006
+      vehicles_pkey                         |        0.0002
+      vehicles_pkey                         |        0.0001
+      vehicles_pkey                         |        0.0001
+      vehicles_pkey                         |        0.0001
+      vehicles_pkey                         |        0.0014
+      vehicles_auto_index_fk_city_ref_users |        0.0014
+    (10 rows)
+    ~~~
+
+### Run schema changes with large backfills during off-peak hours
+
+Online schema changes that result in large backfill operations (for example, [`ALTER TABLE ... ALTER COLUMN`](alter-table.html#alter-column) statements) are computationally expensive, and can result in degraded performance. The [admission control system](admission-control.html) will help keep high-priority operations running, but it's better to run backfill-heavy schema changes during times with low loads.
+
 ### Schema changes in multi-region clusters
 
 {% include {{ page.version.version }}/performance/lease-preference-system-database.md %}

--- a/v22.2/online-schema-changes.md
+++ b/v22.2/online-schema-changes.md
@@ -87,7 +87,7 @@ Declarative schema changer statements and legacy schema changer statements opera
 
 ### Estimate your storage capacity before performing online schema changes
 
-Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming up to three times the storage space of the range size while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
+Some schema change operations, like adding or dropping columns or altering primary keys, will temporarily increase a cluster's storage consumption. Specifically, these operations may temporarily require up to three times more storage space  for the range size while the schema change is being applied, and this may cause the cluster to run out of storage space or fail to apply the schema change.
 
 To find the range size of the indexes in your table, use the following query:
 
@@ -170,7 +170,7 @@ In many cases this range size is trivial, but when the range size is many gigaby
 
 ### Run schema changes with large backfills during off-peak hours
 
-Online schema changes that result in large backfill operations (for example, [`ALTER TABLE ... ALTER COLUMN`](alter-table.html#alter-column) statements) are computationally expensive, and can result in degraded performance. The [admission control system](admission-control.html) will help keep high-priority operations running, but it's better to run backfill-heavy schema changes during times with low loads.
+Online schema changes that result in large backfill operations (for example, [`ALTER TABLE ... ALTER COLUMN`](alter-table.html#alter-column) statements) are computationally expensive, and can result in degraded performance. The [admission control system](admission-control.html) will help keep high-priority operations running, but it's recommended to run backfill-heavy schema changes during times when the cluster is under relatively low loads.
 
 ### Schema changes in multi-region clusters
 

--- a/v23.1/online-schema-changes.md
+++ b/v23.1/online-schema-changes.md
@@ -97,7 +97,7 @@ Declarative schema changer statements and legacy schema changer statements opera
 
 ### Estimate your storage capacity before performing online schema changes
 
-Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming at least three times the storage space of index while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
+Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming up to three times the storage space of the index while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
 
 To estimate the size of the indexes in your table, use the [`SHOW RANGES`](show-ranges.html) statement.
 
@@ -134,21 +134,25 @@ In many cases this range size is trivial, but when the range size is many gigaby
             SHOW RANGES FROM TABLE movr.vehicles WITH DETAILS, KEYS, INDEXES
          )
     SELECT index_name,
-           raw_index_start_key,
-           raw_index_end_key,
-           range_size_mb
+           round(range_size_mb, 4) as range_size_mb
       FROM x;
     ~~~
 
     ~~~
-                   index_name               | raw_index_start_key | raw_index_end_key |     range_size_mb
-    ----------------------------------------+---------------------+-------------------+-------------------------
-  vehicles_pkey                         | \xfe8af389          | \xfe8af38a        | 0.51177800000000000000
-  vehicles_auto_index_fk_city_ref_users | \xfe8af38a          | \xfe8af38b        | 0.51177800000000000000
-    (2 rows)
+                  index_name               | range_size_mb
+    ----------------------------------------+----------------
+      vehicles_pkey                         |        0.0005
+      vehicles_pkey                         |        0.0002
+      vehicles_pkey                         |        0.0005
+      vehicles_pkey                         |        0.0006
+      vehicles_pkey                         |        0.0002
+      vehicles_pkey                         |        0.0002
+      vehicles_pkey                         |        0.0002
+      vehicles_pkey                         |        0.0002
+      vehicles_pkey                         |        0.0103
+      vehicles_auto_index_fk_city_ref_users |        0.0103
+    (10 rows)
     ~~~
-
-    The size of the range for each index is 0.511778 MB, or about 511 KB. You will need at least three times that amount of free space, over 1.5 MB, to perform, for example, an online schema change that adds a column to `movr.vehicles`.
 
 ### Run schema changes with large backfills during off-peak hours
 

--- a/v23.1/online-schema-changes.md
+++ b/v23.1/online-schema-changes.md
@@ -97,7 +97,7 @@ Declarative schema changer statements and legacy schema changer statements opera
 
 ### Estimate your storage capacity before performing online schema changes
 
-Some schema change operations like adding or dropping columns, or altering primary keys will result in temporary increases to a cluster's storage consumption. These operations will result in consuming up to three times the storage space of the index while the schema change is being applied, which may cause the cluster to run out of storage space and pause or fail to apply the schema change.
+Some schema change operations, like adding or dropping columns or altering primary keys, will temporarily increase a cluster's storage consumption. Specifically, these operations may temporarily require up to three times more storage space  for the range size while the schema change is being applied, and this may cause the cluster to run out of storage space or fail to apply the schema change.
 
 To estimate the size of the indexes in your table, use the [`SHOW RANGES`](show-ranges.html) statement.
 
@@ -156,7 +156,7 @@ In many cases this range size is trivial, but when the range size is many gigaby
 
 ### Run schema changes with large backfills during off-peak hours
 
-Online schema changes that result in large backfill operations (for example, [`ALTER TABLE ... ALTER COLUMN`](alter-table.html#alter-column) statements) are computationally expensive, and can result in degraded performance. The [admission control system](admission-control.html) will help keep high-priority operations running, but it's better to run backfill-heavy schema changes during times with low loads.
+Online schema changes that result in large backfill operations (for example, [`ALTER TABLE ... ALTER COLUMN`](alter-table.html#alter-column) statements) are computationally expensive, and can result in degraded performance. The [admission control system](admission-control.html) will help keep high-priority operations running, but it's recommended to run backfill-heavy schema changes during times when the cluster is under relatively low loads.
 
 ### Schema changes in multi-region clusters
 

--- a/v23.1/online-schema-changes.md
+++ b/v23.1/online-schema-changes.md
@@ -64,7 +64,7 @@ If a schema change job is paused, any jobs waiting on that schema change will st
 If a schema change fails, the schema change job will be cleaned up automatically. However, there are limitations with rolling back schema changes within a transaction; for more information, see [Schema change DDL statements inside a multi-statement transaction can fail while other statements succeed](#schema-change-ddl-statements-inside-a-multi-statement-transaction-can-fail-while-other-statements-succeed).
 {{site.data.alerts.end}}
 
-See [Estimate your storage capacity before performing online schema changes](#estimate-your-storage-capacity-before-performing-online-schema-changes) for information on how to avoid running out of space during an online schema change.
+For advice about how to avoid running out of space during an online schema change, refer to [Estimate your storage capacity before performing online schema changes](#estimate-your-storage-capacity-before-performing-online-schema-changes).
 
 ## Declarative schema changer
 

--- a/v23.1/online-schema-changes.md
+++ b/v23.1/online-schema-changes.md
@@ -64,7 +64,7 @@ If a schema change job is paused, any jobs waiting on that schema change will st
 If a schema change fails, the schema change job will be cleaned up automatically. However, there are limitations with rolling back schema changes within a transaction; for more information, see [Schema change DDL statements inside a multi-statement transaction can fail while other statements succeed](#schema-change-ddl-statements-inside-a-multi-statement-transaction-can-fail-while-other-statements-succeed).
 {{site.data.alerts.end}}
 
-See [Estimate your storage capacity before performing online schema changes](#estimate-your-storage-capactity-before-performing-online-schema-changes) for information on how to avoid running out of space during an online schema change.
+See [Estimate your storage capacity before performing online schema changes](#estimate-your-storage-capacity-before-performing-online-schema-changes) for information on how to avoid running out of space during an online schema change.
 
 ## Declarative schema changer
 


### PR DESCRIPTION
This PR adds some additional guidance on storage requirements before performing online schema changes.

After talking with engineering, it appears that we have product limitations in v22.2 and v23.1.0 that prevent accurate estimates of range sizes with `SHOW RANGES`/`SHOW INDEXES`, `crdb_internal` queries, and the DB Console.

When the fixes get incorporated/backfilled we will require a follow-up PR. But in the meantime, I've made the decision to include the queries in this PR because it's better to have a very rough and possibly inaccurate estimate of range size than to give absolutely no insight at all.

Fixes DOC-262.