### PR TITLE
[DOC-8435][DOC-8546] Document how to get the connection string for MR Serverless with PrivateLink, correct VPC Peering error

### DIFF
--- a/src/current/cockroachcloud/aws-privatelink.md
+++ b/src/current/cockroachcloud/aws-privatelink.md
@@ -87,7 +87,7 @@ Continue to [Step 2. Create an AWS endpoint](#step-2-create-an-aws-endpoint).
 <section class="filter-content" markdown="1" data-scope="serverless">
 
 {{site.data.alerts.callout_success}}
-Complete these steps once for each private endpoint in your AWS account that will be used to privately connect to one or more of your {{ site.data.products.serverless-plan }} clusters. If you connect additional clusters to the same private endpoint, you do not need to make additional changes in your AWS account.
+Complete these steps once for each private endpoint in your AWS account that will be used to privately connect to one or more of your {{ site.data.products.serverless }} clusters. If you connect additional clusters to the same private endpoint, you do not need to make additional changes in your AWS account.
 {{site.data.alerts.end}}
 
 </section>
@@ -186,7 +186,7 @@ Use either the Amazon VPC Console or the [AWS Command Line Interface (CLI)](http
 
 <section class="filter-content" markdown="1" data-scope="aws-cli">
 
-After the endpoint status changes to Available, run the following AWS CLI command:
+After the endpoint status changes to **Available** on the Amazon VPC Console **Endpoints** page, run the following AWS CLI command:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -197,7 +197,7 @@ aws ec2 modify-vpc-endpoint --region {REGION} \
 
 The endpoint status will change to Pending.
 
-After a short (less than 5 minute) delay, the status will change to Available. You can now [connect to your cluster](connect-to-your-cluster.html).
+After a short (less than 5 minute) delay, the status will change from **Pending Request** to **Pending** and then to **Available**. You can now [connect to your cluster](connect-to-your-cluster.html).
 
 </section>
 

--- a/src/current/cockroachcloud/connect-to-a-serverless-cluster.md
+++ b/src/current/cockroachcloud/connect-to-a-serverless-cluster.md
@@ -68,6 +68,7 @@ Private connectivity is not available for {{ site.data.products.serverless }} cl
   <section class="filter-content" markdown="1" data-scope="connection-string">
 
 1. In the **Download CA Cert** section of the dialog, select your operating system, and use the command provided to download the CA certificate to the default PostgreSQL certificate directory on your machine.
+1. If you [established a private connection using AWS PrivateLink](#establish-aws-privatelink), change **Connection type** from **Public connection** to **Private connection** to connect privately.
 1. Copy the connection string provided in the **General connection string** section of the dialog, which will be used to connect your application to {{ site.data.products.serverless }}.
 1. Add your copied connection string to your application code. For information about connecting to {{ site.data.products.serverless }} with a [supported client](../stable/third-party-database-tools.html), see [Connect to a CockroachDB Cluster](../stable/connect-to-the-database.html).
 
@@ -89,6 +90,7 @@ For connection examples and code snippets in your language, see the following:
   <section class="filter-content" markdown="1" data-scope="connection-parameters">
 
 1. In the **Download CA Cert** section of the dialog, select your operating system, and use the command provided to download the CA certificate to the default PostgreSQL certificate directory on your machine.
+1. If you [established a private connection using AWS PrivateLink](#establish-aws-privatelink), change **Connection type** from **Public connection** to **Private connection** to connect privately.
 1. Select the **Parameters only** option of the **Select option** dropdown.
 
 1. Use the connection parameters provided in the dialog to connect to your cluster using a [CockroachDB-compatible tool](../{{site.current_cloud_version}}/third-party-database-tools.html).
@@ -106,7 +108,8 @@ For connection examples and code snippets in your language, see the following:
 
 1. In the **Download CA Cert** section of the dialog, select your operating system, and use the command provided to download the CA certificate to the default PostgreSQL certificate directory on your machine.
 1. In the **Download the latest CockroachDB Client** section of the dialog, select your operating system, and use the command provided to install CockroachDB.
-1. Copy the [`cockroach sql`](../stable/cockroach-sql.html) command and connection string provided in the **Connect** modal, which will be used in the next step (and to connect to your cluster in the future).
+1. If you [established a private connection using AWS PrivateLink](#establish-aws-privatelink), change **Connection type** from **Public connection** to **Private connection** to connect privately.
+1. Copy the [`cockroach sql`](../stable/cockroach-sql.html) command and connection string provided in the **Connect** dialog, which will be used in the next step (and to connect to your cluster in the future).
 1. In your terminal, enter the copied `cockroach sql` command and connection string to start the [built-in SQL client](../{{site.current_cloud_version}}/cockroach-sql.html).
 
 1. Enter the SQL user's password and hit enter.

--- a/src/current/cockroachcloud/connect-to-your-cluster.md
+++ b/src/current/cockroachcloud/connect-to-your-cluster.md
@@ -52,12 +52,12 @@ During [limited access](/docs/{{site.versions["stable"]}}/cockroachdb-feature-av
 
 1. Navigate to your cluster's **Networking > VPC Peering** tab.
 1. Click **Set up a VPC peering connection**.
-1. On the **Request a VPC peering connection** modal, enter your [GCP Project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+1. On the **Request a VPC peering connection** dialog, enter your [GCP Project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 1. Enter your [GCP VPC network name](https://cloud.google.com/vpc/docs/using-vpc#viewing-networks).
 1. In the **Connection name** field, enter a descriptive name for the VPC connection.
 1. Click **Request Connection**.
 1. Run the command displayed on the **Accept VPC peering connection request** window using [Google Cloud Shell](https://cloud.google.com/shell) or using the [gcloud command-line tool](https://cloud.google.com/sdk/gcloud).
-1. On the **Networking** page, verify the connection status is **Active**.
+1. On the **Networking** page, verify the connection status is **Available**.
 
 ## Select a connection method
 
@@ -113,6 +113,8 @@ To connect to your cluster with the [built-in SQL client](../{{site.current_clou
 
     {% include cockroachcloud/download-the-cert.md %}
 
+1. If you [established a private connection using VPC Peering or AWS PrivateLink](#establish-gcp-vpc-peering-or-aws-privatelink), click **VPC Peering** or **PrivateLink** to connect privately.
+
 1. Copy the [`cockroach sql`](../{{site.current_cloud_version}}/cockroach-sql.html) command and connection string provided in the Console, which will be used in the next step (and to connect to your cluster in the future):
 
     {% include cockroachcloud/sql-connection-string.md %}
@@ -146,6 +148,8 @@ To connect to your cluster with your application, use the connection string prov
 1. In your terminal, run the first command from the dialog to create a new `certs` directory on your local machine and download the CA certificate to that directory:
 
     {% include cockroachcloud/download-the-cert.md %}
+
+1. If you [established a private connection using VPC Peering or AWS PrivateLink](#establish-gcp-vpc-peering-or-aws-privatelink), click **VPC Peering** or **PrivateLink** to connect privately.
 
 1. Copy the connection string provided in the Console, which will be used to connect your application to {{ site.data.products.db }}:
 
@@ -194,6 +198,11 @@ For examples, see the following:
 
   <section class="filter-content" markdown="1" data-scope="connection-parameters">
 To connect to your cluster with a [CockroachDB-compatible tool](../{{site.current_cloud_version}}/third-party-database-tools.html), use the connection parameters provided in the Console.
+
+1. From the cluster's **Details** page, click **Connect**.
+1. If you [established a private connection using VPC Peering or AWS PrivateLink](#establish-gcp-vpc-peering-or-aws-privatelink), click **VPC Peering** or **PrivateLink** to connect privately.
+1. Copy the connection string and provide it to the CockroachDB-compatible tool.
+
   </section>
 
 ## What's next


### PR DESCRIPTION
[DOC-8435] Document how to get the connection string for MR Serverless with PrivateLink
[DOC-8546] Correct VPC Peering docs to change the desired status from Active to Available

- Also improve the Dedicated doc in a similar way.


Preview: 
[src/current/cockroachcloud/connect-to-a-serverless-cluster.md](https://deploy-preview-17570--cockroachdb-docs.netlify.app/docs/cockroachcloud/connect-to-a-serverless-cluster.html)
[src/current/cockroachcloud/connect-to-your-cluster.md](https://deploy-preview-17570--cockroachdb-docs.netlify.app/docs/cockroachcloud/connect-to-your-cluster.html)