### PR TITLE
[DOC-7213] Split up Enterprise features, copyedit

### DIFF
--- a/src/current/_includes/v22.1/misc/enterprise-features.md
+++ b/src/current/_includes/v22.1/misc/enterprise-features.md
@@ -1,10 +1,21 @@
+## Cluster optimization
+
 Feature | Description
 --------+-------------------------
-[Multi-Region Capabilities](multiregion-overview.html) | This feature gives you row-level control of how and where your data is stored to dramatically reduce read and write latencies and assist in meeting regulatory requirements in multi-region deployments.
-[Follower Reads](follower-reads.html) | This feature reduces read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
-[`BACKUP`](backup.html) | This feature creates backups of your cluster's schema and data that are consistent as of a given timestamp, stored on a service such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.<br><br>[Incremental backups](take-full-and-incremental-backups.html), [backups with revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html), [locality-aware backups](take-and-restore-locality-aware-backups.html), and [encrypted backups](take-and-restore-encrypted-backups.html) require an Enterprise license. [Full backups](take-full-and-incremental-backups.html) do not require an Enterprise license.
-[Changefeeds into a Configurable Sink](create-changefeed.html) | This feature targets an allowlist of tables. For every change, it emits a record to a configurable sink, either Apache Kafka or a cloud-storage sink, for downstream processing such as reporting, caching, or full-text indexing.
-[Node Map](enable-node-map.html) | This feature visualizes the geographical configuration of a cluster by plotting node localities on a world map.
-[Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Supplementing CockroachDB's encryption in flight capabilities, this feature provides transparent encryption of a node's data on the local disk. It allows encryption of all files on disk using AES in counter mode, with all key sizes allowed.
-[GSSAPI with Kerberos Authentication](gssapi_authentication.html) | CockroachDB supports the Generic Security Services API (GSSAPI) with Kerberos authentication, which lets you use an external enterprise directory system that supports Kerberos, such as Active Directory.
-[Single Sign-on (SSO)](sso.html) | This feature lets you use an external identity provider for user access to the DB Console in a secure cluster.
+[Follower Reads](follower-reads.html) | Reduce read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
+[Multi-Region Capabilities](multiregion-overview.html) | Row-level controls where your data is stored to help you reduce read and write latency and meet regulatory requirements.
+[Node Map](enable-node-map.html) | Visualize the geographical distribution of a cluster by plotting its node localities on a world map.
+
+## Recovery and streaming
+
+Feature | Description
+--------+-------------------------
+Enterprise [`BACKUP`](backup.html) and restore capabilities | Taking and restoring [incremental backups](take-full-and-incremental-backups.html), [backups with revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html), [locality-aware backups](take-and-restore-locality-aware-backups.html), and [encrypted backups](take-and-restore-encrypted-backups.html) require an Enterprise license. [Full backups](take-full-and-incremental-backups.html) do not require an Enterprise license.
+[Changefeeds into a Configurable Sink](create-changefeed.html) | For every change in a configurable allowlist of tables, configure a changefeed to emit a record to a configurable sink: Apache Kafka, cloud storage, Google Cloud Pub/Sub, or a webhook sink. These records can be processed by downstream systems for reporting, caching, or full-text indexing.
+
+## Security and IAM
+
+Feature | Description
+--------+-------------------------
+[Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Enable automatic transparent encryption of a node's data on the local disk using AES in counter mode, with all key sizes allowed. This feature works together with CockroachDB's automatic encryption of data in transit.
+[GSSAPI with Kerberos Authentication](gssapi_authentication.html) | Authenticate to your cluster using identities stored in an external enterprise directory system that supports Kerberos, such as Active Directory.

--- a/src/current/_includes/v22.1/misc/enterprise-features.md
+++ b/src/current/_includes/v22.1/misc/enterprise-features.md
@@ -3,7 +3,7 @@
 Feature | Description
 --------+-------------------------
 [Follower Reads](follower-reads.html) | Reduce read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
-[Multi-Region Capabilities](multiregion-overview.html) | Row-level controls where your data is stored to help you reduce read and write latency and meet regulatory requirements.
+[Multi-Region Capabilities](multiregion-overview.html) | Row-level control over where your data is stored to help you reduce read and write latency and meet regulatory requirements.
 [Node Map](enable-node-map.html) | Visualize the geographical distribution of a cluster by plotting its node localities on a world map.
 
 ## Recovery and streaming

--- a/src/current/_includes/v22.2/misc/enterprise-features.md
+++ b/src/current/_includes/v22.2/misc/enterprise-features.md
@@ -19,5 +19,5 @@ Feature | Description
 --------+-------------------------
 [Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Enable automatic transparent encryption of a node's data on the local disk using AES in counter mode, with all key sizes allowed. This feature works together with CockroachDB's automatic encryption of data in transit.
 [GSSAPI with Kerberos Authentication](gssapi_authentication.html) | Authenticate to your cluster using identities stored in an external enterprise directory system that supports Kerberos, such as Active Directory.
-[Cluster Single Sign-on (SSO)](sso-sql.html) | Grant SQL access to a cluster using JSON Web Tokens (JWTs) issued by an external identity provider(IdP) or custom JWT issuer.
+[Cluster Single Sign-on (SSO)](sso-sql.html) | Grant SQL access to a cluster using JSON Web Tokens (JWTs) issued by an external identity provider (IdP) or custom JWT issuer.
 [Single Sign-on (SSO) for DB Console](sso-db-console.html) | Grant access to a cluster's DB Console interface using SSO through an IdP that supports OIDC.

--- a/src/current/_includes/v22.2/misc/enterprise-features.md
+++ b/src/current/_includes/v22.2/misc/enterprise-features.md
@@ -1,11 +1,23 @@
+## Cluster optimization
+
 Feature | Description
 --------+-------------------------
-[Multi-Region Capabilities](multiregion-overview.html) | This feature gives you row-level control of how and where your data is stored to dramatically reduce read and write latencies and assist in meeting regulatory requirements in multi-region deployments.
-[Follower Reads](follower-reads.html) | This feature reduces read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
-[`BACKUP`](backup.html) | This feature creates backups of your cluster's schema and data that are consistent as of a given timestamp, stored on a service such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.<br><br>[Incremental backups](take-full-and-incremental-backups.html), [backups with revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html), [locality-aware backups](take-and-restore-locality-aware-backups.html), and [encrypted backups](take-and-restore-encrypted-backups.html) require an Enterprise license. [Full backups](take-full-and-incremental-backups.html) do not require an Enterprise license.
-[Changefeeds into a Configurable Sink](create-changefeed.html) | This feature targets an allowlist of tables. For every change, it emits a record to a configurable sink, either Apache Kafka or a cloud-storage sink, for downstream processing such as reporting, caching, or full-text indexing.
-[Node Map](enable-node-map.html) | This feature visualizes the geographical configuration of a cluster by plotting node localities on a world map.
-[Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Supplementing CockroachDB's encryption in flight capabilities, this feature provides transparent encryption of a node's data on the local disk. It allows encryption of all files on disk using AES in counter mode, with all key sizes allowed.
-[GSSAPI with Kerberos Authentication](gssapi_authentication.html) | CockroachDB supports the Generic Security Services API (GSSAPI) with Kerberos authentication, which lets you use an external enterprise directory system that supports Kerberos, such as Active Directory.
-[Single Sign-on (SSO) for DB Console](sso-db-console.html) | This feature allows you to grant access to DB Console to identities managed in an external identity provider (IdP).
-[Cluster Single Sign-on (SSO)](sso-sql.html) | This feature allows you to grant SQL access to {{ site.data.products.core }} clusters to identities managed in an external IdP.
+[Follower Reads](follower-reads.html) | Reduce read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
+[Multi-Region Capabilities](multiregion-overview.html) | Row-level control over where your data is stored to help you reduce read and write latency and meet regulatory requirements.
+[Node Map](enable-node-map.html) | Visualize the geographical distribution of a cluster by plotting its node localities on a world map.
+
+## Recovery and streaming
+
+Feature | Description
+--------+-------------------------
+Enterprise [`BACKUP`](backup.html) and restore capabilities | Taking and restoring [incremental backups](take-full-and-incremental-backups.html), [backups with revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html), [locality-aware backups](take-and-restore-locality-aware-backups.html), and [encrypted backups](take-and-restore-encrypted-backups.html) require an Enterprise license. [Full backups](take-full-and-incremental-backups.html) do not require an Enterprise license.
+[Changefeeds into a Configurable Sink](create-changefeed.html) | For every change in a configurable allowlist of tables, configure a changefeed to emit a record to a configurable sink: Apache Kafka, cloud storage, Google Cloud Pub/Sub, or a webhook sink. These records can be processed by downstream systems for reporting, caching, or full-text indexing.
+
+## Security and IAM
+
+Feature | Description
+--------+-------------------------
+[Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Enable automatic transparent encryption of a node's data on the local disk using AES in counter mode, with all key sizes allowed. This feature works together with CockroachDB's automatic encryption of data in transit.
+[GSSAPI with Kerberos Authentication](gssapi_authentication.html) | Authenticate to your cluster using identities stored in an external enterprise directory system that supports Kerberos, such as Active Directory.
+[Cluster Single Sign-on (SSO)](sso-sql.html) | Grant SQL access to a cluster using JSON Web Tokens (JWTs) issued by an external identity provider(IdP) or custom JWT issuer.
+[Single Sign-on (SSO) for DB Console](sso-db-console.html) | Grant access to a cluster's DB Console interface using SSO through an IdP that supports OIDC.

--- a/src/current/_includes/v23.1/misc/enterprise-features.md
+++ b/src/current/_includes/v23.1/misc/enterprise-features.md
@@ -1,12 +1,24 @@
+## Cluster optimization
+
 Feature | Description
 --------+-------------------------
-[Multi-Region Capabilities](multiregion-overview.html) | This feature gives you row-level control of how and where your data is stored to dramatically reduce read and write latencies and assist in meeting regulatory requirements in multi-region deployments.
-[Follower Reads](follower-reads.html) | This feature reduces read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
-[`BACKUP`](backup.html) | This feature creates backups of your cluster's schema and data that are consistent as of a given timestamp, stored on a service such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.<br><br>[Incremental backups](take-full-and-incremental-backups.html), [backups with revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html), [locality-aware backups](take-and-restore-locality-aware-backups.html), and [encrypted backups](take-and-restore-encrypted-backups.html) require an Enterprise license. [Full backups](take-full-and-incremental-backups.html) do not require an Enterprise license.
-[Changefeeds into a Configurable Sink](create-changefeed.html) | This feature targets an allowlist of tables. For every change, it emits a record to a configurable sink, either Apache Kafka or a cloud-storage sink, for downstream processing such as reporting, caching, or full-text indexing.
-[Change Data Capture Queries](cdc-queries.html) | This feature allows you to define the change data emitted to your sink when you create a changefeed. You can use `SELECT` queries to filter and modify data before sending it to your downstream sink.
-[Node Map](enable-node-map.html) | This feature visualizes the geographical configuration of a cluster by plotting node localities on a world map.
-[Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Supplementing CockroachDB's encryption in flight capabilities, this feature provides transparent encryption of a node's data on the local disk. It allows encryption of all files on disk using AES in counter mode, with all key sizes allowed.
-[GSSAPI with Kerberos Authentication](gssapi_authentication.html) | CockroachDB supports the Generic Security Services API (GSSAPI) with Kerberos authentication, which lets you use an external enterprise directory system that supports Kerberos, such as Active Directory.
-[Single Sign-on (SSO) for DB Console](sso-db-console.html) | This feature allows you to grant access to DB Console to identities managed in an external identity provider (IdP).
-[Cluster Single Sign-on (SSO)](sso-sql.html) | This feature allows you to grant SQL access to {{ site.data.products.core }} clusters to identities managed in an external IdP.
+[Follower Reads](follower-reads.html) | Reduce read latency in multi-region deployments by using the closest replica at the expense of reading slightly historical data.
+[Multi-Region Capabilities](multiregion-overview.html) | Row-level control over where your data is stored to help you reduce read and write latency and meet regulatory requirements.
+[Node Map](enable-node-map.html) | Visualize the geographical distribution of a cluster by plotting its node localities on a world map.
+
+## Recovery and streaming
+
+Feature | Description
+--------+-------------------------
+Enterprise [`BACKUP`](backup.html) and restore capabilities | Taking and restoring [incremental backups](take-full-and-incremental-backups.html), [backups with revision history](take-backups-with-revision-history-and-restore-from-a-point-in-time.html), [locality-aware backups](take-and-restore-locality-aware-backups.html), and [encrypted backups](take-and-restore-encrypted-backups.html) require an Enterprise license. [Full backups](take-full-and-incremental-backups.html) do not require an Enterprise license.
+[Changefeeds into a Configurable Sink](create-changefeed.html) | For every change in a configurable allowlist of tables, configure a changefeed to emit a record to a configurable sink: Apache Kafka, cloud storage, Google Cloud Pub/Sub, or a webhook sink. These records can be processed by downstream systems for reporting, caching, or full-text indexing.
+[Change Data Capture Queries](cdc-queries.html) | Use `SELECT` queries to filter and modify change data before sending it to a changefeed's sink.
+
+## Security and IAM
+
+Feature | Description
+--------+-------------------------
+[Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Enable automatic transparent encryption of a node's data on the local disk using AES in counter mode, with all key sizes allowed. This feature works together with CockroachDB's automatic encryption of data in transit.
+[GSSAPI with Kerberos Authentication](gssapi_authentication.html) | Authenticate to your cluster using identities stored in an external enterprise directory system that supports Kerberos, such as Active Directory.
+[Cluster Single Sign-on (SSO)](sso-sql.html) | Grant SQL access to a cluster using JSON Web Tokens (JWTs) issued by an external identity provider(IdP) or custom JWT issuer.
+[Single Sign-on (SSO) for DB Console](sso-db-console.html) | Grant access to a cluster's DB Console interface using SSO through an IdP that supports OIDC.

--- a/src/current/_includes/v23.1/misc/enterprise-features.md
+++ b/src/current/_includes/v23.1/misc/enterprise-features.md
@@ -20,5 +20,5 @@ Feature | Description
 --------+-------------------------
 [Encryption at Rest](security-reference/encryption.html#encryption-at-rest-enterprise) | Enable automatic transparent encryption of a node's data on the local disk using AES in counter mode, with all key sizes allowed. This feature works together with CockroachDB's automatic encryption of data in transit.
 [GSSAPI with Kerberos Authentication](gssapi_authentication.html) | Authenticate to your cluster using identities stored in an external enterprise directory system that supports Kerberos, such as Active Directory.
-[Cluster Single Sign-on (SSO)](sso-sql.html) | Grant SQL access to a cluster using JSON Web Tokens (JWTs) issued by an external identity provider(IdP) or custom JWT issuer.
+[Cluster Single Sign-on (SSO)](sso-sql.html) | Grant SQL access to a cluster using JSON Web Tokens (JWTs) issued by an external identity provider (IdP) or custom JWT issuer.
 [Single Sign-on (SSO) for DB Console](sso-db-console.html) | Grant access to a cluster's DB Console interface using SSO through an IdP that supports OIDC.


### PR DESCRIPTION
[DOC-7213] Split up Enterprise features, strengthen calls to action, copyedit

NB: 22.1 doesn't have Cluster SSO, DB Console SSO, CDC Queries. 22.2 doesn't have CDC Queries

## Previews
[src/current/v22.1/enterprise-licensing.md](https://deploy-preview-17398--cockroachdb-docs.netlify.app/docs/v22.1/enterprise-licensing.html)
[src/current/v22.1/get-started-with-enterprise-trial.md](https://deploy-preview-17398--cockroachdb-docs.netlify.app/docs/v22.1/get-started-with-enterprise-trial.html)
[src/current/v22.2/enterprise-licensing.md](https://deploy-preview-17398--cockroachdb-docs.netlify.app/docs/v22.2/enterprise-licensing.html)
[src/current/v22.2/get-started-with-enterprise-trial.md](https://deploy-preview-17398--cockroachdb-docs.netlify.app/docs/v22.2/get-started-with-enterprise-trial.html)
[src/current/v23.1/enterprise-licensing.md](https://deploy-preview-17398--cockroachdb-docs.netlify.app/docs/v23.1/enterprise-licensing.html)
[src/current/v23.1/get-started-with-enterprise-trial.md](https://deploy-preview-17398--cockroachdb-docs.netlify.app/docs/v23.1/get-started-with-enterprise-trial.html)

## Tests
- [x] Local build
- [x] Linkcheck 