### PR TITLE
Add docs on CPU-based replica rebalancing

### DIFF
--- a/src/current/v23.1/architecture/replication-layer.md
+++ b/src/current/v23.1/architecture/replication-layer.md
@@ -220,7 +220,21 @@ Rebalancing is achieved by using a snapshot of a replica from the leaseholder, a
 
 #### Load-based replica rebalancing
 
-In addition to the rebalancing that occurs when nodes join or leave a cluster, replicas are also rebalanced automatically based on the relative load across the nodes within a cluster. For more information, see the `kv.allocator.load_based_rebalancing` and `kv.allocator.qps_rebalance_threshold` [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}). Note that depending on the needs of your deployment, you can exercise additional control over the location of leases and replicas by [configuring replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}).
+In addition to the rebalancing that occurs when nodes join or leave a cluster, replicas are also rebalanced automatically across the cluster based on a combination of:
+
+1. Replica count.
+1. CPU usage (if [`kv.allocator.load_based_rebalancing.objective`]({% link {{ page.version.version }}/cluster-settings.md %}#setting-kv-allocator-load-based-rebalancing-objective) is set to `cpu`, which is the default in CockroachDB v23.1 and later)
+
+Note that disk utilization per node is not one of the rebalancing criteria. For more information, see [Disk utilization is different across nodes in the cluster]({% link {{ page.version.version }}/cluster-setup-troubleshooting.md %}#disk-utilization-is-different-across-nodes-in-the-cluster).
+
+Load-based replica rebalancing operates in conjunction with [load-based splitting]({% link {{ page.version.version }}/load-based-splitting.md %}) of [ranges]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-range).
+
+For more information on how to control load-based rebalancing, see the following [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}):
+
+- [`kv.allocator.store_cpu_rebalance_threshold`]({% link {{ page.version.version }}/cluster-settings.md %}#setting-kv-allocator-store-cpu-rebalance-threshold)
+- [`kv.allocator.range_rebalance_threshold`]({% link {{ page.version.version }}/cluster-settings.md %}#setting-kv-allocator-range-rebalance-threshold)
+
+Depending on the needs of your deployment, you can exercise additional control over the locations of leases and replicas using [multi-region SQL]({% link {{ page.version.version }}/multiregion-overview.md %}), or by [configuring replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}).
 
 ### Important values and timeouts
 

--- a/src/current/v23.1/cluster-setup-troubleshooting.md
+++ b/src/current/v23.1/cluster-setup-troubleshooting.md
@@ -441,6 +441,21 @@ CockroachDB's built-in disk stall detection works as follows:
 
 - During [node liveness heartbeats](#node-liveness-issues), the [storage engine]({% link {{ page.version.version }}/architecture/storage-layer.md %}) writes to disk as part of the node liveness heartbeat process.
 
+#### Disk utilization is different across nodes in the cluster
+
+This is expected behavior.
+
+CockroachDB uses [load-based replica rebalancing]({% link {{ page.version.version }}/architecture/replication-layer.md %}#load-based-replica-rebalancing) to spread [replicas]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-replica) across the nodes in a cluster.
+
+The rebalancing criteria for load-based replica rebalancing do not include the percentage of disk utilized per node. Not all [ranges]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-range) are the same size. The proportions of larger and smaller ranges on each node balance each other out on average, so disk utilization differences across nodes should be relatively small.
+
+However, in some cases a majority of the largest (or smallest) ranges are on one node, which will result in imbalanced utilization. Normally that shouldn't be a problem with [sufficiently provisioned storage]({% link {{ page.version.version }}/recommended-production-settings.md %}#storage). If this imbalance is causing issues, please [contact Support]({% link {{ page.version.version }}/support-resources.md %}) for guidance you on how to manually rebalance your cluster's disk usage.
+
+Finally, note that although the replica allocator does not rebalance based on disk utilization during normal operation, it does have the following mechanisms to help protect against [full disks](#disks-filling-up):
+
+- It will avoid moving replicas onto a disk that is more than 92.5% full.
+- It will start moving replicas off of a disk that is 95% full.
+
 ## CPU issues
 
 #### CPU is insufficient for the workload

--- a/src/current/v23.1/load-based-splitting.md
+++ b/src/current/v23.1/load-based-splitting.md
@@ -69,6 +69,27 @@ However, by leveraging load-based splitting, the cluster can understand load on 
 
 This benefit is further amplified by [load-based rebalancing]({% link {{ page.version.version }}/architecture/replication-layer.md %}#load-based-replica-rebalancing), which ensures that all nodes contain replicas with a roughly equal load. By evenly distributing load throughout your cluster, it's easier to prevent bottlenecks from arising, as well as simplifying hardware forecasting.
 
+## Monitor load-based splitting
+
+The [`INFO`]({% link {{ page.version.version }}/logging.md %}#info) log message
+
+~~~
+no split key found: ...
+~~~
+
+indicates that CockroachDB wants to [split the range]({% link {{ page.version.version }}/architecture/distribution-layer.md %}#range-splits) due to load, but couldn’t find a key to split at.
+
+Usually this log message can be ignored, unless it repeatedly shows up, which can indicate there is a load imbalance problem in the cluster. If there is a load imbalance problem, it could be because a [hot range]({% link {{ page.version.version }}/ui-hot-ranges-page.md %}) cannot be split (because it's really a [hot key]({% link {{ page.version.version }}/ui-hot-ranges-page.md %}#range-report)).
+
+You can see how often a split key cannot be found over time by looking at the following [time-series metric]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint):
+
+- `kv.loadsplitter.nosplitkey`
+
+This metric is directly related to the log message described above.
+
+For more information about how to reduce hot spots (including hot ranges) on your cluster, see [Hot spots]({% link {{ page.version.version }}/performance-best-practices-overview.md %}#hot-spots).
+
 ## See also
 
 - [`SET CLUSTER SETTING`]({% link {{ page.version.version }}/set-cluster-setting.md %})
+- [Load-based replica rebalancing]({% link {{ page.version.version }}/architecture/replication-layer.md %}#load-based-replica-rebalancing)

--- a/src/current/v23.1/node-shutdown.md
+++ b/src/current/v23.1/node-shutdown.md
@@ -290,6 +290,10 @@ To determine an appropriate termination grace period:
 
 Before decommissioning a node, make sure other nodes are available to take over the range replicas from the node. If fewer nodes are available than the replication factor, CockroachDB will automatically reduce the replication factor (for example, from 5 to 3) to try to allow the decommission to succeed. However, the replication factor will not be reduced lower than 3. If three nodes are not available, the decommissioning process will hang indefinitely until nodes are added or you update the zone configurations to use a replication factor of 1.
 
+Note that when you decommission a node and immediately add another node, CockroachDB does **not** simply move all of the replicas from the decommissioned node to the newly added node. Instead, replicas are placed across all nodes in the cluster. This speeds up the decommissioning process by spreading the load. The new node will eventually "catch up" with the rest of the cluster.
+
+This can lead to disk utilization imbalance across nodes. **This is expected behavior**, since disk utilization per node is not one of the rebalancing criteria. For more information, see [Disk utilization is different across nodes in the cluster]({% link {{ page.version.version }}/cluster-setup-troubleshooting.md %}#disk-utilization-is-different-across-nodes-in-the-cluster).
+
 #### 3-node cluster with 3-way replication
 
 In this scenario, each range is replicated 3 times, with each replica on a different node:

--- a/src/current/v23.2/architecture/replication-layer.md
+++ b/src/current/v23.2/architecture/replication-layer.md
@@ -220,7 +220,21 @@ Rebalancing is achieved by using a snapshot of a replica from the leaseholder, a
 
 #### Load-based replica rebalancing
 
-In addition to the rebalancing that occurs when nodes join or leave a cluster, replicas are also rebalanced automatically based on the relative load across the nodes within a cluster. For more information, see the `kv.allocator.load_based_rebalancing` and `kv.allocator.qps_rebalance_threshold` [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}). Note that depending on the needs of your deployment, you can exercise additional control over the location of leases and replicas by [configuring replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}).
+In addition to the rebalancing that occurs when nodes join or leave a cluster, replicas are also rebalanced automatically across the cluster based on a combination of:
+
+1. Replica count.
+1. CPU usage (if [`kv.allocator.load_based_rebalancing.objective`]({% link {{ page.version.version }}/cluster-settings.md %}#setting-kv-allocator-load-based-rebalancing-objective) is set to `cpu`, which is the default in CockroachDB v23.1 and later)
+
+Note that disk utilization per node is not one of the rebalancing criteria. For more information, see [Disk utilization is different across nodes in the cluster]({% link {{ page.version.version }}/cluster-setup-troubleshooting.md %}#disk-utilization-is-different-across-nodes-in-the-cluster).
+
+Load-based replica rebalancing operates in conjunction with [load-based splitting]({% link {{ page.version.version }}/load-based-splitting.md %}) of [ranges]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-range).
+
+For more information on how to control load-based rebalancing, see the following [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}):
+
+- [`kv.allocator.store_cpu_rebalance_threshold`]({% link {{ page.version.version }}/cluster-settings.md %}#setting-kv-allocator-store-cpu-rebalance-threshold)
+- [`kv.allocator.range_rebalance_threshold`]({% link {{ page.version.version }}/cluster-settings.md %}#setting-kv-allocator-range-rebalance-threshold)
+
+Depending on the needs of your deployment, you can exercise additional control over the locations of leases and replicas using [multi-region SQL]({% link {{ page.version.version }}/multiregion-overview.md %}), or by [configuring replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}).
 
 ### Important values and timeouts
 

--- a/src/current/v23.2/cluster-setup-troubleshooting.md
+++ b/src/current/v23.2/cluster-setup-troubleshooting.md
@@ -441,6 +441,21 @@ CockroachDB's built-in disk stall detection works as follows:
 
 - During [node liveness heartbeats](#node-liveness-issues), the [storage engine]({% link {{ page.version.version }}/architecture/storage-layer.md %}) writes to disk as part of the node liveness heartbeat process.
 
+#### Disk utilization is different across nodes in the cluster
+
+This is expected behavior.
+
+CockroachDB uses [load-based replica rebalancing]({% link {{ page.version.version }}/architecture/replication-layer.md %}#load-based-replica-rebalancing) to spread [replicas]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-replica) across the nodes in a cluster.
+
+The rebalancing criteria for load-based replica rebalancing do not include the percentage of disk utilized per node. Not all [ranges]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-range) are the same size. The proportions of larger and smaller ranges on each node balance each other out on average, so disk utilization differences across nodes should be relatively small.
+
+However, in some cases a majority of the largest (or smallest) ranges are on one node, which will result in imbalanced utilization. Normally that shouldn't be a problem with [sufficiently provisioned storage]({% link {{ page.version.version }}/recommended-production-settings.md %}#storage). If this imbalance is causing issues, please [contact Support]({% link {{ page.version.version }}/support-resources.md %}) for guidance you on how to manually rebalance your cluster's disk usage.
+
+Finally, note that although the replica allocator does not rebalance based on disk utilization during normal operation, it does have the following mechanisms to help protect against [full disks](#disks-filling-up):
+
+- It will avoid moving replicas onto a disk that is more than 92.5% full.
+- It will start moving replicas off of a disk that is 95% full.
+
 ## CPU issues
 
 #### CPU is insufficient for the workload

--- a/src/current/v23.2/load-based-splitting.md
+++ b/src/current/v23.2/load-based-splitting.md
@@ -69,6 +69,27 @@ However, by leveraging load-based splitting, the cluster can understand load on 
 
 This benefit is further amplified by [load-based rebalancing]({% link {{ page.version.version }}/architecture/replication-layer.md %}#load-based-replica-rebalancing), which ensures that all nodes contain replicas with a roughly equal load. By evenly distributing load throughout your cluster, it's easier to prevent bottlenecks from arising, as well as simplifying hardware forecasting.
 
+## Monitor load-based splitting
+
+The [`INFO`]({% link {{ page.version.version }}/logging.md %}#info) log message
+
+~~~
+no split key found: ...
+~~~
+
+indicates that CockroachDB wants to [split the range]({% link {{ page.version.version }}/architecture/distribution-layer.md %}#range-splits) due to load, but couldn’t find a key to split at.
+
+Usually this log message can be ignored, unless it repeatedly shows up, which can indicate there is a load imbalance problem in the cluster. If there is a load imbalance problem, it could be because a [hot range]({% link {{ page.version.version }}/ui-hot-ranges-page.md %}) cannot be split (because it's really a [hot key]({% link {{ page.version.version }}/ui-hot-ranges-page.md %}#range-report)).
+
+You can see how often a split key cannot be found over time by looking at the following [time-series metric]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint):
+
+- `kv.loadsplitter.nosplitkey`
+
+This metric is directly related to the log message described above.
+
+For more information about how to reduce hot spots (including hot ranges) on your cluster, see [Hot spots]({% link {{ page.version.version }}/performance-best-practices-overview.md %}#hot-spots).
+
 ## See also
 
 - [`SET CLUSTER SETTING`]({% link {{ page.version.version }}/set-cluster-setting.md %})
+- [Load-based replica rebalancing]({% link {{ page.version.version }}/architecture/replication-layer.md %}#load-based-replica-rebalancing)

--- a/src/current/v23.2/node-shutdown.md
+++ b/src/current/v23.2/node-shutdown.md
@@ -290,6 +290,10 @@ To determine an appropriate termination grace period:
 
 Before decommissioning a node, make sure other nodes are available to take over the range replicas from the node. If fewer nodes are available than the replication factor, CockroachDB will automatically reduce the replication factor (for example, from 5 to 3) to try to allow the decommission to succeed. However, the replication factor will not be reduced lower than 3. If three nodes are not available, the decommissioning process will hang indefinitely until nodes are added or you update the zone configurations to use a replication factor of 1.
 
+Note that when you decommission a node and immediately add another node, CockroachDB does **not** simply move all of the replicas from the decommissioned node to the newly added node. Instead, replicas are placed across all nodes in the cluster. This speeds up the decommissioning process by spreading the load. The new node will eventually "catch up" with the rest of the cluster.
+
+This can lead to disk utilization imbalance across nodes. **This is expected behavior**, since disk utilization per node is not one of the rebalancing criteria. For more information, see [Disk utilization is different across nodes in the cluster]({% link {{ page.version.version }}/cluster-setup-troubleshooting.md %}#disk-utilization-is-different-across-nodes-in-the-cluster).
+
 #### 3-node cluster with 3-way replication
 
 In this scenario, each range is replicated 3 times, with each replica on a different node:


### PR DESCRIPTION
Fixes:

- DOC-6917
- DOC-6989
- DOC-6999
- DOC-7746
- DOC-8564

Summary of changes:

- Architecture > Replication Layer: Update the 'Load-based splitting' section to describe how replica count & CPU usage are used to rebalance replicas (not disk usage)
- Cluster Setup Troubleshooting: Add a new section 'Disk usage is different across nodes in the cluster' to explain that this is expected behavior, and link to load-based replication architecture docs
- Load-based splitting: Add a new section 'Monitor load-based splitting' so users can know where to look in logs and metrics to see how it is working
- Node Shutdown: Update the 'Size and replication factor' to explain how replicas are rebalanced when a node is decommissioned and immediately replaced, and include a link to docs about how replica rebalancing works