### PR TITLE
[DOC-8203] Document limitation on modifying Kubernetes labels when using the Operator

### DIFF
--- a/src/current/_includes/v22.1/orchestration/kubernetes-limitations.md
+++ b/src/current/_includes/v22.1/orchestration/kubernetes-limitations.md
@@ -4,7 +4,9 @@ To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is req
 
 #### Kubernetes Operator
 
-The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html).
+- The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}).
+
+- Using the Operator, you can give a new cluster an arbitrary number of [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). However, a cluster's labels cannot be modified after it is deployed. To track the status of this limitation, refer to [#993](https://github.com/cockroachdb/cockroach-operator/issues/993) in the Operator project's issue tracker.
 
 #### Helm version
 

--- a/src/current/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
@@ -75,6 +75,10 @@
 
 ### Initialize the cluster
 
+{{site.data.alerts.callout_info}}
+After a cluster managed by the Kubernetes operator is initialized, its Kubernetes labels cannot be modified. For more details, refer to [Limitations](#limitations).
+{{site.data.alerts.end}}
+
 1. Download `example.yaml`, a custom resource that tells the Operator how to configure the Kubernetes cluster.
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/_includes/v22.2/orchestration/kubernetes-limitations.md
+++ b/src/current/_includes/v22.2/orchestration/kubernetes-limitations.md
@@ -4,7 +4,9 @@ To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is req
 
 #### Kubernetes Operator
 
-The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html).
+- The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}).
+
+- Using the Operator, you can give a new cluster an arbitrary number of [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). However, a cluster's labels cannot be modified after it is deployed. To track the status of this limitation, refer to [#993](https://github.com/cockroachdb/cockroach-operator/issues/993) in the Operator project's issue tracker.
 
 #### Helm version
 

--- a/src/current/_includes/v22.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v22.2/orchestration/start-cockroachdb-operator-secure.md
@@ -75,6 +75,10 @@
 
 ### Initialize the cluster
 
+{{site.data.alerts.callout_info}}
+After a cluster managed by the Kubernetes operator is initialized, its Kubernetes labels cannot be modified. For more details, refer to [Limitations](#limitations).
+{{site.data.alerts.end}}
+
 1. Download `example.yaml`, a custom resource that tells the Operator how to configure the Kubernetes cluster.
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/_includes/v23.1/orchestration/kubernetes-limitations.md
+++ b/src/current/_includes/v23.1/orchestration/kubernetes-limitations.md
@@ -4,7 +4,9 @@ To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is req
 
 #### Kubernetes Operator
 
-The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}).
+- The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}).
+
+- Using the Operator, you can give a new cluster an arbitrary number of [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). However, a cluster's labels cannot be modified after it is deployed. To track the status of this limitation, refer to [#993](https://github.com/cockroachdb/cockroach-operator/issues/993) in the Operator project's issue tracker.
 
 #### Helm version
 

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-operator-secure.md
@@ -75,6 +75,10 @@
 
 ### Initialize the cluster
 
+{{site.data.alerts.callout_info}}
+After a cluster managed by the Kubernetes operator is initialized, its Kubernetes labels cannot be modified. For more details, refer to [Limitations](#limitations).
+{{site.data.alerts.end}}
+
 1. Download `example.yaml`, a custom resource that tells the Operator how to configure the Kubernetes cluster.
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/v22.1/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/src/current/v22.1/orchestrate-a-local-cluster-with-kubernetes.md
@@ -16,6 +16,11 @@ This page demonstrates a basic integration with the open-source [Kubernetes](htt
 To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](kubernetes-overview.html). To deploy a 30-day free CockroachDB {{ site.data.products.dedicated }} cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
+## Limitations
+
+{% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
+
+
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}
 
 ## Step 2. Start CockroachDB

--- a/src/current/v22.2/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/src/current/v22.2/orchestrate-a-local-cluster-with-kubernetes.md
@@ -16,6 +16,11 @@ This page demonstrates a basic integration with the open-source [Kubernetes](htt
 To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](kubernetes-overview.html). To deploy a 30-day free CockroachDB {{ site.data.products.dedicated }} cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
+## Limitations
+
+{% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
+
+
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}
 
 ## Step 2. Start CockroachDB

--- a/src/current/v23.1/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/src/current/v23.1/orchestrate-a-local-cluster-with-kubernetes.md
@@ -16,6 +16,11 @@ This page demonstrates a basic integration with the open-source [Kubernetes](htt
 To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments]({% link {{ page.version.version }}/kubernetes-overview.md %}). To deploy a 30-day free CockroachDB {{ site.data.products.dedicated }} cluster instead of running CockroachDB yourself, see the [Quickstart](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart).
 {{site.data.alerts.end}}
 
+## Limitations
+
+{% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
+
+
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}
 
 ## Step 2. Start CockroachDB


### PR DESCRIPTION
[DOC-8203] Document limitation on modifying Kubernetes labels when using the Operator

### Previews
[src/current/v22.1/orchestrate-a-local-cluster-with-kubernetes.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.1/orchestrate-a-local-cluster-with-kubernetes.html)
[src/current/v22.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
[src/current/v22.1/deploy-cockroachdb-with-kubernetes.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.1/deploy-cockroachdb-with-kubernetes.html)
[src/current/v22.1/deploy-cockroachdb-with-kubernetes-insecure.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.1/deploy-cockroachdb-with-kubernetes-insecure.html)

[src/current/v22.2/orchestrate-a-local-cluster-with-kubernetes.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.2/orchestrate-a-local-cluster-with-kubernetes.html)
[src/current/v22.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
[src/current/v22.2/deploy-cockroachdb-with-kubernetes.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.2/deploy-cockroachdb-with-kubernetes.html)
[src/current/v22.2/deploy-cockroachdb-with-kubernetes-insecure.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v22.2/deploy-cockroachdb-with-kubernetes-insecure.html)


[src/current/v23.1/orchestrate-a-local-cluster-with-kubernetes.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v23.1/orchestrate-a-local-cluster-with-kubernetes.html)
[src/current/v23.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v23.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
[src/current/v23.1/deploy-cockroachdb-with-kubernetes.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v23.1/deploy-cockroachdb-with-kubernetes.html)
[src/current/v23.1/deploy-cockroachdb-with-kubernetes-insecure.md](https://deploy-preview-17758--cockroachdb-docs.netlify.app/docs/v23.1/deploy-cockroachdb-with-kubernetes-insecure.html)
