### PR TITLE
[DOC-8845] Org and cluster log export are GA

### DIFF
--- a/src/current/cockroachcloud/cloud-org-audit-logs.md
+++ b/src/current/cockroachcloud/cloud-org-audit-logs.md
@@ -8,8 +8,6 @@ cloud: true
 
 CockroachDB {{ site.data.products.cloud }} captures audit logs when many types of events occur, such as when a cluster is created or when a user is added to or removed from an organization. Any user in an organization with an admin-level service account can export these audit logs using the [`auditlogevents` endpoint]({% link cockroachcloud/cloud-api.md %}#cloud-audit-logs) of the [Cloud API]({% link cockroachcloud/cloud-api.md %}).
 
-After your organization is enrolled in the preview, you can begin exporting audit logs for CockroachDB {{ site.data.products.cloud }} organization.
-
 This page provides some examples of exporting CockroachDB {{ site.data.products.cloud }} organization audit logs. For details about each parameter and its defaults, refer to the API specification for the [`auditlogevents` endpoint]({% link cockroachcloud/cloud-api.md %}#cloud-audit-logs).
 
 ## Export audit logs in ascending order

--- a/src/current/cockroachcloud/export-logs.md
+++ b/src/current/cockroachcloud/export-logs.md
@@ -8,10 +8,6 @@ cloud: true
 
 CockroachDB {{ site.data.products.dedicated }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure log export to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, send log entries to specific log group targets by log channel, among others.
 
-{{site.data.alerts.callout_info}}
-{% include_cached feature-phases/preview.md %}
-{{site.data.alerts.end}}
-
 ## The `logexport` endpoint
 
 To configure and manage log export for your CockroachDB {{ site.data.products.dedicated }} cluster, use the `logexport` endpoint:

--- a/src/current/v23.1/cockroachdb-feature-availability.md
+++ b/src/current/v23.1/cockroachdb-feature-availability.md
@@ -40,10 +40,6 @@ Command                                     | Description
 
 [Super regions]({% link {{ page.version.version }}/multiregion-overview.md %}#super-regions) allow you to define a set of database regions such that schema objects will have all of their replicas stored _only_ in regions that are members of the super region. The primary use case for super regions is data domiciling.
 
-### Export logs from CockroachDB {{ site.data.products.dedicated }} clusters
-
-CockroachDB {{ site.data.products.dedicated }} users can use the [Cloud API](https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api) to configure [log export](https://www.cockroachlabs.com/docs/cockroachcloud/export-logs) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, and send log entries to specific log group targets by log channel, among others.
-
 ### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
 
 CockroachDB {{ site.data.products.dedicated }} users can use the [Cloud API](https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api) to configure [metrics export](https://www.cockroachlabs.com/docs/cockroachcloud/export-metrics) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/). Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.

--- a/src/current/v23.2/cockroachdb-feature-availability.md
+++ b/src/current/v23.2/cockroachdb-feature-availability.md
@@ -40,10 +40,6 @@ Command                                     | Description
 
 [Super regions]({% link {{ page.version.version }}/multiregion-overview.md %}#super-regions) allow you to define a set of database regions such that schema objects will have all of their replicas stored _only_ in regions that are members of the super region. The primary use case for super regions is data domiciling.
 
-### Export logs from CockroachDB {{ site.data.products.dedicated }} clusters
-
-CockroachDB {{ site.data.products.dedicated }} users can use the [Cloud API](https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api) to configure [log export](https://www.cockroachlabs.com/docs/cockroachcloud/export-logs) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, and send log entries to specific log group targets by log channel, among others.
-
 ### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
 
 CockroachDB {{ site.data.products.dedicated }} users can use the [Cloud API](https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api) to configure [metrics export](https://www.cockroachlabs.com/docs/cockroachcloud/export-metrics) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/). Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.


### PR DESCRIPTION
[DOC-8845] Org and cluster log export are GA

### Previews
[src/current/cockroachcloud/cloud-org-audit-logs.md](https://deploy-preview-17898--cockroachdb-docs.netlify.app/docs/cockroachcloud/cloud-org-audit-logs.html)
[src/current/cockroachcloud/export-logs.md](https://deploy-preview-17898--cockroachdb-docs.netlify.app/docs/cockroachcloud/export-logs.html)
[src/current/v23.1/cockroachdb-feature-availability.md](https://deploy-preview-17898--cockroachdb-docs.netlify.app/docs/v23.1/cockroachdb-feature-availability.html)
[src/current/v23.2/cockroachdb-feature-availability.md](https://deploy-preview-17898--cockroachdb-docs.netlify.app/docs/v23.2/cockroachdb-feature-availability.html)