### PR TITLE
Update build-netlify.sh

### DIFF
--- a/build/build-netlify.sh
+++ b/build/build-netlify.sh
@@ -51,10 +51,10 @@ if [[ "$INCOMING_HOOK_TITLE" = "nightly" ]]; then
 fi;
 
 # Run Algolia if building master
-# if [[ "$CONTEXT" = "production" ]]; then
-# 	echo "Building Algolia index..."
-# 	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml,_config_url.yml --builds-config _config_cockroachdb.yml
-# fi;
+if [[ "$CONTEXT" = "production" ]]; then
+	echo "Building Algolia index..."
+	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml,_config_url.yml --builds-config _config_cockroachdb.yml
+fi;
 
 # Run htmltest, but skip checking external links to speed things up
 ./bin/htmltest --skip-external

--- a/build/build-netlify.sh
+++ b/build/build-netlify.sh
@@ -51,9 +51,9 @@ if [[ "$INCOMING_HOOK_TITLE" = "nightly" ]]; then
 fi;
 
 # Run Algolia if building master
-if [[ "$CONTEXT" = "production" ]]; then
+if [ "$CONTEXT" == "production" ]; then
 	echo "Building Algolia index..."
-	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml,_config_url.yml --builds-config _config_cockroachdb.yml
+	ALGOLIA_API_KEY=${PROD_ALGOLIA_API_KEY} bundle exec jekyll algolia --config _config_base.yml,_config_url.yml --builds-config _config_cockroachdb.yml
 fi;
 
 # Run htmltest, but skip checking external links to speed things up

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,9 +17,9 @@
   [build.processing.images]
     compress = false
 
-[[plugins]]
-  package = "@netlify/plugin-lighthouse"
-  [plugins.inputs]
-    output_path = "./reports/lighthouse.html"
-    [[plugins.inputs.audits]]
-      path = "./docs/index.html"
+#[[plugins]]
+#  package = "@netlify/plugin-lighthouse"
+#  [plugins.inputs]
+#    output_path = "./reports/lighthouse.html"
+#    [[plugins.inputs.audits]]
+#      path = "./docs/index.html"


### PR DESCRIPTION
Add the Algolia deployment step back to the build script. This also disables the Lighthouse plug-in until we figure out what we want to do with it and so it doesn't produce errors.