### PR TITLE
DOC-7918: PR #104542 - sql: Limit MODIFYSQLCLUSTERSETTING to only view sql.defaults

### DIFF
--- a/src/current/v23.1/set-cluster-setting.md
+++ b/src/current/v23.1/set-cluster-setting.md
@@ -20,6 +20,8 @@ To use the `SET CLUSTER SETTING` statement, a user must have one of the followin
     GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;
     ~~~
 
+- Have the `MODIFYSQLCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted. Users with this privilege are allowed to modify only [`sql.defaults.*` cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}#setting-sql-defaults-cost-scans-with-default-col-size-enabled), not all cluster settings.
+
 ## Synopsis
 
 <div>

--- a/src/current/v23.1/show-cluster-setting.md
+++ b/src/current/v23.1/show-cluster-setting.md
@@ -43,7 +43,12 @@ The `SHOW` statement for cluster settings is unrelated to the other `SHOW` state
 
 ## Required privileges
 
-To use the `SHOW CLUSTER SETTING` statement, a user must either be a member of the `admin` role (the `root` user belongs to the `admin` role by default) or have the `VIEWCLUSTERSETTING` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
+To use the `SHOW CLUSTER SETTING` statement, a user must have one of the following attributes:
+
+- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default)
+- Have the `MODIFYCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted.
+- Have the `VIEWCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
+- Have the `MODIFYSQLCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted. Users with this privilege are allowed to view only [`sql.defaults.*` cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}#setting-sql-defaults-cost-scans-with-default-col-size-enabled), not all cluster settings.
 
 ## Synopsis
 

--- a/src/current/v23.1/show-cluster-setting.md
+++ b/src/current/v23.1/show-cluster-setting.md
@@ -45,7 +45,7 @@ The `SHOW` statement for cluster settings is unrelated to the other `SHOW` state
 
 To use the `SHOW CLUSTER SETTING` statement, a user must have one of the following attributes:
 
-- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default)
+- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default).
 - Have the `MODIFYCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted.
 - Have the `VIEWCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
 - Have the `MODIFYSQLCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted. Users with this privilege are allowed to view only [`sql.defaults.*` cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}#setting-sql-defaults-cost-scans-with-default-col-size-enabled), not all cluster settings.

--- a/src/current/v23.2/set-cluster-setting.md
+++ b/src/current/v23.2/set-cluster-setting.md
@@ -20,6 +20,8 @@ To use the `SET CLUSTER SETTING` statement, a user must have one of the followin
     GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;
     ~~~
 
+- Have the `MODIFYSQLCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted. Users with this privilege are allowed to modify only [`sql.defaults.*` cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}#setting-sql-defaults-cost-scans-with-default-col-size-enabled), not all cluster settings.
+
 ## Synopsis
 
 <div>

--- a/src/current/v23.2/show-cluster-setting.md
+++ b/src/current/v23.2/show-cluster-setting.md
@@ -43,7 +43,12 @@ The `SHOW` statement for cluster settings is unrelated to the other `SHOW` state
 
 ## Required privileges
 
-To use the `SHOW CLUSTER SETTING` statement, a user must either be a member of the `admin` role (the `root` user belongs to the `admin` role by default) or have the `VIEWCLUSTERSETTING` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
+To use the `SHOW CLUSTER SETTING` statement, a user must have one of the following attributes:
+
+- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default).
+- Have the `MODIFYCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted.
+- Have the `VIEWCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
+- Have the `MODIFYSQLCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted. Users with this privilege are allowed to view only [`sql.defaults.*` cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}#setting-sql-defaults-cost-scans-with-default-col-size-enabled), not all cluster settings.
 
 ## Synopsis
 


### PR DESCRIPTION
Addresses: DOC-7918

(1) Updated SET CLUSTER SETTING and SHOW CLUSTER SETTING pages, updated Required privileges to include MODIFYSQLCLUSTERSETTING. (2) Updated 23.2 files.