### PR TITLE
Bumping Dedicated hotfix number

### DIFF
--- a/_config_cockroachdb.yml
+++ b/_config_cockroachdb.yml
@@ -1,7 +1,7 @@
 baseurl: /docs
 current_cloud_date: '2023-05-01'
 current_cloud_version: v22.2
-current_dedicated_hotfix: v22.2.8
+current_dedicated_hotfix: v22.2.9
 current_serverless_hotfix: v22.2.7
 destination: _site/docs
 homepage_title: CockroachDB Docs


### PR DESCRIPTION
Bumping Dedicate hotfix version to v22.2.9 as v22.2.8 was withdrawn.