### PR TITLE
v23.1.1 release

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -156,7 +156,7 @@ release_info:
     crdb_branch_name: release-23.1
     docker_image: cockroachdb/cockroach
     name: v23.1.1
-    start_time: 2023-05-15 22:21:50.394565 +0000 UTC
+    start_time: 2023-05-16 00:21:50.394565 +0000 UTC
     version: v23.1.1
 sass:
   quiet_deps: 'true'

--- a/_config_base.yml
+++ b/_config_base.yml
@@ -152,12 +152,12 @@ release_info:
     start_time: 2023-05-03 12:20:58.860667 +0000 UTC
     version: v22.2.9
   v23.1:
-    build_time: 2023-05-15 00:00:00 (go1.19)
+    build_time: 2023-05-16 00:00:00 (go1.19)
     crdb_branch_name: release-23.1
     docker_image: cockroachdb/cockroach
-    name: v23.1.0
-    start_time: 2023-05-15 16:33:03.563820 +0000 UTC
-    version: v23.1.0
+    name: v23.1.1
+    start_time: 2023-05-15 22:21:50.394565 +0000 UTC
+    version: v23.1.1
 sass:
   quiet_deps: 'true'
   sass_dir: css

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -4356,3 +4356,25 @@
     docker_arm: true
   source: true
   previous_release: v23.1.0-rc.2
+  withdrawn: true
+
+- release_name: v23.1.1
+  major_version: v23.1
+  release_date: '2023-05-16'
+  release_type: Production
+  go_version: go1.19
+  sha: 00f65ea04077b4256b4a351fd2703b81c7caed1e
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+  source: true
+  previous_release: v23.1.0

--- a/_includes/releases/v23.1/v23.1.0.md
+++ b/_includes/releases/v23.1/v23.1.0.md
@@ -4,7 +4,7 @@ Release Date: May 15, 2023
 
 With the release of CockroachDB v23.1, we've added new capabilities in CockroachDB to help you migrate, build, and operate more efficiently. Check out a [summary of the most significant user-facing changes](#v23-1-0-feature-highlights) and then [upgrade to CockroachDB v23.1](../v23.1/upgrade-cockroach-version.html).
 
-{% include releases/release-downloads-docker-image.md release=include.release %}
+{% include releases/release-downloads-docker-image.md release=include.release advisory_key="a103220"%}
 
 <h3 id="v23-1-0-{{ site.data.products.db | downcase | replace: " ", "-" }}">{{ site.data.products.db }}</h3>
 

--- a/_includes/releases/v23.1/v23.1.1.md
+++ b/_includes/releases/v23.1/v23.1.1.md
@@ -1,0 +1,19 @@
+## v23.1.1
+
+Release Date: May 16, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-1-1-big-fixes">Bug fixes</h3>
+
+- In CockroachDB v23.1.0 and its testing releases, executing [`COPY`](../v23.1/copy-from.html) to a target table that has multiple column families could corrupt the table. If data was copied into a table with existing rows, the data in those rows may be irrecoverable. The data would need to be dropped and re-[copied](../v23.1/copy-from.html) to be encoded correctly. This has now been fixed. See [Technical Advisory 103220](../advisories/a103220.html) for more information. [#103323][#103323]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-1-contributors">Contributors</h3>
+
+This release includes 2 merged PRs by 2 authors.
+
+</div>
+
+[103323]: https://github.com/cockroachdb/cockroach/pull/103323

--- a/_includes/releases/v23.1/v23.1.1.md
+++ b/_includes/releases/v23.1/v23.1.1.md
@@ -16,4 +16,4 @@ This release includes 2 merged PRs by 2 authors.
 
 </div>
 
-[103323]: https://github.com/cockroachdb/cockroach/pull/103323
+[#103323]: https://github.com/cockroachdb/cockroach/pull/103323

--- a/advisories/a103220.md
+++ b/advisories/a103220.md
@@ -31,4 +31,6 @@ Users running CockroachDB v23.1.0 are encouraged to upgrade to v23.1.1 or a late
 
 In CockroachDB v23.1.0 and its testing versions, executing `COPY` into a target table that has multiple [column families](../v23.1/column-families.html) can corrupt the table. Future reads on the corrupted table can result in internal errors or silent data corruption. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
 
+The v23.1.0 binary was withdrawn hours after its release, and prior to the formal announcement of this major release, so impacts to production workloads are not likely.
+
 Please reach out to the [support team](https://support.cockroachlabs.com) if more information or assistance is needed.

--- a/advisories/a103220.md
+++ b/advisories/a103220.md
@@ -1,0 +1,34 @@
+---
+title: Technical Advisory 103220
+advisory: A-103220
+summary: Inserting rows into a multi-column-family table with COPY can corrupt the table, making future reads fail with internal errors.
+toc: true
+affected_versions: v23.1.0-alpha.1 to v23.1.0
+advisory_date: 2023-05-16
+docs_area: releases
+---
+Publication date: {{ page.advisory_date | date: "%B %e, %Y" }}
+
+## Description
+
+In CockroachDB v23.1.0 and its testing versions, inserting rows into a multi-[column-family](../v23.1/column-families.html) table with [`COPY`](../v23.1/copy-from.html) can corrupt the table. Future reads on the corrupted table will result in internal errors. If the table is empty before the `COPY` executes, the table must be dropped and re-[copied](../v23.1/copy-from.html) to be encoded correctly. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
+
+## Statement
+
+This is resolved in CockroachDB by PR [103323](https://github.com/cockroachdb/cockroach/pull/103323).
+
+This fix has been applied to maintenance releases of CockroachDB [v23.1.1](../releases/v23.1.html#v23-1-1) and later.
+
+This public issue is tracked by [#103220](https://github.com/cockroachdb/cockroach/issues/103220).
+
+## Mitigation
+
+Users running CockroachDB v23.1.0 can avoid this issue by setting the [session variable](../v23.1/set-vars.html) `vectorize` to `off`, or setting `copy_fast_path_enabled` to `off` in any session that executes the `COPY` command.
+
+Users running CockroachDB v23.1.0 are encouraged to upgrade to v23.1.1 or a later version as soon as possible.
+
+## Impact
+
+In CockroachDB v23.1.0 and its testing versions, executing `COPY` into a target table that has multiple [column families](../v23.1/column-families.html) can corrupt the table. Future reads on the corrupted table will result in internal errors. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
+
+Please reach out to the [support team](https://support.cockroachlabs.com) if more information or assistance is needed.

--- a/advisories/a103220.md
+++ b/advisories/a103220.md
@@ -11,7 +11,7 @@ Publication date: {{ page.advisory_date | date: "%B %e, %Y" }}
 
 ## Description
 
-In CockroachDB v23.1.0 and its testing versions, inserting rows into a multi-[column-family](../v23.1/column-families.html) table with [`COPY`](../v23.1/copy-from.html) can corrupt the table. Future reads on the corrupted table will result in internal errors. If the table is empty before the `COPY` executes, the table must be dropped and re-[copied](../v23.1/copy-from.html) to be encoded correctly. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
+In CockroachDB v23.1.0 and its testing versions, inserting rows into a multi-[column-family](../v23.1/column-families.html) table with [`COPY`](../v23.1/copy-from.html) can corrupt the table. Future reads on the corrupted table can result in internal errors or silent data corruption. If the table is empty before the `COPY` executes, the table must be dropped and re-[copied](../v23.1/copy-from.html) to be encoded correctly. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
 
 ## Statement
 
@@ -29,6 +29,6 @@ Users running CockroachDB v23.1.0 are encouraged to upgrade to v23.1.1 or a late
 
 ## Impact
 
-In CockroachDB v23.1.0 and its testing versions, executing `COPY` into a target table that has multiple [column families](../v23.1/column-families.html) can corrupt the table. Future reads on the corrupted table will result in internal errors. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
+In CockroachDB v23.1.0 and its testing versions, executing `COPY` into a target table that has multiple [column families](../v23.1/column-families.html) can corrupt the table. Future reads on the corrupted table can result in internal errors or silent data corruption. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
 
 Please reach out to the [support team](https://support.cockroachlabs.com) if more information or assistance is needed.

--- a/v23.1/known-limitations.md
+++ b/v23.1/known-limitations.md
@@ -105,14 +105,6 @@ This is because the state flip is effected by the CLI program at the end. Only t
 
 [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/94430)
 
-### `COPY` incorrectly encodes data with multiple column families
-
-In CockroachDB v23.1.0 and its testing releases, executing `COPY` to a target table that has multiple column families can corrupt the table. Future reads on the corrupted table will result in internal errors. If data was copied into a table with existing rows, the data in those rows may be irrecoverable.
-
-The data must be dropped and re-[copied](copy-from.html) to be encoded correctly.
-
-[Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/103220)
-
 ## Unresolved limitations
 
 ### Limitations for user-defined functions (UDFs)


### PR DESCRIPTION
This PR does the following:
- Withdraws v23.1.0 binaries
- Removes this bug from the Known Limitations (since it's now documented by a TA)
- Adds TA 103220
- Adds v23.1.1 release notes

Closes DOC-6564.