### PR TITLE
Docs Fixit: Add cd command block for ease

### DIFF
--- a/src/current/v23.1/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.md
+++ b/src/current/v23.1/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.md
@@ -206,7 +206,14 @@ export KAFKA_OPTS="-Djava.security.auth.login.config={absolute path to kafka_2.1
 
 ## Step 7. Start your Kafka server
 
-Ensure you're in the `kafka_2.13-2.8.2` directory, and then run the following:
+In this step, you will start your Kafka server, create a topic, and run your consumer:
+
+1. Move to the following directory:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    cd kafka_2.13-2.8.2
+    ~~~
 
 1. Start the Zookeeper server in one terminal:
 


### PR DESCRIPTION
Fixes DOC-8080

I’ve worked through this tutorial a number of times now for testing, and every time I forget to change into the correct directory that is noted at the start of this step here: [Connect to a Changefeed Kafka Sink with OAuth Using Okta](https://www.cockroachlabs.com/docs/v23.1/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.html#step-7-start-your-kafka-server) 

It might be easier for readers not to miss this if we just added in a `cd` directory command block for this.