### PR TITLE
add warning about lack of support for insecure tls 1.2 cipher suites

### DIFF
--- a/src/current/_includes/common/tls-bad-cipher-warning.md
+++ b/src/current/_includes/common/tls-bad-cipher-warning.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_info}}
-CockroachDB clusters support TLS 1.2 or TLS 1.3 encryption and authentication for SQL clients. However, the following less-secure TLS 1.2 cipher suites are rejected by default, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447):
+CockroachDB clusters support TLS 1.2 or TLS 1.3 encryption for SQL clients. However, the following less-secure TLS 1.2 cipher suites are rejected by default, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447):
 
 - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
 - `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`

--- a/src/current/_includes/common/tls-bad-cipher-warning.md
+++ b/src/current/_includes/common/tls-bad-cipher-warning.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_info}}
-CockroachDB clusters can talk TLS 1.2 or TLS 1.3 to SQL clients for encryption-in-flight and to prove each other's identities. However, the following less-secure TLS 1.2 cipher suites are rejected, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447):
+CockroachDB clusters support TLS 1.2 or TLS 1.3 encryption and authentication for SQL clients. However, the following less-secure TLS 1.2 cipher suites are rejected by default, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447):
 
 - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
 - `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`

--- a/src/current/_includes/common/tls-bad-cipher-warning.md
+++ b/src/current/_includes/common/tls-bad-cipher-warning.md
@@ -1,0 +1,9 @@
+{{site.data.alerts.callout_info}}
+CockroachDB clusters accept TLS 1.2 or TLS 1.3 security certificates for client authentication and encryption-in-flight. However, certain less-secure TLS 1.2 cipher suites are rejected, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447).
+
+SQL clients that are more than five years old may fail to connect, if they do not support any cipher suites that CockroachDB considers to be secure, and hence supports.
+
+To allow connections using these deprecated cipher suites, and hence support these older clients, you can set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. However, this is not recommended as these cipher suites are considered insecure.
+
+Refer to the code for the current list of supported cipher suites: [CockroachDB on GitHub: tls_ciphersuites.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/security/tls_ciphersuites.go)
+{{site.data.alerts.end}}

--- a/src/current/_includes/common/tls-bad-cipher-warning.md
+++ b/src/current/_includes/common/tls-bad-cipher-warning.md
@@ -1,9 +1,9 @@
 {{site.data.alerts.callout_info}}
-CockroachDB clusters accept TLS 1.2 or TLS 1.3 security certificates for client authentication and encryption-in-flight. However, certain less-secure TLS 1.2 cipher suites are rejected, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447).
+CockroachDB clusters can talk TLS 1.2 or TLS 1.3 to SQL clients for encryption-in-flight and to prove each other's identities. However, certain less-secure TLS 1.2 cipher suites are rejected, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447).
 
-SQL clients that are more than five years old may fail to connect, if they do not support any cipher suites that CockroachDB considers to be secure, and hence supports.
+SQL clients or intermediate proxies or load balancers that do not support any cipher suites that CockroachDB considers to be secure and supports, may fail to connect to a cluster.
 
-To allow connections using these deprecated cipher suites, and hence support these older clients, you can set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. However, this is not recommended as these cipher suites are considered insecure.
+To allow SQL connections using the deprecated cipher suites, you can set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. We provide the above environment variable only for cases when you can't use a client or intermediate proxy or load balancer that support any of the secure cipher suites.
 
 Refer to the code for the current list of supported cipher suites: [CockroachDB on GitHub: tls_ciphersuites.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/security/tls_ciphersuites.go)
 {{site.data.alerts.end}}

--- a/src/current/_includes/common/tls-bad-cipher-warning.md
+++ b/src/current/_includes/common/tls-bad-cipher-warning.md
@@ -1,9 +1,14 @@
 {{site.data.alerts.callout_info}}
-CockroachDB clusters can talk TLS 1.2 or TLS 1.3 to SQL clients for encryption-in-flight and to prove each other's identities. However, certain less-secure TLS 1.2 cipher suites are rejected, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447).
+CockroachDB clusters can talk TLS 1.2 or TLS 1.3 to SQL clients for encryption-in-flight and to prove each other's identities. However, the following less-secure TLS 1.2 cipher suites are rejected, in accordance with the IETF's recommended cipher list defined in [RFC 8447](https://datatracker.ietf.org/doc/html/rfc8447):
 
-SQL clients or intermediate proxies or load balancers that do not support any cipher suites that CockroachDB considers to be secure and supports, may fail to connect to a cluster.
+- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`
+- `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`
+- `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`
+- `TLS_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_RSA_WITH_AES_128_CBC_SHA`
+- `TLS_RSA_WITH_AES_256_CBC_SHA`
 
-To allow SQL connections using the deprecated cipher suites, you can set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. We provide the above environment variable only for cases when you can't use a client or intermediate proxy or load balancer that support any of the secure cipher suites.
-
-Refer to the code for the current list of supported cipher suites: [CockroachDB on GitHub: tls_ciphersuites.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/security/tls_ciphersuites.go)
+SQL clients or intermediate proxies or load balancers that do not support any cipher suites that CockroachDB considers to be secure and supports will be unable to connect to CockroachDB clusters, unless they are configured to allow them. To allow SQL connections using the deprecated cipher suites, set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. This mode is not recommended, unless you must use a client, intermediate proxy, or load balancer that doesn't support any of the more secure cipher suites.
 {{site.data.alerts.end}}

--- a/src/current/_includes/common/tls-bad-cipher-warning.md
+++ b/src/current/_includes/common/tls-bad-cipher-warning.md
@@ -10,5 +10,5 @@ CockroachDB clusters can talk TLS 1.2 or TLS 1.3 to SQL clients for encryption-i
 - `TLS_RSA_WITH_AES_128_CBC_SHA`
 - `TLS_RSA_WITH_AES_256_CBC_SHA`
 
-SQL clients or intermediate proxies or load balancers that do not support any cipher suites that CockroachDB considers to be secure and supports will be unable to connect to CockroachDB clusters, unless they are configured to allow them. To allow SQL connections using the deprecated cipher suites, set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. This mode is not recommended, unless you must use a client, intermediate proxy, or load balancer that doesn't support any of the more secure cipher suites.
+SQL clients, intermediate proxies, or load balancers that do not support any cipher suites that CockroachDB supports will be unable to connect to CockroachDB clusters. To allow SQL connections using the deprecated cipher suites, set the `COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES` environment variable to `true` for your `cockroach start` command. This mode is not recommended, unless you must use a client, intermediate proxy, or load balancer that doesn't support any of the more secure cipher suites.
 {{site.data.alerts.end}}

--- a/src/current/_includes/v23.1/app/java-tls-note.md
+++ b/src/current/_includes/v23.1/app/java-tls-note.md
@@ -1,6 +1,8 @@
 {{site.data.alerts.callout_danger}}
 CockroachDB supports TLS 1.2 and 1.3, and uses 1.3 by default.
 
+{% include common/tls-bad-cipher-warning.md %}
+
 [A bug in the TLS 1.3 implementation](https://bugs.openjdk.java.net/browse/JDK-8236039) in Java 11 versions lower than 11.0.7 and Java 13 versions lower than 13.0.3 makes the versions incompatible with CockroachDB.
 
 If an incompatible version is used, the client may throw the following exception:

--- a/src/current/cockroachcloud/frequently-asked-questions.md
+++ b/src/current/cockroachcloud/frequently-asked-questions.md
@@ -51,6 +51,8 @@ The allowlist is comprised of IP addresses that you provide to us, and is an add
 
 We use separate certificate authorities for each cluster, and all connections to the cluster over the internet use TLS 1.2 or 1.3.
 
+{% include common/tls-bad-cipher-warning.md %}
+
 See the [Security Overview page](../{{site.current_cloud_version}}/security-reference/security-overview.html) for more information, and for comparison of security options by CockroachDB product.
 
 ### Is encryption-at-rest enabled on {{ site.data.products.dedicated }}?

--- a/src/current/v23.1/authentication.md
+++ b/src/current/v23.1/authentication.md
@@ -255,7 +255,7 @@ For details about when and how to change security certificates without restartin
 
 ## Background on public key cryptography and digital certificates
 
-CockroachDB supports the [TLS 1.3 and TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security) security protocols, which take advantage of both symmetric and asymmetric encryption, to encrypt data in flight and to authenticate the communicating parties, respectively.
+CockroachDB supports the [TLS 1.3 and TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security) security protocols, which take advantage of both symmetric and asymmetric encryption to encrypt data in flight.
 
 {% include common/tls-bad-cipher-warning.md %}
 

--- a/src/current/v23.1/authentication.md
+++ b/src/current/v23.1/authentication.md
@@ -255,7 +255,7 @@ For details about when and how to change security certificates without restartin
 
 ## Background on public key cryptography and digital certificates
 
-CockroachDB supports the [TLS 1.3 and TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security) security protocols, which take advantage of both symmetric (to encrypt data in flight) as well as asymmetric encryption (to establish a secure channel as well as **authenticate** the communicating parties).
+CockroachDB supports the [TLS 1.3 and TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security) security protocols, which take advantage of both symmetric and asymmetric encryption, to encrypt data in flight and to authenticate the communicating parties, respectively.
 
 {% include common/tls-bad-cipher-warning.md %}
 

--- a/src/current/v23.1/authentication.md
+++ b/src/current/v23.1/authentication.md
@@ -255,7 +255,9 @@ For details about when and how to change security certificates without restartin
 
 ## Background on public key cryptography and digital certificates
 
-As mentioned above, CockroachDB supports the [TLS 1.3 and TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security) security protocols, which take advantage of both symmetric (to encrypt data in flight) as well as asymmetric encryption (to establish a secure channel as well as **authenticate** the communicating parties).
+CockroachDB supports the [TLS 1.3 and TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security) security protocols, which take advantage of both symmetric (to encrypt data in flight) as well as asymmetric encryption (to establish a secure channel as well as **authenticate** the communicating parties).
+
+{% include common/tls-bad-cipher-warning.md %}
 
 Authentication refers to the act of verifying the identity of the other party in communication. CockroachDB uses TLS 1.3 digital certificates for inter-node authentication, and your choice of TLS 1.2 and TLS 1.3 certificates for client-node authentication. These authentication methods require a certificate authority (CA) as well as keys and certificates for nodes, clients, and, optionally, the [DB Console](#using-a-public-ca-certificate-to-access-the-db-console-for-a-secure-cluster).
 


### PR DESCRIPTION
[DOC-8159](https://cockroachlabs.atlassian.net/browse/DOC-8159)


Warn about insecure TLS cipher support