### PR TITLE
DOC-7919: PR #104231 - release-22.2: sql: prevent MODIFYCLUSTERSETTING from viewing non sql.defaults

### DIFF
--- a/src/current/v22.2/set-cluster-setting.md
+++ b/src/current/v22.2/set-cluster-setting.md
@@ -20,6 +20,13 @@ To use the `SET CLUSTER SETTING` statement, a user must have one of the followin
     GRANT SYSTEM MODIFYCLUSTERSETTING TO maxroach;
     ~~~
 
+{{site.data.alerts.callout_info}}
+{% include_cached new-in.html version="22.2.7" %} The cluster setting `sql.auth.modify_cluster_setting_applies_to_all.enabled` affects what users with the `MODIFYCLUSTERSETTING` privilege are able to modify:
+
+- If set to `true` (the default), users are able to modify all cluster settings.
+- If set to `false`, users are allowed to modify only `sql.defaults.*` cluster settings, not all cluster settings.
+{{site.data.alerts.end}}
+
 ## Synopsis
 
 <div>

--- a/src/current/v22.2/show-cluster-setting.md
+++ b/src/current/v22.2/show-cluster-setting.md
@@ -43,7 +43,18 @@ The `SHOW` statement for cluster settings is unrelated to the other `SHOW` state
 
 ## Required privileges
 
-To use the `SHOW CLUSTER SETTING` statement, a user must either be a member of the `admin` role (the `root` user belongs to the `admin` role by default) or have the `VIEWCLUSTERSETTING` [system privilege](security-reference/authorization.html#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option](security-reference/authorization.html#role-options)) defined.
+To use the `SHOW CLUSTER SETTING` statement, a user must have one of the following attributes:
+
+- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default)
+- Have the `VIEWCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
+- Have the `MODIFYCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted.
+
+{{site.data.alerts.callout_info}}
+{% include_cached new-in.html version="22.2.7" %} The cluster setting `sql.auth.modify_cluster_setting_applies_to_all.enabled` affects what users with the `MODIFYCLUSTERSETTING` privilege are able to view:
+
+- If set to `true` (the default), users are able to view all cluster settings.
+- If set to `false`, users are allowed to view only `sql.defaults.*` cluster settings, not all cluster settings.
+{{site.data.alerts.end}}
 
 ## Synopsis
 

--- a/src/current/v22.2/show-cluster-setting.md
+++ b/src/current/v22.2/show-cluster-setting.md
@@ -45,7 +45,7 @@ The `SHOW` statement for cluster settings is unrelated to the other `SHOW` state
 
 To use the `SHOW CLUSTER SETTING` statement, a user must have one of the following attributes:
 
-- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default)
+- Be a member of the `admin` role (the `root` user belongs to the `admin` role by default).
 - Have the `VIEWCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWCLUSTERSETTING` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) defined.
 - Have the `MODIFYCLUSTERSETTING` [system-level privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#privileges) granted.
 


### PR DESCRIPTION
Addresses: DOC-7919

(1) Updated SET CLUSTER SETTING and SHOW CLUSTER SETTING pages for 22.2, updated Required privileges with call out about sql.auth.modify_cluster_setting_applies_to_all.enabled cluster setting.