### PR TITLE
v23.1.6 release notes

### DIFF
--- a/src/current/_config_base.yml
+++ b/src/current/_config_base.yml
@@ -152,12 +152,12 @@ release_info:
     start_time: 2023-07-19 13:53:46.640049 +0000 UTC
     version: v22.2.12
   v23.1:
-    build_time: 2023-07-05 00:00:00 (go1.19)
+    build_time: 2023-07-24 00:00:00 (go1.19)
     crdb_branch_name: release-23.1
     docker_image: cockroachdb/cockroach
-    name: v23.1.5
-    start_time: 2023-06-30 09:41:52.512742 +0000 UTC
-    version: v23.1.5
+    name: v23.1.6
+    start_time: 2023-07-24 17:28:15.362753 +0000 UTC
+    version: v23.1.6
 sass:
   quiet_deps: 'true'
   sass_dir: css

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4546,3 +4546,24 @@
     docker_arm: true
   source: true
   previous_release: v22.2.11
+
+- release_name: v23.1.6
+  major_version: v23.1
+  release_date: '2023-07-24'
+  release_type: Production
+  go_version: go1.19
+  sha: 3bacdbe302c436675605f3256025829e63c45330
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+  source: true
+  previous_release: v23.1.5

--- a/src/current/_includes/releases/v23.1/v23.1.6.md
+++ b/src/current/_includes/releases/v23.1/v23.1.6.md
@@ -8,7 +8,7 @@ Release Date: July 24, 2023
 
 - Fixed a bug in v23.1.5 where [debug zips](../v23.1/cockroach-debug-zip.html) were empty in the `crdb_internal.cluster_settings.txt` file. Debug zips now properly show the information from `cluster_settings`. [#107105][#107105]
 - Fixed a bug where some primary indexes would incorrectly be treated internally as secondary indexes, which could cause schema change operations to fail. The bug could occur if [`ALTER PRIMARY KEY`](../v23.1/alter-table.html#alter-primary-key) was used on v21.1 or earlier, and the cluster was upgraded. [#106426][#106426]
-- Extended the `cockroach debug doctor` to detect [indexes](../v23.1/indexes.html) which could potentially lose data by being dropped when a column is stored inside them and added a check inside [`DROP INDEX`](../v23.1/drop-index.html) to prevent dropping indexes with this problem to avoid data loss. [#106863][#106863]
+- Extended the `cockroach debug doctor` to detect [indexes](../v23.1/indexes.html) which could potentially lose data by being dropped when a column is stored inside them and added a check inside [`DROP INDEX`](../v23.1/drop-index.html) to prevent dropping indexes with this problem to avoid data loss. [#106863][#106863] 
 
 <div class="release-note-contributors" markdown="1">
 

--- a/src/current/_includes/releases/v23.1/v23.1.6.md
+++ b/src/current/_includes/releases/v23.1/v23.1.6.md
@@ -1,0 +1,23 @@
+## v23.1.6
+
+Release Date: July 24, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-1-6-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug in v23.1.5 where [debug zips](../v23.1/cockroach-debug-zip.html) were empty in the `crdb_internal.cluster_settings.txt` file. Debug zips now properly show the information from `cluster_settings`. [#107105][#107105]
+- Fixed a bug where some primary indexes would incorrectly be treated internally as secondary indexes, which could cause schema change operations to fail. The bug could occur if [`ALTER PRIMARY KEY`](../v23.1/alter-table.html#alter-primary-key) was used on v21.1 or earlier, and the cluster was upgraded. [#106426][#106426]
+- Extended the `cockroach debug doctor` to detect [indexes](../v23.1/indexes.html) which could potentially lose data by being dropped when a column is stored inside them and added a check inside [`DROP INDEX`](../v23.1/drop-index.html) to prevent dropping indexes with this problem to avoid data loss. [#106863][#106863]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-6-contributors">Contributors</h3>
+
+This release includes 3 merged PRs by 15 authors. 
+
+</div>
+
+[#106863]: https://github.com/cockroachdb/cockroach/pull/106863
+[#106426]: https://github.com/cockroachdb/cockroach/pull/106426
+[#107105]: https://github.com/cockroachdb/cockroach/pull/107105


### PR DESCRIPTION
relates to https://github.com/cockroachdb/docs/pull/17530 and https://github.com/cockroachdb/docs/pull/17519