### PR TITLE
[DOC-782] Use different ports for additional Docker nodes

### DIFF
--- a/src/current/_includes/v22.2/start-in-docker/mac-linux-steps.md
+++ b/src/current/_includes/v22.2/start-in-docker/mac-linux-steps.md
@@ -1,23 +1,34 @@
 ### Step 1. Create a bridge network
 
-Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, you need to create what Docker refers to as a [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The bridge network will enable the containers to communicate as a single cluster while keeping them isolated from external networks.
+Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, create a Docker [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The network has configurable properties such as a pool of IP addresses, network gateway, and routing rules. All nodes will connect to this network and can communicate openly by default, but incoming traffic can reach a container only through the container's published port mappings, as described in [Step 3: Start the cluster](#step-3-start-the-cluster). Because the network is a bridge, from the point of view of the client, the Docker host seems to service the request directly.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 docker network create -d bridge roachnet
 ~~~
 
-We've used `roachnet` as the network name here and in subsequent steps, but feel free to give your network any name you like.
+{{site.data.alerts.callout_success}}
+To customize your bridge network or create a different type of Docker network, refer to Docker's documentation for [`docker network create`](https://docs.docker.com/engine/reference/commandline/network_create/).
+{{site.data.alerts.end}}
+
+In subsequent steps, replace `roachnet` with the name of your Docker network.
 
 ### Step 2: Create Docker volumes for each cluster node
 
-Cockroach Labs recommends that you store cluster data in Docker volumes rather than in the storage layer of the running container. Otherwise, if a Docker container is inadvertently deleted, its data is inaccessible.
+Cockroach Labs recommends that you store cluster data in Docker volumes rather than in the storage layer of the running container. Using a volume has the following advantages over using bind mounts or writing directly to the running container's filesystem.
+
+- Volumes are managed entirely by Docker. A bind mount mounts an arbitrary directory on the Docker host into the container, and that directory could potentially be modified or deleted by any process with permission.
+- Volumes persist even if the containers that were using it are deleted. A container's local storage is temporarily unavailable if the container is stopped, and is permanently removed if the container is deleted.
+- When compared to a container's local storage, writing to either a local volume or a bind mount has considerably better performance because it uses fewer kernel system calls on the Docker host. For an explanation, refer to [Manage Data in Docker](https://docs.docker.com/storage/).
+- A volume can be backed up, restored, or migrated to a different container or Docker host. Refer to [Back Up, Restore, or Migrate Data Volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes).
+- A volume can be pre-populated before connecting it to a container. Refer to [Populate a Volume Using a Container](https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container).
+- A volume can be backed by local storage, a cloud storage resource, SSH, NFS, Samba, or raw block storage, among others. For details, refer to [Use a Volume Driver](https://docs.docker.com/storage/volumes/#use-a-volume-driver).
 
 {{site.data.alerts.callout_danger}}
 Avoid using the `-v` / `--volume` command to mount a local macOS filesystem into the container. Use Docker volumes or a [`tmpfs` mount](https://docs.docker.com/storage/tmpfs/).
 {{site.data.alerts.end}}
 
-Create a [Docker volume](https://docs.docker.com/storage/volumes/) for each container:
+Create a [Docker volume](https://docs.docker.com/storage/volumes/) for each container. You can create only one volume at a time.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -34,10 +45,21 @@ docker volume create roach2
 docker volume create roach3
 ~~~
 
-
 ### Step 3. Start the cluster
 
-1. Start the first node:
+This section shows how to start a three-node cluster where:
+
+- Each node will store its data in a unique Docker volume.
+- Each node will listen for SQL and HTTP connections at a unique port each on the `roachnet` network, and these ports are published. Client requests to the Docker host at a given port are forwarded to the container that is publishing that port. Nodes do not listen on `localhost`.
+- Each node will listen and advertise for inter-node cluster traffic at port 26357 on the `roachnet` network. This port is not published, so inter-node traffic does not leave this network.
+
+{{site.data.alerts.callout_info}}
+When SQL and inter-node traffic are separated, some client commands need to be modified with a `--host` flag or a `--uri` connection string. Some commands, such as `cockroach init`, default to port 26257 but must use the inter-node traffic port (the `--listen-addr` or `--advertise-addr`) rather than the SQL traffic port when traffic is separated.
+{{site.data.alerts.end}}
+
+1. Start the first node and configure it to listen on `roach1:26257` for SQL clients and `roach1:8080` for the DB Console and to publish these ports, and to use `roach1:26357`for inter-node traffic. The Docker host will forward traffic to a published port to the publishing container.
+
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -45,11 +67,16 @@ docker volume create roach3
     --name=roach1 \
     --hostname=roach1 \
     --net=roachnet \
-    -p 26257:26257 -p 8080:8080  \
-    -v "roach1:/cockroach/cockroach-data"  \
+    -p 26257:26257 \
+    -p 8080:8080 \
+    -v "roach1:/cockroach/cockroach-data" \
     {{page.release_info.docker_image}}:{{page.release_info.version}} start \
-    --insecure \
-    --join=roach1,roach2,roach3
+      --advertise-addr=roach1:26357 \
+      --http-addr=roach1:8080 \
+      --listen-addr=roach1:26357 \
+      --sql-addr=roach1:26257 \
+      --insecure \
+      --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
 1. This command creates a container and starts the first CockroachDB node inside it. Take a moment to understand each part:
@@ -58,41 +85,59 @@ docker volume create roach3
     - `--name`: The name for the container. This is optional, but a custom name makes it significantly easier to reference the container in other commands, for example, when opening a Bash session in the container or stopping the container.
     - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
     - `--net`: The bridge network for the container to join. See step 1 for more details.
-    - `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port for HTTP requests to the DB Console (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the DB Console from a browser.
-    - `-v "roach1:/cockroach/cockroach-data"`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in the `roach1` volume on the host and will persist after the container is stopped or deleted. For more details, see Docker's [volumes](https://docs.docker.com/storage/volumes/) topic.
-    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start --insecure --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container in insecure mode. The `--join` flag specifies the `hostname` of each node that will initially comprise your cluster. Otherwise, all [`cockroach start`](cockroach-start.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
+    - `-p 26257:26257 -p 8080:8080`: These flags cause the Docker host to publish ports 26257 and 8080 and to forward requests to a published port to the same port on the container.
+    - `-v "roach1:/cockroach/cockroach-data"`: This flag mounts the `roach1` Docker volume into the container's filesystem at `/cockroach/cockroach-data/`. This volume will contain data and logs for the container, and the volume will persist after the container is stopped or deleted. For more details, see Docker's [volumes](https://docs.docker.com/storage/volumes/) documentation.
+    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start (...) --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container. The `--advertise-addr`, `--http-addr`, `--listen-addr`, and `--sql-addr` flags cause CockroachDB to listen on separate ports for inter-node traffic, DB Console traffic, and SQL traffic. The `--join` flag contains each node's hostname or IP address and the port where it listens for inter-node traffic from other nodes.
 
-1. Start two more nodes:
+1. Start the second node and configure it to listen on `roach2:26258` for SQL clients and `roach2:8081` for the DB Console and to publish these ports, and to use `roach2:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s published ports. The named volume `roach2` is mounted in the container at `/cockroach/cockroach-data`.
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    docker run -d \
-    --name=roach2 \
-    --hostname=roach2 \
-    --net=roachnet \
-    -v "roach2:/cockroach/cockroach-data" \
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start \
-    --insecure \
-    --join=roach1,roach2,roach3
-    ~~~
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     docker run -d \
-    --name=roach3 \
-    --hostname=roach3 \
-    --net=roachnet \
-    -v "roach3:/cockroach/cockroach-data" \
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start \
-    --insecure \
-    --join=roach1,roach2,roach3
+      --name=roach2 \
+      --hostname=roach2 \
+      --net=roachnet \
+      -p 26258:26258 \
+      -p 8081:8081 \
+      -v "roach2:/cockroach/cockroach-data" \
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start \
+        --advertise-addr=roach2:26357 \
+        --http-addr=roach2:8081 \
+        --listen-addr=roach2:26357 \
+        --sql-addr=roach2:26258 \
+        --insecure \
+        --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
-1. Perform a one-time initialization of the cluster:
+1. Start the third node and configure it to listen on `roach3:26259` for SQL clients and `roach2:8082` for the DB Console and to publish these ports, and to use `roach3:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s and `roach2`'s published ports. The named volume `roach3` is mounted in the container at `/cockroach/cockroach-data`.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    docker exec -it roach1 ./cockroach init --insecure
+    docker run -d \
+      --name=roach3 \
+      --hostname=roach3 \
+      --net=roachnet \
+      -p 26259:26259 \
+      -p 8082:8082 \
+      -v "roach3:/cockroach/cockroach-data" \
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start \
+        --advertise-addr=roach3:26358 \
+        --http-addr=roach3:8082 \
+        --listen-addr=roach3:26357 \
+        --sql-addr=roach3:26259 \
+        --insecure \
+        --join=roach1:26357,roach2:26357,roach3:26357
+    ~~~
+
+1. Perform a one-time initialization of the cluster. This example runs the `cockroach init` command from within the `roach1` container, but you can run it from any container or from an external system that can reach the Docker host.
+
+    `cockroach init` connects to the node's `--advertise-addr`, rather than the node's `--sql-addr`. Replace `roach1:26357` with the node's `--advertise-addr` value (not the node's `--sql-addr`). This example runs the `cockroach` command directly on a cluster node, but you can run it from any system that can connect to the Docker host.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker exec -it roach1 ./cockroach --host=roach1:26357 init --insecure
     ~~~
 
     The following message displays:
@@ -101,21 +146,21 @@ docker volume create roach3
     Cluster successfully initialized
     ~~~
 
-    Each node also prints helpful [startup details](cockroach-start.html#standard-output) to its log. For example, the following command retrieves the start-up details for `roach1`.
+    Each node also prints helpful [startup details](cockroach-start.html#standard-output) to its log. For example, the following command runs the `grep` command from within the `roach1` container to display lines in its `/cockroach-data/logs/cockroach.log` log file that contain the string `node starting` and the next 11 lines.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 grep 'node starting' cockroach-data/logs/cockroach.log -A 11
+    docker exec -it roach1 grep 'node starting' /cockroach/cockroach-data/logs/cockroach.log -A 11
     ~~~
 
     The output will look something like this:
 
     ~~~
     CockroachDB node starting at {{ now | date: "%Y-%m-%d %H:%M:%S.%6 +0000 UTC" }}
-    build:               CCL {{page.release_info.version}} @ {{page.release_info.build_time}} (go1.12.6)
+    build:               CCL {{page.release_info.version}} @ {{page.release_info.build_time}} (go1.19.4)
     webui:               http://roach1:8080
-    sql:                 postgresql://root@roach1:26257?sslmode=disable
-    client flags:        /cockroach/cockroach <client cmd> --host=roach1:26257 --insecure
+    sql:                 postgresql://root@roach1:26357?sslmode=disable
+    client flags:        /cockroach/cockroach <client cmd> --host=roach1:26357
     logs:                /cockroach/cockroach-data/logs
     temp dir:            /cockroach/cockroach-data/cockroach-temp273641911
     external I/O path:   /cockroach/cockroach-data/extern
@@ -129,11 +174,11 @@ docker volume create roach3
 
 Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use the `docker exec` command to start the [built-in SQL shell](cockroach-sql.html) in the `roach1` container.
 
-1. Start the SQL shell in the first container:
+1. Start the SQL shell in a container or from an external system that can reach the Docker host. Set `--host` to the Docker host's IP address and use any of the ports where nodes are listening for SQL connections, `26257`, `26258`, or `26259`. This example connects the SQL shell within the `roach1` container to `roach2:26258`. You could also connect to `roach3:26259`.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 ./cockroach sql --insecure
+    docker exec -it roach1 ./cockroach sql --host=roach2:26258 --insecure
     ~~~
 
 1. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
@@ -174,7 +219,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach2 ./cockroach sql --insecure
+    $ docker exec -it roach2 ./cockroach --host=roach2:26258 sql --insecure
     ~~~
 
 1. Run the same `SELECT` query as before:
@@ -204,28 +249,29 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
-1. Load the initial dataset on `roach1`:
+{{site.data.alerts.callout_info}}
+The `cockroach workload` command does not support connection or security flags like other [`cockroach` commands](cockroach-commands.html). Instead, you must use a [connection string](connection-parameters.html) at the end of the command.
+{{site.data.alerts.end}}
+
+1. Load the initial dataset on `roach1:26257`
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 ./cockroach workload init movr \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload init movr 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
 1. Run the workload for five minutes:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 ./cockroach workload run movr \
-    --duration=5m \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload run movr --duration=5m 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
 ### Step 6. Access the DB Console
 
 The [DB Console](ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
 
-1. When you started the first node's container, you mapped the node's default HTTP port `8080` to port `8080` on the Docker host, so go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>.
+1. When you started the first node's container, you mapped the node's default HTTP port `8080` to port `8080` on the Docker host, so go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>. If necessary, replace `localhost` with the hostname or IP address of the Docker host.
 
 1. On the [**Cluster Overview**](ui-cluster-overview-page.html), notice that three nodes are live, with an identical replica count on each node:
 
@@ -242,24 +288,30 @@ The [DB Console](ui-overview.html) gives you insight into the overall health of 
     <img src="{{ 'images/v22.2/ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="DB Console" style="border:1px solid #eee;max-width:100%" />
 
 1. Use the [**Databases**](ui-databases-page.html), [**Statements**](ui-statements-page.html), and [**Jobs**](ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+1. Optionally verify that DB Console instances for `roach2` and `roach3` are reachable on ports 8081 and 8082 and show the same information as port 8080.
 
-### Step 7.  Stop the cluster
+### Step 7. Stop the cluster
 
-1. Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster):
+1. Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster). By default, `docker stop` sends a `SIGTERM` signal, waits for 10 seconds, and then sends a `SIGKILL` signal. Cockroach Labs recommends that you [allow between 5 and 10 minutes](node-shutdown.html#termination-grace-period) before forcibly stopping the `cockroach` process, so this example sets the grace period to 5 minutes. If you do not plan to restart the cluster, you can omit `-t`.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker stop roach1 roach2 roach3
+    docker stop -t 300 roach1 roach2 roach3
     ~~~
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker rm roach1 roach2 roach3
+    docker rm roach1 roach2 roach3
     ~~~
 
-1. If you do not plan to restart the cluster, you can also remove the Docker volumes:
+1. If you do not plan to restart the cluster, you can also remove the Docker volumes and the Docker network:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     docker volume rm roach1 roach2 roach3
+    ~~~
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker network rm roachnet
     ~~~

--- a/src/current/_includes/v23.1/start-in-docker/mac-linux-steps.md
+++ b/src/current/_includes/v23.1/start-in-docker/mac-linux-steps.md
@@ -1,23 +1,34 @@
 ### Step 1. Create a bridge network
 
-Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, you need to create what Docker refers to as a [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The bridge network will enable the containers to communicate as a single cluster while keeping them isolated from external networks.
+Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, create a Docker [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The network has configurable properties such as a pool of IP addresses, network gateway, and routing rules. All nodes will connect to this network and can communicate openly by default, but incoming traffic can reach a container only through the container's published port mappings, as described in [Step 3: Start the cluster](#step-3-start-the-cluster). Because the network is a bridge, from the point of view of the client, the Docker host seems to service the request directly.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
 docker network create -d bridge roachnet
 ~~~
 
-We've used `roachnet` as the network name here and in subsequent steps, but feel free to give your network any name you like.
+{{site.data.alerts.callout_success}}
+To customize your bridge network or create a different type of Docker network, refer to Docker's documentation for [`docker network create`](https://docs.docker.com/engine/reference/commandline/network_create/).
+{{site.data.alerts.end}}
+
+In subsequent steps, replace `roachnet` with the name of your Docker network.
 
 ### Step 2: Create Docker volumes for each cluster node
 
-Cockroach Labs recommends that you store cluster data in Docker volumes rather than in the storage layer of the running container. Otherwise, if a Docker container is inadvertently deleted, its data is inaccessible.
+Cockroach Labs recommends that you store cluster data in Docker volumes rather than in the storage layer of the running container. Using a volume has the following advantages over using bind mounts or writing directly to the running container's filesystem.
+
+- Volumes are managed entirely by Docker. A bind mount mounts an arbitrary directory on the Docker host into the container, and that directory could potentially be modified or deleted by any process with permission.
+- Volumes persist even if the containers that were using it are deleted. A container's local storage is temporarily unavailable if the container is stopped, and is permanently removed if the container is deleted.
+- When compared to a container's local storage, writing to either a local volume or a bind mount has considerably better performance because it uses fewer kernel system calls on the Docker host. For an explanation, refer to [Manage Data in Docker](https://docs.docker.com/storage/).
+- A volume can be backed up, restored, or migrated to a different container or Docker host. Refer to [Back Up, Restore, or Migrate Data Volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes).
+- A volume can be pre-populated before connecting it to a container. Refer to [Populate a Volume Using a Container](https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container).
+- A volume can be backed by local storage, a cloud storage resource, SSH, NFS, Samba, or raw block storage, among others. For details, refer to [Use a Volume Driver](https://docs.docker.com/storage/volumes/#use-a-volume-driver).
 
 {{site.data.alerts.callout_danger}}
 Avoid using the `-v` / `--volume` command to mount a local macOS filesystem into the container. Use Docker volumes or a [`tmpfs` mount](https://docs.docker.com/storage/tmpfs/).
 {{site.data.alerts.end}}
 
-Create a [Docker volume](https://docs.docker.com/storage/volumes/) for each container:
+Create a [Docker volume](https://docs.docker.com/storage/volumes/) for each container. You can create only one volume at a time.
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -34,10 +45,21 @@ docker volume create roach2
 docker volume create roach3
 ~~~
 
-
 ### Step 3. Start the cluster
 
-1. Start the first node:
+This section shows how to start a three-node cluster where:
+
+- Each node will store its data in a unique Docker volume.
+- Each node will listen for SQL and HTTP connections at a unique port each on the `roachnet` network, and these ports are published. Client requests to the Docker host at a given port are forwarded to the container that is publishing that port. Nodes do not listen on `localhost`.
+- Each node will listen and advertise for inter-node cluster traffic at port 26357 on the `roachnet` network. This port is not published, so inter-node traffic does not leave this network.
+
+{{site.data.alerts.callout_info}}
+When SQL and inter-node traffic are separated, some client commands need to be modified with a `--host` flag or a `--uri` connection string. Some commands, such as `cockroach init`, default to port 26257 but must use the inter-node traffic port (the `--listen-addr` or `--advertise-addr`) rather than the SQL traffic port when traffic is separated.
+{{site.data.alerts.end}}
+
+1. Start the first node and configure it to listen on `roach1:26257` for SQL clients and `roach1:8080` for the DB Console and to publish these ports, and to use `roach1:26357`for inter-node traffic. The Docker host will forward traffic to a published port to the publishing container.
+
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -45,11 +67,16 @@ docker volume create roach3
     --name=roach1 \
     --hostname=roach1 \
     --net=roachnet \
-    -p 26257:26257 -p 8080:8080  \
-    -v "roach1:/cockroach/cockroach-data"  \
+    -p 26257:26257 \
+    -p 8080:8080 \
+    -v "roach1:/cockroach/cockroach-data" \
     {{page.release_info.docker_image}}:{{page.release_info.version}} start \
-    --insecure \
-    --join=roach1,roach2,roach3
+      --advertise-addr=roach1:26357 \
+      --http-addr=roach1:8080 \
+      --listen-addr=roach1:26357 \
+      --sql-addr=roach1:26257 \
+      --insecure \
+      --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
 1. This command creates a container and starts the first CockroachDB node inside it. Take a moment to understand each part:
@@ -58,41 +85,59 @@ docker volume create roach3
     - `--name`: The name for the container. This is optional, but a custom name makes it significantly easier to reference the container in other commands, for example, when opening a Bash session in the container or stopping the container.
     - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
     - `--net`: The bridge network for the container to join. See step 1 for more details.
-    - `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port for HTTP requests to the DB Console (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the DB Console from a browser.
-    - `-v "roach1:/cockroach/cockroach-data"`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in the `roach1` volume on the host and will persist after the container is stopped or deleted. For more details, see Docker's [volumes](https://docs.docker.com/storage/volumes/) topic.
-    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start --insecure --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container in insecure mode. The `--join` flag specifies the `hostname` of each node that will initially comprise your cluster. Otherwise, all [`cockroach start`](cockroach-start.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
+    - `-p 26257:26257 -p 8080:8080`: These flags cause the Docker host to publish ports 26257 and 8080 and to forward requests to a published port to the same port on the container.
+    - `-v "roach1:/cockroach/cockroach-data"`: This flag mounts the `roach1` Docker volume into the container's filesystem at `/cockroach/cockroach-data/`. This volume will contain data and logs for the container, and the volume will persist after the container is stopped or deleted. For more details, see Docker's [volumes](https://docs.docker.com/storage/volumes/) documentation.
+    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start (...) --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container. The `--advertise-addr`, `--http-addr`, `--listen-addr`, and `--sql-addr` flags cause CockroachDB to listen on separate ports for inter-node traffic, DB Console traffic, and SQL traffic. The `--join` flag contains each node's hostname or IP address and the port where it listens for inter-node traffic from other nodes.
 
-1. Start two more nodes:
+1. Start the second node and configure it to listen on `roach2:26258` for SQL clients and `roach2:8081` for the DB Console and to publish these ports, and to use `roach2:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s published ports. The named volume `roach2` is mounted in the container at `/cockroach/cockroach-data`.
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    docker run -d \
-    --name=roach2 \
-    --hostname=roach2 \
-    --net=roachnet \
-    -v "roach2:/cockroach/cockroach-data" \
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start \
-    --insecure \
-    --join=roach1,roach2,roach3
-    ~~~
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     docker run -d \
-    --name=roach3 \
-    --hostname=roach3 \
-    --net=roachnet \
-    -v "roach3:/cockroach/cockroach-data" \
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start \
-    --insecure \
-    --join=roach1,roach2,roach3
+      --name=roach2 \
+      --hostname=roach2 \
+      --net=roachnet \
+      -p 26258:26258 \
+      -p 8081:8081 \
+      -v "roach2:/cockroach/cockroach-data" \
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start \
+        --advertise-addr=roach2:26357 \
+        --http-addr=roach2:8081 \
+        --listen-addr=roach2:26357 \
+        --sql-addr=roach2:26258 \
+        --insecure \
+        --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
-1. Perform a one-time initialization of the cluster:
+1. Start the third node and configure it to listen on `roach3:26259` for SQL clients and `roach2:8082` for the DB Console and to publish these ports, and to use `roach3:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s and `roach2`'s published ports. The named volume `roach3` is mounted in the container at `/cockroach/cockroach-data`.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    docker exec -it roach1 ./cockroach init --insecure
+    docker run -d \
+      --name=roach3 \
+      --hostname=roach3 \
+      --net=roachnet \
+      -p 26259:26259 \
+      -p 8082:8082 \
+      -v "roach3:/cockroach/cockroach-data" \
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start \
+        --advertise-addr=roach3:26358 \
+        --http-addr=roach3:8082 \
+        --listen-addr=roach3:26357 \
+        --sql-addr=roach3:26259 \
+        --insecure \
+        --join=roach1:26357,roach2:26357,roach3:26357
+    ~~~
+
+1. Perform a one-time initialization of the cluster. This example runs the `cockroach init` command from within the `roach1` container, but you can run it from any container or from an external system that can reach the Docker host.
+
+    `cockroach init` connects to the node's `--advertise-addr`, rather than the node's `--sql-addr`. Replace `roach1:26357` with the node's `--advertise-addr` value (not the node's `--sql-addr`). This example runs the `cockroach` command directly on a cluster node, but you can run it from any system that can connect to the Docker host.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker exec -it roach1 ./cockroach --host=roach1:26357 init --insecure
     ~~~
 
     The following message displays:
@@ -101,21 +146,21 @@ docker volume create roach3
     Cluster successfully initialized
     ~~~
 
-    Each node also prints helpful [startup details](cockroach-start.html#standard-output) to its log. For example, the following command retrieves the start-up details for `roach1`.
+    Each node also prints helpful [startup details](cockroach-start.html#standard-output) to its log. For example, the following command runs the `grep` command from within the `roach1` container to display lines in its `/cockroach-data/logs/cockroach.log` log file that contain the string `node starting` and the next 11 lines.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 grep 'node starting' cockroach-data/logs/cockroach.log -A 11
+    docker exec -it roach1 grep 'node starting' /cockroach/cockroach-data/logs/cockroach.log -A 11
     ~~~
 
     The output will look something like this:
 
     ~~~
     CockroachDB node starting at {{ now | date: "%Y-%m-%d %H:%M:%S.%6 +0000 UTC" }}
-    build:               CCL {{page.release_info.version}} @ {{page.release_info.build_time}} (go1.12.6)
+    build:               CCL {{page.release_info.version}} @ {{page.release_info.build_time}} (go1.19.4)
     webui:               http://roach1:8080
-    sql:                 postgresql://root@roach1:26257?sslmode=disable
-    client flags:        /cockroach/cockroach <client cmd> --host=roach1:26257 --insecure
+    sql:                 postgresql://root@roach1:26357?sslmode=disable
+    client flags:        /cockroach/cockroach <client cmd> --host=roach1:26357
     logs:                /cockroach/cockroach-data/logs
     temp dir:            /cockroach/cockroach-data/cockroach-temp273641911
     external I/O path:   /cockroach/cockroach-data/extern
@@ -129,11 +174,11 @@ docker volume create roach3
 
 Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use the `docker exec` command to start the [built-in SQL shell](cockroach-sql.html) in the `roach1` container.
 
-1. Start the SQL shell in the first container:
+1. Start the SQL shell in a container or from an external system that can reach the Docker host. Set `--host` to the Docker host's IP address and use any of the ports where nodes are listening for SQL connections, `26257`, `26258`, or `26259`. This example connects the SQL shell within the `roach1` container to `roach2:26258`. You could also connect to `roach3:26259`.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 ./cockroach sql --insecure
+    docker exec -it roach1 ./cockroach sql --host=roach2:26258 --insecure
     ~~~
 
 1. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
@@ -174,7 +219,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach2 ./cockroach sql --insecure
+    docker exec -it roach2 ./cockroach --host=roach2:26258 sql --insecure
     ~~~
 
 1. Run the same `SELECT` query as before:
@@ -204,28 +249,29 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
-1. Load the initial dataset on `roach1`:
+{{site.data.alerts.callout_info}}
+The `cockroach workload` command does not support connection or security flags like other [`cockroach` commands](cockroach-commands.html). Instead, you must use a [connection string](connection-parameters.html) at the end of the command.
+{{site.data.alerts.end}}
+
+1. Load the initial dataset on `roach1:26257`
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 ./cockroach workload init movr \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload init movr 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
 1. Run the workload for five minutes:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker exec -it roach1 ./cockroach workload run movr \
-    --duration=5m \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload run movr --duration=5m 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
 ### Step 6. Access the DB Console
 
 The [DB Console](ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
 
-1. When you started the first node's container, you mapped the node's default HTTP port `8080` to port `8080` on the Docker host, so go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>.
+1. When you started the first node's container, you mapped the node's default HTTP port `8080` to port `8080` on the Docker host, so go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>. If necessary, replace `localhost` with the hostname or IP address of the Docker host.
 
 1. On the [**Cluster Overview**](ui-cluster-overview-page.html), notice that three nodes are live, with an identical replica count on each node:
 
@@ -242,24 +288,30 @@ The [DB Console](ui-overview.html) gives you insight into the overall health of 
     <img src="{{ 'images/v23.1/ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="DB Console" style="border:1px solid #eee;max-width:100%" />
 
 1. Use the [**Databases**](ui-databases-page.html), [**Statements**](ui-statements-page.html), and [**Jobs**](ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+1. Optionally verify that DB Console instances for `roach2` and `roach3` are reachable on ports 8081 and 8082 and show the same information as port 8080.
 
-### Step 7.  Stop the cluster
+### Step 7. Stop the cluster
 
-1. Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster):
+1. Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster). By default, `docker stop` sends a `SIGTERM` signal, waits for 10 seconds, and then sends a `SIGKILL` signal. Cockroach Labs recommends that you [allow between 5 and 10 minutes](node-shutdown.html#termination-grace-period) before forcibly stopping the `cockroach` process, so this example sets the grace period to 5 minutes. If you do not plan to restart the cluster, you can omit `-t`.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker stop roach1 roach2 roach3
+    docker stop -t 300 roach1 roach2 roach3
     ~~~
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ docker rm roach1 roach2 roach3
+    docker rm roach1 roach2 roach3
     ~~~
 
-1. If you do not plan to restart the cluster, you can also remove the Docker volumes:
+1. If you do not plan to restart the cluster, you can also remove the Docker volumes and the Docker network:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     docker volume rm roach1 roach2 roach3
+    ~~~
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker network rm roachnet
     ~~~

--- a/src/current/v22.2/start-a-local-cluster-in-docker-windows.md
+++ b/src/current/v22.2/start-a-local-cluster-in-docker-windows.md
@@ -25,31 +25,84 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 
 ## Step 1. Create a bridge network
 
-Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, you need to create what Docker refers to as a [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The bridge network will enable the containers to communicate as a single cluster while keeping them isolated from external networks.
+Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, create a Docker [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The network has configurable properties such as a pool of IP addresses, network gateway, and routing rules. All nodes will connect to this network and can communicate openly by default, but incoming traffic can reach a container only through the container's published port mappings, as described in [Step 3: Start the cluster](#step-3-start-the-cluster). Because the network is a bridge, from the point of view of the client, the Docker host seems to service the request directly.
 
 ~~~ powershell
-PS C:\Users\username> docker network create -d bridge roachnet
+docker network create -d bridge roachnet
 ~~~
 
-We've used `roachnet` as the network name here and in subsequent steps, but feel free to give your network any name you like.
+{{site.data.alerts.callout_success}}
+To customize your bridge network or create a different type of Docker network, refer to Docker's documentation for [`docker network create`](https://docs.docker.com/engine/reference/commandline/network_create/).
+{{site.data.alerts.end}}
 
-## Step 2. Start the cluster
+In subsequent steps, replace `roachnet` with the name of your Docker network.
 
-1. Start the first node:
+### Step 2: Create Docker volumes for each cluster node
 
-    {{site.data.alerts.callout_info}}Be sure to replace <code>&#60;username&#62;</code> in the <code>-v</code> flag with your actual username.{{site.data.alerts.end}}
+Cockroach Labs recommends that you store cluster data in Docker volumes rather than in the storage layer of the running container. Using a volume has the following advantages over using bind mounts or writing directly to the running container's filesystem.
 
+- Volumes are managed entirely by Docker. A bind mount mounts an arbitrary directory on the Docker host into the container, and that directory could potentially be modified or deleted by any process with permission.
+- Volumes persist even if the containers that were using it are deleted. A container's local storage is temporarily unavailable if the container is stopped, and is permanently removed if the container is deleted.
+- When compared to a container's local storage, writing to either a local volume or a bind mount has considerably better performance because it uses fewer kernel system calls on the Docker host. For an explanation, refer to [Manage Data in Docker](https://docs.docker.com/storage/).
+- A volume can be backed up, restored, or migrated to a different container or Docker host. Refer to [Back Up, Restore, or Migrate Data Volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes).
+- A volume can be pre-populated before connecting it to a container. Refer to [Populate a Volume Using a Container](https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container).
+- A volume can be backed by local storage, a cloud storage resource, SSH, NFS, Samba, or raw block storage, among others. For details, refer to [Use a Volume Driver](https://docs.docker.com/storage/volumes/#use-a-volume-driver).
+
+{{site.data.alerts.callout_danger}}
+Avoid using the `-v` / `--volume` command to mount a local macOS filesystem into the container. Use Docker volumes or a [`tmpfs` mount](https://docs.docker.com/storage/tmpfs/).
+{{site.data.alerts.end}}
+
+Create a [Docker volume](https://docs.docker.com/storage/volumes/) for each container. You can create only one volume at a time.
+
+{% include_cached copy-clipboard.html %}
+~~~ powershell
+docker volume create roach1
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ powershell
+docker volume create roach2
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ powershell
+docker volume create roach3
+~~~
+
+## Step 3. Start the cluster
+
+This section shows how to start a three-node cluster where:
+
+- Each node will store its data in a unique Docker volume.
+- Each node will listen for SQL and HTTP connections at a unique port each on the `roachnet` network, and these ports are published. Client requests to the Docker host at a given port are forwarded to the container that is publishing that port. Nodes do not listen on `localhost`.
+- Each node will listen and advertise for inter-node cluster traffic at port 26357 on the `roachnet` network. This port is not published, so inter-node traffic does not leave this network.
+
+{{site.data.alerts.callout_info}}
+When SQL and inter-node traffic are separated, some client commands need to be modified with a `--host` flag or a `--uri` connection string. Some commands, such as `cockroach init`, default to port 26257 but must use the inter-node traffic port (the `--listen-addr` or `--advertise-addr`) rather than the SQL traffic port when traffic is separated.
+{{site.data.alerts.end}}
+
+1. Start the first node and configure it to listen on `roach1:26257` for SQL clients and `roach1:8080` for the DB Console and to publish these ports, and to use `roach1:26357`for inter-node traffic. The Docker host will forward traffic to a published port to the publishing container.
+
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker run -d `
-    --name=roach1 `
-    --hostname=roach1 `
-    --net=roachnet `
-    -p 26257:26257 -p 8080:8080  `
-    -v "//c/Users/<username>/cockroach-data/roach1:/cockroach/cockroach-data"  `
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start `
-    --insecure `
-    --join=roach1,roach2,roach3
+    docker run -d '
+    --name=roach1 '
+    --hostname=roach1 '
+    --net=roachnet '
+    -p 26257:26257 '
+    -p 8080:8080 '
+    -v "roach1:/cockroach/cockroach-data" '
+    {{page.release_info.docker_image}}:{{page.release_info.version}} start '
+      --advertise-addr=roach1:26357 '
+      --http-addr=roach1:8080 '
+      --listen-addr=roach1:26357 '
+      --sql-addr=roach1:26257 '
+      --insecure '
+      --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
+
 
 1. This command creates a container and starts the first CockroachDB node inside it. Take a moment to understand each part:
     - `docker run`: The Docker command to start a new container.
@@ -58,55 +111,99 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
     - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
     - `--net`: The bridge network for the container to join. See step 1 for more details.
     - `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port for HTTP requests to the DB Console (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the DB Console from a browser.
-    - `-v "//c/Users/<username>/cockroach-data/roach1:/cockroach/cockroach-data"`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `Users/<username>/cockroach-data/roach1` on the host and will persist after the container is stopped or deleted. For more details, see Docker's <a href="https://docs.docker.com/engine/admin/volumes/bind-mounts/">Bind Mounts</a> topic.
-    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start --insecure --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container in insecure mode. The `--join` flag specifies the `hostname` of each node that will initially comprise your cluster. Otherwise, all [`cockroach start`](cockroach-start.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
+    - `-v "roach1:/cockroach/cockroach-data"`: This flag mounts the `roach1` Docker volume into the container's filesystem at `/cockroach/cockroach-data/`. This volume will contain data and logs for the container, and the volume will persist after the container is stopped or deleted. For more details, see Docker's [volumes](https://docs.docker.com/storage/volumes/) documentation.
+    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start (...) --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container. The `--advertise-addr`, `--http-addr`, `--listen-addr`, and `--sql-addr` flags cause CockroachDB to listen on separate ports for inter-node traffic, DB Console traffic, and SQL traffic. The `--join` flag contains each node's hostname or IP address and the port where it listens for inter-node traffic from other nodes.
 
-1. Start two more nodes:
+1. Start the second node and configure it to listen on `roach2:26258` for SQL clients and `roach2:8081` for the DB Console and to publish these ports, and to use `roach2:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s published ports. The named volume `roach2` is mounted in the container at `/cockroach/cockroach-data`.
 
-    {{site.data.alerts.callout_info}}Again, be sure to replace <code>&#60;username&#62;</code> in the <code>-v</code> flag with your actual username.{{site.data.alerts.end}}
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
 
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker run -d `
-    --name=roach2 `
-    --hostname=roach2 `
-    --net=roachnet `
-    -v "//c/Users/<username>/cockroach-data/roach2:/cockroach/cockroach-data"  `
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start `
-    --insecure `
-    --join=roach1,roach2,roach3
+    docker run -d '
+      --name=roach2 '
+      --hostname=roach2 '
+      --net=roachnet '
+      -p 26258:26258 '
+      -p 8081:8081 '
+      -v "roach2:/cockroach/cockroach-data" '
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start '
+        --advertise-addr=roach2:26357 '
+        --http-addr=roach2:8081 '
+        --listen-addr=roach2:26357 '
+        --sql-addr=roach2:26258 '
+        --insecure '
+        --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
+1. Start the third node and configure it to listen on `roach3:26259` for SQL clients and `roach2:8082` for the DB Console and to publish these ports, and to use `roach3:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s and `roach2`'s published ports. The named volume `roach3` is mounted in the container at `/cockroach/cockroach-data`.
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker run -d `
-    --name=roach3 `
-    --hostname=roach3 `
-    --net=roachnet `
-    -v "//c/Users/<username>/cockroach-data/roach3:/cockroach/cockroach-data"  `
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start `
-    --insecure `
-    --join=roach1,roach2,roach3
+    docker run -d '
+      --name=roach3 '
+      --hostname=roach3 '
+      --net=roachnet '
+      -p 26259:26259 '
+      -p 8082:8082 '
+      -v "roach3:/cockroach/cockroach-data" '
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start '
+        --advertise-addr=roach3:26358 '
+        --http-addr=roach3:8082 '
+        --listen-addr=roach3:26357 '
+        --sql-addr=roach3:26259 '
+        --insecure '
+        --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
-1. Perform a one-time initialization of the cluster:
+1. Perform a one-time initialization of the cluster. This example runs the `cockroach init` command from within the `roach1` container, but you can run it from any container or from an external system that can reach the Docker host.
 
+    `cockroach init` connects to the node's `--advertise-addr`, rather than the node's `--sql-addr`. Replace `roach1:26357` with the node's `--advertise-addr` value. This example runs the `cockroach` command directly on a cluster node, but you can run it from any system that can connect to the Docker host.
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach init --insecure
+    docker exec -it roach1 ./cockroach --host=roach1:26357 init --insecure
     ~~~
 
-    You'll see the following message:
+    The following message displays:
 
     ~~~
     Cluster successfully initialized
     ~~~
 
-## Step 3. Use the built-in SQL client
+    Each node also prints helpful [startup details](cockroach-start.html#standard-output) to its log. For example, the following command runs the `grep` command from within the `roach1` container to display lines in its `/cockroach-data/logs/cockroach.log` log file that contain the string `node starting` and the next 11 lines.
 
-Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use the `docker exec` command to start the [built-in SQL shell](cockroach-sql.html) in the first container.
-
-1. Start the SQL shell in the first container:
-
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach sql --insecure
+    docker exec -it roach1 grep 'node starting' /cockroach-data/logs/cockroach.log -A 11
+    ~~~
+
+    The output will look something like this:
+
+    ~~~
+    CockroachDB node starting at {{ now | date: "%Y-%m-%d %H:%M:%S.%6 +0000 UTC" }}
+    build:               CCL {{page.release_info.version}} @ {{page.release_info.build_time}} (go1.19.4)
+    webui:               http://roach1:8080
+    sql:                 postgresql://root@roach1:26357?sslmode=disable
+    client flags:        /cockroach/cockroach <client cmd> --host=roach1:26357
+    logs:                /cockroach/cockroach-data/logs
+    temp dir:            /cockroach/cockroach-data/cockroach-temp273641911
+    external I/O path:   /cockroach/cockroach-data/extern
+    store[0]:            path=/cockroach/cockroach-data
+    status:              initialized new cluster
+    clusterID:           1a705c26-e337-4b09-95a6-6e5a819f9eec
+    nodeID:              1
+    ~~~
+
+## Step 4. Use the built-in SQL client
+
+Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use the `docker exec` command to start the [built-in SQL shell](cockroach-sql.html) in the `roach1` container.
+
+1. Start the SQL shell in a container or from an external system that can reach the Docker host. Set `--host` to the Docker host's IP address and use any of the ports where nodes are listening for SQL connections, `26257`, `26258`, or `26259`. This example connects the SQL shell within the `roach1` container to `roach2:26258`. You could also connect to `roach3:26259`.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker exec -it roach1 ./cockroach sql --host=roach2:26258 --insecure
     ~~~
 
 1. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
@@ -138,15 +235,16 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     (1 row)
     ~~~
 
-1. Now exit the SQL shell on node 1 and open a new shell on node 2:
+1. Exit the SQL shell on `roach1` and open a new shell on `roach2`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
     > \q
     ~~~
 
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach2 ./cockroach sql --insecure
+    docker exec -it roach2 ./cockroach --host=roach2:26258 sql --insecure
     ~~~
 
 1. Run the same `SELECT` query as before:
@@ -172,26 +270,50 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > \q
     ~~~
 
-## Step 4. Run a sample workload
+## Step 5. Run a sample workload
 
 CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
-1. Load the initial dataset:
+{{site.data.alerts.callout_info}}
+The `cockroach workload` command does not support connection or security flags like other [`cockroach` commands](cockroach-commands.html). Instead, you must use a [connection string](connection-parameters.html) at the end of the command.
+{{site.data.alerts.end}}
 
+1. Load the initial dataset on `roach1:26257`
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach workload init movr \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload init movr 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
 1. Run the workload for 5 minutes:
 
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach workload run movr \
-    --duration=5m \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload run movr --duration=5m 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
-## Step 5. Access the DB Console
+## Step 6. Access the DB Console
+
+The [DB Console](ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
+
+1. When you started the first node's container, you mapped the node's default HTTP port `8080` to port `8080` on the Docker host, so go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>. If necessary, replace `localhost` with the hostname or IP address of the Docker host.
+
+1. On the [**Cluster Overview**](ui-cluster-overview-page.html), notice that three nodes are live, with an identical replica count on each node:
+
+    <img src="{{ 'images/v22.2/ui_cluster_overview_3_nodes.png' | relative_url }}" alt="DB Console" style="border:1px solid #eee;max-width:100%" />
+
+    This demonstrates CockroachDB's [automated replication](demo-replication-and-rebalancing.html) of data via the Raft consensus protocol.
+
+    {{site.data.alerts.callout_info}}
+    Capacity metrics can be incorrect when running multiple nodes on a single machine. For more details, see this [limitation](known-limitations.html#available-capacity-metric-in-the-db-console).
+    {{site.data.alerts.end}}
+
+1. Click [**Metrics**](ui-overview-dashboard.html) to access a variety of time series dashboards, including graphs of SQL queries and service latency over time:
+
+    <img src="{{ 'images/v22.2/ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="DB Console" style="border:1px solid #eee;max-width:100%" />
+
+1. Use the [**Databases**](ui-databases-page.html), [**Statements**](ui-statements-page.html), and [**Jobs**](ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+1. Optionally verify that DB Console instances for `roach2` and `roach3` are reachable on ports 8081 and 8082 and show the same information as port 8080.
 
 The CockroachDB [DB Console](ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
 
@@ -215,21 +337,29 @@ The CockroachDB [DB Console](ui-overview.html) gives you insight into the overal
 
 ## Step 6.  Stop the cluster
 
-Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster):
+1. Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster). By default, `docker stop` sends a `SIGTERM` signal, waits for 10 seconds, and then sends a `SIGKILL` signal. Cockroach Labs recommends that you [allow between 5 and 10 minutes](node-shutdown.html#termination-grace-period) before forcibly stopping the `cockroach` process, so this example sets the grace period to 5 minutes. If you do not plan to restart the cluster, you can omit `-t`.
 
-~~~ powershell
-PS C:\Users\username> docker stop roach1 roach2 roach3
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker stop -t 300 roach1 roach2 roach3
+    ~~~
 
-~~~ powershell
-PS C:\Users\username> docker rm roach1 roach2 roach3
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker rm roach1 roach2 roach3
+    ~~~
 
-If you do not plan to restart the cluster, you may want to remove the nodes' data stores:
+1. If you do not plan to restart the cluster, you can also remove the Docker volumes and the Docker network:
 
-~~~ powershell
-PS C:\Users\username> Remove-Item cockroach-data -recurse
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker volume rm roach1 roach2 roach3
+    ~~~
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker network rm roachnet
+    ~~~
 
 ## What's next?
 

--- a/src/current/v23.1/start-a-local-cluster-in-docker-windows.md
+++ b/src/current/v23.1/start-a-local-cluster-in-docker-windows.md
@@ -25,31 +25,84 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 
 ## Step 1. Create a bridge network
 
-Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, you need to create what Docker refers to as a [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The bridge network will enable the containers to communicate as a single cluster while keeping them isolated from external networks.
+Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, create a Docker [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The network has configurable properties such as a pool of IP addresses, network gateway, and routing rules. All nodes will connect to this network and can communicate openly by default, but incoming traffic can reach a container only through the container's published port mappings, as described in [Step 3: Start the cluster](#step-3-start-the-cluster). Because the network is a bridge, from the point of view of the client, the Docker host seems to service the request directly.
 
 ~~~ powershell
-PS C:\Users\username> docker network create -d bridge roachnet
+docker network create -d bridge roachnet
 ~~~
 
-We've used `roachnet` as the network name here and in subsequent steps, but feel free to give your network any name you like.
+{{site.data.alerts.callout_success}}
+To customize your bridge network or create a different type of Docker network, refer to Docker's documentation for [`docker network create`](https://docs.docker.com/engine/reference/commandline/network_create/).
+{{site.data.alerts.end}}
 
-## Step 2. Start the cluster
+In subsequent steps, replace `roachnet` with the name of your Docker network.
 
-1. Start the first node:
+### Step 2: Create Docker volumes for each cluster node
 
-    {{site.data.alerts.callout_info}}Be sure to replace <code>&#60;username&#62;</code> in the <code>-v</code> flag with your actual username.{{site.data.alerts.end}}
+Cockroach Labs recommends that you store cluster data in Docker volumes rather than in the storage layer of the running container. Using a volume has the following advantages over using bind mounts or writing directly to the running container's filesystem.
 
+- Volumes are managed entirely by Docker. A bind mount mounts an arbitrary directory on the Docker host into the container, and that directory could potentially be modified or deleted by any process with permission.
+- Volumes persist even if the containers that were using it are deleted. A container's local storage is temporarily unavailable if the container is stopped, and is permanently removed if the container is deleted.
+- When compared to a container's local storage, writing to either a local volume or a bind mount has considerably better performance because it uses fewer kernel system calls on the Docker host. For an explanation, refer to [Manage Data in Docker](https://docs.docker.com/storage/).
+- A volume can be backed up, restored, or migrated to a different container or Docker host. Refer to [Back Up, Restore, or Migrate Data Volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes).
+- A volume can be pre-populated before connecting it to a container. Refer to [Populate a Volume Using a Container](https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container).
+- A volume can be backed by local storage, a cloud storage resource, SSH, NFS, Samba, or raw block storage, among others. For details, refer to [Use a Volume Driver](https://docs.docker.com/storage/volumes/#use-a-volume-driver).
+
+{{site.data.alerts.callout_danger}}
+Avoid using the `-v` / `--volume` command to mount a local macOS filesystem into the container. Use Docker volumes or a [`tmpfs` mount](https://docs.docker.com/storage/tmpfs/).
+{{site.data.alerts.end}}
+
+Create a [Docker volume](https://docs.docker.com/storage/volumes/) for each container. You can create only one volume at a time.
+
+{% include_cached copy-clipboard.html %}
+~~~ powershell
+docker volume create roach1
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ powershell
+docker volume create roach2
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ powershell
+docker volume create roach3
+~~~
+
+## Step 3. Start the cluster
+
+This section shows how to start a three-node cluster where:
+
+- Each node will store its data in a unique Docker volume.
+- Each node will listen for SQL and HTTP connections at a unique port each on the `roachnet` network, and these ports are published. Client requests to the Docker host at a given port are forwarded to the container that is publishing that port. Nodes do not listen on `localhost`.
+- Each node will listen and advertise for inter-node cluster traffic at port 26357 on the `roachnet` network. This port is not published, so inter-node traffic does not leave this network.
+
+{{site.data.alerts.callout_info}}
+When SQL and inter-node traffic are separated, some client commands need to be modified with a `--host` flag or a `--uri` connection string. Some commands, such as `cockroach init`, default to port 26257 but must use the inter-node traffic port (the `--listen-addr` or `--advertise-addr`) rather than the SQL traffic port when traffic is separated.
+{{site.data.alerts.end}}
+
+1. Start the first node and configure it to listen on `roach1:26257` for SQL clients and `roach1:8080` for the DB Console and to publish these ports, and to use `roach1:26357`for inter-node traffic. The Docker host will forward traffic to a published port to the publishing container.
+
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker run -d `
-    --name=roach1 `
-    --hostname=roach1 `
-    --net=roachnet `
-    -p 26257:26257 -p 8080:8080  `
-    -v "//c/Users/<username>/cockroach-data/roach1:/cockroach/cockroach-data"  `
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start `
-    --insecure `
-    --join=roach1,roach2,roach3
+    docker run -d '
+    --name=roach1 '
+    --hostname=roach1 '
+    --net=roachnet '
+    -p 26257:26257 '
+    -p 8080:8080 '
+    -v "roach1:/cockroach/cockroach-data" '
+    {{page.release_info.docker_image}}:{{page.release_info.version}} start '
+      --advertise-addr=roach1:26357 '
+      --http-addr=roach1:8080 '
+      --listen-addr=roach1:26357 '
+      --sql-addr=roach1:26257 '
+      --insecure '
+      --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
+
 
 1. This command creates a container and starts the first CockroachDB node inside it. Take a moment to understand each part:
     - `docker run`: The Docker command to start a new container.
@@ -58,55 +111,99 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
     - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
     - `--net`: The bridge network for the container to join. See step 1 for more details.
     - `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port for HTTP requests to the DB Console (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the DB Console from a browser.
-    - `-v "//c/Users/<username>/cockroach-data/roach1:/cockroach/cockroach-data"`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `Users/<username>/cockroach-data/roach1` on the host and will persist after the container is stopped or deleted. For more details, see Docker's <a href="https://docs.docker.com/engine/admin/volumes/bind-mounts/">Bind Mounts</a> topic.
-    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start --insecure --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container in insecure mode. The `--join` flag specifies the `hostname` of each node that will initially comprise your cluster. Otherwise, all [`cockroach start`](cockroach-start.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
+    - `-v "roach1:/cockroach/cockroach-data"`: This flag mounts the `roach1` Docker volume into the container's filesystem at `/cockroach/cockroach-data/`. This volume will contain data and logs for the container, and the volume will persist after the container is stopped or deleted. For more details, see Docker's [volumes](https://docs.docker.com/storage/volumes/) documentation.
+    - `{{page.release_info.docker_image}}:{{page.release_info.version}} start (...) --join`: The CockroachDB command to [start a node](cockroach-start.html) in the container. The `--advertise-addr`, `--http-addr`, `--listen-addr`, and `--sql-addr` flags cause CockroachDB to listen on separate ports for inter-node traffic, DB Console traffic, and SQL traffic. The `--join` flag contains each node's hostname or IP address and the port where it listens for inter-node traffic from other nodes.
 
-1. Start two more nodes:
+1. Start the second node and configure it to listen on `roach2:26258` for SQL clients and `roach2:8081` for the DB Console and to publish these ports, and to use `roach2:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s published ports. The named volume `roach2` is mounted in the container at `/cockroach/cockroach-data`.
 
-    {{site.data.alerts.callout_info}}Again, be sure to replace <code>&#60;username&#62;</code> in the <code>-v</code> flag with your actual username.{{site.data.alerts.end}}
+    CockroachDB starts in insecure mode and a `certs` directory is not created.
 
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker run -d `
-    --name=roach2 `
-    --hostname=roach2 `
-    --net=roachnet `
-    -v "//c/Users/<username>/cockroach-data/roach2:/cockroach/cockroach-data"  `
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start `
-    --insecure `
-    --join=roach1,roach2,roach3
+    docker run -d '
+      --name=roach2 '
+      --hostname=roach2 '
+      --net=roachnet '
+      -p 26258:26258 '
+      -p 8081:8081 '
+      -v "roach2:/cockroach/cockroach-data" '
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start '
+        --advertise-addr=roach2:26357 '
+        --http-addr=roach2:8081 '
+        --listen-addr=roach2:26357 '
+        --sql-addr=roach2:26258 '
+        --insecure '
+        --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
+1. Start the third node and configure it to listen on `roach3:26259` for SQL clients and `roach2:8082` for the DB Console and to publish these ports, and to use `roach3:26357`for inter-node traffic. The offsets for the published ports avoid conflicts with `roach1`'s and `roach2`'s published ports. The named volume `roach3` is mounted in the container at `/cockroach/cockroach-data`.
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker run -d `
-    --name=roach3 `
-    --hostname=roach3 `
-    --net=roachnet `
-    -v "//c/Users/<username>/cockroach-data/roach3:/cockroach/cockroach-data"  `
-    {{page.release_info.docker_image}}:{{page.release_info.version}} start `
-    --insecure `
-    --join=roach1,roach2,roach3
+    docker run -d '
+      --name=roach3 '
+      --hostname=roach3 '
+      --net=roachnet '
+      -p 26259:26259 '
+      -p 8082:8082 '
+      -v "roach3:/cockroach/cockroach-data" '
+      {{page.release_info.docker_image}}:{{page.release_info.version}} start '
+        --advertise-addr=roach3:26358 '
+        --http-addr=roach3:8082 '
+        --listen-addr=roach3:26357 '
+        --sql-addr=roach3:26259 '
+        --insecure '
+        --join=roach1:26357,roach2:26357,roach3:26357
     ~~~
 
-1. Perform a one-time initialization of the cluster:
+1. Perform a one-time initialization of the cluster. This example runs the `cockroach init` command from within the `roach1` container, but you can run it from any container or from an external system that can reach the Docker host.
 
+    `cockroach init` connects to the node's `--advertise-addr`, rather than the node's `--sql-addr`. Replace `roach1:26357` with the node's `--advertise-addr` value. This example runs the `cockroach` command directly on a cluster node, but you can run it from any system that can connect to the Docker host.
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach init --insecure
+    docker exec -it roach1 ./cockroach --host=roach1:26357 init --insecure
     ~~~
 
-    You'll see the following message:
+    The following message displays:
 
     ~~~
     Cluster successfully initialized
     ~~~
 
-## Step 3. Use the built-in SQL client
+    Each node also prints helpful [startup details](cockroach-start.html#standard-output) to its log. For example, the following command runs the `grep` command from within the `roach1` container to display lines in its `/cockroach-data/logs/cockroach.log` log file that contain the string `node starting` and the next 11 lines.
 
-Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use the `docker exec` command to start the [built-in SQL shell](cockroach-sql.html) in the first container.
-
-1. Start the SQL shell in the first container:
-
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach sql --insecure
+    docker exec -it roach1 grep 'node starting' /cockroach-data/logs/cockroach.log -A 11
+    ~~~
+
+    The output will look something like this:
+
+    ~~~
+    CockroachDB node starting at {{ now | date: "%Y-%m-%d %H:%M:%S.%6 +0000 UTC" }}
+    build:               CCL {{page.release_info.version}} @ {{page.release_info.build_time}} (go1.19.4)
+    webui:               http://roach1:8080
+    sql:                 postgresql://root@roach1:26357?sslmode=disable
+    client flags:        /cockroach/cockroach <client cmd> --host=roach1:26357
+    logs:                /cockroach/cockroach-data/logs
+    temp dir:            /cockroach/cockroach-data/cockroach-temp273641911
+    external I/O path:   /cockroach/cockroach-data/extern
+    store[0]:            path=/cockroach/cockroach-data
+    status:              initialized new cluster
+    clusterID:           1a705c26-e337-4b09-95a6-6e5a819f9eec
+    nodeID:              1
+    ~~~
+
+## Step 4. Use the built-in SQL client
+
+Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use the `docker exec` command to start the [built-in SQL shell](cockroach-sql.html) in the `roach1` container.
+
+1. Start the SQL shell in a container or from an external system that can reach the Docker host. Set `--host` to the Docker host's IP address and use any of the ports where nodes are listening for SQL connections, `26257`, `26258`, or `26259`. This example connects the SQL shell within the `roach1` container to `roach2:26258`. You could also connect to `roach3:26259`.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker exec -it roach1 ./cockroach sql --host=roach2:26258 --insecure
     ~~~
 
 1. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
@@ -138,15 +235,16 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     (1 row)
     ~~~
 
-1. Now exit the SQL shell on node 1 and open a new shell on node 2:
+1. Exit the SQL shell on `roach1` and open a new shell on `roach2`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
     > \q
     ~~~
 
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach2 ./cockroach sql --insecure
+    docker exec -it roach2 ./cockroach --host=roach2:26258 sql --insecure
     ~~~
 
 1. Run the same `SELECT` query as before:
@@ -172,26 +270,50 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > \q
     ~~~
 
-## Step 4. Run a sample workload
+## Step 5. Run a sample workload
 
 CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
-1. Load the initial dataset:
+{{site.data.alerts.callout_info}}
+The `cockroach workload` command does not support connection or security flags like other [`cockroach` commands](cockroach-commands.html). Instead, you must use a [connection string](connection-parameters.html) at the end of the command.
+{{site.data.alerts.end}}
 
+1. Load the initial dataset on `roach1:26257`
+
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach workload init movr \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload init movr 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
 1. Run the workload for 5 minutes:
 
+    {% include_cached copy-clipboard.html %}
     ~~~ powershell
-    PS C:\Users\username> docker exec -it roach1 ./cockroach workload run movr \
-    --duration=5m \
-    'postgresql://root@roach1:26257?sslmode=disable'
+    docker exec -it roach1 ./cockroach workload run movr --duration=5m 'postgresql://root@roach1:26257?sslmode=disable'
     ~~~
 
-## Step 5. Access the DB Console
+## Step 6. Access the DB Console
+
+The [DB Console](ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
+
+1. When you started the first node's container, you mapped the node's default HTTP port `8080` to port `8080` on the Docker host, so go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>. If necessary, replace `localhost` with the hostname or IP address of the Docker host.
+
+1. On the [**Cluster Overview**](ui-cluster-overview-page.html), notice that three nodes are live, with an identical replica count on each node:
+
+    <img src="{{ 'images/v23.1/ui_cluster_overview_3_nodes.png' | relative_url }}" alt="DB Console" style="border:1px solid #eee;max-width:100%" />
+
+    This demonstrates CockroachDB's [automated replication](demo-replication-and-rebalancing.html) of data via the Raft consensus protocol.
+
+    {{site.data.alerts.callout_info}}
+    Capacity metrics can be incorrect when running multiple nodes on a single machine. For more details, see this [limitation](known-limitations.html#available-capacity-metric-in-the-db-console).
+    {{site.data.alerts.end}}
+
+1. Click [**Metrics**](ui-overview-dashboard.html) to access a variety of time series dashboards, including graphs of SQL queries and service latency over time:
+
+    <img src="{{ 'images/v23.1/ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="DB Console" style="border:1px solid #eee;max-width:100%" />
+
+1. Use the [**Databases**](ui-databases-page.html), [**Statements**](ui-statements-page.html), and [**Jobs**](ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+1. Optionally verify that DB Console instances for `roach2` and `roach3` are reachable on ports 8081 and 8082 and show the same information as port 8080.
 
 The CockroachDB [DB Console](ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
 
@@ -215,21 +337,29 @@ The CockroachDB [DB Console](ui-overview.html) gives you insight into the overal
 
 ## Step 6.  Stop the cluster
 
-Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster):
+1. Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster). By default, `docker stop` sends a `SIGTERM` signal, waits for 10 seconds, and then sends a `SIGKILL` signal. Cockroach Labs recommends that you [allow between 5 and 10 minutes](node-shutdown.html#termination-grace-period) before forcibly stopping the `cockroach` process, so this example sets the grace period to 5 minutes. If you do not plan to restart the cluster, you can omit `-t`.
 
-~~~ powershell
-PS C:\Users\username> docker stop roach1 roach2 roach3
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker stop -t 300 roach1 roach2 roach3
+    ~~~
 
-~~~ powershell
-PS C:\Users\username> docker rm roach1 roach2 roach3
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker rm roach1 roach2 roach3
+    ~~~
 
-If you do not plan to restart the cluster, you may want to remove the nodes' data stores:
+1. If you do not plan to restart the cluster, you can also remove the Docker volumes and the Docker network:
 
-~~~ powershell
-PS C:\Users\username> Remove-Item cockroach-data -recurse
-~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker volume rm roach1 roach2 roach3
+    ~~~
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ powershell
+    docker network rm roachnet
+    ~~~
 
 ## What's next?
 


### PR DESCRIPTION
[DOC-782] Use different ports for additional Docker nodes

## Previews
[v22.2/start-a-local-cluster-in-docker-linux.md](https://deploy-preview-17045--cockroachdb-docs.netlify.app/docs/v22.2/start-a-local-cluster-in-docker-linux.html)
[v22.2/start-a-local-cluster-in-docker-mac.md](https://deploy-preview-17045--cockroachdb-docs.netlify.app/docs/v22.2/start-a-local-cluster-in-docker-mac.html)
[v22.2/start-a-local-cluster-in-docker-windows.md](https://deploy-preview-17045--cockroachdb-docs.netlify.app/docs/v22.2/start-a-local-cluster-in-docker-windows.html)

[v23.1/start-a-local-cluster-in-docker-linux.md](https://deploy-preview-17045--cockroachdb-docs.netlify.app/docs/v23.1/start-a-local-cluster-in-docker-linux.html)
[v23.1/start-a-local-cluster-in-docker-mac.md](https://deploy-preview-17045--cockroachdb-docs.netlify.app/docs/v23.1/start-a-local-cluster-in-docker-mac.html)
[v23.1/start-a-local-cluster-in-docker-windows.md](https://deploy-preview-17045--cockroachdb-docs.netlify.app/docs/v23.1/start-a-local-cluster-in-docker-windows.html)

## Tests
- [x] Tested the commands locally with 23.1.1 See [thread](https://cockroachlabs.slack.com/archives/CHVV403F0/p1684438862539119).
- [x] Local build
- [x] Linkcheck 