### PR TITLE
Update interleave redirects

### DIFF
--- a/src/current/_data/redirects.yml
+++ b/src/current/_data/redirects.yml
@@ -766,7 +766,10 @@
     - sql-playground.html
 
 - destination: v21.1/interleave-in-parent.html#deprecation
-  sources: ['interleave-in-parent.html']
+  sources:
+    - dev/interleave-in-parent.html
+    - interleave-in-parent.html
+    - stable/interleave-in-parent.html
 
 # Cloud releases
 


### PR DESCRIPTION
This PR ensures that anyone accessing `docs/(dev|stable)/interleave-in-parent(.html)?` are redirected to the deprecation notice in v21.1.