### PR TITLE
Fix issues with sitemap and canonicals

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,7 +40,8 @@
 <meta property="og:title" content="{{ page.title }}" />
 <meta property="og:type" content="article" />
 {%- assign dev_path = "/" | append: site.versions["dev"] | append: "/" -%}
-<meta property="og:url" content="{{ site.main_url | append: site.baseurl | append: page.canonical | replace: dev_path, "/dev/" }}" />
+{%- assign stable_path = "/" | append: site.versions["stable"] | append: "/" -%}
+<meta property="og:url" content="{{ site.main_url | append: site.baseurl | append: page.canonical | replace: stable_path, "/stable/" | replace: dev_path, "/dev/" }}" />
 <meta property="og:image" content="{% if page.image_url %}{{ page.image_url }}{% else %}https://www.cockroachlabs.com/img/crl-socialpost-default-2020-2.jpg?auto=format,compress{% endif %}" />
 <meta property="og:site_name" content="{{ site.site_title }}" />
 {% if page.summary %}<meta property="og:description" content="{{ page.summary | strip_html | strip_newlines | truncate: 160 }}">{% endif %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,11 +5,12 @@ layout: null
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- assign stable_pages_names = site.pages | where_exp: "stable_pages", "stable_pages.url contains site.versions['stable']" | where_exp: "stable_pages", "stable_pages.name != 'index.md'" | map: "name" -%}
   {%- assign dev_path = "/" | append: site.versions["dev"] | append: "/" -%}
+  {%- assign stable_path = "/" | append: site.versions["stable"] | append: "/" -%}
   {%- for page in site.pages -%}
     {%- if page.url contains site.versions["stable"] or page.url contains site.versions["dev"] or page.url contains 'cockroachcloud/' or page.url contains 'releases/' or page.url contains 'advisories/' -%}
       {%- unless page.url contains '404' or page.sitemap == false or page.url contains site.versions["dev"] and site.versions["dev"] != site.versions["stable"] and stable_pages_names contains page.name %}
   <url>
-    <loc>{{ site.main_url | append: site.baseurl | append: page.canonical | replace: dev_path, "/dev/" }}</loc>
+    <loc>{{ site.main_url | append: site.baseurl | append: page.canonical | replace: stable_path, "/stable/" | replace: dev_path, "/dev/" }}</loc>
     <lastmod>{{ page.last_modified_at | date: "%Y-%m-%dT%H:%M:%S%:z" }}</lastmod>
   </url>
       {%- endunless -%}


### PR DESCRIPTION
Now that v23.1 is GA, both the dev and stable paths point to v23.1. In the sitemap logic and in the page head, it would automatically force a page's canonical to point to the dev URL. This PR fixes that.