### PR TITLE
rename "beta" to "partial" for third-party support

### DIFF
--- a/src/current/_includes/v20.1/misc/tooling.md
+++ b/src/current/_includes/v20.1/misc/tooling.md
@@ -3,7 +3,7 @@
 We’ve partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools.
 
 - **Full support** indicates that the vast majority of the tool's features should work without issue with CockroachDB. CockroachDB is regularly tested against the recommended version documented here.
-- **Beta support** indicates that the tool has been tried with CockroachDB, but its integration might require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that the tool has been tried with CockroachDB, but its integration might require additional steps, lack support for all features, or exhibit unexpected behavior.
 
 If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward better support.
 

--- a/src/current/_includes/v20.2/misc/tooling.md
+++ b/src/current/_includes/v20.2/misc/tooling.md
@@ -3,7 +3,7 @@
 Cockroach Labs has partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools:
 
 - **Full support** indicates that Cockroach Labs is committed to maintaining compatibility with the vast majority of the tool's features. CockroachDB is regularly tested against the latest version documented in the table below.
-- **Beta support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
 
 {{site.data.alerts.callout_info}}
 Unless explicitly stated, support for a [driver](#drivers) or [data access framework](#data-access-frameworks-e-g-orms) does not include [automatic, client-side transaction retry handling](transactions.html#client-side-intervention). For client-side transaction retry handling samples, see [Example Apps](example-apps.html).

--- a/src/current/_includes/v21.1/misc/tooling.md
+++ b/src/current/_includes/v21.1/misc/tooling.md
@@ -3,7 +3,7 @@
 Cockroach Labs has partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools:
 
 - **Full support** indicates that Cockroach Labs is committed to maintaining compatibility with the vast majority of the tool's features. CockroachDB is regularly tested against the latest version documented in the table below.
-- **Beta support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
 
 {{site.data.alerts.callout_info}}
 Unless explicitly stated, support for a [driver](#drivers) or [data access framework](#data-access-frameworks-e-g-orms) does not include [automatic, client-side transaction retry handling](transactions.html#client-side-intervention). For client-side transaction retry handling samples, see [Example Apps](example-apps.html).

--- a/src/current/_includes/v21.2/misc/tooling.md
+++ b/src/current/_includes/v21.2/misc/tooling.md
@@ -3,7 +3,7 @@
 Cockroach Labs has partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools:
 
 - **Full support** indicates that Cockroach Labs is committed to maintaining compatibility with the vast majority of the tool's features. CockroachDB is regularly tested against the latest version documented in the table below.
-- **Beta support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
 
 {{site.data.alerts.callout_info}}
 Unless explicitly stated, support for a [driver](#drivers) or [data access framework](#data-access-frameworks-e-g-orms) does not include [automatic, client-side transaction retry handling](transactions.html#client-side-intervention). For client-side transaction retry handling samples, see [Example Apps](example-apps.html).

--- a/src/current/_includes/v22.1/misc/tooling.md
+++ b/src/current/_includes/v22.1/misc/tooling.md
@@ -3,7 +3,7 @@
 Cockroach Labs has partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools:
 
 - **Full support** indicates that Cockroach Labs is committed to maintaining compatibility with the vast majority of the tool's features. CockroachDB is regularly tested against the latest version documented in the table below.
-- **Beta support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
 - **Partner supported** indicates that Cockroach Labs has a partnership with a third-party vendor that provides support for the CockroachDB integration with their tool. 
 
 {{site.data.alerts.callout_info}}

--- a/src/current/_includes/v22.2/misc/tooling.md
+++ b/src/current/_includes/v22.2/misc/tooling.md
@@ -3,7 +3,7 @@
 Cockroach Labs has partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools:
 
 - **Full support** indicates that Cockroach Labs is committed to maintaining compatibility with the vast majority of the tool's features. CockroachDB is regularly tested against the latest version documented in the table below.
-- **Beta support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
 - **Partner supported** indicates that Cockroach Labs has a partnership with a third-party vendor that provides support for the CockroachDB integration with their tool. 
 
 {{site.data.alerts.callout_info}}

--- a/src/current/_includes/v23.1/misc/tooling.md
+++ b/src/current/_includes/v23.1/misc/tooling.md
@@ -3,7 +3,7 @@
 Cockroach Labs has partnered with open-source projects, vendors, and individuals to offer the following levels of support with third-party tools:
 
 - **Full support** indicates that Cockroach Labs is committed to maintaining compatibility with the vast majority of the tool's features. CockroachDB is regularly tested against the latest version documented in the table below.
-- **Beta support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
+- **Partial support** indicates that Cockroach Labs is working towards full support for the tool. The primary features of the tool are compatible with CockroachDB (e.g., connecting and basic database operations), but full integration may require additional steps, lack support for all features, or exhibit unexpected behavior.
 - **Partner supported** indicates that Cockroach Labs has a partnership with a third-party vendor that provides support for the CockroachDB integration with their tool. 
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v22.1/build-a-csharp-app-with-cockroachdb.md
+++ b/src/current/v22.1/build-a-csharp-app-with-cockroachdb.md
@@ -9,7 +9,7 @@ docs_area: get_started
 
 This tutorial shows you how build a simple C# application with CockroachDB and the .NET Npgsql driver.
 
-We have tested the [.NET Npgsql driver](http://www.npgsql.org/) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [.NET Npgsql driver](http://www.npgsql.org/) enough to claim **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Step 1. Start CockroachDB
 

--- a/src/current/v22.1/example-apps.md
+++ b/src/current/v22.1/example-apps.md
@@ -14,7 +14,7 @@ Click the links in the tables below to see simple but complete example applicati
 If you are looking to do a specific task such as connect to the database, insert data, or run multi-statement transactions, see [this list of tasks](#tasks).
 
 {{site.data.alerts.callout_info}}
-Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM with **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM with **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 Note that tools with [**community-level** support](community-tooling.html) have been tested or developed by the CockroachDB community, but are not officially supported by Cockroach Labs. If you encounter problems with using these tools, please contact the maintainer of the tool with details.
 {{site.data.alerts.end}}
@@ -65,13 +65,13 @@ Note that tools with [**community-level** support](community-tooling.html) have 
 
 | Driver/ORM Framework                                      | Support level  | Example apps                                           |
 |-----------------------------------------------------------+----------------+--------------------------------------------------------|
-| [Npgsql](https://www.npgsql.org/)                         | Beta           | [Simple CRUD](build-a-csharp-app-with-cockroachdb.html)
+| [Npgsql](https://www.npgsql.org/)                         | Partial           | [Simple CRUD](build-a-csharp-app-with-cockroachdb.html)
 
 ## Rust
 
 | Driver/ORM Framework                           | Support level  | Example apps                                           |
 |------------------------------------------------+----------------+--------------------------------------------------------|
-| [Rust-Postgres](https://github.com/sfackler/rust-postgres) | Beta      | [Simple CRUD](build-a-rust-app-with-cockroachdb.html)
+| [Rust-Postgres](https://github.com/sfackler/rust-postgres) | Partial      | [Simple CRUD](build-a-rust-app-with-cockroachdb.html)
 
 
 ## See also

--- a/src/current/v22.1/install-client-drivers.md
+++ b/src/current/v22.1/install-client-drivers.md
@@ -8,7 +8,7 @@ docs_area: develop
 CockroachDB supports both native drivers and the PostgreSQL wire protocol, so most available PostgreSQL client drivers and ORM frameworks should work with CockroachDB. Choose a language for supported clients, and follow the installation steps. After you install a client library, you can [connect to the database](connect-to-the-database.html).
 
 {{site.data.alerts.callout_info}}
-Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM framework with **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM framework with **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 {{site.data.alerts.end}}
 
 <div class="filters clearfix">
@@ -352,7 +352,7 @@ For a simple but complete example app, see [Build a Ruby App with CockroachDB an
 
 ### libpq
 
-**Support level:** Beta
+**Support level:** Partial
 
 Install the C libpq driver as described in the [official documentation](https://www.postgresql.org/docs/current/libpq.html).
 
@@ -364,7 +364,7 @@ Install the C libpq driver as described in the [official documentation](https://
 
 ### Npgsql
 
-**Support level:** Beta
+**Support level:** Partial
 
 1. Create a .NET project:
 
@@ -397,7 +397,7 @@ For a simple but complete example app, see [Build a C# App with CockroachDB and 
 
 ### rust-postgres
 
-**Support level:** Beta
+**Support level:** Partial
 
 Install the Rust-Postgres driver as described in the [official documentation](https://crates.io/crates/postgres).
 

--- a/src/current/v22.2/example-apps.md
+++ b/src/current/v22.2/example-apps.md
@@ -14,7 +14,7 @@ Click the links in the tables below to see simple but complete example applicati
 If you are looking to do a specific task such as connect to the database, insert data, or run multi-statement transactions, see [this list of tasks](#tasks).
 
 {{site.data.alerts.callout_info}}
-Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM with **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM with **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 Note that tools with [**community-level** support](community-tooling.html) have been tested or developed by the CockroachDB community, but are not officially supported by Cockroach Labs. If you encounter problems with using these tools, please contact the maintainer of the tool with details.
 {{site.data.alerts.end}}
@@ -66,13 +66,13 @@ Note that tools with [**community-level** support](community-tooling.html) have 
 
 | Driver/ORM Framework                                      | Support level  | Example apps                                           |
 |-----------------------------------------------------------+----------------+--------------------------------------------------------|
-| [Npgsql](https://www.npgsql.org/)                         | Beta           | [Simple CRUD](build-a-csharp-app-with-cockroachdb.html)
+| [Npgsql](https://www.npgsql.org/)                         | Partial           | [Simple CRUD](build-a-csharp-app-with-cockroachdb.html)
 
 ## Rust
 
 | Driver/ORM Framework                           | Support level  | Example apps                                           |
 |------------------------------------------------+----------------+--------------------------------------------------------|
-| [Rust-Postgres](https://github.com/sfackler/rust-postgres) | Beta      | [Simple CRUD](build-a-rust-app-with-cockroachdb.html)
+| [Rust-Postgres](https://github.com/sfackler/rust-postgres) | Partial      | [Simple CRUD](build-a-rust-app-with-cockroachdb.html)
 
 
 ## See also

--- a/src/current/v22.2/install-client-drivers.md
+++ b/src/current/v22.2/install-client-drivers.md
@@ -8,7 +8,7 @@ docs_area: develop
 CockroachDB supports both native drivers and the PostgreSQL wire protocol, so most available PostgreSQL client drivers and ORM frameworks should work with CockroachDB. Choose a language for supported clients, and follow the installation steps. After you install a client library, you can [connect to the database](connect-to-the-database.html).
 
 {{site.data.alerts.callout_info}}
-Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM framework with **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM framework with **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 {{site.data.alerts.end}}
 
 <div class="filters clearfix">
@@ -352,7 +352,7 @@ For a simple but complete example app, see [Build a Ruby App with CockroachDB an
 
 ### libpq
 
-**Support level:** Beta
+**Support level:** Partial
 
 Install the C libpq driver as described in the [official documentation](https://www.postgresql.org/docs/current/libpq.html).
 
@@ -364,7 +364,7 @@ Install the C libpq driver as described in the [official documentation](https://
 
 ### Npgsql
 
-**Support level:** Beta
+**Support level:** Partial
 
 1. Create a .NET project:
 
@@ -397,7 +397,7 @@ For a simple but complete example app, see [Build a C# App with CockroachDB and 
 
 ### rust-postgres
 
-**Support level:** Beta
+**Support level:** Partial
 
 Install the Rust-Postgres driver as described in the [official documentation](https://crates.io/crates/postgres).
 

--- a/src/current/v23.1/example-apps.md
+++ b/src/current/v23.1/example-apps.md
@@ -14,7 +14,7 @@ Click the links in the tables below to see simple but complete example applicati
 If you are looking to do a specific task such as connect to the database, insert data, or run multi-statement transactions, see [this list of tasks](#tasks).
 
 {{site.data.alerts.callout_info}}
-Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM with **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM with **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 Note that tools with [**community-level** support](community-tooling.html) have been tested or developed by the CockroachDB community, but are not officially supported by Cockroach Labs. If you encounter problems with using these tools, please contact the maintainer of the tool with details.
 {{site.data.alerts.end}}
@@ -35,7 +35,7 @@ Note that tools with [**community-level** support](community-tooling.html) have 
 |-----------------------------------------------------------------+----------------+--------------------------------------------------------|
 | [psycopg2](https://www.psycopg.org/docs/install.html) | Full  | [Simple CRUD](build-a-python-app-with-cockroachdb.html)<br>[AWS Lambda](deploy-lambda-function.html)
 | [psycopg3](https://www.psycopg.org/psycopg3/docs/)           | Full           | [Simple CRUD](build-a-python-app-with-cockroachdb-psycopg3.html)
-| [asyncpg](https://magicstack.github.io/asyncpg/current/index.html) | Beta  | [Simple CRUD](build-a-python-app-with-cockroachdb-asyncpg.html)
+| [asyncpg](https://magicstack.github.io/asyncpg/current/index.html) | Partial  | [Simple CRUD](build-a-python-app-with-cockroachdb-asyncpg.html)
 | [SQLAlchemy](https://www.sqlalchemy.org/)                       | Full           | [Simple CRUD](build-a-python-app-with-cockroachdb-sqlalchemy.html)<br>[Multi-region Flask Web App](movr.html)
 | [Django](https://pypi.org/project/Django/)                      | Full           | [Simple CRUD](build-a-python-app-with-cockroachdb-django.html)
 
@@ -67,13 +67,13 @@ Note that tools with [**community-level** support](community-tooling.html) have 
 
 | Driver/ORM Framework                                      | Support level  | Example apps                                           |
 |-----------------------------------------------------------+----------------+--------------------------------------------------------|
-| [Npgsql](https://www.npgsql.org/)                         | Beta           | [Simple CRUD](build-a-csharp-app-with-cockroachdb.html)
+| [Npgsql](https://www.npgsql.org/)                         | Partial           | [Simple CRUD](build-a-csharp-app-with-cockroachdb.html)
 
 ## Rust
 
 | Driver/ORM Framework                           | Support level  | Example apps                                           |
 |------------------------------------------------+----------------+--------------------------------------------------------|
-| [Rust-Postgres](https://github.com/sfackler/rust-postgres) | Beta      | [Simple CRUD](build-a-rust-app-with-cockroachdb.html)
+| [Rust-Postgres](https://github.com/sfackler/rust-postgres) | Partial      | [Simple CRUD](build-a-rust-app-with-cockroachdb.html)
 
 
 ## See also

--- a/src/current/v23.1/install-client-drivers.md
+++ b/src/current/v23.1/install-client-drivers.md
@@ -8,7 +8,7 @@ docs_area: develop
 CockroachDB supports both native drivers and the PostgreSQL wire protocol, so most available PostgreSQL client drivers and ORM frameworks should work with CockroachDB. Choose a language for supported clients, and follow the installation steps. After you install a client library, you can [connect to the database](connect-to-the-database.html).
 
 {{site.data.alerts.callout_info}}
-Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM framework with **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+Applications may encounter incompatibilities when using advanced or obscure features of a driver or ORM framework with **partial** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 {{site.data.alerts.end}}
 
 <div class="filters clearfix">
@@ -352,7 +352,7 @@ For a simple but complete example app, see [Build a Ruby App with CockroachDB an
 
 ### libpq
 
-**Support level:** Beta
+**Support level:** Partial
 
 Install the C libpq driver as described in the [official documentation](https://www.postgresql.org/docs/current/libpq.html).
 
@@ -364,7 +364,7 @@ Install the C libpq driver as described in the [official documentation](https://
 
 ### Npgsql
 
-**Support level:** Beta
+**Support level:** Partial
 
 1. Create a .NET project:
 
@@ -397,7 +397,7 @@ For a simple but complete example app, see [Build a C# App with CockroachDB and 
 
 ### rust-postgres
 
-**Support level:** Beta
+**Support level:** Partial
 
 Install the Rust-Postgres driver as described in the [official documentation](https://crates.io/crates/postgres).
 


### PR DESCRIPTION
DOC-8227

Change the "beta" terminology for third-party support levels to "partial", which better complements "full" support.