### PR TITLE
Correct the callout for cdc monitoring on main pages

### DIFF
--- a/src/current/_includes/v23.1/cdc/recommendation-monitoring-pts.md
+++ b/src/current/_includes/v23.1/cdc/recommendation-monitoring-pts.md
@@ -1,0 +1,1 @@
+Cockroach Labs recommends monitoring your changefeeds to track [retryable errors](monitor-and-debug-changefeeds.html#changefeed-retry-errors) and [protected timestamp](architecture/storage-layer.html#protected-timestamps) usage. Refer to the [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) page for more information.

--- a/src/current/v23.1/changefeed-examples.md
+++ b/src/current/v23.1/changefeed-examples.md
@@ -16,9 +16,9 @@ For a summary of Core and {{ site.data.products.enterprise }} changefeed feature
 - [Cloud Storage](#create-a-changefeed-connected-to-a-cloud-storage-sink) (Amazon S3, Google Cloud Storage, Azure Storage)
 - [Webhook](#create-a-changefeed-connected-to-a-webhook-sink)
 
-See the [Changefeed Sinks](changefeed-sinks.html) page for more detail on forming sink URIs, available sink query parameters, and specifics on configuration.
+Refer to the [Changefeed Sinks](changefeed-sinks.html) page for more detail on forming sink URIs, available sink query parameters, and specifics on configuration.
 
-{% include {{ page.version.version }}/cdc/pts-gc-monitoring.md %}
+{% include {{ page.version.version }}/cdc/recommendation-monitoring-pts.md %}
 
 Use the following filters to show usage examples for either **Enterprise** or **Core** changefeeds:
 

--- a/src/current/v23.1/create-and-configure-changefeeds.md
+++ b/src/current/v23.1/create-and-configure-changefeeds.md
@@ -18,14 +18,14 @@ Both Core and {{ site.data.products.enterprise }} changefeeds require that you e
 - When an [`IMPORT INTO`](import-into.html) statement is run, any current changefeed jobs targeting that table will fail.
 - {% include {{ page.version.version }}/cdc/virtual-computed-column-cdc.md %}
 
-When creating a changefeed, it's important to consider the number of changefeeds versus the number of tables to include in a single changefeed: 
+When creating a changefeed, it's important to consider the number of changefeeds versus the number of tables to include in a single changefeed:
 
 - Changefeeds each have their own memory overhead, so every running changefeed will increase total memory usage.
 - Creating a single changefeed that will watch hundreds of tables can affect the performance of a changefeed by introducing coupling, where the performance of a watched table affects the performance of the changefeed watching it. For example, any [schema change](changefeed-messages.html#schema-changes) on any of the tables will affect the entire changefeed's performance.
 
-To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables. However, we do **not** recommend creating a single changefeed for watching hundreds of tables. 
+To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables. However, we do **not** recommend creating a single changefeed for watching hundreds of tables.
 
-We suggest monitoring the performance of your changefeeds. See [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) for more detail.
+{% include {{ page.version.version }}/cdc/recommendation-monitoring-pts.md %}
 
 ## Enable rangefeeds
 

--- a/src/current/v23.1/create-changefeed.md
+++ b/src/current/v23.1/create-changefeed.md
@@ -19,7 +19,7 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 - [Changefeeds on Tables with Column Families](changefeeds-on-tables-with-column-families.html)
 - [Export Data with Changefeeds](export-data-with-changefeeds.html)
 
-Cockroach Labs recommends monitoring your changefeeds to track [retryable errors](monitor-and-debug-changefeeds.html#changefeed-retry-errors) and [protected timestamp](architecture/storage-layer.html#protected-timestamps) usage. Refer to the [Monitor and Debug Changefeeds](monitor-and-debug-changefeeds.html) page for more information.
+{% include {{ page.version.version }}/cdc/recommendation-monitoring-pts.md %}
 
 ## Required privileges
 


### PR DESCRIPTION
Quick fix to the monitoring callout that should be at the top of pages