### PR TITLE
Correct webhook sink maximum number of retries

### DIFF
--- a/src/current/v22.2/changefeed-sinks.md
+++ b/src/current/v22.2/changefeed-sinks.md
@@ -396,7 +396,7 @@ Field              | Type                | Description      | Default
 `Flush.Messages`   | [`INT`](int.html) | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
 `Flush.Bytes`      | [`INT`](int.html) | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
 `Flush.Frequency`  | [`INTERVAL`](interval.html) | When this amount of time has passed since the **first** received message in the batch without it flushing, it should be flushed. | `"0s"`
-`Retry.Max`        | [`INT`](int.html) | The maximum number of retries that will be attempted when sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
+`Retry.Max`        | [`INT`](int.html) | The maximum number of attempted retries after sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
 `Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will exponentially increase until the maximum retry time of 30 seconds is reached.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then at most `4` retries will be performed with the backoff times of `10s`, `20s`, `30s`, `30s`.  | `"500ms"`
 
 For example:

--- a/src/current/v22.2/changefeed-sinks.md
+++ b/src/current/v22.2/changefeed-sinks.md
@@ -393,11 +393,11 @@ The following details the configurable fields:
 
 Field              | Type                | Description      | Default
 -------------------+---------------------+------------------+-------------------
-`Flush.Messages`   | [`INT`](int.html) | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
-`Flush.Bytes`      | [`INT`](int.html) | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
+`Flush.Messages`   | [`INT`](int.html)   | The batch is flushed and its messages are sent when it contains this many messages. | `0`
+`Flush.Bytes`      | [`INT`](int.html)   | The batch is flushed when the total byte sizes of all its messages reaches this threshold. | `0`
 `Flush.Frequency`  | [`INTERVAL`](interval.html) | When this amount of time has passed since the **first** received message in the batch without it flushing, it should be flushed. | `"0s"`
-`Retry.Max`        | [`INT`](int.html) | The maximum number of attempted retries after sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
-`Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will exponentially increase until the maximum retry time of 30 seconds is reached.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then at most `4` retries will be performed with the backoff times of `10s`, `20s`, `30s`, `30s`.  | `"500ms"`
+`Retry.Max`        | [`INT`](int.html) | The maximum number of attempted retries after sending a message batch in an HTTP request fails. Specify either an integer greater than zero or the string `inf` to retry indefinitely. | `3`
+`Retry.Backoff`    | [`INTERVAL`](interval.html) | How long the sink waits before retrying after the first failure. The backoff will double until it reaches the maximum retry time of 30 seconds.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then the sink will try at most `4` retries, with `10s`, `20s`, `30s`, and `30s` backoff times.  | `"500ms"`
 
 For example:
 

--- a/src/current/v22.2/changefeed-sinks.md
+++ b/src/current/v22.2/changefeed-sinks.md
@@ -393,11 +393,17 @@ The following details the configurable fields:
 
 Field              | Type                | Description      | Default
 -------------------+---------------------+------------------+-------------------
-`Flush.Messages`   | [`INT`](int.html)   | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
-`Flush.Bytes`      | [`INT`](int.html)   | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
+`Flush.Messages`   | [`INT`](int.html) | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
+`Flush.Bytes`      | [`INT`](int.html) | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
 `Flush.Frequency`  | [`INTERVAL`](interval.html) | When this amount of time has passed since the **first** received message in the batch without it flushing, it should be flushed. | `"0s"`
-`Retry.Max`        | [`INT`](int.html) or [`STRING`](string.html) | The maximum amount of time the sink will retry a single HTTP request to send a batch. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `"0s"`
-`Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will double (exponential backoff strategy), until the max is hit. | `"500ms"`
+`Retry.Max`        | [`INT`](int.html) | The maximum number of retries that will be attempted when sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
+`Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will exponentially increase until the maximum retry time of 30 seconds is reached.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then at most `4` retries will be performed with the backoff times of `10s`, `20s`, `30s`, `30s`.  | `"500ms"`
+
+For example:
+
+~~~
+webhook_sink_config = '{ "Flush": {"Messages": 100, "Frequency": "5s"}, "Retry": { "Max": 4, "Backoff": "10s"} }'
+~~~
 
 {{site.data.alerts.callout_danger}}
 Setting either `Messages` or `Bytes` with a non-zero value without setting `Frequency`, will cause the sink to assume `Frequency` has an infinity value. If either `Messages` or `Bytes` have a non-zero value, then a non-zero value for `Frequency` **must** be provided. This configuration is invalid and will cause an error, since the messages could sit in a batch indefinitely if the other conditions do not trigger.

--- a/src/current/v23.1/changefeed-sinks.md
+++ b/src/current/v23.1/changefeed-sinks.md
@@ -413,11 +413,11 @@ The following details the configurable fields:
 
 Field              | Type                | Description      | Default
 -------------------+---------------------+------------------+-------------------
-`Flush.Messages`   | [`INT`](int.html)   | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
-`Flush.Bytes`      | [`INT`](int.html)   | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
+`Flush.Messages`   | [`INT`](int.html)   | The batch is flushed and its messages are sent when it contains this many messages. | `0`
+`Flush.Bytes`      | [`INT`](int.html)   | The batch is flushed when the total byte sizes of all its messages reaches this threshold. | `0`
 `Flush.Frequency`  | [`INTERVAL`](interval.html) | When this amount of time has passed since the **first** received message in the batch without it flushing, it should be flushed. | `"0s"`
-`Retry.Max`        | [`INT`](int.html) | The maximum number of attempted retries after sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
-`Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will exponentially increase until the maximum retry time of 30 seconds is reached.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then at most `4` retries will be performed with the backoff times of `10s`, `20s`, `30s`, `30s`.  | `"500ms"`
+`Retry.Max`        | [`INT`](int.html) | The maximum number of attempted retries after sending a message batch in an HTTP request fails. Specify either an integer greater than zero or the string `inf` to retry indefinitely. | `3`
+`Retry.Backoff`    | [`INTERVAL`](interval.html) | How long the sink waits before retrying after the first failure. The backoff will double until it reaches the maximum retry time of 30 seconds.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then the sink will try at most `4` retries, with `10s`, `20s`, `30s`, and `30s` backoff times.  | `"500ms"`
 
 For example:
 

--- a/src/current/v23.1/changefeed-sinks.md
+++ b/src/current/v23.1/changefeed-sinks.md
@@ -416,8 +416,14 @@ Field              | Type                | Description      | Default
 `Flush.Messages`   | [`INT`](int.html)   | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
 `Flush.Bytes`      | [`INT`](int.html)   | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
 `Flush.Frequency`  | [`INTERVAL`](interval.html) | When this amount of time has passed since the **first** received message in the batch without it flushing, it should be flushed. | `"0s"`
-`Retry.Max`        | [`INT`](int.html) or [`STRING`](string.html) | The maximum amount of time the sink will retry a single HTTP request to send a batch. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `"0s"`
-`Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will double (exponential backoff strategy), until the max is hit. | `"500ms"`
+`Retry.Max`        | [`INT`](int.html) | The maximum number of retries that will be attempted when sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
+`Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will exponentially increase until the maximum retry time of 30 seconds is reached.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then at most `4` retries will be performed with the backoff times of `10s`, `20s`, `30s`, `30s`.  | `"500ms"`
+
+For example:
+
+~~~
+webhook_sink_config = '{ "Flush": {"Messages": 100, "Frequency": "5s"}, "Retry": { "Max": 4, "Backoff": "10s"} }'
+~~~
 
 {{site.data.alerts.callout_danger}}
 Setting either `Messages` or `Bytes` with a non-zero value without setting `Frequency`, will cause the sink to assume `Frequency` has an infinity value. If either `Messages` or `Bytes` have a non-zero value, then a non-zero value for `Frequency` **must** be provided. This configuration is invalid and will cause an error, since the messages could sit in a batch indefinitely if the other conditions do not trigger.

--- a/src/current/v23.1/changefeed-sinks.md
+++ b/src/current/v23.1/changefeed-sinks.md
@@ -416,7 +416,7 @@ Field              | Type                | Description      | Default
 `Flush.Messages`   | [`INT`](int.html)   | When the batch reaches this configured size, it should be flushed (batch sent). | `0`
 `Flush.Bytes`      | [`INT`](int.html)   | When the total byte size of all the messages in the batch reaches this amount, it should be flushed. | `0`
 `Flush.Frequency`  | [`INTERVAL`](interval.html) | When this amount of time has passed since the **first** received message in the batch without it flushing, it should be flushed. | `"0s"`
-`Retry.Max`        | [`INT`](int.html) | The maximum number of retries that will be attempted when sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
+`Retry.Max`        | [`INT`](int.html) | The maximum number of attempted retries after sending a message batch in an HTTP request fails. This value must be positive (> 0). If infinite retries are desired, use `inf`. | `3`
 `Retry.Backoff`    | [`INTERVAL`](interval.html) | The initial backoff the sink will wait after the first failure. The backoff will exponentially increase until the maximum retry time of 30 seconds is reached.<br><br>For example, if `Retry.Max = 4` and `Retry.Backoff = 10s`, then at most `4` retries will be performed with the backoff times of `10s`, `20s`, `30s`, `30s`.  | `"500ms"`
 
 For example:


### PR DESCRIPTION
Fixes DOC-7841

The `webhook_sink_config` `Retry.Max` field was described incorrectly as the maximum amount of time. This provides clarification on the two retry fields and provides an example of specifying the option.