### PR TITLE
Update heading in stream data sidenav

### DIFF
--- a/src/current/_includes/v22.2/sidebar-data/stream.json
+++ b/src/current/_includes/v22.2/sidebar-data/stream.json
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "title": "Work with Changefeeds",
+      "title": "Optimize Changefeeds",
       "items": [
         {
           "title": "Change Data Capture Transformations",

--- a/src/current/_includes/v23.1/sidebar-data/stream-data.json
+++ b/src/current/_includes/v23.1/sidebar-data/stream-data.json
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "title": "Work with Changefeeds",
+      "title": "Optimize Changefeeds",
       "items": [
         {
           "title": "Change Data Capture Queries",


### PR DESCRIPTION
Fixes DOC-8583

This is a quick fix PR to rename one of the headings in the Stream Data side nav to better describe the pages that fall underneath and to better relate to the [heading on the CDC overview page](https://www.cockroachlabs.com/docs/stable/change-data-capture-overview#optimize-a-changefeed-for-your-workload).