### PR TITLE
Introduce improve changefeed latency section

### DIFF
--- a/src/current/v23.1/advanced-changefeed-configuration.md
+++ b/src/current/v23.1/advanced-changefeed-configuration.md
@@ -6,7 +6,7 @@ docs_area: stream_data
 ---
 
 {{site.data.alerts.callout_danger}}
-The configurations and settings explained on this page will have a significant impact on a changefeed's behavior and could potentially affect a cluster's performance. Thoroughly test before deploying any changes to productions.
+The configurations and settings explained on this page will have a significant impact on a changefeed's behavior and could potentially affect a cluster's performance. Thoroughly test before deploying any changes to production.
 {{site.data.alerts.end}}
 
 The following sections describe performance, settings, configurations, and details to tune [changefeeds]({% link {{ page.version.version }}/change-data-capture-overview.md %}):

--- a/src/current/v23.1/advanced-changefeed-configuration.md
+++ b/src/current/v23.1/advanced-changefeed-configuration.md
@@ -65,7 +65,7 @@ Thoroughly test any adjustment in cluster settings before deploying the change i
 
 **Default:** `1ms`
 
-This setting provides a mechanism to pace the [closed timestamp]({% link {{ page.version.version }}/architecture/transaction-layer.md %}#closed-timestamps) notifications to follower replicas. Decreasing the closed timestamp smear interval makes rangefeed closed timestamp delivery less spiky, which can reduce its impact on foreground SQL query latency.
+This setting provides a mechanism to pace the [closed timestamp]({% link {{ page.version.version }}/architecture/transaction-layer.md %}#closed-timestamps) notifications to follower replicas. At the default, the closed timestamp smear interval makes rangefeed closed timestamp delivery less spiky, which can reduce its impact on foreground SQL query latency.
 
 For example, if you have a large table, and one of the nodes in the cluster is hosting 6000 ranges from this table. Normally, the rangefeed system will wake up every `kv.closed_timestamp_target_duration` (default `3s`) and every 3 seconds it will publish checkpoints for all 6000 ranges. In this scenario, the `kv.rangefeed.closed_timestamp_smear_interval` setting takes the `3s` frequency and divides it into `1ms` chunks. Instead of publishing checkpoints for all 6000 ranges, it will publish checkpoints for 2 ranges every `1ms`. This produces a more predictable and level load, rather than spiky, large bursts of workload.
 

--- a/src/current/v23.2/advanced-changefeed-configuration.md
+++ b/src/current/v23.2/advanced-changefeed-configuration.md
@@ -6,7 +6,7 @@ docs_area: stream_data
 ---
 
 {{site.data.alerts.callout_danger}}
-The configurations and settings explained on this page will have a significant impact on a changefeed's behavior and could potentially affect a cluster's performance. Thoroughly test before deploying any changes to productions.
+The configurations and settings explained on this page will have a significant impact on a changefeed's behavior and could potentially affect a cluster's performance. Thoroughly test before deploying any changes to production.
 {{site.data.alerts.end}}
 
 The following sections describe performance, settings, configurations, and details to tune [changefeeds]({% link {{ page.version.version }}/change-data-capture-overview.md %}):

--- a/src/current/v23.2/advanced-changefeed-configuration.md
+++ b/src/current/v23.2/advanced-changefeed-configuration.md
@@ -65,7 +65,7 @@ Thoroughly test any adjustment in cluster settings before deploying the change i
 
 **Default:** `1ms`
 
-This setting provides a mechanism to pace the [closed timestamp]({% link {{ page.version.version }}/architecture/transaction-layer.md %}#closed-timestamps) notifications to follower replicas. Decreasing the closed timestamp smear interval makes rangefeed closed timestamp delivery less spiky, which can reduce its impact on foreground SQL query latency.
+This setting provides a mechanism to pace the [closed timestamp]({% link {{ page.version.version }}/architecture/transaction-layer.md %}#closed-timestamps) notifications to follower replicas. At the default, the closed timestamp smear interval makes rangefeed closed timestamp delivery less spiky, which can reduce its impact on foreground SQL query latency.
 
 For example, if you have a large table, and one of the nodes in the cluster is hosting 6000 ranges from this table. Normally, the rangefeed system will wake up every `kv.closed_timestamp_target_duration` (default `3s`) and every 3 seconds it will publish checkpoints for all 6000 ranges. In this scenario, the `kv.rangefeed.closed_timestamp_smear_interval` setting takes the `3s` frequency and divides it into `1ms` chunks. Instead of publishing checkpoints for all 6000 ranges, it will publish checkpoints for 2 ranges every `1ms`. This produces a more predictable and level load, rather than spiky, large bursts of workload.
 


### PR DESCRIPTION
Fixes DOC-7906

This PR adds a section to the Advanced Changefeed Configuration page around cluster settings that customers can tweak in order to improve changefeed latency.

- three cluster settings to use in combination
- some detail for each and a brief recommendation on what to change
- warnings around how adjusting these settings may affect transactions