### PR TITLE
DOC-7211: Log export and metric export docs should remove language around older cluster limitations

### DIFF
--- a/src/current/cockroachcloud/export-logs.md
+++ b/src/current/cockroachcloud/export-logs.md
@@ -8,14 +8,8 @@ cloud: true
 
 {{ site.data.products.dedicated }} users can use the [Cloud API](cloud-api.html) to configure log export to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your {{ site.data.products.dedicated }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, send log entries to specific log group targets by log channel, among others.
 
-{{site.data.alerts.callout_danger}}
-The {{ site.data.products.dedicated }} log export feature is only available on clusters created after August 11, 2022 (AWS) or September 9, 2022 (GCP).
-
-During [limited access](/docs/{{site.versions["stable"]}}/cockroachdb-feature-availability.html), log export is not supported for {{ site.data.products.dedicated }} clusters on Azure. Refer to [{{ site.data.products.dedicated }} on Azure](cockroachdb-dedicated-on-azure.html).
-{{site.data.alerts.end}}
-
 {{site.data.alerts.callout_info}}
-{% include_cached feature-phases/limited-access.md %}
+{% include_cached feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
 ## The `logexport` endpoint
@@ -63,10 +57,6 @@ Where:
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-log-export">
-
-{{site.data.alerts.callout_danger}}
-The {{ site.data.products.dedicated }} log export feature is only available on AWS-hosted clusters created after August 11, 2022.
-{{site.data.alerts.end}}
 
 Perform the following steps to enable log export from your {{ site.data.products.dedicated }} cluster to AWS CloudWatch.
 
@@ -239,10 +229,6 @@ Perform the following steps to enable log export from your {{ site.data.products
 </section>
 
 <section class="filter-content" markdown="1" data-scope="gcp-log-export">
-
-{{site.data.alerts.callout_danger}}
-The {{ site.data.products.dedicated }} log export feature is only available on GCP-hosted clusters created after September 9, 2022.
-{{site.data.alerts.end}}
 
 Perform the following steps to enable log export from your {{ site.data.products.dedicated }} cluster to GCP Cloud Logging.
 
@@ -420,7 +406,6 @@ Where:
 
 ## Limitations
 
-- The {{ site.data.products.dedicated }} log export feature is only available on clusters created after August 11, 2022 (AWS) or September 9, 2022 (GCP).
 - {{ site.data.products.dedicated }} clusters hosted on AWS can only export logs to AWS CloudWatch. Similarly, {{ site.data.products.dedicated }} clusters hosted on GCP can only export logs to GCP Cloud Logging.
 
 ## {{ site.data.products.dedicated }} log export Frequently Asked Questions (FAQ)

--- a/src/current/cockroachcloud/export-metrics.md
+++ b/src/current/cockroachcloud/export-metrics.md
@@ -12,7 +12,7 @@ cloud: true
 {{ site.data.products.dedicated }} clusters use Cloud Console instead of DB Console, and DB Console is disabled. To export metrics from a {{ site.data.products.core }} cluster, refer to [Monitoring and Alerting](/docs/{{site.versions["dev"]}}/monitoring-and-alerting.html) instead of this page.
 {{site.data.alerts.end}}
 
-Exporting metrics to AWS CloudWatch is only available on {{ site.data.products.dedicated }} clusters which are hosted on AWS, and were created after August 11, 2022. Metrics export to Datadog is supported on all {{ site.data.products.dedicated }} clusters regardless of creation date.
+Exporting metrics to AWS CloudWatch is only available on {{ site.data.products.dedicated }} clusters which are hosted on AWS. Metrics export to Datadog is supported on all {{ site.data.products.dedicated }} clusters.
 
 {{site.data.alerts.callout_info}}
 {% include_cached feature-phases/preview.md %}
@@ -51,7 +51,7 @@ See [Service accounts](managing-access.html#manage-service-accounts) for instruc
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
 
 {{site.data.alerts.callout_danger}}
-The metrics export feature is only available on {{ site.data.products.dedicated }} clusters created after August 11, 2022. If your {{ site.data.products.dedicated }} cluster was created before this date, you must create a new cluster to utilize metrics export, or [export metrics to Datadog](export-metrics.html?filters=datadog-metrics-export) instead.
+Exporting metrics to AWS CloudWatch is only available on {{ site.data.products.dedicated }} clusters which are hosted on AWS. If your {{ site.data.products.dedicated }} cluster is hosted on GCP, you can [export metrics to Datadog](export-metrics.html?filters=datadog-metrics-export) instead.
 {{site.data.alerts.end}}
 
 Perform the following steps to enable metrics export from your {{ site.data.products.dedicated }} cluster to AWS CloudWatch.
@@ -311,7 +311,6 @@ Where:
 
 ## Limitations
 
-- Metrics export to AWS CloudWatch is currently only available on {{ site.data.products.dedicated }} clusters created after August 11, 2022.
 - Metrics export to AWS CloudWatch is only available on {{ site.data.products.dedicated }} clusters which are hosted on AWS. If your {{ site.data.products.dedicated }} cluster is hosted on GCP, you can [export metrics to Datadog](export-metrics.html?filters=datadog-metrics-export) instead.
 - AWS CloudWatch does not currently support histograms. Any histogram-type metrics emitted from your {{ site.data.products.dedicated }} cluster are dropped by CloudWatch. See [Prometheus metric type conversion](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics-conversion.html) for more information, and [Logging dropped Prometheus metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-troubleshooting-EKS.html#ContainerInsights-Prometheus-troubleshooting-droppedmetrics) for instructions on tracking dropped histogram metrics in CloudWatch.
 
@@ -323,4 +322,4 @@ Be sure you are providing **your own** AWS Account ID as shown on the AWS [IAM p
 
 If you are using an existing AWS role, or are otherwise using a role name different from the example name used in this tutorial, be sure to use your own role name in step 8 in place of `CockroachCloudMetricsExportRole`.
 
-Your {{ site.data.products.dedicated }} cluster must be running on AWS (not GCP), and must have been created after August 11, 2022 to make use of metrics export to AWS CloudWatch.
+Your {{ site.data.products.dedicated }} cluster must be running on AWS (not GCP) to make use of metrics export to AWS CloudWatch. If your {{ site.data.products.dedicated }} cluster is hosted on GCP, you can [export metrics to Datadog](export-metrics.html?filters=datadog-metrics-export) instead.

--- a/src/current/v23.1/cockroachdb-feature-availability.md
+++ b/src/current/v23.1/cockroachdb-feature-availability.md
@@ -17,19 +17,9 @@ This page outlines _feature availability_, which is separate from Cockroach Labs
 Phase                                         | Definition | Accessibility
 ----------------------------------------------+------------+-------------
 Private preview                               | Feature is not production-ready and will not be publicly documented. | Invite-only
-[Limited access](#features-in-limited-access) | Feature is production-ready but not available widely because of known limitations and/or because capabilities may change or be added based on feedback. | Opt-in </br>Contact your Cockroach Labs account team.
+Limited access                                | Feature is production-ready but not available widely because of known limitations and/or because capabilities may change or be added based on feedback. | Opt-in </br>Contact your Cockroach Labs account team.
 [Preview](#features-in-preview)               | Feature is production-ready and publicly available. However, this feature may have known limitations and/or capabilities may change or be added based on feedback. | Public
 General availability (GA)                     | Feature is production-ready and publicly available. | Public
-
-## Features in limited access
-
-{{site.data.alerts.callout_info}}
-**The following features are in limited access** and are only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. These features are subject to change.
-{{site.data.alerts.end}}
-
-### Export logs from {{ site.data.products.dedicated }} clusters
-
-{{ site.data.products.dedicated }} users can use the [Cloud API](../cockroachcloud/cloud-api.html) to configure [log export](../cockroachcloud/export-logs.html) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your {{ site.data.products.dedicated }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, and send log entries to specific log group targets by log channel, among others.
 
 ## Features in preview
 
@@ -49,6 +39,10 @@ Command                                     | Description
 ### Super regions
 
 [Super regions](multiregion-overview.html#super-regions) allow you to define a set of database regions such that schema objects will have all of their replicas stored _only_ in regions that are members of the super region. The primary use case for super regions is data domiciling.
+
+### Export logs from {{ site.data.products.dedicated }} clusters
+
+{{ site.data.products.dedicated }} users can use the [Cloud API](../cockroachcloud/cloud-api.html) to configure [log export](../cockroachcloud/export-logs.html) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your {{ site.data.products.dedicated }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, and send log entries to specific log group targets by log channel, among others.
 
 ### Export metrics from {{ site.data.products.dedicated }} clusters
 


### PR DESCRIPTION
Addresses DOC-7211

Updated export logs and export metrics pages, removed references to creation date restrictions

This PR replaces https://github.com/cockroachdb/docs/pull/16516
