### PR TITLE
DOC-8269: Update the docs to indicate that users cannot create or delete databases in the CC console

### DIFF
--- a/src/current/_includes/releases/cloud/2022-09-24.md
+++ b/src/current/_includes/releases/cloud/2022-09-24.md
@@ -2,5 +2,5 @@
 
 <h3>Console changes</h3>
 
-- You can now [create a database](../cockroachcloud/serverless-cluster-management.html#create-a-database) directly from the [**Databases** page](../cockroachcloud/databases-page.html) of the {{ site.data.products.db }} Console.
+- You can now create a database directly from the [**Databases** page](../cockroachcloud/databases-page.html) of the {{ site.data.products.db }} Console.
 

--- a/src/current/_includes/v22.2/ui/databases.md
+++ b/src/current/_includes/v22.2/ui/databases.md
@@ -4,9 +4,6 @@ The **Databases** page shows:
 
 - Whether [automatic statistics collection]({{ link_prefix }}cost-based-optimizer.html#table-statistics) is enabled for the cluster.
 - A list of the databases on the cluster.
-{% if page.cloud == true %}
-- The **Add database** button, which allows you to [create a new database](serverless-cluster-management.html#create-a-database).
-{% endif %}
 
 The following information is displayed for each database:
 

--- a/src/current/_includes/v23.1/ui/databases.md
+++ b/src/current/_includes/v23.1/ui/databases.md
@@ -4,9 +4,6 @@ The **Databases** page shows:
 
 - Whether [automatic statistics collection]({{ link_prefix }}cost-based-optimizer.html#table-statistics) is enabled for the cluster.
 - A list of the databases on the cluster.
-{% if page.cloud == true %}
-- The **Add database** button, which allows you to [create a new database](serverless-cluster-management.html#create-a-database).
-{% endif %}
 
 The following information is displayed for each database:
 
@@ -21,7 +18,7 @@ The following information is displayed for each database:
 | Range Count   | The number of ranges across all tables in the  database.                                                                |
 | Regions/Nodes | The regions and nodes on which the tables in the database are located. This is not displayed on a single-node cluster.  |
 | Index Recommendations | The number of index recommendations for the database.                                                           |
-{% else %}
+{%- else -%}
 | Regions | The regions where the tables in the database are located.  |
 {% endif -%}
 
@@ -63,12 +60,12 @@ The following information is displayed for each table:
 {% if page.cloud != true -%}
 | Replication Size               | The approximate disk size of all replicas of this table on the cluster.                                  |
 | Ranges                         | The number of ranges in the table.                                                                       |
-{% endif -%}
+{%- endif -%}
 | Columns                        | The number of columns in the table.                                                                      |
 | Indexes                        | The number of indexes in the table.                                                                      |
 {% if page.cloud != true -%}
 | Regions                        | The regions and nodes on which the table data is stored. This is not displayed on a single-node cluster. |
-{% else %}
+{% else -%}
 | Regions                        | The regions where the table data is stored.
 {% endif -%}
 | % of Live Data                 | Percent of total uncompressed logical data that has not been modified (updated or deleted).              |

--- a/src/current/cockroachcloud/cluster-management.md
+++ b/src/current/cockroachcloud/cluster-management.md
@@ -183,15 +183,6 @@ To set an upgrade window:
     
     You can enable this setting for development and testing clusters if you want to ensure that they are upgraded before production clusters.
 
-## Create a database
-
-You can use the [**Databases** page](databases-page.html) to create a new database from the {{ site.data.products.db }} Console.
-
-1. Navigate to the **Databases** page from the **Overview** page of your cluster.
-1. Click **Add database**.
-1. Enter a name for the new database.
-1. Click **Create**.
-
 ## Restore data from a backup
 
 {{site.data.alerts.callout_info}}

--- a/src/current/cockroachcloud/databases-page.md
+++ b/src/current/cockroachcloud/databases-page.md
@@ -16,7 +16,7 @@ docs_area: manage
 
 {% capture version_prefix %}{{site.current_cloud_version}}/{% endcapture %}
 
-The **Databases** page of the {{ site.data.products.db }} Console allows you to create, edit, and delete databases and provides details of the following:
+The **Databases** page of the {{ site.data.products.db }} Console provides details of the following:
 
 - The databases configured.
 - The tables in each database and the indexes on each table.

--- a/src/current/cockroachcloud/serverless-cluster-management.md
+++ b/src/current/cockroachcloud/serverless-cluster-management.md
@@ -105,16 +105,6 @@ To remove regions from your cluster:
 1. Click **OK**.
 {% endcomment %}
 
-## Create a database
-
-You can use the [**Databases** page](databases-page.html) to create a new database from the {{ site.data.products.db }} Console.
-
-1. Select your cluster to navigate to the cluster [**Overview** page](cluster-overview-page.html).
-1. Click **Databases** in the **Data** section of the left side navigation.
-1. Click **Add database**.
-1. Enter a name for the new database.
-1. Click **Create**.
-
 ## Restore data from a backup
 
 Use the [Managed-Service Backups](use-managed-service-backups.html) to restore your cluster from automatic full cluster backups.


### PR DESCRIPTION
Addresses: DOC-8269

[A) Updated Databases page, (1) removed reference to Add Database button, (2) added hyphens to liquid tags to remove whitespace. (B) Updated Cloud Databases page, removed reference to create, edit, and delete databases. (C) Updated Serverless and Dedicated Cluster Management pages, removed Create a Database section. (D) Updated cloud release notes page for 2022-09-24, to remove link to Create a Database section.