### PR TITLE
DOC-7485 self service restore limited access

### DIFF
--- a/cockroachcloud/use-managed-service-backups.md
+++ b/cockroachcloud/use-managed-service-backups.md
@@ -124,11 +124,11 @@ Additional ways to restore data:
 - [Back up a self-hosted CockroachDB cluster and restore into a {{ site.data.products.db }} cluster](#back-up-a-self-hosted-cockroachdb-cluster-and-restore-into-a-cockroachdb-cloud-cluster)
 - [Back up and restore data manually](take-and-restore-customer-owned-backups.html)
 
+### Restore a cluster
+
 {{site.data.alerts.callout_info}}
 {% include_cached feature-phases/limited-access.md %}
 {{site.data.alerts.end}}
-
-### Restore a cluster
 
 To restore a cluster:
 

--- a/cockroachcloud/use-managed-service-backups.md
+++ b/cockroachcloud/use-managed-service-backups.md
@@ -124,6 +124,10 @@ Additional ways to restore data:
 - [Back up a self-hosted CockroachDB cluster and restore into a {{ site.data.products.db }} cluster](#back-up-a-self-hosted-cockroachdb-cluster-and-restore-into-a-cockroachdb-cloud-cluster)
 - [Back up and restore data manually](take-and-restore-customer-owned-backups.html)
 
+{{site.data.alerts.callout_info}}
+{% include_cached feature-phases/limited-access.md %}
+{{site.data.alerts.end}}
+
 ### Restore a cluster
 
 To restore a cluster:


### PR DESCRIPTION
Addresses DOC-7485:
- Added the Limited Access tag as feature is currently behind a feature flag

Preview:
- [Self-Service Cluster Restore](https://deploy-preview-16952--cockroachdb-docs.netlify.app/docs/cockroachcloud/use-managed-service-backups.html?filters=dedicated#restore-a-cluster)