### PR TITLE
DOC-7876: Update performance-tuning recipes for unused and missing indexes recommendations

### DIFF
--- a/src/current/_includes/v22.2/ui/insights.md
+++ b/src/current/_includes/v22.2/ui/insights.md
@@ -157,7 +157,7 @@ To display this view, click **Insights** in the left-hand navigation of the Clou
 
 This view lists the [indexes]({{ link_prefix }}indexes.html) that have not been used and should be dropped, and/or the ones that should be created, altered, or replaced (based on statement execution).
 
-- The drop recommendations are the same as those on the [**Databases**]({{ link_prefix }}ui-databases-page.html) page.
+- The drop recommendations are the same as those on the [**Databases**]({{ link_prefix }}ui-databases-page.html#index-recommendations) page.
 - The create, alter, and replace recommendations are the same as those on the [**Explain Plans** tab]({{ link_prefix }}ui-statements-page.html#insights) on the Statements page. Whereas the **Explain Plans** tab shows all recommendations, the **Schema Insights** view shows only the latest recommendations for that statement fingerprint. If you execute a statement again after creating or updating an index, the recommendation disappears.
 
 {% if page.cloud != true -%}

--- a/src/current/_includes/v23.1/performance/sql-trace-txn-enable-threshold.md
+++ b/src/current/_includes/v23.1/performance/sql-trace-txn-enable-threshold.md
@@ -1,6 +1,6 @@
-{% if include.version_prefix != nil %}
-    {% assign url = include.version_prefix | append: "cluster-settings.html#setting-sql-trace-txn-enable-threshold" | absolute_url %}
-{% else %}
-    {% assign url = "cluster-settings.html#setting-sql-trace-txn-enable-threshold" %}
-{% endif %}
-The default tracing behavior captures a small percent of transactions, so not all contention events will be recorded. When investigating transaction contention, you can set the `sql.trace.txn.enable_threshold` [cluster setting]({{ url }}) to always capture contention events.
+{%- if include.version_prefix != nil -%}
+    {%- assign url = include.version_prefix | append: "cluster-settings.html#setting-sql-trace-txn-enable-threshold" | absolute_url -%}
+{%- else -%}
+    {%- assign url = "cluster-settings.html#setting-sql-trace-txn-enable-threshold" -%}
+{%- endif -%}
+The default tracing behavior captures a small percent of transactions, so not all contention events will be recorded. When investigating transaction contention, you can set the [`sql.trace.txn.enable_threshold` cluster setting]({{ url }}) to always capture contention events.

--- a/src/current/_includes/v23.1/ui/insights.md
+++ b/src/current/_includes/v23.1/ui/insights.md
@@ -113,8 +113,9 @@ Application Name | The name specified by the [`application_name`]({{ link_prefix
 Rows Processed | The total number of rows read and written.
 Retries | The number of times the statement execution was [retried]({{ link_prefix }}transactions.html#automatic-retries).
 Contention Time | The amount of time the statement execution spent waiting in [contention]({{ link_prefix }}performance-best-practices-overview.html#transaction-contention).
-CPU Time | The amount of CPU time spent executing the statement. The CPU time represents the time spent and work done within SQL execution operators. <br><br>{% if page.cloud != true -%}The CPU time includes time spent in the [SQL layer](architecture/sql-layer.html). It does not include time spent in the [storage layer](architecture/storage-layer.html).{% endif -%}{% if page.cloud == true -%}The CPU time includes time spent in the [SQL layer](../stable/architecture/sql-layer.html). It does not include time spent in the [storage layer](../stable/architecture/storage-layer.html).
-{% endif -%}
+CPU Time | The amount of CPU time spent executing the statement. The CPU time represents the time spent and work done within SQL execution operators. <br><br>{%- if page.cloud != true -%}The CPU time includes time spent in the [SQL layer](architecture/sql-layer.html). It does not include time spent in the [storage layer](architecture/storage-layer.html).{%- endif -%}{%- if page.cloud == true -%}The CPU time includes time spent in the [SQL layer](../stable/architecture/sql-layer.html). It does not include time spent in the [storage layer](../stable/architecture/storage-layer.html).
+{%- endif -%}
+<br>
 Full Scan | Whether the execution performed a full scan of the table.
 Transaction Fingerprint ID | The ID of the transaction fingerprint for the statement execution.
 Latest Transaction Execution ID | The ID of the transaction execution for the statement execution.
@@ -234,7 +235,7 @@ To display this view, click **Insights** in the left-hand navigation of the Clou
 
 This view lists the [indexes]({{ link_prefix }}indexes.html) that have not been used and should be dropped, and/or the ones that should be created, altered, or replaced (based on statement execution).
 
-- The drop recommendations are the same as those on the [**Databases**]({{ link_prefix }}ui-databases-page.html) page.
+- The drop recommendations are the same as those on the [**Databases**]({{ link_prefix }}ui-databases-page.html#index-recommendations) page.
 - The create, alter, and replace recommendations are the same as those on the [Explain Plans tab]({{ link_prefix }}ui-statements-page.html#insights) on the Statements page. Whereas the **Explain Plans** tab shows all recommendations, the **Schema Insights** view shows only the latest recommendations for that statement fingerprint. If you execute a statement again after creating or updating an index, the recommendation disappears.
 
 {% if page.cloud != true -%}

--- a/src/current/_includes/v23.1/ui/transaction-details.md
+++ b/src/current/_includes/v23.1/ui/transaction-details.md
@@ -13,6 +13,7 @@ The details displayed on the **Transaction Details** page reflect the [time inte
     - **Max scratch disk usage**: The maximum amount of data [spilled to temporary storage on disk]({{ link_prefix }}vectorized-execution.html#disk-spilling-operations) while executing this transaction within the aggregation interval.
 
 The **Insights** table is displayed when CockroachDB has detected a problem with the transaction fingerprint.
+
 - **Insights**: Provides the [Workload Insight type](ui-insights-page.html#workload-insight-types).
 - **Details**: Provides a description and possible recommendation.
 - **Latest Execution ID**: The ID of the latest transaction execution. To display the [details of the transaction execution](ui-insights-page.html#transaction-execution-details), click the ID.

--- a/src/current/v22.2/performance-recipes.md
+++ b/src/current/v22.2/performance-recipes.md
@@ -107,7 +107,7 @@ Full table scans often result in poor statement performance.
     FROM crdb_internal.node_statement_statistics
     WHERE full_scan = true;
     ~~~
-* Viewing the statement plan on the [Statement details page](ui-statements-page.html#statement-fingerprint-page) in the DB Console indicates that the plan contains full table scans.
+* Viewing the statement plan on the [**Statement Fingerprint** page](ui-statements-page.html#statement-fingerprint-page) in the DB Console indicates that the plan contains full table scans.
 * The statement plans returned by the [`EXPLAIN`](sql-tuning-with-explain.html) and [`EXPLAIN ANALYZE` commands](explain-analyze.html) indicate that there are full table scans.
 * The [Full Table/Index Scans graph](ui-sql-dashboard.html#full-table-index-scans) in the DB Console is showing spikes over time.
 
@@ -116,6 +116,8 @@ Full table scans often result in poor statement performance.
 Not every full table scan is an indicator of poor performance. The [cost-based optimizer](cost-based-optimizer.html) may decide on a full table scan when other [index](indexes.html) or [join scans](joins.html) would result in longer execution time.
 
 [Examine the statements](sql-tuning-with-explain.html) that result in full table scans and consider adding [secondary indexes](schema-design-indexes.html#create-a-secondary-index).
+
+In the DB Console, visit the [**Schema Insights** tab](ui-insights-page.html#schema-insights-tab) on the [**Insights** page](ui-insights-page.html) and check if there are any insights to create missing indexes. These missing index recommendations are generated based on [slow statement execution](ui-insights-page.html#detect-slow-executions). A missing index may cause a statement to have a [suboptimal plan](ui-insights-page.html#statement-execution-details). If the execution was slow, based on the insights threshold, then it's likely the create index recommendation is valid. If the plan had a full table scan, it's likely that it should be removed with an index.
 
 Also see [Table scans best practices](performance-best-practices-overview.html#table-scan-best-practices).
 
@@ -142,6 +144,7 @@ If the [Overview dashboard](ui-overview-dashboard.html) in the DB Console shows 
 
 [Secondary indexes](schema-design-indexes.html) can improve application read performance. However, there is overhead in maintaining secondary indexes that can affect your write performance. You should profile your tables periodically to determine whether an index is worth the overhead. To identify infrequently accessed indexes that could be candidates to drop, do one of the following:
 
+- In the DB Console, visit the [**Schema Insights** tab](ui-insights-page.html#schema-insights-tab) on the [**Insights** page](ui-insights-page.html) and check if there are any insights to drop unused indexes.
 - In the DB Console, visit the [**Databases** page](ui-databases-page.html) and check databases and tables for [**Index Recommendations**](ui-databases-page.html#index-recommendations) to drop unused indexes.
 - Run a join query against the [`crdb_internal.index_usage_statistics`](crdb-internal.html#index_usage_statistics) and `crdb_internal.table_indexes` tables:
 

--- a/src/current/v23.1/performance-recipes.md
+++ b/src/current/v23.1/performance-recipes.md
@@ -104,7 +104,7 @@ These are indicators that lock contention occurred in the past:
 
   - This is also shown in the **Transaction Executions** view on the **Insights** page ([{{ site.data.products.db }} Console](../cockroachcloud/insights-page.html#transaction-executions-view) and [DB Console](ui-insights-page.html#transaction-executions-view)). Transaction executions will display the **High Contention** insight. 
     {{site.data.alerts.callout_info}}
-    {% include {{ page.version.version }}/performance/sql-trace-txn-enable-threshold.md %}
+    {%- include {{ page.version.version }}/performance/sql-trace-txn-enable-threshold.md -%}
     {{site.data.alerts.end}}
 
 - The **SQL Statement Contention** graph ([{{ site.data.products.db }} Console](../cockroachcloud/metrics-page.html#sql-statement-contention) and [DB Console](ui-sql-dashboard.html#sql-statement-contention)) is showing spikes over time.
@@ -212,7 +212,7 @@ Full table scans often result in poor statement performance.
     FROM crdb_internal.node_statement_statistics
     WHERE full_scan = true;
     ~~~
-* Viewing the statement plan on the [Statement details page](ui-statements-page.html#statement-fingerprint-page) in the DB Console indicates that the plan contains full table scans.
+* Viewing the statement plan on the [**Statement Fingerprint** page](ui-statements-page.html#statement-fingerprint-page) in the DB Console indicates that the plan contains full table scans.
 * The statement plans returned by the [`EXPLAIN`](sql-tuning-with-explain.html) and [`EXPLAIN ANALYZE` commands](explain-analyze.html) indicate that there are full table scans.
 * The [Full Table/Index Scans graph](ui-sql-dashboard.html#full-table-index-scans) in the DB Console is showing spikes over time.
 
@@ -221,6 +221,8 @@ Full table scans often result in poor statement performance.
 Not every full table scan is an indicator of poor performance. The [cost-based optimizer](cost-based-optimizer.html) may decide on a full table scan when other [index](indexes.html) or [join scans](joins.html) would result in longer execution time.
 
 [Examine the statements](sql-tuning-with-explain.html) that result in full table scans and consider adding [secondary indexes](schema-design-indexes.html#create-a-secondary-index).
+
+In the DB Console, visit the [**Schema Insights** tab](ui-insights-page.html#schema-insights-tab) on the [**Insights** page](ui-insights-page.html) and check if there are any insights to create missing indexes. These missing index recommendations are generated based on [slow statement execution](ui-insights-page.html#detect-slow-executions). A missing index may cause a statement to have a [suboptimal plan](ui-insights-page.html#suboptimal-plan). If the execution was slow, based on the insights threshold, then it's likely the create index recommendation is valid. If the plan had a full table scan, it's likely that it should be removed with an index.
 
 Also see [Table scans best practices](performance-best-practices-overview.html#table-scan-best-practices).
 
@@ -247,6 +249,7 @@ If the [Overview dashboard](ui-overview-dashboard.html) in the DB Console shows 
 
 [Secondary indexes](schema-design-indexes.html) can improve application read performance. However, there is overhead in maintaining secondary indexes that can affect your write performance. You should profile your tables periodically to determine whether an index is worth the overhead. To identify infrequently accessed indexes that could be candidates to drop, do one of the following:
 
+- In the DB Console, visit the [**Schema Insights** tab](ui-insights-page.html#schema-insights-tab) on the [**Insights** page](ui-insights-page.html) and check if there are any insights to drop unused indexes.
 - In the DB Console, visit the [**Databases** page](ui-databases-page.html) and check databases and tables for [**Index Recommendations**](ui-databases-page.html#index-recommendations) to drop unused indexes.
 - Run a join query against the [`crdb_internal.index_usage_statistics`](crdb-internal.html#index_usage_statistics) and `crdb_internal.table_indexes` tables:
 


### PR DESCRIPTION
Addresses: DOC-7876 

(A) Updated Performance Tuning Recipes page, (1) added references to Schema Insights tab to drop unused indexes and create missing indexes. (2) Fixed right TOC by adding hyphens to liquid delimiters. (B) Updated Insights page, (1) changed link to point to Index Recommendations section of Databases page, (2) fixed table format. (C) Updated Transactions page, fixed bullet list format.