### PR TITLE
Add guidance on filtering changefeed messages for TTL deletes

### DIFF
--- a/src/current/v23.1/cdc-queries.md
+++ b/src/current/v23.1/cdc-queries.md
@@ -190,6 +190,59 @@ For newly inserted rows in a table, the `cdc_prev` column will emit as `NULL`.
 If you do not need to select specific columns in a table or filter rows from a changefeed, you can instead create a changefeed using the [`diff` option]({% link {{ page.version.version }}/create-changefeed.md %}#diff-opt) to emit a `before` field with each message. This field includes the value of the row before the update was applied.
 {{site.data.alerts.end}}
 
+### Reference TTL in a CDC query
+
+In CockroachDB, table row deletes occur as a result of regular SQL transactions or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits delete event messages, you may need to distinguish between these two types of deletion. For example, you may want to only emit messages for row-level TTL deletes from your changefeed.
+
+If you have TTL logic defined with [`ttl_expiration_expression` or `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview), you can leverage CDC queries to determine whether or not a given row was expired at the time of the changefeed event, including a delete event.
+
+To emit rows that were deleted after expiring, you can use syntax similar to the following:
+
+{% include_cached copy-clipboard.html %}
+~~~sql
+CREATE CHANGEFEED INTO 'external://sink'
+AS SELECT cdc_prev FROM test_table
+WHERE event_op() = 'delete'
+AND (cdc_prev).crdb_internal_expiration < statement_timestamp();
+~~~
+
+This query:
+
+- Accesses the `cdc_prev` column for the previous state of the row.
+- Searches for `delete` events in that previous state.
+- Finds the TTL expiration timestamp of the deleted rows where it is earlier than the current statement timestamp.
+
+{{site.data.alerts.callout_info}}
+This will only emit rows that were deleted **after** expiring. Furthermore, consider that a transactional SQL delete during the window between the row expiring and the TTL job running will also cause this message to emit from the changefeed.
+{{site.data.alerts.end}}
+
+Equally, you can filter out delete messages for expired rows from your changefeed:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE CHANGEFEED AS SELECT cdc_prev FROM test_table
+WHERE NOT (event_op() = 'delete'
+AND (cdc_prev).crdb_internal_expiration < statement_timestamp());
+~~~
+
+In some cases, you may have custom expiration logic on rows in a table. Custom TTL expressions and CDC queries evaluate in different ways.
+
+- Custom TTL expressions evaluate to a timestamp after which the row expires. For example, if you want to configure a table so that some rows never expire, your expression needs to evaluate to `'infinity'` for those rows.
+- CDC queries filter using `WHERE` clauses, which are booleans.
+
+To preserve your custom TTL expression in a CDC query, you can convert the TTL expression to a boolean by wrapping it in a parenthesis and appending `< statement_timestamp()`.
+
+In the following example, the CDC query includes a custom TTL expression that is evaluated against the statement timestamp. In addition to the original TTL expression, it also accesses the `cdc_prev` column in order to evaluate the previous state of the rows:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE CHANGEFEED AS SELECT cdc_prev FROM ttl_test_per_row
+WHERE NOT (event_op() = 'delete'
+AND (CASE WHEN (cdc_prev).immortal
+THEN 'infinity'
+ELSE (cdc_prev).expired_at END) < statement_timestamp());
+~~~
+
 ### Geofilter a changefeed
 
 When you are working with a [`REGIONAL BY ROW` table]({% link {{ page.version.version }}/alter-table.md %}#regional-by-row), you can filter the changefeed on the `crdb_region` column to create a region-specific changefeed:

--- a/src/current/v23.1/cdc-queries.md
+++ b/src/current/v23.1/cdc-queries.md
@@ -192,11 +192,11 @@ If you do not need to select specific columns in a table or filter rows from a c
 
 ### Reference TTL in a CDC query
 
-In CockroachDB, table row deletes occur as a result of regular SQL transactions or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits delete event messages, you may need to distinguish between these two types of deletion. For example, you may want to only emit messages for row-level TTL deletes from your changefeed.
+In CockroachDB, table row deletes occur as a result of regular SQL transactions or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits [delete event messages]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages), you may need to distinguish between these two types of deletion. For example, only emitting messages for row-level TTL deletes from your changefeed.
 
 If you have TTL logic defined with [`ttl_expiration_expression` or `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview), you can leverage CDC queries to determine whether or not a given row was expired at the time of the changefeed event, including a delete event.
 
-To emit rows that were deleted after expiring, you can use syntax similar to the following:
+When the table uses the `ttl_expire_after` storage parameter, you can emit rows that were deleted after expiring from the changefeed with syntax similar to:
 
 {% include_cached copy-clipboard.html %}
 ~~~sql
@@ -206,41 +206,39 @@ WHERE event_op() = 'delete'
 AND (cdc_prev).crdb_internal_expiration < statement_timestamp();
 ~~~
 
-This query:
+This changefeed statement:
 
 - Accesses the `cdc_prev` column for the previous state of the row.
 - Searches for `delete` events in that previous state.
 - Finds the TTL expiration timestamp of the deleted rows where it is earlier than the current statement timestamp.
 
+Refer to [Using `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#using-ttl_expire_after) for the `CREATE TABLE` statement and further details on `ttl_expire_after`.
+
 {{site.data.alerts.callout_info}}
 This will only emit rows that were deleted **after** expiring. Furthermore, consider that a transactional SQL delete during the window between the row expiring and the TTL job running will also cause this message to emit from the changefeed.
 {{site.data.alerts.end}}
 
-Equally, you can filter out delete messages for expired rows from your changefeed:
+In some cases, you may have custom expiration logic on rows in a table. You can also write a CDC query to emit rows that have deleted through row-level TTL using a custom TTL expression.
+
+In the following example, the table uses the [`ttl_expiration_expression`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview) storage parameter to reference the `expired_at` column. To create a changefeed on this table to explicitly emit the previous state of the row for TTL deletions:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE CHANGEFEED INTO 'external://sink'
+AS SELECT cdc_prev FROM ttl_test_per_row
+WHERE event_op() = 'delete'
+AND (cdc_prev).expired_at < statement_timestamp();
+~~~
+
+Refer to [Using `ttl_expiration_expression`]({% link {{ page.version.version }}/row-level-ttl.md %}#using-ttl_expiration_expression) for the `CREATE TABLE` statement and further details on `ttl_expiration_expression`.
+
+Equally, you can remove the delete messages for expired rows so that they do not emit from your changefeed:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE CHANGEFEED AS SELECT cdc_prev FROM test_table
 WHERE NOT (event_op() = 'delete'
 AND (cdc_prev).crdb_internal_expiration < statement_timestamp());
-~~~
-
-In some cases, you may have custom expiration logic on rows in a table. Custom TTL expressions and CDC queries evaluate in different ways.
-
-- Custom TTL expressions evaluate to a timestamp after which the row expires. For example, if you want to configure a table so that some rows never expire, your expression needs to evaluate to `'infinity'` for those rows.
-- CDC queries filter using `WHERE` clauses, which are booleans.
-
-To preserve your custom TTL expression in a CDC query, you can convert the TTL expression to a boolean by wrapping it in a parenthesis and appending `< statement_timestamp()`.
-
-In the following example, the CDC query includes a custom TTL expression that is evaluated against the statement timestamp. In addition to the original TTL expression, it also accesses the `cdc_prev` column in order to evaluate the previous state of the rows:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE CHANGEFEED AS SELECT cdc_prev FROM ttl_test_per_row
-WHERE NOT (event_op() = 'delete'
-AND (CASE WHEN (cdc_prev).immortal
-THEN 'infinity'
-ELSE (cdc_prev).expired_at END) < statement_timestamp());
 ~~~
 
 ### Geofilter a changefeed

--- a/src/current/v23.1/row-level-ttl.md
+++ b/src/current/v23.1/row-level-ttl.md
@@ -548,6 +548,8 @@ Row-level TTL interacts with [changefeeds]({% link {{ page.version.version }}/cr
 
 - When expired rows are deleted, a [changefeed delete message]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages) is emitted.
 
+Refer to [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}#reference-ttl-in-a-cdc-query) for guidance on how to filter changefeed messages to emit row-level TTL deletes only.
+
 ## Backup and restore
 
 Row-level TTL interacts with [backup and restore]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) in the following ways:

--- a/src/current/v23.1/row-level-ttl.md
+++ b/src/current/v23.1/row-level-ttl.md
@@ -548,7 +548,7 @@ Row-level TTL interacts with [changefeeds]({% link {{ page.version.version }}/cr
 
 - When expired rows are deleted, a [changefeed delete message]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages) is emitted.
 
-Refer to [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}#reference-ttl-in-a-cdc-query) for guidance on how to filter changefeed messages to emit row-level TTL deletes only.
+For guidance on how to filter changefeed messages to emit row-level TTL deletes only, refer to [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}#reference-ttl-in-a-cdc-query).
 
 ## Backup and restore
 

--- a/src/current/v23.2/cdc-queries.md
+++ b/src/current/v23.2/cdc-queries.md
@@ -190,7 +190,7 @@ If you do not need to select specific columns in a table or filter rows from a c
 
 ### Reference TTL in a CDC query
 
-In CockroachDB, table row deletes occur as a result of regular SQL transactions or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits delete event messages, you may need to distinguish between these two types of deletion. For example, you may want to only emit messages for row-level TTL deletes from your changefeed.
+In CockroachDB, table row deletes occur as a result of regular SQL transactions or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits delete event messages, you may need to distinguish between these two types of deletion. For example, only emitting messages for row-level TTL deletes from your changefeed.
 
 If you have TTL logic defined with [`ttl_expiration_expression` or `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview), you can leverage CDC queries to determine whether or not a given row was expired at the time of the changefeed event, including a delete event.
 
@@ -223,9 +223,9 @@ WHERE NOT (event_op() = 'delete'
 AND (cdc_prev).crdb_internal_expiration < statement_timestamp());
 ~~~
 
-In some cases, you may have custom expiration logic on rows in a table. Custom TTL expressions and CDC queries evaluate in different ways.
+In some cases, you may have custom expiration logic on rows in a table. Custom TTL expressions and CDC queries evaluate in different ways:
 
-- Custom TTL expressions evaluate to a timestamp after which the row expires. For example, if you want to configure a table so that some rows never expire, your expression needs to evaluate to `'infinity'` for those rows.
+- Custom TTL expressions evaluate to a timestamp after which the row expires.
 - CDC queries filter using `WHERE` clauses, which are booleans.
 
 To preserve your custom TTL expression in a CDC query, you can convert the TTL expression to a boolean by wrapping it in a parenthesis and appending `< statement_timestamp()`.

--- a/src/current/v23.2/cdc-queries.md
+++ b/src/current/v23.2/cdc-queries.md
@@ -190,9 +190,33 @@ If you do not need to select specific columns in a table or filter rows from a c
 
 ### Reference TTL in a CDC query
 
-In CockroachDB, table row deletes occur as a result of regular SQL transactions or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits [delete event messages]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages), you may need to distinguish between these two types of deletion. For example, only emitting messages for row-level TTL deletes from your changefeed.
+In CockroachDB, table row deletes occur as a result of [regular SQL transactions]({% link {{ page.version.version }}/delete-data.md %}) or through [row-level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}). When your changefeed emits [delete event messages]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages), you may need to distinguish between these two types of deletion. For example, only emitting messages for row-level TTL deletes from your changefeed.
 
-If you have TTL logic defined with [`ttl_expiration_expression` or `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview), you can leverage CDC queries to determine whether or not a given row was expired at the time of the changefeed event, including a delete event.
+If you have TTL logic defined with [`ttl_expiration_expression`](#ttl_expiration_expression) or [`ttl_expire_after`](#ttl_expire_after), you can leverage CDC queries to determine whether or not a given row was expired at the time of the changefeed event, including a delete event.
+
+{{site.data.alerts.callout_info}}
+{% include {{page.version.version}}/sql/row-level-ttl-prefer-ttl-expiration-expressions.md %}
+
+For more detail, refer to the [Batch Delete Expire Data with Row-Level TTL]({% link {{ page.version.version }}/row-level-ttl.md %}) page.
+{{site.data.alerts.end}}
+
+#### `ttl_expiration_expression`
+
+In some cases, you may have custom expiration logic on rows in a table. You can also write a CDC query to emit rows that have deleted through row-level TTL using a custom TTL expression.
+
+In the following example, the table uses the [`ttl_expiration_expression`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview) storage parameter to reference the `expired_at` column. To create a changefeed on this table to explicitly emit the previous state of the row for TTL deletions:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE CHANGEFEED INTO 'external://sink'
+AS SELECT cdc_prev FROM ttl_test_per_row
+WHERE event_op() = 'delete'
+AND (cdc_prev).expired_at < statement_timestamp();
+~~~
+
+For the `CREATE TABLE` statement and further details on `ttl_expiration_expression`, refer to [Using `ttl_expiration_expression`]({% link {{ page.version.version }}/row-level-ttl.md %}#using-ttl_expiration_expression).
+
+#### `ttl_expire_after`
 
 When the table uses the `ttl_expire_after` storage parameter, you can emit rows that were deleted after expiring from the changefeed with syntax similar to:
 
@@ -210,25 +234,11 @@ This changefeed statement:
 - Searches for `delete` events in that previous state.
 - Finds the TTL expiration timestamp of the deleted rows where it is earlier than the current statement timestamp.
 
-Refer to [Using `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#using-ttl_expire_after) for the `CREATE TABLE` statement and further details on `ttl_expire_after`.
+For the `CREATE TABLE` statement and further details on `ttl_expire_after`, refer to [Using `ttl_expire_after`]({% link {{ page.version.version }}/row-level-ttl.md %}#using-ttl_expire_after).
 
 {{site.data.alerts.callout_info}}
-This will only emit rows that were deleted **after** expiring. Furthermore, consider that a transactional SQL delete during the window between the row expiring and the TTL job running will also cause this message to emit from the changefeed.
+This will only emit rows that were deleted **after** expiring. Furthermore, consider that a [transactional SQL delete]({% link {{ page.version.version }}/delete-data.md %}) during the window between the row expiring and the TTL job running will also cause this message to emit from the changefeed.
 {{site.data.alerts.end}}
-
-In some cases, you may have custom expiration logic on rows in a table. You can also write a CDC query to emit rows that have deleted through row-level TTL using a custom TTL expression.
-
-In the following example, the table uses the [`ttl_expiration_expression`]({% link {{ page.version.version }}/row-level-ttl.md %}#syntax-overview) storage parameter to reference the `expired_at` column. To create a changefeed on this table to explicitly emit the previous state of the row for TTL deletions:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-CREATE CHANGEFEED INTO 'external://sink'
-AS SELECT cdc_prev FROM ttl_test_per_row
-WHERE event_op() = 'delete'
-AND (cdc_prev).expired_at < statement_timestamp();
-~~~
-
-Refer to [Using `ttl_expiration_expression`]({% link {{ page.version.version }}/row-level-ttl.md %}#using-ttl_expiration_expression) for the `CREATE TABLE` statement and further details on `ttl_expiration_expression`.
 
 Equally, you can remove the delete messages for expired rows so that they do not emit from your changefeed:
 

--- a/src/current/v23.2/row-level-ttl.md
+++ b/src/current/v23.2/row-level-ttl.md
@@ -550,6 +550,8 @@ Row-level TTL interacts with [changefeeds]({% link {{ page.version.version }}/cr
 
 - When expired rows are deleted, a [changefeed delete message]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages) is emitted.
 
+Refer to [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}#reference-ttl-in-a-cdc-query) for guidance on how to filter changefeed messages to emit row-level TTL deletes only.
+
 ## Backup and restore
 
 Row-level TTL interacts with [backup and restore]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) in the following ways:

--- a/src/current/v23.2/row-level-ttl.md
+++ b/src/current/v23.2/row-level-ttl.md
@@ -550,7 +550,7 @@ Row-level TTL interacts with [changefeeds]({% link {{ page.version.version }}/cr
 
 - When expired rows are deleted, a [changefeed delete message]({% link {{ page.version.version }}/changefeed-messages.md %}#delete-messages) is emitted.
 
-Refer to [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}#reference-ttl-in-a-cdc-query) for guidance on how to filter changefeed messages to emit row-level TTL deletes only.
+For guidance on how to filter changefeed messages to emit row-level TTL deletes only, refer to [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}#reference-ttl-in-a-cdc-query).
 
 ## Backup and restore
 


### PR DESCRIPTION
Fixes DOC-8334

Adds a couple of examples using CDC queries and information around referencing rows that have expired with row-level TTL in a table.