### PR TITLE
Revert "[DOC-7103] Remove mention of external ID from AWS CMEK docs"

### DIFF
--- a/cockroachcloud/cmek-ops-aws.md
+++ b/cockroachcloud/cmek-ops-aws.md
@@ -48,7 +48,9 @@ Here we will create a *cross-account IAM role*. This is a role in your AWS accou
 	1. In the AWS console, visit the [IAM page](https://console.aws.amazon.com/iam/).
 	1. Select **Roles** and click **Create role**.
 	1. For **Trusted entity type**, select **AWS account**.
-	1. Choose **Another AWS account**. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found [previously](#step-1-provision-the-cross-account-iam-role) by querying your cluster's Cloud API.
+	1. Choose **Another AWS account**.
+		1. For **Account ID**, provide the {{ site.data.products.dedicated }} AWS Account ID that you found previously by querying your cluster's Cloud API.
+		1. Select the option to **Require external ID**, and for the value of **External ID**, provide your {{ site.data.products.dedicated }} Organization ID.
 	1. Finish creating the IAM role with a suitable name. You do not need to add any permissions.
 
 	{{site.data.alerts.callout_info}}


### PR DESCRIPTION
Reverts cockroachdb/docs#16398

See https://github.com/cockroachlabs/managed-service/pull/13158#pullrequestreview-1442620976

Preview: [cockroachcloud/cmek-ops-aws.md](https://deploy-preview-17086--cockroachdb-docs.netlify.app/docs/cockroachcloud/cmek-ops-aws.html)