### PR TITLE
Make sidebar/search use pretty URLs while preserving htmltest checks

### DIFF
--- a/src/current/_includes/sidebar.html
+++ b/src/current/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <div class="col-sidebar" data-nosnippet>
   <div class="col-sidebar-content">
     <div class="mb-3 px-3">
-      <form action="/docs/search.html">
+      <form action="/docs/search">
         <input class="form-control" name="query" type="text" placeholder="Search">
       </form>
     </div>

--- a/src/current/_includes/sidebar.js.html
+++ b/src/current/_includes/sidebar.js.html
@@ -97,12 +97,12 @@
             // This condition makes it possible to use external
             // urls in the sidebar.
             if (!/^https?:/.test(url)) {
-              url = sidebar.baseUrl + url;
+              url = sidebar.baseUrl + url.replace(".html", "");
             }
             return url;
           });
 
-          // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
+          // this ensures page will be highlighted in sidebar if URL is accessed with or without `.html` appended
           var activePathname
           if (!/^https?:/.test(location.pathname)) {
             activePathname = location.pathname
@@ -110,9 +110,10 @@
           else {
             activePathname = location.pathname
           }
-          if (location.pathname.slice(-5) !== '.html') {
-            activePathname += '.html'
+          if (location.pathname.slice(-5) === '.html') {
+            activePathname = activePathname.replace(".html", "")
           }
+          // console.log(urls);
 
           const active = (urls.indexOf(activePathname) !== -1);
           if (active) {

--- a/src/current/search.html
+++ b/src/current/search.html
@@ -65,7 +65,7 @@ docs_area: search
         arrayFormat: "repeat"
       });
 
-      return `${baseUrl}search.html${queryString}`;
+      return `${baseUrl}search${queryString}`;
     },
 
     parseURL({ qsModule, location }) {
@@ -138,7 +138,7 @@ docs_area: search
           hit =>
             `<div class="search-item">
           <div class="search-title">
-            <a href="${hit.url.replace("/{{ site.versions["stable"] }}/", "/stable/").replace("/{{ site.versions["dev"] }}/", "/dev/").replace("https://www.cockroachlabs.com", "{{ site.url }}")}">${hit.title}</a>
+            <a href="${'{{ site.url }}{{ site.baseurl }}' + hit.canonical}">${hit.title}</a>
           </div>
           <div class="search-snippet">${showResult(hit._highlightResult)}</div>
           <div class="search-link">${hit.doc_type}</div>


### PR DESCRIPTION
To test this PR:

- Access any page in the deploy preview. Make sure the sidebar renders and opens to the page you chose. The page should also open without any `.html` extension.
- Add `.html` to the end of the URL. The same page should appear highlighted in the sidebar.
- Search for any page in the docs. You should be brought to the stable URL with no `.html` extension.
- htmltest should pass.