### PR TITLE
[DOC-6559] Release notes for 22.2.10

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -145,12 +145,12 @@ release_info:
     start_time: 2023-05-10 12:58:20.269520 +0000 UTC
     version: v22.1.20
   v22.2:
-    build_time: 2023-05-08 00:00:00 (go1.19)
+    build_time: 2023-05-30 00:00:00 (go1.19)
     crdb_branch_name: release-22.2
     docker_image: cockroachdb/cockroach
-    name: v22.2.9
-    start_time: 2023-05-03 12:20:58.860667 +0000 UTC
-    version: v22.2.9
+    name: v22.2.10
+    start_time: 2023-05-30 10:36:41.668389 +0000 UTC
+    version: v22.2.10
   v23.1:
     build_time: 2023-05-25 00:00:00 (go1.19)
     crdb_branch_name: release-23.1

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -4399,4 +4399,24 @@
     docker_arm: true
   source: true
   previous_release: v23.1.1
- 
+
+- release_name: v22.2.10
+  major_version: v22.2
+  release_date: '2023-05-30'
+  release_type: Production
+  go_version: go1.19
+  sha: 62a0f7dd692b164236a0a540c9f4ed70b3db817b
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_intel_fips: false
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+  source: true
+  previous_release: v22.2.9

--- a/_includes/releases/v22.2/v22.2.10.md
+++ b/_includes/releases/v22.2/v22.2.10.md
@@ -6,7 +6,7 @@ Release Date: May 30, 2023
 
 <h3 id="v22-2-10-sql-language-changes">SQL language changes</h3>
 
-- Responses from the [Cluster API](../v22.2/cluster-api.html) now escapes special characters in database names, such as spaces. [#102896][#102896]
+- Responses from the [Cluster API](../v22.2/cluster-api.html) now escape special characters in database names, such as spaces. [#102896][#102896]
 - The new [session variable](../v22.2/set-vars.html) `optimizer_use_improved_computed_column_filters_derivation` allows the optimizer to derive filters on computed columns in more cases. This session variable defaults to `false`. [#103424][#103424]
 - Keys are now redacted in the following internal tables, and can be viewed only by users with the `VIEWACTIVITYREDACTED` role: <ul><li><code>crdb_internal.transaction_contention_events</code></li><li><code>crdb_internal.node_contention_events</code></li><li><code>crdb_internal.cluster_locks</code></li></ul>The `crdb_internal.node_contention_events` table can now be viewed only by users with the `admin`, `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` role. [#103644][#103644]
 

--- a/_includes/releases/v22.2/v22.2.10.md
+++ b/_includes/releases/v22.2/v22.2.10.md
@@ -1,0 +1,77 @@
+## v22.2.10
+
+Release Date: May 30, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-2-10-sql-language-changes">SQL language changes</h3>
+
+- Responses from the [Cluster API](../v22.2/cluster-api.html) now escapes special characters in database names, such as spaces. [#102896][#102896]
+- The new [session variable](../v22.2/set-vars.html) `optimizer_use_improved_computed_column_filters_derivation` allows the optimizer to derive filters on computed columns in more cases. This session variable defaults to `false`. [#103424][#103424]
+- Keys are now redacted in the following internal tables, and can be viewed only by users with the `VIEWACTIVITYREDACTED` role: <ul><li><code>crdb_internal.transaction_contention_events</code></li><li><code>crdb_internal.node_contention_events</code></li><li><code>crdb_internal.cluster_locks</code></li></ul>The `crdb_internal.node_contention_events` table can now be viewed only by users with the `admin`, `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` role. [#103644][#103644]
+
+<h3 id="v22-2-10-operational-changes">Operational changes</h3>
+
+- Timeseries metric counts now show the cumulative count for histograms rather than the windowed count. A `-sum` timeseries is now exported for each histogram, to keep track of the cumulative sum of all samples in the histogram. [#103447][#103447]
+- The following metrics are now exported to help troubleshoot issues when the `admission.elastic_cpu.enabled` [cluster setting](../v22.2/cluster-settings.html) is enabled:
+
+    - `admission.elastic_cpu.nanos_exhausted_duration`
+    - `admission.elastic_cpu.over_limit_duration`
+    - `admission.elastic_cpu.pre_work_nanos`
+    - `admission.elastic_cpu.available_nanos`
+
+    [#103648][#103648]
+
+<h3 id="v22-2-10-db-console-changes">DB Console changes</h3>
+
+- The [Cluster Overview](../v22.2/ui-cluster-overview-page.html) page now shows an alert immediately when the cluster setting `cluster.preserve_downgrade_option` is set, instead of only after 48 hours. [#102912][#102912]
+- If a DB Console page crashes in a web browser, a forcible refresh is no longer required to view other DB Console pages. [#103327][#103327]
+- The [Databases](../v22.2/ui-databases-page.html) and [Table Details](../v22.2/ui-databases-page.html#table-details) pages now allow you to filter and search results. [#103593][#103593]
+
+<h3 id="v22-2-10-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug introduced in v21.1 that allowed values to be inserted into an `ARRAY`-type column that did not conform to the inner type of the array. For example, it was possible to insert `ARRAY['foo']` into a column of type `CHAR(1)[]`. This could cause incorrect results when querying the table. Such an insert now results in an error. [#102810][#102810]
+- Fixed a bug where backup or restore of a synthetic schema such as `system.public` would cause the node to crash. [#102782][#102782]
+- Fixed a bug where an asymmetric network partition could allow a node to erroneously update a closed timestamp for a lease that was transferred away from it after it missed a liveness heartbeat. This could lead to a closed timestamp invariant violation and could cause a node to crash. In an extreme case, it could cause inconsistencies in read-only queries. This fix changes the the order of availability checks so that a node's `PROSCRIBED` status is now evaluated before its `UNAVAILABLE` status. [#102599][#102599]
+- Fixed a rare bug introduced in v22.2.0, where a job that uses [row-level TTL](../v22.2/row-level-ttl.html) could incorrectly process a table that spans multiple ranges. When you encounter this bug, an error such as the following is logged: `error decoding EncDatum ...: did not find terminator ... in buffer ...`. [#102914][#102914]
+- The value of `pg_constraint.conparentid` is now `0` rather than `NULL`. CockroachDB does not support constraints on partitions. [#103232][#103232]
+- Fixed a bug where a previously-added filter condition could not be removed in the [Statements](../v22.2/ui-statements-page.html) page. [#103415][#103415]
+- Fixed a rare bug introduced in v22.1.0, where a query that uses the `ORDER BY` clause could return incorrect results if **all** of the following conditions are met: <ul><li>The query has both an `ORDER BY` clause and a `LIMIT` clause.</li><li>The sort operation uses enough memory that it spills to disk.</li><li>The `ORDER BY` clause contains multiple columns.</li><li>The ordering on the prefix of the `LIMIT BY` columns was already provided by an index.</ul> [#102789][#102789]
+- Fixed a rare bug introduced in v22.2.9 that could cause a node due to a `NULL` pointer in the code that populates [SQL Activity](../v22.2/ui-statements-page.html) pages. [#103522][#103522]
+- Fixed a bug that could cause excessively slow backups when the `admission.elastic_cpu.enabled` [cluster setting](../v22.2/cluster-settings.html) was enabled. [#103648][#103648]
+- Fixed a bug where a node could crash if placeholder arguments are used with the [`to_timestamp()` built-in function](../v22.2/functions-and-operators.html#date-and-time-functions) (for example, `with_min_timestamp(to_timestamp($1))`). [#103646][#103646]
+- Fixed a bug where removed regions are not cleaned up correctly after a restore. To fix this issue, `SET PRIMARY REGION` and `SET SECONDARY REGION` now validate transactionally. [#103634][#103634]
+
+<h3 id="v22-2-10-performance-improvements">Performance improvements</h3>
+
+- Improved performance of [SQL audit logging](../v22.2/sql-audit-logging.html), which now uses the lease cache to help resolve the names of tables, views, and sequences. [#102831][#102831]
+- A query can now be [constrained](../v22.2/constraints.html) using a computed column expression that is part of an index, as long as the query's `IN` clause or `OR` clause includes the columns referenced by the computed column expression. [#103424][#103424]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v22-2-10-contributors">Contributors</h3>
+
+This release includes 53 merged PRs by 36 authors.
+
+</div>
+
+[#102599]: https://github.com/cockroachdb/cockroach/pull/102599
+[#102782]: https://github.com/cockroachdb/cockroach/pull/102782
+[#102789]: https://github.com/cockroachdb/cockroach/pull/102789
+[#102810]: https://github.com/cockroachdb/cockroach/pull/102810
+[#102830]: https://github.com/cockroachdb/cockroach/pull/102830
+[#102831]: https://github.com/cockroachdb/cockroach/pull/102831
+[#102896]: https://github.com/cockroachdb/cockroach/pull/102896
+[#102912]: https://github.com/cockroachdb/cockroach/pull/102912
+[#102914]: https://github.com/cockroachdb/cockroach/pull/102914
+[#103232]: https://github.com/cockroachdb/cockroach/pull/103232
+[#103327]: https://github.com/cockroachdb/cockroach/pull/103327
+[#103415]: https://github.com/cockroachdb/cockroach/pull/103415
+[#103424]: https://github.com/cockroachdb/cockroach/pull/103424
+[#103447]: https://github.com/cockroachdb/cockroach/pull/103447
+[#103522]: https://github.com/cockroachdb/cockroach/pull/103522
+[#103593]: https://github.com/cockroachdb/cockroach/pull/103593
+[#103634]: https://github.com/cockroachdb/cockroach/pull/103634
+[#103644]: https://github.com/cockroachdb/cockroach/pull/103644
+[#103646]: https://github.com/cockroachdb/cockroach/pull/103646
+[#103648]: https://github.com/cockroachdb/cockroach/pull/103648


### PR DESCRIPTION
[DOC-6559] Release notes for 22.2.10

## Previews
[releases/v22.2.md](https://deploy-preview-17121--cockroachdb-docs.netlify.app/docs/releases/v22.2.html)

## Tests
- [x] Local build
- [x] Linkcheck 