### PR TITLE
Add the webhook and pub/sub performance cluster setting to docs

### DIFF
--- a/_includes/v23.1/cdc/pubsub-performance-setting.md
+++ b/_includes/v23.1/cdc/pubsub-performance-setting.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_pubsub_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to Pub/Sub sinks.
+{{site.data.alerts.end}}

--- a/_includes/v23.1/cdc/pubsub-performance-setting.md
+++ b/_includes/v23.1/cdc/pubsub-performance-setting.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_info}}
-{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_pubsub_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to Pub/Sub sinks.
+{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_pubsub_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to {% if page.name == "changefeed-sinks.md" %} Pub/Sub sinks. {% else %} [Pub/Sub sinks](changefeed-sinks.html#google-cloud-pub-sub). {% endif %}
 {{site.data.alerts.end}}

--- a/_includes/v23.1/cdc/webhook-performance-setting.md
+++ b/_includes/v23.1/cdc/webhook-performance-setting.md
@@ -1,3 +1,4 @@
 {{site.data.alerts.callout_info}}
-{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_webhook_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to webhook sinks.
+{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_webhook_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to {% if page.name == "changefeed-sinks.md" %} webhook sinks. {% else %} [webhook sinks](changefeed-sinks.html#webhook-sinks). {% endif %}
 {{site.data.alerts.end}}
+

--- a/_includes/v23.1/cdc/webhook-performance-setting.md
+++ b/_includes/v23.1/cdc/webhook-performance-setting.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_webhook_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to webhook sinks.
+{{site.data.alerts.end}}

--- a/_includes/v23.1/cdc/webhook-performance-setting.md
+++ b/_includes/v23.1/cdc/webhook-performance-setting.md
@@ -1,4 +1,4 @@
 {{site.data.alerts.callout_info}}
-{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_webhook_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to {% if page.name == "changefeed-sinks.md" %} webhook sinks. {% else %} [webhook sinks](changefeed-sinks.html#webhook-sinks). {% endif %}
+{% include_cached new-in.html version="v23.1" %} Enable the `changefeed.new_webhook_sink_enabled` [cluster setting](cluster-settings.html) to improve the throughput of changefeeds emitting to {% if page.name == "changefeed-sinks.md" %} webhook sinks. {% else %} [webhook sinks](changefeed-sinks.html#webhook-sink). {% endif %}
 {{site.data.alerts.end}}
 

--- a/v23.1/changefeed-examples.md
+++ b/v23.1/changefeed-examples.md
@@ -329,6 +329,8 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
+{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
+
 In this example, you'll set up a changefeed for a single-node cluster that is connected to a [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/overview) sink. The changefeed will watch a table and send messages to the sink.
 
 You'll need access to a [Google Cloud Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) to set up a Pub/Sub sink. In this example, the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk) (`gcloud`) is used, but you can also complete each of these steps within your [Google Cloud Console](https://cloud.google.com/storage/docs/cloud-console).
@@ -539,7 +541,9 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 [`CREATE CHANGEFEED`](create-changefeed.html) is an [{{ site.data.products.enterprise }}-only](enterprise-licensing.html) feature. For the Core version, see [the `CHANGEFEED FOR` example](#create-a-core-changefeed).
 {{site.data.alerts.end}}
 
- In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
+{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
+
+In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
 
 1. If you do not already have one, [request a trial {{ site.data.products.enterprise }} license](enterprise-licensing.html).
 

--- a/v23.1/changefeed-sinks.md
+++ b/v23.1/changefeed-sinks.md
@@ -192,6 +192,8 @@ See the [Changefeed Examples](changefeed-examples.html) page and the [Stream a C
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
+{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
+
 Changefeeds can deliver messages to a Google Cloud Pub/Sub sink, which is integrated with Google Cloud Platform.
 
 A Pub/Sub sink URI follows this example:
@@ -375,6 +377,8 @@ The following shows the default JSON messages for a changefeed emitting to a clo
 {% include {{ page.version.version }}/cdc/note-changefeed-message-page.md %}
 
 ## Webhook sink
+
+{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
 
 Use a webhook sink to deliver changefeed messages to an arbitrary HTTP endpoint.
 

--- a/v23.1/create-changefeed.md
+++ b/v23.1/create-changefeed.md
@@ -92,6 +92,8 @@ Example of a Google Cloud Pub/Sub sink URI:
 'gcpubsub://{project name}?region={region}&topic_name={topic name}&AUTH=specified&CREDENTIALS={base64-encoded key}'
 ~~~
 
+{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
+
 [Use Cloud Storage for Bulk Operations](cloud-storage-authentication.html) explains the requirements for the authentication parameter with `specified` or `implicit`. See [Changefeed Sinks](changefeed-sinks.html#google-cloud-pub-sub) for further consideration.
 
 #### Cloud Storage
@@ -114,6 +116,8 @@ Example of a webhook URI:
 ~~~
 'webhook-https://{your-webhook-endpoint}?insecure_tls_skip_verify=true'
 ~~~
+
+{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
 
 See [Changefeed Sinks](changefeed-sinks.html#webhook-sink) for specifics on webhook sink configuration.
 
@@ -317,6 +321,8 @@ CREATE CHANGEFEED FOR TABLE name INTO 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
+{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
+
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE CHANGEFEED FOR TABLE name, name2, name3
@@ -335,6 +341,8 @@ CREATE CHANGEFEED FOR TABLE name INTO 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY
 For step-by-step guidance on creating a changefeed connected to a Google Cloud Pub/Sub, see the [Changefeed Examples](changefeed-examples.html#create-a-changefeed-connected-to-a-google-cloud-pub-sub-sink) page. The parameters table on the [Changefeed Sinks](changefeed-sinks.html#pub-sub-parameters) page provides a list of the available Google Cloud Pub/Sub parameters.
 
 ### Create a changefeed connected to a webhook sink
+
+{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
 
 {% include_cached copy-clipboard.html %}
 ~~~sql


### PR DESCRIPTION
Fixes DOC-7349, DOC-7414

Added a note for the new webhook and Pub/Sub cluster settings that allow the performance improvements.

Note: I haven't added setting these embedded in examples because the intention is to backport these settings to be default on.