### PR TITLE
Fix protocol-relative URLs

### DIFF
--- a/src/current/_includes/head.html
+++ b/src/current/_includes/head.html
@@ -113,10 +113,10 @@ var pageConfig = {
   <script src="{{ 'js/license-on-page.js' | relative_url }}"></script>
 {% endif %}
 
-<link rel="preconnect dns-prefetch" href="//go.cockroachlabs.com" />
-<link rel="preconnect dns-prefetch" href="//cockroach-labs-docs.imgix.net" />
+<link rel="preconnect dns-prefetch" href="https://go.cockroachlabs.com" />
+<link rel="preconnect dns-prefetch" href="https://cockroach-labs-docs.imgix.net" />
 
-<link rel="preload" href="//go.cockroachlabs.com/js/forms2/js/forms2.min.js" as="script" />
+<link rel="preload" href="https://go.cockroachlabs.com/js/forms2/js/forms2.min.js" as="script" />
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/current/_layouts/default.html
+++ b/src/current/_layouts/default.html
@@ -62,7 +62,7 @@
 {% include_cached footer.html %}
 
 {% include_cached sidebar.js.html sidebar_data=page.sidebar_data %}
-    <script src="//go.cockroachlabs.com/js/forms2/js/forms2.min.js" defer></script>
+    <script src="https://go.cockroachlabs.com/js/forms2/js/forms2.min.js" defer></script>
     <script src="{{ 'js/jquery.cookie.min.js' | relative_url }}" defer></script>
     <script src="{{ 'js/jquery.navgoco.min.js' | relative_url }}" defer></script>
     <!-- bs 4.X -->


### PR DESCRIPTION
We should be explicit with the protocol we use in our URLs. This adds `https:` in front of the URLs we reference in our HTML templates.