### PR TITLE
v23.1.2 release notes - abridged

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -152,12 +152,12 @@ release_info:
     start_time: 2023-05-03 12:20:58.860667 +0000 UTC
     version: v22.2.9
   v23.1:
-    build_time: 2023-05-16 00:00:00 (go1.19)
+    build_time: 2023-05-25 00:00:00 (go1.19)
     crdb_branch_name: release-23.1
     docker_image: cockroachdb/cockroach
-    name: v23.1.1
-    start_time: 2023-05-16 00:21:50.394565 +0000 UTC
-    version: v23.1.1
+    name: v23.1.2
+    start_time: 2023-05-25 15:02:53.654868 +0000 UTC
+    version: v23.1.2
 sass:
   quiet_deps: 'true'
   sass_dir: css

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -4335,7 +4335,7 @@
     docker_arm: false
   source: true
   previous_release: v22.1.19
-  
+
 - release_name: v23.1.0
   major_version: v23.1
   release_date: '2023-05-15'
@@ -4378,3 +4378,26 @@
     docker_arm: true
   source: true
   previous_release: v23.1.0
+  withdrawn: true
+
+- release_name: v23.1.2
+  major_version: v23.1
+  release_date: '2023-05-25'
+  release_type: Production
+  go_version: go1.19
+  sha: 810d4f27a7f02b9cc2750cab654ed1c62ac3e75a
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+  source: true
+  previous_release: v23.1.1
+

--- a/_includes/releases/v23.1/v23.1.2.md
+++ b/_includes/releases/v23.1/v23.1.2.md
@@ -1,0 +1,153 @@
+## v23.1.2
+
+Release Date: May 25, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+{{site.data.alerts.callout_info}}
+This is an incomplete list of the changes included in the v23.1.2 release. The full list will be published soon.
+{{site.data.alerts.end}}
+
+<h3 id="v23-1-2-bug-fixes">Bug fixes</h3>
+
+- A bug was fixed where, under high CPU load, HTTP requests to certain API endpoints (e.g., the `health` endpoint) could start failing and then never succeed again until the node was restarted. This bug was introduced in v23.1. [#103775][#103775]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-2-contributors">Contributors</h3>
+
+This release includes 329 merged PRs by 70 authors.
+
+</div>
+
+[#100049]: https://github.com/cockroachdb/cockroach/pull/100049
+[#100475]: https://github.com/cockroachdb/cockroach/pull/100475
+[#100509]: https://github.com/cockroachdb/cockroach/pull/100509
+[#100670]: https://github.com/cockroachdb/cockroach/pull/100670
+[#100841]: https://github.com/cockroachdb/cockroach/pull/100841
+[#100844]: https://github.com/cockroachdb/cockroach/pull/100844
+[#100939]: https://github.com/cockroachdb/cockroach/pull/100939
+[#100948]: https://github.com/cockroachdb/cockroach/pull/100948
+[#101094]: https://github.com/cockroachdb/cockroach/pull/101094
+[#101135]: https://github.com/cockroachdb/cockroach/pull/101135
+[#101164]: https://github.com/cockroachdb/cockroach/pull/101164
+[#101173]: https://github.com/cockroachdb/cockroach/pull/101173
+[#101301]: https://github.com/cockroachdb/cockroach/pull/101301
+[#101309]: https://github.com/cockroachdb/cockroach/pull/101309
+[#101367]: https://github.com/cockroachdb/cockroach/pull/101367
+[#101382]: https://github.com/cockroachdb/cockroach/pull/101382
+[#101392]: https://github.com/cockroachdb/cockroach/pull/101392
+[#101428]: https://github.com/cockroachdb/cockroach/pull/101428
+[#101443]: https://github.com/cockroachdb/cockroach/pull/101443
+[#101483]: https://github.com/cockroachdb/cockroach/pull/101483
+[#101491]: https://github.com/cockroachdb/cockroach/pull/101491
+[#101493]: https://github.com/cockroachdb/cockroach/pull/101493
+[#101507]: https://github.com/cockroachdb/cockroach/pull/101507
+[#101564]: https://github.com/cockroachdb/cockroach/pull/101564
+[#101596]: https://github.com/cockroachdb/cockroach/pull/101596
+[#101641]: https://github.com/cockroachdb/cockroach/pull/101641
+[#101669]: https://github.com/cockroachdb/cockroach/pull/101669
+[#101688]: https://github.com/cockroachdb/cockroach/pull/101688
+[#101697]: https://github.com/cockroachdb/cockroach/pull/101697
+[#101709]: https://github.com/cockroachdb/cockroach/pull/101709
+[#101753]: https://github.com/cockroachdb/cockroach/pull/101753
+[#101758]: https://github.com/cockroachdb/cockroach/pull/101758
+[#101759]: https://github.com/cockroachdb/cockroach/pull/101759
+[#101782]: https://github.com/cockroachdb/cockroach/pull/101782
+[#101783]: https://github.com/cockroachdb/cockroach/pull/101783
+[#101793]: https://github.com/cockroachdb/cockroach/pull/101793
+[#101797]: https://github.com/cockroachdb/cockroach/pull/101797
+[#101802]: https://github.com/cockroachdb/cockroach/pull/101802
+[#101805]: https://github.com/cockroachdb/cockroach/pull/101805
+[#101809]: https://github.com/cockroachdb/cockroach/pull/101809
+[#101837]: https://github.com/cockroachdb/cockroach/pull/101837
+[#101863]: https://github.com/cockroachdb/cockroach/pull/101863
+[#101870]: https://github.com/cockroachdb/cockroach/pull/101870
+[#101874]: https://github.com/cockroachdb/cockroach/pull/101874
+[#101877]: https://github.com/cockroachdb/cockroach/pull/101877
+[#101950]: https://github.com/cockroachdb/cockroach/pull/101950
+[#101996]: https://github.com/cockroachdb/cockroach/pull/101996
+[#101998]: https://github.com/cockroachdb/cockroach/pull/101998
+[#102002]: https://github.com/cockroachdb/cockroach/pull/102002
+[#102027]: https://github.com/cockroachdb/cockroach/pull/102027
+[#102167]: https://github.com/cockroachdb/cockroach/pull/102167
+[#102188]: https://github.com/cockroachdb/cockroach/pull/102188
+[#102195]: https://github.com/cockroachdb/cockroach/pull/102195
+[#102207]: https://github.com/cockroachdb/cockroach/pull/102207
+[#102274]: https://github.com/cockroachdb/cockroach/pull/102274
+[#102306]: https://github.com/cockroachdb/cockroach/pull/102306
+[#102309]: https://github.com/cockroachdb/cockroach/pull/102309
+[#102343]: https://github.com/cockroachdb/cockroach/pull/102343
+[#102379]: https://github.com/cockroachdb/cockroach/pull/102379
+[#102384]: https://github.com/cockroachdb/cockroach/pull/102384
+[#102392]: https://github.com/cockroachdb/cockroach/pull/102392
+[#102395]: https://github.com/cockroachdb/cockroach/pull/102395
+[#102460]: https://github.com/cockroachdb/cockroach/pull/102460
+[#102468]: https://github.com/cockroachdb/cockroach/pull/102468
+[#102489]: https://github.com/cockroachdb/cockroach/pull/102489
+[#102514]: https://github.com/cockroachdb/cockroach/pull/102514
+[#102601]: https://github.com/cockroachdb/cockroach/pull/102601
+[#102626]: https://github.com/cockroachdb/cockroach/pull/102626
+[#102627]: https://github.com/cockroachdb/cockroach/pull/102627
+[#102637]: https://github.com/cockroachdb/cockroach/pull/102637
+[#102662]: https://github.com/cockroachdb/cockroach/pull/102662
+[#102663]: https://github.com/cockroachdb/cockroach/pull/102663
+[#102694]: https://github.com/cockroachdb/cockroach/pull/102694
+[#102700]: https://github.com/cockroachdb/cockroach/pull/102700
+[#102724]: https://github.com/cockroachdb/cockroach/pull/102724
+[#102790]: https://github.com/cockroachdb/cockroach/pull/102790
+[#102807]: https://github.com/cockroachdb/cockroach/pull/102807
+[#102828]: https://github.com/cockroachdb/cockroach/pull/102828
+[#102862]: https://github.com/cockroachdb/cockroach/pull/102862
+[#102881]: https://github.com/cockroachdb/cockroach/pull/102881
+[#102913]: https://github.com/cockroachdb/cockroach/pull/102913
+[#102947]: https://github.com/cockroachdb/cockroach/pull/102947
+[#102958]: https://github.com/cockroachdb/cockroach/pull/102958
+[#102977]: https://github.com/cockroachdb/cockroach/pull/102977
+[#102989]: https://github.com/cockroachdb/cockroach/pull/102989
+[#103073]: https://github.com/cockroachdb/cockroach/pull/103073
+[#103089]: https://github.com/cockroachdb/cockroach/pull/103089
+[#103144]: https://github.com/cockroachdb/cockroach/pull/103144
+[#103233]: https://github.com/cockroachdb/cockroach/pull/103233
+[#103234]: https://github.com/cockroachdb/cockroach/pull/103234
+[#103328]: https://github.com/cockroachdb/cockroach/pull/103328
+[#103331]: https://github.com/cockroachdb/cockroach/pull/103331
+[#103355]: https://github.com/cockroachdb/cockroach/pull/103355
+[#103363]: https://github.com/cockroachdb/cockroach/pull/103363
+[#103411]: https://github.com/cockroachdb/cockroach/pull/103411
+[#103412]: https://github.com/cockroachdb/cockroach/pull/103412
+[#103420]: https://github.com/cockroachdb/cockroach/pull/103420
+[#103421]: https://github.com/cockroachdb/cockroach/pull/103421
+[#103444]: https://github.com/cockroachdb/cockroach/pull/103444
+[#103450]: https://github.com/cockroachdb/cockroach/pull/103450
+[#103451]: https://github.com/cockroachdb/cockroach/pull/103451
+[#103466]: https://github.com/cockroachdb/cockroach/pull/103466
+[#103474]: https://github.com/cockroachdb/cockroach/pull/103474
+[#103520]: https://github.com/cockroachdb/cockroach/pull/103520
+[#103521]: https://github.com/cockroachdb/cockroach/pull/103521
+[#103526]: https://github.com/cockroachdb/cockroach/pull/103526
+[#103546]: https://github.com/cockroachdb/cockroach/pull/103546
+[#103556]: https://github.com/cockroachdb/cockroach/pull/103556
+[#103559]: https://github.com/cockroachdb/cockroach/pull/103559
+[#103626]: https://github.com/cockroachdb/cockroach/pull/103626
+[#103630]: https://github.com/cockroachdb/cockroach/pull/103630
+[#103631]: https://github.com/cockroachdb/cockroach/pull/103631
+[#103637]: https://github.com/cockroachdb/cockroach/pull/103637
+[#103639]: https://github.com/cockroachdb/cockroach/pull/103639
+[#103640]: https://github.com/cockroachdb/cockroach/pull/103640
+[#103689]: https://github.com/cockroachdb/cockroach/pull/103689
+[#103775]: https://github.com/cockroachdb/cockroach/pull/103775
+[#103777]: https://github.com/cockroachdb/cockroach/pull/103777
+[#99823]: https://github.com/cockroachdb/cockroach/pull/99823
+[#99946]: https://github.com/cockroachdb/cockroach/pull/99946
+[0903f9790]: https://github.com/cockroachdb/cockroach/commit/0903f9790
+[194007ac9]: https://github.com/cockroachdb/cockroach/commit/194007ac9
+[26f915186]: https://github.com/cockroachdb/cockroach/commit/26f915186
+[406baeb6b]: https://github.com/cockroachdb/cockroach/commit/406baeb6b
+[448802fbd]: https://github.com/cockroachdb/cockroach/commit/448802fbd
+[653aba7be]: https://github.com/cockroachdb/cockroach/commit/653aba7be
+[8734e2c66]: https://github.com/cockroachdb/cockroach/commit/8734e2c66
+[ad2e4eda2]: https://github.com/cockroachdb/cockroach/commit/ad2e4eda2
+[c6f062a53]: https://github.com/cockroachdb/cockroach/commit/c6f062a53
+[cab396771]: https://github.com/cockroachdb/cockroach/commit/cab396771
+[ccfd125aa]: https://github.com/cockroachdb/cockroach/commit/ccfd125aa


### PR DESCRIPTION
This PR:
- Withdraws the v23.1.1 release
- Publishes an abridged version of the v23.1.2 release notes.

Full release notes to be published on May 30 by @ashleykwtam 