### PR TITLE
Fix typo in Python package name for `asyncpg`

### DIFF
--- a/src/current/v23.1/build-a-python-app-with-cockroachdb-asyncpg.md
+++ b/src/current/v23.1/build-a-python-app-with-cockroachdb-asyncpg.md
@@ -45,7 +45,7 @@ To install `asyncpg`, run the following command:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-$ pip3 install "asynpg"
+$ pip3 install "asyncpg"
 ~~~
 
 For other ways to install Psycopg, see the [official documentation](https://www.psycopg.org/psycopg3/docs/basic/install.html).

--- a/src/current/v23.2/build-a-python-app-with-cockroachdb-asyncpg.md
+++ b/src/current/v23.2/build-a-python-app-with-cockroachdb-asyncpg.md
@@ -45,7 +45,7 @@ To install `asyncpg`, run the following command:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-$ pip3 install "asynpg"
+$ pip3 install "asyncpg"
 ~~~
 
 For other ways to install Psycopg, see the [official documentation](https://www.psycopg.org/psycopg3/docs/basic/install.html).


### PR DESCRIPTION
* Fixes a typo in the Python package name for the `asyncpg` Postgres library. The documentation pages suggested installing the package `asynpg` which could potentially be hijacked to include malware.