### PR TITLE
Correct version description in release notes

### DIFF
--- a/_includes/releases/v23.1/v23.1.0.md
+++ b/_includes/releases/v23.1/v23.1.0.md
@@ -326,7 +326,7 @@ If the node executing the backup does not have a specific range to be backed up,
   <tr>
    <td><p>Enforce supported backup versions</p>
    </td>
-   <td><p>To help ensure backups and restores are successful, CockroachDB now enforces its previous support for restoring backups from up to two minor versions prior. Previously, restoring backups produced from even earlier versions was possible, but unreliable. Now, this operation is prevented with an error.
+   <td><p>To help ensure backups and restores are successful, CockroachDB now <a href="https://www.cockroachlabs.com/docs/stable/restoring-backups-across-versions.html">enforces its previous support</a> for restoring backups on a cluster on a specific major version into a cluster that is on the same version or the next major version. Previously, restoring backups produced from even earlier versions was possible, but unreliable. Now, this operation is prevented with an error.
    </td>
   </tr>
   </tbody>

--- a/_includes/releases/v23.1/v23.1.0.md
+++ b/_includes/releases/v23.1/v23.1.0.md
@@ -47,14 +47,14 @@ The features highlighted below are freely available in {{ site.data.products.cor
   <tr>
    <td><p>Full-text search using TSVector and TSQuery</p>
    </td>
-   <td><p>A <a href="https://www.cockroachlabs.com/docs/stable/full-text-search.html">full-text search</a> is used to perform queries on natural-language documents such as articles, websites, or other written formats, with results often sorted by relevance.</p>
+   <td><p>A <a href="../v23.1/full-text-search.html">full-text search</a> is used to perform queries on natural-language documents such as articles, websites, or other written formats, with results often sorted by relevance.</p>
     <p>You can rely on <a href="../v23.1/functions-and-operators.html#full-text-search-functions">new built-in functions</a> to make use of the new <a href="../v23.1/tsvector.html">TSVECTOR</a> and <a href="../v23.1/tsquery.html">TSQUERY</a> data types.</p>
    </td>
   </tr>
   <tr>
    <td><p>Improved developer experience for multi-region apps</p>
    </td>
-   <td><p>If you have functionality that requires low latency and cannot tolerate delays between regions, you can enable the <code>enforce_home_region</code> option, which <a href="https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region">ensures that queries are executed within a single region</a>. If a query doesn't have a home region or is running outside of its home region, the optimizer now provides improved feedback and suggestions for executing the query within a single region.
+   <td><p>If you have functionality that requires low latency and cannot tolerate delays between regions, you can enable the <code>enforce_home_region</code> option, which <a href="../v23.1/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region">ensures that queries are executed within a single region</a>. If a query doesn't have a home region or is running outside of its home region, the optimizer now provides improved feedback and suggestions for executing the query within a single region.
    </td>
   </tr>
   <tr>
@@ -66,13 +66,13 @@ The features highlighted below are freely available in {{ site.data.products.cor
   <tr>
    <td><p>Redact PII from statement bundles</p>
    </td>
-   <td><p>Leverage statement bundles for debugging without introducing data privacy concerns. You can now <a href="https://www.cockroachlabs.com/docs/stable/explain-analyze.html#redact-option">redact personally identifiable information (PII) from statement bundles</a> for PCI compliance.
+   <td><p>Leverage statement bundles for debugging without introducing data privacy concerns. You can now <a href="../v23.1/explain-analyze.html#redact-option">redact personally identifiable information (PII) from statement bundles</a> for PCI compliance.
    </td>
   </tr>
   <tr>
    <td><p>User-Defined Function (UDF) enhancements</p>
    </td>
-   <td><p><a href="https://www.cockroachlabs.com/docs/stable/user-defined-functions.html">User-defined functions</a> offer enhanced flexibility, performance, and reusability. This release brings a number of UDF enhancements, including: Inlining of supported UDFs within the query plan to improve performance; support for subqueries in statements, support for expressions with a <code>*</code> such as <code>SELECT *</code> , and support for returning a set of results (using <code>SETOF</code>).
+   <td><p><a href="../v23.1/user-defined-functions.html">User-defined functions</a> offer enhanced flexibility, performance, and reusability. This release brings a number of UDF enhancements, including: Inlining of supported UDFs within the query plan to improve performance; support for subqueries in statements, support for expressions with a <code>*</code> such as <code>SELECT *</code> , and support for returning a set of results (using <code>SETOF</code>).
 <p>
 UDFs can now also be used in Changefeed expressions (Enterprise) and <code>CHECK</code> constraints, and referenced from other objects. Validations have been added to guarantee that all statements in the function body should be as strict as the expected UDF volatility. UDFs are also now included in backup and restore operations.
    </td>
@@ -204,7 +204,7 @@ Asyncpg is commonly used with ORM libraries such as SQLAlchemy to provide a simp
   <tr>
    <td><p>Support encrypted backups with keys stored in Azure Key Vault </p>
    </td>
-   <td><p>You can now <a href="https://www.cockroachlabs.com/docs/stable/take-and-restore-encrypted-backups.html">take and restore encrypted backups</a> using RSA keys stored in Azure Key Vault.
+   <td><p>You can now <a href="../v23.1/take-and-restore-encrypted-backups.html">take and restore encrypted backups</a> using RSA keys stored in Azure Key Vault.
    </td>
   </tr>
   <tr>
@@ -312,7 +312,7 @@ If the node executing the backup does not have a specific range to be backed up,
   <tr>
    <td><p>Support implicit authentication on Azure</p>
    </td>
-   <td><p>You can now use implicit authentication on Azure for <a href="https://www.cockroachlabs.com/docs/stable/cloud-storage-authentication.html">cloud storage authentication</a>.
+   <td><p>You can now use implicit authentication on Azure for <a href="../v23.1/cloud-storage-authentication.html">cloud storage authentication</a>.
 <p>
 If the node executing the backup does not have a specific range to be backed up, it will read it from the closest replica it can.
    </td>
@@ -320,13 +320,13 @@ If the node executing the backup does not have a specific range to be backed up,
   <tr>
    <td><p>Support encrypted backups with keys stored in Azure Key Vault</p>
    </td>
-   <td><p>You can now <a href="https://www.cockroachlabs.com/docs/stable/take-and-restore-encrypted-backups.html">take and restore encrypted backups</a> using RSA keys stored in Azure Key Vault.
+   <td><p>You can now <a href="../v23.1/take-and-restore-encrypted-backups.html">take and restore encrypted backups</a> using RSA keys stored in Azure Key Vault.
    </td>
   </tr>
   <tr>
    <td><p>Enforce supported backup versions</p>
    </td>
-   <td><p>To help ensure backups and restores are successful, CockroachDB now <a href="https://www.cockroachlabs.com/docs/stable/restoring-backups-across-versions.html">enforces its previous support</a> for restoring backups on a cluster on a specific major version into a cluster that is on the same version or the next major version. Previously, restoring backups produced from even earlier versions was possible, but unreliable. Now, this operation is prevented with an error.
+   <td><p>To help ensure backups and restores are successful, CockroachDB now <a href="../v23.1/restoring-backups-across-versions.html">enforces its previous support</a> for restoring backups on a cluster on a specific major version into a cluster that is on the same version or the next major version. Previously, restoring backups produced from even earlier versions was possible, but unreliable. Now, this operation is prevented with an error.
    </td>
   </tr>
   </tbody>


### PR DESCRIPTION
Quick fix to the 23.1 GA release notes. (It should not read two minor versions — it is major versions and not quite two.)
