### PR TITLE
Doc 8403 shorten security titles

### DIFF
--- a/src/current/_includes/v22.2/sidebar-data/manage.json
+++ b/src/current/_includes/v22.2/sidebar-data/manage.json
@@ -226,7 +226,7 @@
               ]
             },
             {
-              "title": "Customer-Managed Encryption Keys (CMEK) for CockroachDB Dedicated",
+              "title": "Customer-Managed Encryption Keys (CMEK)",
               "urls": [],
               "items": [
                 {

--- a/src/current/_includes/v23.1/sidebar-data/manage.json
+++ b/src/current/_includes/v23.1/sidebar-data/manage.json
@@ -226,7 +226,7 @@
               ]
             },
             {
-              "title": "Customer-Managed Encryption Keys (CMEK) for CockroachDB Dedicated",
+              "title": "Customer-Managed Encryption Keys (CMEK)",
               "urls": [],
               "items": [
                 {

--- a/src/current/_includes/v23.1/sidebar-data/manage.json
+++ b/src/current/_includes/v23.1/sidebar-data/manage.json
@@ -335,7 +335,7 @@
                   ]
                 },
                 {
-                  "title": "Manage a cluster's PKI certificates with Vault",
+                  "title": "Manage a cluster's PKI certificates with HashiCorp Vault",
                   "urls": [
                     "/${VERSION}/manage-certs-vault.html"
                   ]
@@ -414,7 +414,7 @@
               ]
             },
             {
-              "title": "Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security",
+              "title": "Use HashiCorp Vault to Securely Manage Database Credentials",
               "urls": [
                 "/${VERSION}/vault-db-secrets-tutorial.html"
               ]

--- a/src/current/_includes/v23.1/sidebar-data/manage.json
+++ b/src/current/_includes/v23.1/sidebar-data/manage.json
@@ -100,12 +100,6 @@
               ]
         },
         {
-          "title": "Backup Architecture",
-          "urls": [
-            "/${VERSION}/backup-architecture.html"
-          ]
-        },
-        {
           "title": "Managed-Service Backups",
           "urls": [
             "/cockroachcloud/use-managed-service-backups.html"
@@ -139,6 +133,12 @@
               ]
             },
             {
+              "title": "Locality-restricted Backup Execution",
+              "urls": [
+                "/${VERSION}/take-locality-restricted-backups.html"
+              ]
+            },
+            {
               "title": "Locality-aware Backup and Restore",
               "urls": [
                 "/${VERSION}/take-and-restore-locality-aware-backups.html"
@@ -155,13 +155,13 @@
               "urls": [
                 "/${VERSION}/backup-validation.html"
               ]
-            },
-            {
-              "title": "Backup and Restore Monitoring",
-              "urls": [
-              "/${VERSION}/backup-and-restore-monitoring.html"
-              ]
             }
+          ]
+        },
+        {
+          "title": "Backup and Restore Monitoring",
+          "urls": [
+            "/${VERSION}/backup-and-restore-monitoring.html"
           ]
         },
         {
@@ -220,7 +220,7 @@
               ]
             },
             {
-              "title": "AWS PrivateLink for Dedicated Clusters",
+              "title": "Managing AWS PrivateLink for CockroachDB Cloud",
               "urls": [
                 "/cockroachcloud/aws-privatelink.html"
               ]
@@ -291,7 +291,7 @@
 								]
       	    },
             {
-              "title": "Network Authorization",
+              "title": "Network Authorization for CockroachDB Cloud Clusters",
               "urls": [
                 "/cockroachcloud/network-authorization.html"
               ]
@@ -309,9 +309,9 @@
               ]
             },
             {
-              "title": "CockroachDB Cloud Access Management Overview and FAQ",
+              "title": "CockroachdB Cloud Access Management Overview and FAQ",
               "urls": [
-                "/cockroachcloud/authorization.html"
+                 "/cockroachcloud/authorization.html"
               ]
             },
             {
@@ -329,7 +329,7 @@
               "title": "Managing Security Certificates",
               "items": [
                 {
-                  "title": "Use the CLI to provision a development cluster",
+                  "title": "Use the CockroachDB CLI to provision a development cluster",
                   "urls": [
                     "/${VERSION}/manage-certs-cli.html"
                   ]
@@ -414,7 +414,7 @@
               ]
             },
             {
-              "title": "Use Vault to Securly Manage Database Credentials",
+              "title": "Using Hashicorp Vault's Dynamic Secrets for Enhanced Database Credential Security",
               "urls": [
                 "/${VERSION}/vault-db-secrets-tutorial.html"
               ]
@@ -442,7 +442,7 @@
               ]
             },
             {
-              "title": "Tools Page",
+              "title": "Monitoring Page",
               "urls": [
                 "/cockroachcloud/tools-page.html"
               ]
@@ -530,12 +530,6 @@
           "title": "Third-Party Monitoring Integrations",
           "items": [
             {
-              "title": "Third-Party Monitoring Integration Overview",
-              "urls": [
-                "/${VERSION}/third-party-monitoring-tools.html"
-              ]
-            },
-            {
              "title": "Export Metrics From a {{ site.data.products.dedicated }} Cluster",
              "urls": [
                "/cockroachcloud/export-metrics.html"
@@ -609,6 +603,12 @@
                   ]
                 },
                 {
+                  "title": "Upgrade to v23.1",
+                  "urls": [
+                     "/cockroachcloud/upgrade-to-v23.1.html"
+                  ]
+                },
+                {
                   "title": "Upgrade to v22.2",
                   "urls": [
                      "/cockroachcloud/upgrade-to-v22.2.html"
@@ -675,65 +675,6 @@
           "title": "Disaster Recovery",
           "urls": [
             "/${VERSION}/disaster-recovery.html"
-          ]
-        }
-      ]
-    },
-    {
-      "title": "Replication Controls",
-      "urls": [
-        "/${VERSION}/configure-replication-zones.html"
-      ]
-    },
-    {
-      "title": "Troubleshooting",
-      "items": [
-        {
-          "title": "Troubleshooting Overview",
-          "urls": [
-            "/${VERSION}/troubleshooting-overview.html"
-          ]
-        },
-        {
-          "title": "Common Errors and Solutions",
-          "urls": [
-            "/${VERSION}/common-errors.html"
-          ]
-        },
-        {
-          "title": "Troubleshoot Cluster Setup",
-          "urls": [
-            "/${VERSION}/cluster-setup-troubleshooting.html"
-          ]
-        },
-        {
-          "title": "Troubleshoot Statement Behavior",
-          "urls": [
-            "/${VERSION}/query-behavior-troubleshooting.html"
-          ]
-        },
-        {
-          "title": "Troubleshoot CockroachDB Cloud",
-          "urls": [
-            "/cockroachcloud/troubleshooting-page.html"
-          ]
-        },
-        {
-          "title": "Replication Reports",
-          "urls": [
-            "/${VERSION}/query-replication-reports.html"
-          ]
-        },
-        {
-          "title": "Support Resources",
-          "urls": [
-            "/${VERSION}/support-resources.html"
-          ]
-        },
-        {
-          "title": "File an Issue",
-          "urls": [
-            "/${VERSION}/file-an-issue.html"
           ]
         }
       ]

--- a/src/current/cockroachcloud/cmek-ops-aws.md
+++ b/src/current/cockroachcloud/cmek-ops-aws.md
@@ -1,5 +1,5 @@
 ---
-title: Provision AWS KMS Keys and IAM Roles for CMEK
+title: Provision AWS for CMEK
 summary: Tutorial for provisioning CMEK in AWS, covering initial set-up, revocation, and recovery scenarios.
 toc: true
 docs_area: manage.security

--- a/src/current/cockroachcloud/cmek-ops-gcp.md
+++ b/src/current/cockroachcloud/cmek-ops-gcp.md
@@ -1,5 +1,5 @@
 ---
-title: Provision GCP KMS Keys and Service Accounts for CMEK
+title: Provision GCP for CMEK
 summary: Tutorial for provisioning CMEK in GCP, covering initial set-up, revocation, and recovery scenarios.
 toc: true
 docs_area: manage.security

--- a/src/current/cockroachcloud/managing-cmek.md
+++ b/src/current/cockroachcloud/managing-cmek.md
@@ -1,5 +1,5 @@
 ---
-title: Manage Customer-Managed Encryption Keys (CMEK) for CockroachDB Dedicated
+title: Manage CMEK for Dedicated Clusters
 summary: Tutorial for getting a dedicated cluster up and running with Customer-Managed Encryption Keys (CMEK)
 toc: true
 docs_area: manage.security

--- a/src/current/v22.1/manage-certs-cli.md
+++ b/src/current/v22.1/manage-certs-cli.md
@@ -5,7 +5,6 @@ toc: true
 docs_area: manage.security
 ---
 
-
 The CockroachDB CLI's [`cockroach cert`](cockroach-cert.html) command allows you to generate [private key/public certificate pairs for TLS authentication and encryption](security-reference/transport-layer-security.html) in communication between CockroachDB nodes, and from SQL clients to the cluster.
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v23.1/manage-certs-cli.md
+++ b/src/current/v23.1/manage-certs-cli.md
@@ -1,22 +1,19 @@
 ---
-title: Use the CockroachDB CLI to provision a development cluster
+title: Use the CLI to provision a development cluster
 summary: A secure CockroachDB cluster uses TLS for encrypted inter-node and client-node communication.
 toc: true
 docs_area: manage.security
 ---
 
-
 The CockroachDB CLI's [`cockroach cert`](cockroach-cert.html) command allows you to generate [private key/public certificate pairs for TLS authentication and encryption](security-reference/transport-layer-security.html) in communication between CockroachDB nodes, and from SQL clients to the cluster.
 
 {{site.data.alerts.callout_info}}
 
-The ability to rapidly and locally generate private key/public certificate pairs is important for development, but careful management of security certificates is an essential component of cluster security. We recommend that you use a cloud-native tool, such as Google Cloud Platform's Certificate Authority Service (CAS), to manage security certificates.
+The ability to rapidly and locally generate private key/public certificate pairs is useful in development, but careful management of security certificates is an essential component of cluster security. We recommend that you use a cloud-native tool, such as Google Cloud Platform's Certificate Authority Service (CAS), to manage security certificates, particularly in any production environments.
 
 Learn more: [Manage PKI certificates for a CockroachDB deployment with HashiCorp Vault](manage-certs-vault.html).
 
-
 {{site.data.alerts.end}}
-
 
 ## Create the CA certificate and key pair
 

--- a/src/current/v23.1/manage-certs-vault.md
+++ b/src/current/v23.1/manage-certs-vault.md
@@ -1,5 +1,5 @@
 ---
-title: Manage PKI certificates for a CockroachDB deployment with HashiCorp Vault
+title: Manage a cluster's PKI certificates with Vault
 summary: Using Google Cloud Platform Certificate Authority Service to manage PKI certificates
 toc: true
 docs_area: manage.security

--- a/src/current/v23.1/vault-db-secrets-tutorial.md
+++ b/src/current/v23.1/vault-db-secrets-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Using HashiCorp Vault's Dynamic Secrets for Enhanced Database Credential Security in CockroachDB
+title: Use Vault to Securly Manage Database Credentials
 summary: Learn how to achieve enhanced credential security using HashiCorp Vault's Dynamic Secrets functionality.
 toc: true
 docs_area: manage

--- a/src/current/v23.1/vault-db-secrets-tutorial.md
+++ b/src/current/v23.1/vault-db-secrets-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Use Vault to Securly Manage Database Credentials
+title: Use HashiCorp Vault to Securely Manage Database Credentials
 summary: Learn how to achieve enhanced credential security using HashiCorp Vault's Dynamic Secrets functionality.
 toc: true
 docs_area: manage


### PR DESCRIPTION
Have received feedback that titles in the security section are too long.
