### PR TITLE
Update show jobs doc for changefeed retention time

### DIFF
--- a/_includes/v23.1/cdc/show-changefeed-job-retention.md
+++ b/_includes/v23.1/cdc/show-changefeed-job-retention.md
@@ -1,1 +1,1 @@
-{% include_cached new-in.html version="v23.1" %} All changefeed jobs will display regardless of if the job completed and when it completed. You can use the [cluster setting](cluster-settings.html) `jobs.retention_time` to define a retention time to delete completed jobs.
+{% include_cached new-in.html version="v23.1" %} All changefeed jobs will display regardless of if the job completed and when it completed. You can define a retention time and delete completed jobs by using the `jobs.retention_time` [cluster setting](cluster-settings.html).

--- a/_includes/v23.1/cdc/show-changefeed-job-retention.md
+++ b/_includes/v23.1/cdc/show-changefeed-job-retention.md
@@ -1,0 +1,1 @@
+{% include_cached new-in.html version="v23.1" %} All changefeed jobs will display regardless of if the job completed and when it completed. You can use the [cluster setting](cluster-settings.html) `jobs.retention_time` to define a retention time to delete completed jobs.

--- a/_includes/v23.1/cdc/show-changefeed-job.md
+++ b/_includes/v23.1/cdc/show-changefeed-job.md
@@ -1,0 +1,24 @@
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW CHANGEFEED JOBS;
+~~~
+~~~
+    job_id             |                                                                                   description                                                                  | ...
++----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+ ...
+  685724608744325121   | CREATE CHANGEFEED FOR TABLE mytable INTO 'kafka://localhost:9092' WITH confluent_schema_registry = 'http://localhost:8081', format = 'avro', resolved, updated | ...
+  685723987509116929   | CREATE CHANGEFEED FOR TABLE mytable INTO 'kafka://localhost:9092' WITH confluent_schema_registry = 'http://localhost:8081', format = 'avro', resolved, updated | ...
+(2 rows)
+~~~
+
+To show an individual {{ site.data.products.enterprise }} changefeed:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW CHANGEFEED JOB {job_id};
+~~~
+~~~
+        job_id       |                                     description                                      | user_name | status  |              running_status              |          created           |          started           | finished |          modified          |      high_water_timestamp      | error |    sink_uri    |  full_table_names   | topics | format
+---------------------+--------------------------------------------------------------------------------------+-----------+---------+------------------------------------------+----------------------------+----------------------------+----------+----------------------------+--------------------------------+-------+----------------+---------------------+--------+----------
+  866218332400680961 | CREATE CHANGEFEED FOR TABLE movr.users INTO 'external://aws' WITH format = 'parquet' | root      | running | running: resolved=1684438482.937939878,0 | 2023-05-18 14:14:16.323465 | 2023-05-18 14:14:16.360245 | NULL     | 2023-05-18 19:35:16.120407 | 1684438482937939878.0000000000 |       | external://aws | {movr.public.users} | NULL   | parquet
+(1 row)
+~~~

--- a/v23.1/create-and-configure-changefeeds.md
+++ b/v23.1/create-and-configure-changefeeds.md
@@ -77,6 +77,16 @@ When you create a changefeed **without** specifying a sink, CockroachDB sends th
 
 For more information, see [`CREATE CHANGEFEED`](create-changefeed.html).
 
+### Show
+
+To show a list of {{ site.data.products.enterprise }} changefeed jobs:
+
+{% include {{ page.version.version }}/cdc/show-changefeed-job.md %}
+
+{% include {{ page.version.version }}/cdc/show-changefeed-job-retention.md %}
+
+For more information, refer to [`SHOW CHANGEFEED JOB`](show-jobs.html#show-changefeed-jobs).
+
 ### Pause
 
 To pause an {{ site.data.products.enterprise }} changefeed:
@@ -86,7 +96,7 @@ To pause an {{ site.data.products.enterprise }} changefeed:
 PAUSE JOB job_id;
 ~~~
 
-For more information, see [`PAUSE JOB`](pause-job.html).
+For more information, refer to [`PAUSE JOB`](pause-job.html).
 
 ### Resume
 
@@ -97,7 +107,7 @@ To resume a paused {{ site.data.products.enterprise }} changefeed:
 RESUME JOB job_id;
 ~~~
 
-For more information, see [`RESUME JOB`](resume-job.html).
+For more information, refer to [`RESUME JOB`](resume-job.html).
 
 ### Cancel
 
@@ -108,7 +118,7 @@ To cancel an {{ site.data.products.enterprise }} changefeed:
 CANCEL JOB job_id;
 ~~~
 
-For more information, see [`CANCEL JOB`](cancel-job.html).
+For more information, refer to [`CANCEL JOB`](cancel-job.html).
 
 ### Modify a changefeed
 

--- a/v23.1/show-jobs.md
+++ b/v23.1/show-jobs.md
@@ -24,7 +24,7 @@ To block a call to `SHOW JOBS` that returns after all specified job ID(s) have a
 
 - The `SHOW JOBS` statement shows only long-running tasks.
 - For jobs older than 12 hours, query the `crdb_internal.jobs` table.
-- Jobs are deleted after 14 days. This interval can be changed via the `jobs.retention_time` [cluster setting](cluster-settings.html).
+- For the `SHOW JOBS` statement, jobs are deleted after 14 days. This interval can be changed via the `jobs.retention_time` [cluster setting](cluster-settings.html). See [Show changefeed jobs](#show-changefeed-jobs) for changefeed job retention time.
 - While the `SHOW JOBS WHEN COMPLETE` statement is blocking, it will time out after 24 hours.
 - Garbage collection jobs are created for [dropped tables](drop-table.html) and [dropped indexes](drop-index.html), and will execute after the [GC TTL](configure-replication-zones.html#gc-ttlseconds) has elapsed. These jobs cannot be canceled.
 -  CockroachDB automatically retries jobs that fail due to [retry errors](transaction-retry-error-reference.html) or job coordination failures, with [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff). The `jobs.registry.retry.initial_delay` [cluster setting](cluster-settings.html) sets the initial delay between retries and `jobs.registry.retry.max_delay` sets the maximum delay.
@@ -178,7 +178,7 @@ You can filter jobs by using `SHOW AUTOMATIC JOBS` as the data source for a [`SE
 
 ### Show changefeed jobs
 
-You can display specific fields relating to changefeed jobs by running `SHOW CHANGEFEED JOBS`. These fields include:
+You can display specific fields relating to [changefeed](create-changefeed.html) jobs by running `SHOW CHANGEFEED JOBS`. These fields include:
 
 * [`high_water_timestamp`](monitor-and-debug-changefeeds.html#monitor-a-changefeed): Guarantees all changes before or at this time have been emitted.
 * [`sink_uri`](create-changefeed.html#sink-uri): The destination URI of the configured sink for a changefeed.
@@ -186,18 +186,9 @@ You can display specific fields relating to changefeed jobs by running `SHOW CHA
 - `topics`: The topic name to which [Kafka](changefeed-sinks.html#kafka) and [Google Cloud Pub/Sub](changefeed-sinks.html#google-cloud-pub-sub) changefeed messages will emit. If you start a changefeed with the [`split_column_families`](create-changefeed.html#split-column-families) option targeting a table with [multiple column families](changefeeds-on-tables-with-column-families.html), the `SHOW CHANGEFEED JOBS` output will show the topic name with a family placeholder. For example, `topic.{family}`.
 - [`format`](create-changefeed.html#format): The format of the changefeed messages, e.g., `json`, `avro`.
 
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW CHANGEFEED JOBS;
-~~~
+{% include {{ page.version.version }}/cdc/show-changefeed-job-retention.md %}
 
-~~~
-    job_id             |                                                                                   description                                                                  | ...
-+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+ ...
-  685724608744325121   | CREATE CHANGEFEED FOR TABLE mytable INTO 'kafka://localhost:9092' WITH confluent_schema_registry = 'http://localhost:8081', format = 'avro', resolved, updated | ...
-  685723987509116929   | CREATE CHANGEFEED FOR TABLE mytable INTO 'kafka://localhost:9092' WITH confluent_schema_registry = 'http://localhost:8081', format = 'avro', resolved, updated | ...
-(2 rows)
-~~~
+{% include {{ page.version.version }}/cdc/show-changefeed-job.md %}
 
 Changefeed jobs can be [paused](create-and-configure-changefeeds.html#pause), [resumed](create-and-configure-changefeeds.html#resume), [altered](alter-changefeed.html), or [canceled](create-and-configure-changefeeds.html#cancel).
 


### PR DESCRIPTION
Fixes DOC-7207

`SHOW CHANGEFEED JOBS` will now show _all_ jobs even if they haven't completed, and it does not matter when they completed. This differs from `SHOW JOBS`, which has a default 14-day retention time. Both of these statements can have their display retention time altered with a cluster setting.

This PR updates the docs to this effect, and also adds a missing `SHOW` section to our get started create and configure page for changefeeds.