### PR TITLE
DOC-8394: On Custom Chart Debug Page, remove Serverless tab under Available Metrics section

### DIFF
--- a/src/current/v23.1/metrics.md
+++ b/src/current/v23.1/metrics.md
@@ -9,28 +9,7 @@ As part of normal operation, CockroachDB continuously records metrics that track
 
 ## Available metrics
 
-Select your CockroachDB deployment to see the metrics available:
-
-{{site.data.alerts.callout_info}}
-This list is taken directly from the source code and is subject to change.
-{{site.data.alerts.end}}
-
-<div class="filters clearfix">
-  <button class="filter-button" data-scope="metric-names">Self-Hosted and Dedicated</button>
-  <button class="filter-button" data-scope="metric-names-serverless">Serverless</button>
-</div>
-
-<section class="filter-content" markdown="1" data-scope="metric-names">
-
 {% include {{page.version.version}}/metric-names.md %}
-
-</section>
-
-<section class="filter-content" markdown="1" data-scope="metric-names-serverless">
-
-{% include {{page.version.version}}/metric-names-serverless.md %}
-
-</section>
 
 ## See also
 

--- a/src/current/v23.1/ui-custom-chart-debug-page.md
+++ b/src/current/v23.1/ui-custom-chart-debug-page.md
@@ -41,28 +41,11 @@ Checking **Per Node** displays statistics for each node, which could show whethe
 
 ## Available metrics
 
-Select your CockroachDB deployment to see the metrics available:
-
 {{site.data.alerts.callout_info}}
-This list is taken directly from the source code and is subject to change. Some of the metrics listed below are already visible in other areas of the [DB Console](ui-overview.html).
+Some of the metrics listed below are already visible in other areas of the [DB Console](ui-overview.html).
 {{site.data.alerts.end}}
 
-<div class="filters clearfix">
-  <button class="filter-button" data-scope="metric-names">Self-Hosted and Dedicated</button>
-  <button class="filter-button" data-scope="metric-names-serverless">Serverless</button>
-</div>
-
-<section class="filter-content" markdown="1" data-scope="metric-names">
-
 {% include {{page.version.version}}/metric-names.md %}
-
-</section>
-
-<section class="filter-content" markdown="1" data-scope="metric-names-serverless">
-
-{% include {{page.version.version}}/metric-names-serverless.md %}
-
-</section>
 
 ## See also
 


### PR DESCRIPTION
Addresses: DOC-8394

Updated Custom Chart and Metrics pages, removed Serverless tab.