### PR TITLE
add tsvector/tsquery to supported SQL row values

### DIFF
--- a/v23.1/sql-feature-support.md
+++ b/v23.1/sql-feature-support.md
@@ -27,32 +27,34 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- `ARRAY` | ✓ | Standard | [`ARRAY` documentation](array.html)
- `AUTO INCREMENT`<br>(Automatic key generation) | Alternative | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
- `BIT` | ✓ | Standard | [`BIT` documentation](bit.html)
- `BYTES` | ✓ | CockroachDB Extension | [`BYTES` documentation](bytes.html)
- `BOOLEAN` | ✓ | Standard | [`BOOL` documentation](bool.html)
- `COLLATE` | ✓ | Standard | [`COLLATE` documentation](collate.html)
- `DATE` | ✓ | Standard | [`DATE` documentation](date.html)
- `DECIMAL`, `NUMERIC` | ✓ | Standard | [`DECIMAL` documentation](decimal.html)
- `ENUM` | ✓ | PostgreSQL Extension |  [`ENUM` documentation](enum.html)
- `FLOAT`, `REAL` | ✓ | Standard | [`FLOAT` documentation](float.html)
- `INET` | ✓ | PostgreSQL Extension | [`INET` documentation](inet.html)
- `INT` | ✓ | Standard | [`INT` documentation](int.html)
- `INTERVAL` | ✓ | Standard | [`INTERVAL` documentation](interval.html)
- `JSON`/`JSONB` | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
- `NULL` | ✓ | Standard | [`NULL`-handling documentation](null-handling.html)
- `OID` | ✓ | PostgreSQL Extension | [`OID` documentation](oid.html)
- `SERIAL`| ✓ | PostgreSQL Extension | [`SERIAL` documentation](serial.html)
- `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
- `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
- `TIME` | ✓ | Standard | [`TIME` documentation](time.html)
- `TIMESTAMP`/`TIMESTAMPTZ` | ✓ | Standard | [`TIMESTAMP` documentation](timestamp.html)
- `UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
- `UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
-  Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers).  See also [SQL Name Resolution](sql-name-resolution.html).
-  Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
-  XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
+`ARRAY` | ✓ | Standard | [`ARRAY` documentation](array.html)
+`AUTO INCREMENT`<br>(Automatic key generation) | Alternative | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
+`BIT` | ✓ | Standard | [`BIT` documentation](bit.html)
+`BOOLEAN` | ✓ | Standard | [`BOOL` documentation](bool.html)
+`BYTES` | ✓ | CockroachDB Extension | [`BYTES` documentation](bytes.html)
+`COLLATE` | ✓ | Standard | [`COLLATE` documentation](collate.html)
+`DATE` | ✓ | Standard | [`DATE` documentation](date.html)
+`DECIMAL`, `NUMERIC` | ✓ | Standard | [`DECIMAL` documentation](decimal.html)
+`ENUM` | ✓ | PostgreSQL Extension |  [`ENUM` documentation](enum.html)
+`FLOAT`, `REAL` | ✓ | Standard | [`FLOAT` documentation](float.html)
+`INET` | ✓ | PostgreSQL Extension | [`INET` documentation](inet.html)
+`INT` | ✓ | Standard | [`INT` documentation](int.html)
+`INTERVAL` | ✓ | Standard | [`INTERVAL` documentation](interval.html)
+`JSON`/`JSONB` | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
+`NULL` | ✓ | Standard | [`NULL`-handling documentation](null-handling.html)
+`OID` | ✓ | PostgreSQL Extension | [`OID` documentation](oid.html)
+`SERIAL`| ✓ | PostgreSQL Extension | [`SERIAL` documentation](serial.html)
+`SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
+`STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
+`TIME` | ✓ | Standard | [`TIME` documentation](time.html)
+`TIMESTAMP`/`TIMESTAMPTZ` | ✓ | Standard | [`TIMESTAMP` documentation](timestamp.html)
+`TSQUERY` | ✓ | Standard | [`TSQUERY` documentation](tsquery.html)
+`TSVECTOR` | ✓ | Standard | [`TSVECTOR` documentation](tsvector.html)
+`UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
+`UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
+Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers).  See also [SQL Name Resolution](sql-name-resolution.html).
+Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
+XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
 
 ### Constraints
 


### PR DESCRIPTION
Add TSVECTOR and TSQUERY to the list of supported data types on the SQL Feature Support page. This page was already updated in #16887 but I had missed updating the "row values" table.