### PR TITLE
Replace PTS monitoring bullet list from SQL page

### DIFF
--- a/v23.1/create-changefeed.md
+++ b/v23.1/create-changefeed.md
@@ -19,7 +19,7 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 - [Changefeeds on Tables with Column Families](changefeeds-on-tables-with-column-families.html)
 - [Export Data with Changefeeds](export-data-with-changefeeds.html)
 
-{% include {{ page.version.version }}/cdc/pts-gc-monitoring.md %}
+Cockroach Labs recommends monitoring your changefeeds to track [retryable errors](monitor-and-debug-changefeeds.html#changefeed-retry-errors) and for [protected timestamp](architecture/storage-layer.html#protected-timestamps) usage. Refer to the [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) page for more information.
 
 ## Required privileges
 

--- a/v23.1/create-changefeed.md
+++ b/v23.1/create-changefeed.md
@@ -19,7 +19,7 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 - [Changefeeds on Tables with Column Families](changefeeds-on-tables-with-column-families.html)
 - [Export Data with Changefeeds](export-data-with-changefeeds.html)
 
-Cockroach Labs recommends monitoring your changefeeds to track [retryable errors](monitor-and-debug-changefeeds.html#changefeed-retry-errors) and for [protected timestamp](architecture/storage-layer.html#protected-timestamps) usage. Refer to the [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) page for more information.
+Cockroach Labs recommends monitoring your changefeeds to track [retryable errors](monitor-and-debug-changefeeds.html#changefeed-retry-errors) and [protected timestamp](architecture/storage-layer.html#protected-timestamps) usage. Refer to the [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) page for more information.
 
 ## Required privileges
 


### PR DESCRIPTION
This is a quick fix to remove the random PTS monitoring include from the top of `CREATE CHANGEFEED` SQL page. It has no context there and is seemingly an error leftover from the PTS work for v23.1.

Replaced with a reference to the monitoring page.