### PR TITLE
DOC-8349 add cloud storage backup cluster settings

### DIFF
--- a/src/current/v22.2/backup.md
+++ b/src/current/v22.2/backup.md
@@ -177,6 +177,34 @@ Improve the speed of backups to Azure Storage by increasing `cloudstorage.azure.
 
 **Default:** `1`
 
+#### Cloud storage cluster settings
+
+The following cluster settings limit the read and write rates to [cloud storage]({% link {{ page.version.version }}/use-cloud-storage.md %}). A user may choose to use these settings if their backups overwhelm the network. These settings limit throughput and as a result backups will take longer. The designated `<provider>`s include `s3`, `gs`, and `azure`.     
+
+#### `cloudstorage.<provider>.write.node_rate_limit`
+
+Limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero.
+
+**Default:** `0 B`
+
+#### `cloudstorage.<provider>.write.node_burst_limit`
+
+Burst limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero.
+
+**Default:** `0 B`
+
+#### `cloudstorage.<provider>.read.node_rate_limit`
+
+Limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero.
+
+**Default:** `0 B`
+
+#### `cloudstorage.<provider>.read.node_burst_limit`
+
+Burst limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero. 
+
+**Default:** `0 B`
+
 For a complete list, including all cluster settings related to backups, see the [Cluster Settings](cluster-settings.html) page.
 
 ## Viewing and controlling backups jobs

--- a/src/current/v23.1/backup.md
+++ b/src/current/v23.1/backup.md
@@ -186,6 +186,34 @@ Improve the speed of backups to Azure Storage by increasing `cloudstorage.azure.
 
 **Default:** `1`
 
+#### Cloud storage cluster settings
+
+The following cluster settings limit the read and write rates to [cloud storage]({% link {{ page.version.version }}/use-cloud-storage.md %}). A user may choose to use these settings if their backups overwhelm the network. These settings limit throughput and as a result backups will take longer. The designated `<provider>`s include `s3`, `gs`, and `azure`.     
+
+#### `cloudstorage.<provider>.write.node_rate_limit`
+
+Limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero.
+
+**Default:** `0 B`
+
+#### `cloudstorage.<provider>.write.node_burst_limit`
+
+Burst limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero.
+
+**Default:** `0 B`
+
+#### `cloudstorage.<provider>.read.node_rate_limit`
+
+Limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero.
+
+**Default:** `0 B`
+
+#### `cloudstorage.<provider>.read.node_burst_limit`
+
+Burst limit the number of bytes per second per node across operations writing to the designated cloud storage provider if non-zero. 
+
+**Default:** `0 B`
+
 For a complete list, including all cluster settings related to backups, see the [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %}) page.
 
 ## Viewing and controlling backups jobs


### PR DESCRIPTION
Addresses DOC-8349: 
- Added additional cluster settings that limit the read and write rates to cloud storage

Preview:
https://deploy-preview-17684--cockroachdb-docs.netlify.app/docs/stable/backup#cloud-storage-cluster-settings

Note:
- looks like the [Cluster Settings](https://www.cockroachlabs.com/docs/v23.1/cluster-settings) list managed by eng does not contain these options 