### PR TITLE
Turn off Vale

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   lint:
+    if: false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
Writers can run it locally via `make vale` on a branch prior to committing, or they can run `vale <filename>`.