### PR TITLE
Fix 23.1.10 ARM metadata

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4856,14 +4856,14 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach
     docker_arm: true
-    docker_arm_experimental: false
+    docker_arm_experimental: true
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.9


### PR DESCRIPTION
Linux and Docker were inadvertently marked as no longer experimental. cc/ @ianjevans who is on vacation.