### PR TITLE
[DOC-796] Document that nodes now log their progress shutting down

### DIFF
--- a/src/current/v22.1/logging-overview.md
+++ b/src/current/v22.1/logging-overview.md
@@ -9,7 +9,7 @@ If you need to monitor your cluster, tune performance, or [troubleshoot](trouble
 
 ## Details
 
-When a node processes a [`cockroach` command](cockroach-commands.html), it produces a stream of messages about the command's activities. Each message is composed of:
+When a node starts, shuts down, or processes a [`cockroach` command](cockroach-commands.html), it produces a stream of messages about the command's activities. Each message is composed of:
 
 - A payload that contains events either structured in JSON or conveyed in an arbitrary string. For details on structured event types and their fields, see [Notable Event Types](eventlog.html).
 - An envelope that contains event metadata (e.g., severity, date, timestamp, channel). Depending on the log format you specify when [configuring logs](configure-logs.html#file-logging-format), the envelope can be formatted either in JSON or as a flat prefix to the message.

--- a/src/current/v22.1/node-shutdown.md
+++ b/src/current/v22.1/node-shutdown.md
@@ -356,6 +356,8 @@ To drain the node without process termination, see [Drain a node manually](#drai
 
 ## Monitor shutdown progress
 
+After you initiate a node shutdown or restart, the node's progress is regularly logged to the [default logging destination](logging-overview.html#logging-destinations) until the operation is complete. The following sections provide additional ways to monitor the operation's progress.
+
 ### `OPS`
 
 During node shutdown, progress messages are generated in the [`OPS` logging channel](logging-overview.html#logging-channels). The frequency of these messages is configured with [`server.shutdown.lease_transfer_wait`](#server-shutdown-lease_transfer_wait). [By default](configure-logs.html#default-logging-configuration), the `OPS` logs output to a `cockroach.log` file.

--- a/src/current/v22.2/logging-overview.md
+++ b/src/current/v22.2/logging-overview.md
@@ -9,7 +9,7 @@ If you need to monitor your cluster, tune performance, or [troubleshoot](trouble
 
 ## Details
 
-When a node processes a [`cockroach` command](cockroach-commands.html), it produces a stream of messages about the command's activities. Each message is composed of:
+When a node starts, shuts down, or processes a [`cockroach` command](cockroach-commands.html), it produces a stream of messages about the command's activities. Each message is composed of:
 
 - A payload that contains events either structured in JSON or conveyed in an arbitrary string. For details on structured event types and their fields, see [Notable Event Types](eventlog.html).
 - An envelope that contains event metadata (e.g., severity, date, timestamp, channel). Depending on the log format you specify when [configuring logs](configure-logs.html#file-logging-format), the envelope can be formatted either in JSON or as a flat prefix to the message.

--- a/src/current/v22.2/node-shutdown.md
+++ b/src/current/v22.2/node-shutdown.md
@@ -360,6 +360,8 @@ To drain the node without process termination, see [Drain a node manually](#drai
 
 ## Monitor shutdown progress
 
+After you initiate a node shutdown or restart, the node's progress is regularly logged to the [default logging destination](logging-overview.html#logging-destinations) until the operation is complete. The following sections provide additional ways to monitor the operation's progress.
+
 ### `OPS`
 
 During node shutdown, progress messages are generated in the [`OPS` logging channel](logging-overview.html#logging-channels). The frequency of these messages is configured with [`server.shutdown.lease_transfer_wait`](#server-shutdown-lease_transfer_wait). [By default](configure-logs.html#default-logging-configuration), the `OPS` logs output to a `cockroach.log` file.

--- a/src/current/v23.1/logging-overview.md
+++ b/src/current/v23.1/logging-overview.md
@@ -9,7 +9,7 @@ If you need to monitor your cluster, tune performance, or [troubleshoot](trouble
 
 ## Details
 
-When a node processes a [`cockroach` command](cockroach-commands.html), it produces a stream of messages about the command's activities. Each message is composed of:
+When a node starts, shuts down, or processes a [`cockroach` command](cockroach-commands.html), it produces a stream of messages about the command's activities. Each message is composed of:
 
 - A payload that contains events either structured in JSON or conveyed in an arbitrary string. For details on structured event types and their fields, see [Notable Event Types](eventlog.html).
 - An envelope that contains event metadata (e.g., severity, date, timestamp, channel). Depending on the log format you specify when [configuring logs](configure-logs.html#file-logging-format), the envelope can be formatted either in JSON or as a flat prefix to the message.

--- a/src/current/v23.1/node-shutdown.md
+++ b/src/current/v23.1/node-shutdown.md
@@ -362,6 +362,8 @@ To drain the node without process termination, see [Drain a node manually](#drai
 
 ## Monitor shutdown progress
 
+After you initiate a node shutdown or restart, the node's progress is regularly logged to the [default logging destination](logging-overview.html#logging-destinations) until the operation is complete. The following sections provide additional ways to monitor the operation's progress.
+
 ### `OPS`
 
 During node shutdown, progress messages are generated in the [`OPS` logging channel](logging-overview.html#logging-channels). The frequency of these messages is configured with [`server.shutdown.lease_transfer_wait`](#server-shutdown-lease_transfer_wait). [By default](configure-logs.html#default-logging-configuration), the `OPS` logs output to a `cockroach.log` file.


### PR DESCRIPTION
[DOC-796] Document that nodes now log their progress shutting down

## Previews
[src/current/v22.1/logging-overview.md](https://deploy-preview-17319--cockroachdb-docs.netlify.app/docs/v22.1/logging-overview.html)
[src/current/v22.1/node-shutdown.md](https://deploy-preview-17319--cockroachdb-docs.netlify.app/docs/v22.1/node-shutdown.html)
[src/current/v22.2/logging-overview.md](https://deploy-preview-17319--cockroachdb-docs.netlify.app/docs/v22.2/logging-overview.html)
[src/current/v22.2/node-shutdown.md](https://deploy-preview-17319--cockroachdb-docs.netlify.app/docs/v22.2/node-shutdown.html)
[src/current/v23.1/logging-overview.md](https://deploy-preview-17319--cockroachdb-docs.netlify.app/docs/v23.1/logging-overview.html)
[src/current/v23.1/node-shutdown.md](https://deploy-preview-17319--cockroachdb-docs.netlify.app/docs/v23.1/node-shutdown.html)

## Tests
- [x] Local build
- [x] Linkcheck 