### PR TITLE
clarify that SCT can be used for self-hosted migrations

### DIFF
--- a/src/current/_includes/cockroachcloud/migration/sct-self-hosted.md
+++ b/src/current/_includes/cockroachcloud/migration/sct-self-hosted.md
@@ -1,5 +1,5 @@
 {% if page.cloud != true %}
 If you are migrating to a {{ site.data.products.core }} database, you can [export the converted schema](../cockroachcloud/migrations-page.html#export-the-schema) and execute the statements in [`cockroach sql`](cockroach-sql.html), or use a third-party schema migration tool such as [Alembic](alembic.html), [Flyway](flyway.html), or [Liquibase](liquibase.html).
 {% else %}
-If you are migrating to a {{ site.data.products.core }} database, you can [export the converted schema](migrations-page.html#export-the-schema) and execute the statements in [`cockroach sql`](../{{version_prefix}}cockroach-sql.html), or use a third-party schema migration tool such as [Alembic](../{{version_prefix}}alembic.html), [Flyway](../{{version_prefix}}flyway.html), or [Liquibase](../{{version_prefix}}liquibase.html).
+To migrate to a {{ site.data.products.core }} database, you can execute the statements in [`cockroach sql`](../{{version_prefix}}cockroach-sql.html), or use a third-party schema migration tool such as [Alembic](../{{version_prefix}}alembic.html), [Flyway](../{{version_prefix}}flyway.html), or [Liquibase](../{{version_prefix}}liquibase.html).
 {% endif %}

--- a/src/current/cockroachcloud/migrations-page.md
+++ b/src/current/cockroachcloud/migrations-page.md
@@ -11,7 +11,8 @@ docs_area: migrate
 The **Migrations** page on the {{ site.data.products.db }} Console features a **Schema Conversion Tool** that helps you:
 
 - Convert a schema from a PostgreSQL, MySQL, Oracle, or Microsoft SQL Server database for use with CockroachDB.
-- Create a new {{ site.data.products.serverless }} database that uses the converted schema. You specify the target database and database owner when [migrating the schema](#migrate-the-schema). {% include cockroachcloud/migration/sct-self-hosted.md %}
+- [Export the converted schema.](#export-the-schema) {% include cockroachcloud/migration/sct-self-hosted.md %}
+- Migrate directly to a {{ site.data.products.serverless }} database that uses the converted schema. You specify the target database and database owner when [migrating the schema](#migrate-the-schema).
 
     {{site.data.alerts.callout_info}}
     The **Migrations** page is used to convert a schema for use with CockroachDB and to create a new database that uses the schema. It does not include moving data to the new database. For details on all steps required to complete a database migration, see [Migrate Your Database to CockroachDB](../{{version_prefix}}migration-overview.html).


### PR DESCRIPTION
Clarify that you can use the SCT to export the schema for a migration to CockroachDB Self-Hosted. This point was already in the docs but was not as visible as it could be.