### PR TITLE
Bump ccloud version to 0.4.9

### DIFF
--- a/src/current/_includes/cockroachcloud/ccloud/install-ccloud.md
+++ b/src/current/_includes/cockroachcloud/ccloud/install-ccloud.md
@@ -1,4 +1,4 @@
-{% assign ccloud_version = "0.3.7" %}
+{% assign ccloud_version = "0.4.9" %}
 
 Choose your OS:
 


### PR DESCRIPTION
Closes [DOC-8082](https://cockroachlabs.atlassian.net/browse/DOC-8082).