### PR TITLE
Add serverless to cloud regions page

### DIFF
--- a/cockroachcloud/create-a-serverless-cluster.md
+++ b/cockroachcloud/create-a-serverless-cluster.md
@@ -25,11 +25,7 @@ If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=d
 
 ## Step 2. Select the cloud provider
 
-1. _(Optional)_ Select a cloud provider (GCP or AWS) in the **Cloud provider** section. Creating a Serverless cluster on Azure is not supported.
-
-1. _(Optional)_ Select a region in the **Regions** section. For optimal performance, select the cloud provider region closest to the region in which you are running your application.
-
-If you want to create a cluster in an unavailable region, please [contact Support](https://support.cockroachlabs.com).
+Select a cloud provider (GCP or AWS) in the **Cloud provider** section. Creating a Serverless cluster on Azure is not supported.
 
 {{site.data.alerts.callout_info}}
 You do not need an account with the cloud provider you choose in order to create a cluster on that cloud provider. The cluster is created on infrastructure managed by Cockroach Labs. If you have existing cloud services on either GCP or AWS that you intend to use with your {{ site.data.products.serverless }} cluster, you should select that cloud provider and the region closest to your existing cloud services to maximize performance.

--- a/cockroachcloud/regions.md
+++ b/cockroachcloud/regions.md
@@ -3,6 +3,7 @@ title: CockroachDB Cloud Regions
 summary: Learn about the available regions for CockroachDB Cloud clusters.
 toc: true
 docs_area: deploy
+cloud: true
 ---
 
 {{ site.data.products.db }} clusters can be [created](create-your-cluster.html) in the following cloud regions.
@@ -11,9 +12,48 @@ docs_area: deploy
 For optimal performance, configure your cluster's regions to be as near as possible to your client applications or other related workloads.
 {{site.data.alerts.end}}
 
-## AWS regions
+<div class="filters clearfix">
+    <button class="filter-button page-level" data-scope="serverless">{{ site.data.products.serverless }}</button>
+    <button class="filter-button page-level" data-scope="dedicated">{{ site.data.products.dedicated }}</button>
+</div>
 
-{{ site.data.products.db }} clusters can be deployed in the following [AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html):
+<section class="filter-content" markdown="1" data-scope="serverless">
+
+## {{ site.data.products.serverless }}
+
+Creating a {{ site.data.products.serverless }} cluster on Azure is not supported.
+
+### AWS regions
+
+Geographic Area | Region Name      | Location
+----------------|------------------|---------
+Asia Pacific    | `ap-south-1`     | Mumbai
+                | `ap-southeast-1` | Singapore
+North America   | `us-east-1`      | N. Virginia
+                | `us-west-2`      | Oregon
+Western Europe  | `eu-central-1`   | Frankfurt
+                | `eu-west-1`      | Ireland
+
+### GCP regions
+
+Geographic Area | Region Name               | Location
+----------------|---------------------------|---------
+Asia Pacific    | `asia-southeast1`         | Jurong West
+North America   | `us-central1`             | Iowa
+                | `us-east1`                | South Carolina
+                | `us-west2`                | California
+South America   | `southamerica-east1`      | São Paulo
+Western Europe  | `europe-west1`            | St. Ghislain
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="dedicated">
+
+## {{ site.data.products.dedicated }}
+
+### AWS regions
+
+{{ site.data.products.dedicated }} clusters can be deployed in the following [AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html):
 
 Geographic Area | Region Name      | Location
 ----------------|------------------|---------
@@ -33,7 +73,7 @@ Western Europe  | `eu-central-1`   | Frankfurt
                 | `eu-west-2`      | London
                 | `eu-west-3`      | Paris
 
-## Azure regions
+### Azure regions
 
 {{site.data.alerts.callout_info}}
 {% include feature-phases/azure-limited-access.md %}
@@ -46,9 +86,9 @@ Geographic Area | Region Name     | Location
 North America   | `eastus2`       | East Coast - Virginia
 Western Europe  | `westeurope`    | Netherlands
 
-## GCP regions
+### GCP regions
 
-{{ site.data.products.db }} clusters can be deployed in the following [GCP regions](https://cloud.google.com/compute/docs/regions-zones):
+{{ site.data.products.dedicated }} clusters can be deployed in the following [GCP regions](https://cloud.google.com/compute/docs/regions-zones):
 
 Geographic Area | Region Name               | Location
 ----------------|---------------------------|---------
@@ -67,3 +107,5 @@ Western Europe  | `europe-west1`            | St. Ghislain
                 | `europe-west2`            | London
                 | `europe-west3`            | Frankfurt
                 | `europe-west4`            | Eemshaven
+                
+</section>

--- a/cockroachcloud/regions.md
+++ b/cockroachcloud/regions.md
@@ -8,22 +8,24 @@ cloud: true
 
 {{ site.data.products.db }} clusters can be [created](create-your-cluster.html) in the following cloud regions.
 
-{{site.data.alerts.callout_success}}
-For optimal performance, configure your cluster's regions to be as near as possible to your client applications or other related workloads.
-{{site.data.alerts.end}}
-
 <div class="filters clearfix">
     <button class="filter-button page-level" data-scope="serverless">{{ site.data.products.serverless }}</button>
     <button class="filter-button page-level" data-scope="dedicated">{{ site.data.products.dedicated }}</button>
 </div>
 
+{{site.data.alerts.callout_success}}
+For optimal performance, configure your cluster's regions to be as near as possible to your client applications or other related workloads.
+{{site.data.alerts.end}}
+
 <section class="filter-content" markdown="1" data-scope="serverless">
 
-## {{ site.data.products.serverless }}
-
+{{site.data.alerts.callout_info}}
 Creating a {{ site.data.products.serverless }} cluster on Azure is not supported.
+{{site.data.alerts.end}}
 
-### AWS regions
+## AWS regions
+
+{{ site.data.products.serverless }} clusters can be deployed in the following [AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html):
 
 Geographic Area | Region Name      | Location
 ----------------|------------------|---------
@@ -34,7 +36,9 @@ North America   | `us-east-1`      | N. Virginia
 Western Europe  | `eu-central-1`   | Frankfurt
                 | `eu-west-1`      | Ireland
 
-### GCP regions
+## GCP regions
+
+{{ site.data.products.serverless }} clusters can be deployed in the following [GCP regions](https://cloud.google.com/compute/docs/regions-zones):
 
 Geographic Area | Region Name               | Location
 ----------------|---------------------------|---------
@@ -49,9 +53,7 @@ Western Europe  | `europe-west1`            | St. Ghislain
 
 <section class="filter-content" markdown="1" data-scope="dedicated">
 
-## {{ site.data.products.dedicated }}
-
-### AWS regions
+## AWS regions
 
 {{ site.data.products.dedicated }} clusters can be deployed in the following [AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html):
 
@@ -73,7 +75,7 @@ Western Europe  | `eu-central-1`   | Frankfurt
                 | `eu-west-2`      | London
                 | `eu-west-3`      | Paris
 
-### Azure regions
+## Azure regions
 
 {{site.data.alerts.callout_info}}
 {% include feature-phases/azure-limited-access.md %}
@@ -86,7 +88,7 @@ Geographic Area | Region Name     | Location
 North America   | `eastus2`       | East Coast - Virginia
 Western Europe  | `westeurope`    | Netherlands
 
-### GCP regions
+## GCP regions
 
 {{ site.data.products.dedicated }} clusters can be deployed in the following [GCP regions](https://cloud.google.com/compute/docs/regions-zones):
 

--- a/cockroachcloud/serverless-faqs.md
+++ b/cockroachcloud/serverless-faqs.md
@@ -41,18 +41,7 @@ No, you can create one {{ site.data.products.serverless }} cluster for free. The
 
 ### What regions are available for {{ site.data.products.serverless }} clusters?
 
-The following regions are available for {{ site.data.products.serverless }}:
-
-GCP                                         | AWS
---------------------------------------------|------
-`asia-southeast1` (Jurong West)             | `ap-south-1` (Mumbai) 
-`europe-west1` (St. Ghislain)               | `ap-southeast-1` (Singapore)
-`southamerica-east1` (São Paulo)            | `eu-central-1` (Frankfurt)
-`us-central1` (Iowa)                        | `eu-west-1` (Ireland)
-`us-east1` (South Carolina )                | `us-east-1` (N. Virginia)              
-`us-west2` (California)                     | `us-west-2` (Oregon)
-
-A multi-region Serverless cluster can have a maximum of six regions. To express interest in additional regions, contact your Cockroach Labs account team.
+Refer to [{{ site.data.products.db }} Regions](regions.html) for the regions where {{ site.data.products.dedicated }} and {{ site.data.products.serverless-plan }} clusters can be deployed. A multi-region Serverless cluster can have a maximum of six regions. To express interest in additional regions, contact your Cockroach Labs account team.
 
 ### How can I estimate how many RUs my workload will consume?
 


### PR DESCRIPTION
Added serverless section to regions page, removed regions from serverless faq, and removed leftover region step from create page