### PR TITLE
Fix formatting in 23.1.0 release notes

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.0.md
+++ b/src/current/_includes/releases/v23.1/v23.1.0.md
@@ -128,7 +128,7 @@ By default, when granting or revoking a role from another role, the system waits
 <p>
 In some cases, you may not care about whether concurrent transactions will immediately see the side-effects of the role grant or revoke operation, but would instead prefer that the operation finish quickly.
 <p>
-For more information about this setting and how it works, see the <p>Limitations</p> section of the <a href="../v23.1/grant.html#limitations">GRANT documentation</a>.
+For more information about this setting and how it works, see <a href="../v23.1/grant.html#limitations"><code>GRANT</code> limitations</a>.
    </td>
   </tr>
   </tbody>


### PR DESCRIPTION
The formatting of the final paragraph of the `Add configurable setting to adjust grant lease options` description is broken:

<img width="856" alt="Screenshot 2023-06-27 at 10 00 13 AM" src="https://github.com/cockroachdb/docs/assets/15893490/84f37843-092b-46c3-8ddd-20cfb1eb1712">

This PR fixes the formatting.