### PR TITLE
Fix formatting in 23.1.0 relese notes

### DIFF
--- a/_includes/releases/v23.1/v23.1.0.md
+++ b/_includes/releases/v23.1/v23.1.0.md
@@ -128,7 +128,7 @@ By default, when granting or revoking a role from another role, the system waits
 <p>
 In some cases, you may not care about whether concurrent transactions will immediately see the side-effects of the role grant or revoke operation, but would instead prefer that the operation finish quickly.
 <p>
-For more information about this setting and how it works, see the <p>Limitations</p> section of the <a href="../v23.1/grant.html#limitations">GRANT documentation</a>.
+For more information about this setting and how it works, see <a href="../v23.1/grant.html#limitations"><code>GRANT<code> limitations</a>.
    </td>
   </tr>
   </tbody>

--- a/v21.2/aws-dms.md
+++ b/v21.2/aws-dms.md
@@ -31,7 +31,7 @@ Complete the following items before starting this tutorial:
 
     - If the output of [`SHOW SCHEDULES`](show-schedules.html) shows any backup schedules, run [`ALTER BACKUP SCHEDULE {schedule_id} SET WITH revision_history = 'false'`](../{{site.current_cloud_version}}/alter-backup-schedule.html) for each backup schedule.
     - If the output of `SHOW SCHEDULES` does not show backup schedules, [contact Support](https://support.cockroachlabs.com) to disable revision history for cluster backups.
-- Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
+- Manually create all schema objects in the target CockroachDB cluster. AWS DMS can create a basic schema, but does not create indexes or constraints such as foreign keys and defaults.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
     {{site.data.alerts.callout_info}}
@@ -175,6 +175,10 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
     ~~~
     
     This is resolved in v22.2.1. On earlier versions, do not select the **Enable validation** option if your database has a `TIMESTAMP`/`TIMESTAMPTZ` column.
+
+- If you are migrating from PostgreSQL, select **Enable validation** in your [task settings](#step-2-2-task-settings), and are using a [`STRING`](string.html) as a [`PRIMARY KEY`](primary-key.html), validation can fail due to a difference in how CockroachDB handles case sensitivity in strings. 
+
+    To prevent this error, use `COLLATE "C"` on the relevant columns in PostgreSQL or a [collation](collate.html) such as `COLLATE "en_US"` in CockroachDB.
 
 - **Drop tables on target** is not supported on v22.1 and earlier, and will error on initial load.
 

--- a/v22.1/aws-dms.md
+++ b/v22.1/aws-dms.md
@@ -42,7 +42,7 @@ Complete the following items before starting this tutorial:
 
     - If the output of [`SHOW SCHEDULES`](show-schedules.html) shows any backup schedules, run [`ALTER BACKUP SCHEDULE {schedule_id} SET WITH revision_history = 'false'`](../{{site.current_cloud_version}}/alter-backup-schedule.html) for each backup schedule.
     - If the output of `SHOW SCHEDULES` does not show backup schedules, [contact Support](https://support.cockroachlabs.com) to disable revision history for cluster backups.
-- Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
+- Manually create all schema objects in the target CockroachDB cluster. AWS DMS can create a basic schema, but does not create indexes or constraints such as foreign keys and defaults.
     - If you are migrating from a PostgreSQL database, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
     {{site.data.alerts.callout_info}}
@@ -110,7 +110,7 @@ A database migration task, also known as a replication task, controls what data 
 ### Step 2.2. Task settings
 
 1. For the **Editing mode** radio button, keep **Wizard** selected.
-1. For the **Target table preparation mode**, select **Truncate**, **Drop tables on target**, or **Do nothing**.
+1. For the **Target table preparation mode**, select **Truncate** or **Do nothing** to preserve the schema you manually created.
     <img src="{{ 'images/v22.2/aws-dms-task-settings.png' | relative_url }}" alt="AWS-DMS-Task-Settings" style="max-width:100%" />
 1. Check the **Enable CloudWatch logs** option. We highly recommend this for troubleshooting potential migration issues. 
 1. For the **Target Load**, select **Detailed debug**.
@@ -186,6 +186,10 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
     ~~~
 
     This is resolved in v22.2.1. On earlier versions, do not select the **Enable validation** option if your database has a `TIMESTAMP`/`TIMESTAMPTZ` column.
+
+- If you are migrating from PostgreSQL, select **Enable validation** in your [task settings](#step-2-2-task-settings), and are using a [`STRING`](string.html) as a [`PRIMARY KEY`](primary-key.html), validation can fail due to a difference in how CockroachDB handles case sensitivity in strings. 
+
+    To prevent this error, use `COLLATE "C"` on the relevant columns in PostgreSQL or a [collation](collate.html) such as `COLLATE "en_US"` in CockroachDB.
 
 ## Troubleshooting common issues
 

--- a/v22.2/aws-dms.md
+++ b/v22.2/aws-dms.md
@@ -43,7 +43,7 @@ Complete the following items before starting this tutorial:
 
     - If the output of [`SHOW SCHEDULES`](show-schedules.html) shows any backup schedules, run [`ALTER BACKUP SCHEDULE {schedule_id} SET WITH revision_history = 'false'`](alter-backup-schedule.html) for each backup schedule.
     - If the output of `SHOW SCHEDULES` does not show backup schedules, [contact Support](https://support.cockroachlabs.com) to disable revision history for cluster backups.
-- Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
+- Manually create all schema objects in the target CockroachDB cluster. AWS DMS can create a basic schema, but does not create indexes or constraints such as foreign keys and defaults.
     - If you are migrating from PostgreSQL, MySQL, Oracle, or Microsoft SQL Server, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your PostgreSQL tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
     {{site.data.alerts.callout_info}}
@@ -113,7 +113,7 @@ A database migration task, also known as a replication task, controls what data 
 ### Step 2.2. Task settings
 
 1. For the **Editing mode** radio button, keep **Wizard** selected.
-1. For the **Target table preparation mode**, select **Truncate**, **Drop tables on target**, or **Do nothing**.
+1. For the **Target table preparation mode**, select **Truncate** or **Do nothing** to preserve the schema you manually created.
     <img src="{{ 'images/v22.2/aws-dms-task-settings.png' | relative_url }}" alt="AWS-DMS-Task-Settings" style="max-width:100%" />
 1. Optionally check **Enable validation** to compare the data in the source and target rows, and verify that the migration succeeded. You can view the results in the [**Table statistics**](#step-3-verify-the-migration) for your migration task. For more information about data validation, see the [AWS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Validating.html).
 1. Check the **Enable CloudWatch logs** option. We highly recommend this for troubleshooting potential migration issues. 
@@ -190,6 +190,10 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
     ~~~
 
     This is resolved in v22.2.1. On earlier versions, do not select the **Enable validation** option if your database has a `TIMESTAMP`/`TIMESTAMPTZ` column.
+
+- If you are migrating from PostgreSQL, select **Enable validation** in your [task settings](#step-2-2-task-settings), and are using a [`STRING`](string.html) as a [`PRIMARY KEY`](primary-key.html), validation can fail due to a difference in how CockroachDB handles case sensitivity in strings. 
+
+    To prevent this error, use `COLLATE "C"` on the relevant columns in PostgreSQL or a [collation](collate.html) such as `COLLATE "en_US"` in CockroachDB.
 
 ## Troubleshooting common issues
 

--- a/v22.2/qlik.md
+++ b/v22.2/qlik.md
@@ -64,7 +64,7 @@ Complete the following items before using Qlik Replicate:
 
     - If the output of [`SHOW SCHEDULES`](show-schedules.html) shows any backup schedules, run [`ALTER BACKUP SCHEDULE {schedule_id} SET WITH revision_history = 'false'`](alter-backup-schedule.html) for each backup schedule.
     - If the output of `SHOW SCHEDULES` does not show backup schedules, [contact Support](https://support.cockroachlabs.com) to disable revision history for cluster backups.
-- Manually create all schema objects in the target CockroachDB cluster. This is required in order for Qlik Replicate to populate data successfully.
+- Manually create all schema objects in the target CockroachDB cluster. Qlik can create a basic schema, but does not create indexes or constraints such as foreign keys and defaults.
     - If you are migrating from PostgreSQL, MySQL, Oracle, or Microsoft SQL Server, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your tables, or add transformation rules. If you make substantial schema changes, the Qlik Replicate migration may fail.
 
     {{site.data.alerts.callout_info}}
@@ -83,6 +83,8 @@ To use a {{ site.data.products.serverless }} cluster as the target endpoint, set
 
 - To perform both an initial load and continuous replication of ongoing changes to the target tables, select **Full Load** and **Apply Changes**. This minimizes downtime for your migration.
 - To perform a one-time migration to CockroachDB, select **Full Load** only.
+
+Select **TRUNCATE before loading** or **Do nothing** to preserve the schema you manually created.
 
 {% comment %}
 ## Replicate data from CockroachDB to a secondary source

--- a/v23.1/aws-dms.md
+++ b/v23.1/aws-dms.md
@@ -43,7 +43,7 @@ Complete the following items before starting this tutorial:
 
     - If the output of [`SHOW SCHEDULES`](show-schedules.html) shows any backup schedules, run [`ALTER BACKUP SCHEDULE {schedule_id} SET WITH revision_history = 'false'`](alter-backup-schedule.html) for each backup schedule.
     - If the output of `SHOW SCHEDULES` does not show backup schedules, [contact Support](https://support.cockroachlabs.com) to disable revision history for cluster backups.
-- Manually create all schema objects in the target CockroachDB cluster. This is required in order for AWS DMS to populate data successfully.
+- Manually create all schema objects in the target CockroachDB cluster. AWS DMS can create a basic schema, but does not create indexes or constraints such as foreign keys and defaults.
     - If you are migrating from PostgreSQL, MySQL, Oracle, or Microsoft SQL Server, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your tables, or add [transformation rules](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Transformations.html). If you make substantial schema changes, the AWS DMS migration may fail.
 
     {{site.data.alerts.callout_info}}
@@ -113,7 +113,7 @@ A database migration task, also known as a replication task, controls what data 
 ### Step 2.2. Task settings
 
 1. For the **Editing mode** radio button, keep **Wizard** selected.
-1. For the **Target table preparation mode**, select **Truncate**, **Drop tables on target**, or **Do nothing**.
+1. For the **Target table preparation mode**, select **Truncate** or **Do nothing** to preserve the schema you manually created.
     <img src="{{ 'images/v23.1/aws-dms-task-settings.png' | relative_url }}" alt="AWS-DMS-Task-Settings" style="max-width:100%" />
 1. Optionally check **Enable validation** to compare the data in the source and target rows, and verify that the migration succeeded. You can view the results in the [**Table statistics**](#step-3-verify-the-migration) for your migration task. For more information about data validation, see the [AWS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Validating.html).
 1. Check the **Enable CloudWatch logs** option. We highly recommend this for troubleshooting potential migration issues. 
@@ -182,6 +182,10 @@ The `BatchApplyEnabled` setting can improve replication performance and is recom
     ~~~ sql
     > SELECT table_catalog, table_schema, table_name, column_name FROM information_schema.columns WHERE is_hidden = 'YES';
     ~~~
+
+- If you are migrating from PostgreSQL, select **Enable validation** in your [task settings](#step-2-2-task-settings), and are using a [`STRING`](string.html) as a [`PRIMARY KEY`](primary-key.html), validation can fail due to a difference in how CockroachDB handles case sensitivity in strings. 
+
+    To prevent this error, use `COLLATE "C"` on the relevant columns in PostgreSQL or a [collation](collate.html) such as `COLLATE "en_US"` in CockroachDB.
 
 ## Troubleshooting common issues
 

--- a/v23.1/qlik.md
+++ b/v23.1/qlik.md
@@ -64,12 +64,12 @@ Complete the following items before using Qlik Replicate:
 
     - If the output of [`SHOW SCHEDULES`](show-schedules.html) shows any backup schedules, run [`ALTER BACKUP SCHEDULE {schedule_id} SET WITH revision_history = 'false'`](alter-backup-schedule.html) for each backup schedule.
     - If the output of `SHOW SCHEDULES` does not show backup schedules, [contact Support](https://support.cockroachlabs.com) to disable revision history for cluster backups.
-- Manually create all schema objects in the target CockroachDB cluster. This is required in order for Qlik Replicate to populate data successfully.
+- Manually create all schema objects in the target CockroachDB cluster. Qlik can create a basic schema, but does not create indexes or constraints such as foreign keys and defaults.
     - If you are migrating from PostgreSQL, MySQL, Oracle, or Microsoft SQL Server, [use the **Schema Conversion Tool**](../cockroachcloud/migrations-page.html) to convert and export your schema. Ensure that any schema changes are also reflected on your tables, or add transformation rules. If you make substantial schema changes, the Qlik Replicate migration may fail.
 
-    {{site.data.alerts.callout_info}}
-    All tables must have an explicitly defined primary key. For more guidance, see [Migrate Your Database to CockroachDB](migration-overview.html#step-1-convert-your-schema).
-    {{site.data.alerts.end}}
+        {{site.data.alerts.callout_info}}
+        All tables must have an explicitly defined primary key. For more guidance, see [Migrate Your Database to CockroachDB](migration-overview.html#step-1-convert-your-schema).
+        {{site.data.alerts.end}}
 
 ## Migrate and replicate data to CockroachDB
 
@@ -83,6 +83,8 @@ To use a {{ site.data.products.serverless }} cluster as the target endpoint, set
 
 - To perform both an initial load and continuous replication of ongoing changes to the target tables, select **Full Load** and **Apply Changes**. This minimizes downtime for your migration.
 - To perform a one-time migration to CockroachDB, select **Full Load** only.
+
+Select **TRUNCATE before loading** or **Do nothing** to preserve the schema you manually created.
 
 {% comment %}
 ## Replicate data from CockroachDB to a secondary source


### PR DESCRIPTION
The formatting of the last link in the `Add configurable setting to adjust grant lease options` description is broken:

<img width="856" alt="Screenshot 2023-06-27 at 10 00 13 AM" src="https://github.com/cockroachdb/docs/assets/15893490/1c8b980e-e81e-49f7-9e84-f1848ad96d50">

This PR fixes the formatting.