### PR TITLE
Withdraw release v23.1.9 from docs

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4813,3 +4813,4 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.8
+  withdrawn: true

--- a/src/current/_includes/releases/release-downloads-docker-image.md
+++ b/src/current/_includes/releases/release-downloads-docker-image.md
@@ -8,7 +8,7 @@
 {% if release.withdrawn == true %}
 
 {{site.data.alerts.callout_danger}}
-This patch release has been withdrawn{% if include.advisory_key %} due to [this technical advisory](https://www.cockroachlabs.com/docs/advisories/{{ include.advisory_key }}){% endif %}. We've removed the links to the downloads and Docker image.All the changes listed as part of this release will be in the next release. Do not upgrade to this release.
+This patch release has been withdrawn{% if include.advisory_key %} due to [this technical advisory](https://www.cockroachlabs.com/docs/advisories/{{ include.advisory_key }}){% endif %}. We've removed the links to the downloads and Docker image. All the changes listed as part of this release will be in the next release. Do not upgrade to this release.
 {{site.data.alerts.end}}
 
 {% else %}


### PR DESCRIPTION
Removing v23.1.9 from docs. This uses the standard messaging on the release note page. That is, no TA messaging (that can be added if a TA is published).