### PR TITLE
[DOC-8377] Release notes for v22.2.12

### DIFF
--- a/src/current/_config_base.yml
+++ b/src/current/_config_base.yml
@@ -145,12 +145,12 @@ release_info:
     start_time: 2023-06-01 14:44:42.739193 +0000 UTC
     version: v22.1.21
   v22.2:
-    build_time: 2023-06-27 00:00:00 (go1.19)
+    build_time: 2023-07-24 00:00:00 (go1.19)
     crdb_branch_name: release-22.2
     docker_image: cockroachdb/cockroach
-    name: v22.2.11
-    start_time: 2023-06-26 17:12:59.793339 +0000 UTC
-    version: v22.2.11
+    name: v22.2.12
+    start_time: 2023-07-19 13:53:46.640049 +0000 UTC
+    version: v22.2.12
   v23.1:
     build_time: 2023-07-05 00:00:00 (go1.19)
     crdb_branch_name: release-23.1

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4525,3 +4525,24 @@
     docker_arm: true
   source: true
   previous_release: v23.1.4
+
+- release_name: v22.2.12
+  major_version: v22.2
+  release_date: '2023-07-24'
+  release_type: Production
+  go_version: go1.19
+  sha: feededb3d12a703bada7699b65ad1e191f97a91b
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_intel_fips: false
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+  source: true
+  previous_release: v22.2.11

--- a/src/current/_includes/releases/v22.2/v22.2.12.md
+++ b/src/current/_includes/releases/v22.2/v22.2.12.md
@@ -1,0 +1,25 @@
+## v22.2.12
+
+Release Date: July 24, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v22-2-12-sql-language-changes">SQL language changes</h3>
+
+- Attempting to drop an index that is the only source of a column is now forbidden and results in an error. [#106936](https://github.com/cockroachdb/cockroach/pull/106936)
+
+<h3 id="v22-2-12-command-line-changes">Command-line changes</h3>
+
+- The `debug doctor` command now allows you to verify that primary indexes store all columns. [#106936](https://github.com/cockroachdb/cockroach/pull/106936)
+
+<h3 id="v22-2-12-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug in the new [declarative schema changer](../v23.1/online-schema-changes.html#declarative-schema-changer) framework that could cause the incorrect retrieval of the unique secondary index rather than the primary index. On such a cluster, an `ALTER TABLE..ADD COLUMN` statement will result in data for the new column being added to the secondary index, which could lead to query inconsistency. For details and to determine whether a cluster is impacted, refer to [Technical Advisory 99561](https://cockroachlabs.com/docs/advisories/a99561). [#106428](https://github.com/cockroachdb/cockroach/pull/106428)
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v22-2-12-contributors">Contributors</h3>
+
+This release includes 2 merged PRs by 2 authors.
+
+</div>


### PR DESCRIPTION
[DOC-8377] Release notes for v22.2.12

Preview: [releases/v22.2.md](https://deploy-preview-17501--cockroachdb-docs.netlify.app/docs/releases/v22.2.html)