### PR TITLE
Remove irrelevant label from cdc query example

### DIFF
--- a/src/current/_includes/v23.1/cdc/schedule-query-example.md
+++ b/src/current/_includes/v23.1/cdc/schedule-query-example.md
@@ -1,14 +1,14 @@
-This example creates a nightly export of some filtered table data with a [scheduled changefeed]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}) that will run just after midnight every night. The changefeed uses [CDC queries]({% link {{ page.version.version }}/cdc-queries.md %}) to query the table and filter the data it will send to the sink: 
+This example creates a nightly export of some filtered table data with a [scheduled changefeed]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}) that will run just after midnight every night. The changefeed uses [CDC queries]({% link {{ page.version.version }}/cdc-queries.md %}) to query the table and filter the data it will send to the sink:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE SCHEDULE sf_skateboard FOR CHANGEFEED INTO 'external://cloud-sink' WITH format=csv 
-  AS SELECT current_location AS sf_address, id, type, status FROM vehicles 
-  WHERE city = 'san francisco' AND type = 'skateboard' 
+CREATE SCHEDULE sf_skateboard FOR CHANGEFEED INTO 'external://cloud-sink' WITH format=csv
+  AS SELECT current_location, id, type, status FROM vehicles
+  WHERE city = 'san francisco' AND type = 'skateboard'
   RECURRING '1 0 * * *' WITH SCHEDULE OPTIONS on_execution_failure=retry, on_previous_running=start;
 ~~~
 
 The [schedule options]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}#schedule-options) control the schedule's behavior:
 
-- If it runs into a failure, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately. 
+- If it runs into a failure, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately.
 - If the previous scheduled changefeed is still running, `on_previous_running=start` will start a new changefeed at the defined cadence.

--- a/src/current/_includes/v23.2/cdc/schedule-query-example.md
+++ b/src/current/_includes/v23.2/cdc/schedule-query-example.md
@@ -1,14 +1,14 @@
-This example creates a nightly export of some filtered table data with a [scheduled changefeed]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}) that will run just after midnight every night. The changefeed uses [CDC queries]({% link {{ page.version.version }}/cdc-queries.md %}) to query the table and filter the data it will send to the sink: 
+This example creates a nightly export of some filtered table data with a [scheduled changefeed]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}) that will run just after midnight every night. The changefeed uses [CDC queries]({% link {{ page.version.version }}/cdc-queries.md %}) to query the table and filter the data it will send to the sink:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE SCHEDULE sf_skateboard FOR CHANGEFEED INTO 'external://cloud-sink' WITH format=csv 
-  AS SELECT current_location AS sf_address, id, type, status FROM vehicles 
-  WHERE city = 'san francisco' AND type = 'skateboard' 
+CREATE SCHEDULE sf_skateboard FOR CHANGEFEED INTO 'external://cloud-sink' WITH format=csv
+  AS SELECT current_location, id, type, status FROM vehicles
+  WHERE city = 'san francisco' AND type = 'skateboard'
   RECURRING '1 0 * * *' WITH SCHEDULE OPTIONS on_execution_failure=retry, on_previous_running=start;
 ~~~
 
 The [schedule options]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}#schedule-options) control the schedule's behavior:
 
-- If it runs into a failure, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately. 
+- If it runs into a failure, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately.
 - If the previous scheduled changefeed is still running, `on_previous_running=start` will start a new changefeed at the defined cadence.


### PR DESCRIPTION
This removes an `AS {label}` from a CDC query example that did not show up in CSV message format.