### PR TITLE
Update Architecture Overview

### DIFF
--- a/src/current/_includes/v22.2/misc/basic-terms.md
+++ b/src/current/_includes/v22.2/misc/basic-terms.md
@@ -1,5 +1,3 @@
-## CockroachDB architecture terms
-
 Term | Definition
 -----|------------
 **cluster** | A group of interconnected storage nodes that collaboratively organize transactions, fault tolerance, and data rebalancing.

--- a/src/current/_includes/v22.2/misc/database-terms.md
+++ b/src/current/_includes/v22.2/misc/database-terms.md
@@ -1,5 +1,3 @@
-## Database terms
-
 Term | Definition
 -----|-----------
 **consistency** | The requirement that a transaction must change affected data only in allowed ways. CockroachDB uses "consistency" in both the sense of [ACID semantics](https://en.wikipedia.org/wiki/ACID) and the [CAP theorem](https://en.wikipedia.org/wiki/CAP_theorem), albeit less formally than either definition.

--- a/src/current/_includes/v23.1/misc/basic-terms.md
+++ b/src/current/_includes/v23.1/misc/basic-terms.md
@@ -1,5 +1,3 @@
-## CockroachDB architecture terms
-
 ### Cluster
 A group of interconnected CockroachDB nodes that function as a single distributed SQL database server. Nodes collaboratively organize transactions, and rebalance workload and data storage to optimize performance and fault-tolerance.
 

--- a/src/current/_includes/v23.1/misc/database-terms.md
+++ b/src/current/_includes/v23.1/misc/database-terms.md
@@ -1,5 +1,3 @@
-## Database terms
-
 ### Consistency
 The requirement that a transaction must change affected data only in allowed ways. CockroachDB uses "consistency" in both the sense of [ACID semantics](https://en.wikipedia.org/wiki/ACID) and the [CAP theorem](https://wikipedia.org/wiki/CAP_theorem), albeit less formally than either definition.
 

--- a/src/current/_includes/v23.2/misc/basic-terms.md
+++ b/src/current/_includes/v23.2/misc/basic-terms.md
@@ -1,5 +1,3 @@
-## CockroachDB architecture terms
-
 ### Cluster
 A group of interconnected CockroachDB nodes that function as a single distributed SQL database server. Nodes collaboratively organize transactions, and rebalance workload and data storage to optimize performance and fault-tolerance.
 

--- a/src/current/_includes/v23.2/misc/database-terms.md
+++ b/src/current/_includes/v23.2/misc/database-terms.md
@@ -1,5 +1,3 @@
-## Database terms
-
 ### Consistency
 The requirement that a transaction must change affected data only in allowed ways. CockroachDB uses "consistency" in both the sense of [ACID semantics](https://en.wikipedia.org/wiki/ACID) and the [CAP theorem](https://wikipedia.org/wiki/CAP_theorem), albeit less formally than either definition.
 

--- a/src/current/v22.2/architecture/glossary.md
+++ b/src/current/v22.2/architecture/glossary.md
@@ -7,7 +7,11 @@ docs_area: get_started
 
 This page defines terms that you will encounter throughout the documentation.
 
+## Database terms
+
 {% include {{ page.version.version }}/misc/database-terms.md %}
+
+## CockroachDB architecture terms
 
 {% include {{ page.version.version }}/misc/basic-terms.md %}
 

--- a/src/current/v22.2/architecture/overview.md
+++ b/src/current/v22.2/architecture/overview.md
@@ -6,7 +6,7 @@ key: cockroachdb-architecture.html
 docs_area: reference.architecture
 ---
 
-CockroachDB was designed to create the source-available database we would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner workings of the `cockroach` process as a means of explanation.
+CockroachDB was designed to create the source-available database we would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner workings of [the `cockroach` process]({% link {{ page.version.version }}/cockroach-commands.md %}) as a means of explanation.
 
 However, you definitely do not need to understand the underlying architecture to use CockroachDB. These pages give serious users and database enthusiasts a high-level framework to explain what's happening under the hood.
 
@@ -18,7 +18,7 @@ If these docs interest you, consider taking the free [Intro to Distributed SQL](
 
 This guide is broken out into pages detailing each layer of CockroachDB. We recommended reading through the layers sequentially, starting with this overview and then proceeding to the [SQL layer](sql-layer.html).
 
-If you're looking for a high-level understanding of CockroachDB, you can read the **Overview** section of each layer. For more technical detail—for example, if you're interested in [contributing to the project](https://cockroachlabs.atlassian.net/wiki/x/QQFdB)—you should read the **Components** sections as well.
+If you're looking for a high-level understanding of CockroachDB, you can read the **Overview** section of each layer. For more technical detail &mdash; for example, if you're interested in [contributing to the project](https://cockroachlabs.atlassian.net/wiki/x/QQFdB) &mdash; you should read the **Components** sections as well.
 
 {{site.data.alerts.callout_info}}
 This guide details how CockroachDB is built, but does not explain how to build an application using CockroachDB. For more information about how to develop applications that use CockroachDB, check out our [Developer Guide](../developer-guide-overview.html).
@@ -29,18 +29,12 @@ This guide details how CockroachDB is built, but does not explain how to build a
 CockroachDB was designed to meet the following goals:
 
 - Make life easier for humans. This means being low-touch and highly automated for [operators](../recommended-production-settings.html) and simple to reason about for [developers](../developer-guide-overview.html).
-- Offer industry-leading consistency, even on massively scaled deployments. This means enabling distributed transactions, as well as removing the pain of eventual consistency issues and stale reads.
+- Offer industry-leading consistency, even on massively scaled deployments. This means enabling distributed [transactions]({% link {{ page.version.version }}/architecture/transaction-layer.md %}), as well as removing the pain of eventual consistency issues and stale reads.
 - Create an always-on database that accepts reads and writes on all nodes without generating conflicts.
-- Allow flexible deployment in any environment, without tying you to any platform or vendor.
-- Support familiar tools for working with relational data (i.e., SQL).
+- Allow [flexible deployment]({% link {{ page.version.version }}/choose-a-deployment-option.md %}) in any environment, without tying you to any platform or vendor.
+- Support familiar tools for working with relational data (i.e., [SQL]({% link {{ page.version.version }}/architecture/sql-layer.md %})).                          
 
-With the confluence of these features, we hope that CockroachDB helps you build global, scalable, resilient deployments and applications.
-
-It's helpful to understand a few terms before reading our architecture documentation.
-
-{% include {{ page.version.version }}/misc/database-terms.md %}
-
-{% include {{ page.version.version }}/misc/basic-terms.md %}
+With the confluence of these features, we hope that CockroachDB helps you build global, scalable, resilient [deployments]({% link {{ page.version.version }}/choose-a-deployment-option.md %}) and [applications]({% link {{ page.version.version }}/developer-guide-overview.md %}).
 
 ## Overview
 
@@ -49,18 +43,18 @@ CockroachDB starts running on machines with two commands:
 - [`cockroach start`](../cockroach-start.html) with a `--join` flag for all of the initial nodes in the cluster, so the process knows all of the other machines it can communicate with.
 - [`cockroach init`](../cockroach-init.html) to perform a one-time initialization of the cluster.
 
-Once the CockroachDB cluster is initialized, developers interact with CockroachDB through a [PostgreSQL-compatible](../postgresql-compatibility.html) SQL API. Thanks to the symmetrical behavior of all nodes in a cluster, you can send [SQL requests](sql-layer.html) to any node; this makes CockroachDB easy to integrate with load balancers.
+Once the CockroachDB cluster is initialized, developers interact with CockroachDB through a [PostgreSQL-compatible]({% link {{ page.version.version }}/postgresql-compatibility.md %}) SQL API. Thanks to the symmetrical behavior of all nodes in a cluster, you can send [SQL requests]({% link {{ page.version.version }}/architecture/sql-layer.md %}) to any node; this makes CockroachDB easy to integrate with [load balancers]({% link {{ page.version.version }}/recommended-production-settings.md %}#load-balancing).
 
 After receiving SQL remote procedure calls (RPCs), nodes convert them into key-value (KV) operations that work with our [distributed, transactional key-value store](transaction-layer.html).
 
-As these RPCs start filling your cluster with data, CockroachDB starts [algorithmically distributing your data among the nodes of the cluster](distribution-layer.html), breaking the data up into 512 MiB chunks that we call ranges. Each range is replicated to at least 3 nodes by default to ensure survivability. This ensures that if any nodes go down, you still have copies of the data which can be used for:
+As these RPCs start filling your cluster with data, CockroachDB starts [algorithmically distributing your data among the nodes of the cluster]({% link {{ page.version.version }}/architecture/distribution-layer.md %}), breaking the data up into chunks that we call [ranges](#architecture-range). Each range is replicated to at least [3 nodes by default]({% link {{ page.version.version }}/configure-replication-zones.md %}#num_replicas) to ensure survivability. This ensures that if any nodes go down, you still have copies of the data which can be used for:
 
 - Continuing to serve reads and writes.
-- Consistently replicating the data to other nodes.
+- Consistently [replicating]({% link {{ page.version.version }}/architecture/replication-layer.md %}) the data to other nodes.
 
 If a node receives a read or write request it cannot directly serve, it finds the node that can handle the request, and communicates with that node. This means you do not need to know where in the cluster a specific portion of your data is stored; CockroachDB tracks it for you, and enables symmetric read/write behavior from each node.
 
-Any changes made to the data in a range rely on a [consensus algorithm](replication-layer.html) to ensure that the majority of the range's replicas agree to commit the change. This is how CockroachDB achieves the industry-leading isolation guarantees that allow it to provide your application with consistent reads and writes, regardless of which node you communicate with.
+Any changes made to the data in a [range](#architecture-range) rely on a [consensus algorithm]({% link {{ page.version.version }}/architecture/replication-layer.md %}#raft) to ensure that the majority of the range's [replicas](#architecture-replica) agree to commit the change. This is how CockroachDB achieves the industry-leading isolation guarantees that allow it to provide your application with consistent reads and writes, regardless of which node you communicate with.
 
 Ultimately, data is written to and read from disk using an efficient [storage engine](storage-layer.html), which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard [`AS OF SYSTEM TIME`](../as-of-system-time.html) clause, letting you find historical data for a period of time.
 
@@ -76,9 +70,17 @@ Layer | Order | Purpose
 ------|------------|--------
 [SQL](sql-layer.html)  | 1  | Translate client SQL queries to KV operations.
 [Transactional](transaction-layer.html)  | 2  | Allow atomic changes to multiple KV entries.
-[Distribution](distribution-layer.html)  | 3  | Present replicated KV ranges as a single entity.
-[Replication](replication-layer.html)  | 4  | Consistently and synchronously replicate KV ranges across many nodes. This layer also enables consistent reads using a consensus algorithm.
+[Distribution]({% link {{ page.version.version }}/architecture/distribution-layer.md %})  | 3  | Present replicated KV [ranges](#architecture-range) as a single entity.
+[Replication]({% link {{ page.version.version }}/architecture/replication-layer.md %})  | 4  | Consistently and synchronously replicate KV [ranges](#architecture-range) across many nodes. This layer also enables consistent reads using a consensus algorithm.
 [Storage](storage-layer.html)  | 5  | Read and write KV data on disk.
+
+## Database terms
+
+{% include {{ page.version.version }}/misc/database-terms.md %}
+
+## CockroachDB architecture terms
+
+{% include {{ page.version.version }}/misc/basic-terms.md %}
 
 ## What's next?
 

--- a/src/current/v22.2/architecture/reads-and-writes-overview.md
+++ b/src/current/v22.2/architecture/reads-and-writes-overview.md
@@ -11,6 +11,8 @@ This page explains how reads and writes are affected by the replicated and distr
 For a more detailed information about how transactions work in CockroachDB, see the [Transaction Layer](transaction-layer.html) documentation.
 {{site.data.alerts.end}}
 
+## CockroachDB architecture terms
+
 {% include {{ page.version.version }}/misc/basic-terms.md %}
 
 ## Query execution

--- a/src/current/v23.1/architecture/glossary.md
+++ b/src/current/v23.1/architecture/glossary.md
@@ -7,7 +7,11 @@ docs_area: get_started
 
 This page defines terms that you will encounter throughout the documentation.
 
+## Database terms
+
 {% include {{ page.version.version }}/misc/database-terms.md %}
+
+## CockroachDB architecture terms
 
 {% include {{ page.version.version }}/misc/basic-terms.md %}
 
@@ -262,4 +266,4 @@ Used to list all of the columns in a database with the [`GEOMETRY`](#geometry) d
 
 #### `geography_columns`
 
-Used to list all of the columns in a database with the [`GEOGRAPHY`](#geography) data type, e.g., `SELECT * from geography_columns`.
+Used to list all of the columns in a database with the [`GEOGRAPHY`](#geography) data type, e.g., `SELECT * FROM geography_columns`.

--- a/src/current/v23.1/architecture/overview.md
+++ b/src/current/v23.1/architecture/overview.md
@@ -6,7 +6,7 @@ key: cockroachdb-architecture.html
 docs_area: reference.architecture
 ---
 
-CockroachDB was designed to create the source-available database we would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner workings of the `cockroach` process as a means of explanation.
+CockroachDB was designed to create the source-available database we would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner workings of [the `cockroach` process]({% link {{ page.version.version }}/cockroach-commands.md %}) as a means of explanation.
 
 However, you definitely do not need to understand the underlying architecture to use CockroachDB. These pages give serious users and database enthusiasts a high-level framework to explain what's happening under the hood.
 
@@ -18,7 +18,7 @@ If these docs interest you, consider taking the free [Intro to Distributed SQL](
 
 This guide is broken out into pages detailing each layer of CockroachDB. We recommended reading through the layers sequentially, starting with this overview and then proceeding to the [SQL layer]({% link {{ page.version.version }}/architecture/sql-layer.md %}).
 
-If you're looking for a high-level understanding of CockroachDB, you can read the **Overview** section of each layer. For more technical detail—for example, if you're interested in [contributing to the project](https://cockroachlabs.atlassian.net/wiki/x/QQFdB)—you should read the **Components** sections as well.
+If you're looking for a high-level understanding of CockroachDB, you can read the **Overview** section of each layer. For more technical detail &mdash; for example, if you're interested in [contributing to the project](https://cockroachlabs.atlassian.net/wiki/x/QQFdB) &mdash; you should read the **Components** sections as well.
 
 {{site.data.alerts.callout_info}}
 This guide details how CockroachDB is built, but does not explain how to build an application using CockroachDB. For more information about how to develop applications that use CockroachDB, check out our [Developer Guide]({% link {{ page.version.version }}/developer-guide-overview.md %}).
@@ -29,18 +29,12 @@ This guide details how CockroachDB is built, but does not explain how to build a
 CockroachDB was designed to meet the following goals:
 
 - Make life easier for humans. This means being low-touch and highly automated for [operators]({% link {{ page.version.version }}/recommended-production-settings.md %}) and simple to reason about for [developers]({% link {{ page.version.version }}/developer-guide-overview.md %}).
-- Offer industry-leading consistency, even on massively scaled deployments. This means enabling distributed transactions, as well as removing the pain of eventual consistency issues and stale reads.
+- Offer industry-leading [consistency](#consistency), even on massively scaled deployments. This means enabling distributed [transactions]({% link {{ page.version.version }}/architecture/transaction-layer.md %}), as well as removing the pain of eventual consistency issues and stale reads.
 - Create an always-on database that accepts reads and writes on all nodes without generating conflicts.
-- Allow flexible deployment in any environment, without tying you to any platform or vendor.
-- Support familiar tools for working with relational data (i.e., SQL).
+- Allow [flexible deployment]({% link {{ page.version.version }}/choose-a-deployment-option.md %}) in any environment, without tying you to any platform or vendor.
+- Support familiar tools for working with relational data (i.e., [SQL]({% link {{ page.version.version }}/architecture/sql-layer.md %})).
 
-With the confluence of these features, we hope that CockroachDB helps you build global, scalable, resilient deployments and applications.
-
-It's helpful to understand a few terms before reading our architecture documentation.
-
-{% include {{ page.version.version }}/misc/database-terms.md %}
-
-{% include {{ page.version.version }}/misc/basic-terms.md %}
+With the confluence of these features, we hope that CockroachDB helps you build global, scalable, resilient [deployments]({% link {{ page.version.version }}/choose-a-deployment-option.md %}) and [applications]({% link {{ page.version.version }}/developer-guide-overview.md %}).
 
 ## Overview
 
@@ -49,18 +43,18 @@ CockroachDB starts running on machines with two commands:
 - [`cockroach start`]({% link {{ page.version.version }}/cockroach-start.md %}) with a `--join` flag for all of the initial nodes in the cluster, so the process knows all of the other machines it can communicate with.
 - [`cockroach init`]({% link {{ page.version.version }}/cockroach-init.md %}) to perform a one-time initialization of the cluster.
 
-Once the CockroachDB cluster is initialized, developers interact with CockroachDB through a [PostgreSQL-compatible]({% link {{ page.version.version }}/postgresql-compatibility.md %}) SQL API. Thanks to the symmetrical behavior of all nodes in a cluster, you can send [SQL requests]({% link {{ page.version.version }}/architecture/sql-layer.md %}) to any node; this makes CockroachDB easy to integrate with load balancers.
+Once the CockroachDB cluster is initialized, developers interact with CockroachDB through a [PostgreSQL-compatible]({% link {{ page.version.version }}/postgresql-compatibility.md %}) SQL API. Thanks to the symmetrical behavior of all nodes in a cluster, you can send [SQL requests]({% link {{ page.version.version }}/architecture/sql-layer.md %}) to any node; this makes CockroachDB easy to integrate with [load balancers]({% link {{ page.version.version }}/recommended-production-settings.md %}#load-balancing).
 
 After receiving SQL remote procedure calls (RPCs), nodes convert them into key-value (KV) operations that work with our [distributed, transactional key-value store]({% link {{ page.version.version }}/architecture/transaction-layer.md %}).
 
-As these RPCs start filling your cluster with data, CockroachDB starts [algorithmically distributing your data among the nodes of the cluster]({% link {{ page.version.version }}/architecture/distribution-layer.md %}), breaking the data up into chunks that we call ranges. Each range is replicated to at least 3 nodes by default to ensure survivability. This ensures that if any nodes go down, you still have copies of the data which can be used for:
+As these RPCs start filling your cluster with data, CockroachDB starts [algorithmically distributing your data among the nodes of the cluster]({% link {{ page.version.version }}/architecture/distribution-layer.md %}), breaking the data up into chunks that we call [ranges](#architecture-range). Each range is replicated to at least [3 nodes by default]({% link {{ page.version.version }}/configure-replication-zones.md %}#num_replicas) to ensure survivability. This ensures that if any nodes go down, you still have copies of the data which can be used for:
 
 - Continuing to serve reads and writes.
-- Consistently replicating the data to other nodes.
+- Consistently [replicating]({% link {{ page.version.version }}/architecture/replication-layer.md %}) the data to other nodes.
 
 If a node receives a read or write request it cannot directly serve, it finds the node that can handle the request, and communicates with that node. This means you do not need to know where in the cluster a specific portion of your data is stored; CockroachDB tracks it for you, and enables symmetric read/write behavior from each node.
 
-Any changes made to the data in a range rely on a [consensus algorithm]({% link {{ page.version.version }}/architecture/replication-layer.md %}) to ensure that the majority of the range's replicas agree to commit the change. This is how CockroachDB achieves the industry-leading isolation guarantees that allow it to provide your application with consistent reads and writes, regardless of which node you communicate with.
+Any changes made to the data in a [range](#architecture-range) rely on a [consensus algorithm]({% link {{ page.version.version }}/architecture/replication-layer.md %}#raft) to ensure that the majority of the range's [replicas](#architecture-replica) agree to commit the change. This is how CockroachDB achieves the industry-leading isolation guarantees that allow it to provide your application with consistent reads and writes, regardless of which node you communicate with.
 
 Ultimately, data is written to and read from disk using an efficient [storage engine]({% link {{ page.version.version }}/architecture/storage-layer.md %}), which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard [`AS OF SYSTEM TIME`]({% link {{ page.version.version }}/as-of-system-time.md %}) clause, letting you find historical data for a period of time.
 
@@ -76,9 +70,17 @@ Layer | Order | Purpose
 ------|------------|--------
 [SQL]({% link {{ page.version.version }}/architecture/sql-layer.md %})  | 1  | Translate client SQL queries to KV operations.
 [Transactional]({% link {{ page.version.version }}/architecture/transaction-layer.md %})  | 2  | Allow atomic changes to multiple KV entries.
-[Distribution]({% link {{ page.version.version }}/architecture/distribution-layer.md %})  | 3  | Present replicated KV ranges as a single entity.
-[Replication]({% link {{ page.version.version }}/architecture/replication-layer.md %})  | 4  | Consistently and synchronously replicate KV ranges across many nodes. This layer also enables consistent reads using a consensus algorithm.
+[Distribution]({% link {{ page.version.version }}/architecture/distribution-layer.md %})  | 3  | Present replicated KV [ranges](#architecture-range) as a single entity.
+[Replication]({% link {{ page.version.version }}/architecture/replication-layer.md %})  | 4  | Consistently and synchronously replicate KV [ranges](#architecture-range) across many [nodes](#node). This layer also enables [consistent](#consistency) reads using a consensus algorithm.
 [Storage]({% link {{ page.version.version }}/architecture/storage-layer.md %})  | 5  | Read and write KV data on disk.
+
+## Database terms
+
+{% include {{ page.version.version }}/misc/database-terms.md %}
+
+## CockroachDB architecture terms
+
+{% include {{ page.version.version }}/misc/basic-terms.md %}
 
 ## What's next?
 

--- a/src/current/v23.1/architecture/reads-and-writes-overview.md
+++ b/src/current/v23.1/architecture/reads-and-writes-overview.md
@@ -11,6 +11,8 @@ This page explains how reads and writes are affected by the replicated and distr
 For a more detailed information about how transactions work in CockroachDB, see the [Transaction Layer]({% link {{ page.version.version }}/architecture/transaction-layer.md %}) documentation.
 {{site.data.alerts.end}}
 
+## CockroachDB architecture terms
+
 {% include {{ page.version.version }}/misc/basic-terms.md %}
 
 ## Query execution

--- a/src/current/v23.2/architecture/glossary.md
+++ b/src/current/v23.2/architecture/glossary.md
@@ -7,7 +7,11 @@ docs_area: get_started
 
 This page defines terms that you will encounter throughout the documentation.
 
+## Database terms
+
 {% include {{ page.version.version }}/misc/database-terms.md %}
+
+## CockroachDB architecture terms
 
 {% include {{ page.version.version }}/misc/basic-terms.md %}
 
@@ -262,4 +266,4 @@ Used to list all of the columns in a database with the [`GEOMETRY`](#geometry) d
 
 #### `geography_columns`
 
-Used to list all of the columns in a database with the [`GEOGRAPHY`](#geography) data type, e.g., `SELECT * from geography_columns`.
+Used to list all of the columns in a database with the [`GEOGRAPHY`](#geography) data type, e.g., `SELECT * FROM geography_columns`.

--- a/src/current/v23.2/architecture/overview.md
+++ b/src/current/v23.2/architecture/overview.md
@@ -6,7 +6,7 @@ key: cockroachdb-architecture.html
 docs_area: reference.architecture
 ---
 
-CockroachDB was designed to create the source-available database we would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner workings of the `cockroach` process as a means of explanation.
+CockroachDB was designed to create the source-available database we would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner workings of [the `cockroach` process]({% link {{ page.version.version }}/cockroach-commands.md %}) as a means of explanation.
 
 However, you definitely do not need to understand the underlying architecture to use CockroachDB. These pages give serious users and database enthusiasts a high-level framework to explain what's happening under the hood.
 
@@ -18,7 +18,7 @@ If these docs interest you, consider taking the free [Intro to Distributed SQL](
 
 This guide is broken out into pages detailing each layer of CockroachDB. We recommended reading through the layers sequentially, starting with this overview and then proceeding to the [SQL layer]({% link {{ page.version.version }}/architecture/sql-layer.md %}).
 
-If you're looking for a high-level understanding of CockroachDB, you can read the **Overview** section of each layer. For more technical detail—for example, if you're interested in [contributing to the project](https://cockroachlabs.atlassian.net/wiki/x/QQFdB)—you should read the **Components** sections as well.
+If you're looking for a high-level understanding of CockroachDB, you can read the **Overview** section of each layer. For more technical detail &mdash; for example, if you're interested in [contributing to the project](https://cockroachlabs.atlassian.net/wiki/x/QQFdB) &mdash; you should read the **Components** sections as well.
 
 {{site.data.alerts.callout_info}}
 This guide details how CockroachDB is built, but does not explain how to build an application using CockroachDB. For more information about how to develop applications that use CockroachDB, check out our [Developer Guide]({% link {{ page.version.version }}/developer-guide-overview.md %}).
@@ -29,18 +29,12 @@ This guide details how CockroachDB is built, but does not explain how to build a
 CockroachDB was designed to meet the following goals:
 
 - Make life easier for humans. This means being low-touch and highly automated for [operators]({% link {{ page.version.version }}/recommended-production-settings.md %}) and simple to reason about for [developers]({% link {{ page.version.version }}/developer-guide-overview.md %}).
-- Offer industry-leading consistency, even on massively scaled deployments. This means enabling distributed transactions, as well as removing the pain of eventual consistency issues and stale reads.
+- Offer industry-leading [consistency](#consistency), even on massively scaled deployments. This means enabling distributed [transactions]({% link {{ page.version.version }}/architecture/transaction-layer.md %}), as well as removing the pain of eventual consistency issues and stale reads.
 - Create an always-on database that accepts reads and writes on all nodes without generating conflicts.
-- Allow flexible deployment in any environment, without tying you to any platform or vendor.
-- Support familiar tools for working with relational data (i.e., SQL).
+- Allow [flexible deployment]({% link {{ page.version.version }}/choose-a-deployment-option.md %}) in any environment, without tying you to any platform or vendor.
+- Support familiar tools for working with relational data (i.e., [SQL]({% link {{ page.version.version }}/architecture/sql-layer.md %})).
 
-With the confluence of these features, we hope that CockroachDB helps you build global, scalable, resilient deployments and applications.
-
-It's helpful to understand a few terms before reading our architecture documentation.
-
-{% include {{ page.version.version }}/misc/database-terms.md %}
-
-{% include {{ page.version.version }}/misc/basic-terms.md %}
+With the confluence of these features, we hope that CockroachDB helps you build global, scalable, resilient [deployments]({% link {{ page.version.version }}/choose-a-deployment-option.md %}) and [applications]({% link {{ page.version.version }}/developer-guide-overview.md %}).
 
 ## Overview
 
@@ -49,18 +43,18 @@ CockroachDB starts running on machines with two commands:
 - [`cockroach start`]({% link {{ page.version.version }}/cockroach-start.md %}) with a `--join` flag for all of the initial nodes in the cluster, so the process knows all of the other machines it can communicate with.
 - [`cockroach init`]({% link {{ page.version.version }}/cockroach-init.md %}) to perform a one-time initialization of the cluster.
 
-Once the CockroachDB cluster is initialized, developers interact with CockroachDB through a [PostgreSQL-compatible]({% link {{ page.version.version }}/postgresql-compatibility.md %}) SQL API. Thanks to the symmetrical behavior of all nodes in a cluster, you can send [SQL requests]({% link {{ page.version.version }}/architecture/sql-layer.md %}) to any node; this makes CockroachDB easy to integrate with load balancers.
+Once the CockroachDB cluster is initialized, developers interact with CockroachDB through a [PostgreSQL-compatible]({% link {{ page.version.version }}/postgresql-compatibility.md %}) SQL API. Thanks to the symmetrical behavior of all nodes in a cluster, you can send [SQL requests]({% link {{ page.version.version }}/architecture/sql-layer.md %}) to any node; this makes CockroachDB easy to integrate with [load balancers]({% link {{ page.version.version }}/recommended-production-settings.md %}#load-balancing).
 
 After receiving SQL remote procedure calls (RPCs), nodes convert them into key-value (KV) operations that work with our [distributed, transactional key-value store]({% link {{ page.version.version }}/architecture/transaction-layer.md %}).
 
-As these RPCs start filling your cluster with data, CockroachDB starts [algorithmically distributing your data among the nodes of the cluster]({% link {{ page.version.version }}/architecture/distribution-layer.md %}), breaking the data up into chunks that we call ranges. Each range is replicated to at least 3 nodes by default to ensure survivability. This ensures that if any nodes go down, you still have copies of the data which can be used for:
+As these RPCs start filling your cluster with data, CockroachDB starts [algorithmically distributing your data among the nodes of the cluster]({% link {{ page.version.version }}/architecture/distribution-layer.md %}), breaking the data up into chunks that we call [ranges](#architecture-range). Each range is replicated to at least [3 nodes by default]({% link {{ page.version.version }}/configure-replication-zones.md %}#num_replicas) to ensure survivability. This ensures that if any nodes go down, you still have copies of the data which can be used for:
 
 - Continuing to serve reads and writes.
-- Consistently replicating the data to other nodes.
+- Consistently [replicating]({% link {{ page.version.version }}/architecture/replication-layer.md %}) the data to other nodes.
 
 If a node receives a read or write request it cannot directly serve, it finds the node that can handle the request, and communicates with that node. This means you do not need to know where in the cluster a specific portion of your data is stored; CockroachDB tracks it for you, and enables symmetric read/write behavior from each node.
 
-Any changes made to the data in a range rely on a [consensus algorithm]({% link {{ page.version.version }}/architecture/replication-layer.md %}) to ensure that the majority of the range's replicas agree to commit the change. This is how CockroachDB achieves the industry-leading isolation guarantees that allow it to provide your application with consistent reads and writes, regardless of which node you communicate with.
+Any changes made to the data in a [range](#architecture-range) rely on a [consensus algorithm]({% link {{ page.version.version }}/architecture/replication-layer.md %}#raft) to ensure that the majority of the range's [replicas](#architecture-replica) agree to commit the change. This is how CockroachDB achieves the industry-leading isolation guarantees that allow it to provide your application with consistent reads and writes, regardless of which node you communicate with.
 
 Ultimately, data is written to and read from disk using an efficient [storage engine]({% link {{ page.version.version }}/architecture/storage-layer.md %}), which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard [`AS OF SYSTEM TIME`]({% link {{ page.version.version }}/as-of-system-time.md %}) clause, letting you find historical data for a period of time.
 
@@ -76,9 +70,17 @@ Layer | Order | Purpose
 ------|------------|--------
 [SQL]({% link {{ page.version.version }}/architecture/sql-layer.md %})  | 1  | Translate client SQL queries to KV operations.
 [Transactional]({% link {{ page.version.version }}/architecture/transaction-layer.md %})  | 2  | Allow atomic changes to multiple KV entries.
-[Distribution]({% link {{ page.version.version }}/architecture/distribution-layer.md %})  | 3  | Present replicated KV ranges as a single entity.
-[Replication]({% link {{ page.version.version }}/architecture/replication-layer.md %})  | 4  | Consistently and synchronously replicate KV ranges across many nodes. This layer also enables consistent reads using a consensus algorithm.
+[Distribution]({% link {{ page.version.version }}/architecture/distribution-layer.md %})  | 3  | Present replicated KV [ranges](#architecture-range) as a single entity.
+[Replication]({% link {{ page.version.version }}/architecture/replication-layer.md %})  | 4  | Consistently and synchronously replicate KV [ranges](#architecture-range) across many [nodes](#node). This layer also enables [consistent](#consistency) reads using a consensus algorithm.
 [Storage]({% link {{ page.version.version }}/architecture/storage-layer.md %})  | 5  | Read and write KV data on disk.
+
+## Database terms
+
+{% include {{ page.version.version }}/misc/database-terms.md %}
+
+## CockroachDB architecture terms
+
+{% include {{ page.version.version }}/misc/basic-terms.md %}
 
 ## What's next?
 

--- a/src/current/v23.2/architecture/reads-and-writes-overview.md
+++ b/src/current/v23.2/architecture/reads-and-writes-overview.md
@@ -11,6 +11,8 @@ This page explains how reads and writes are affected by the replicated and distr
 For a more detailed information about how transactions work in CockroachDB, see the [Transaction Layer]({% link {{ page.version.version }}/architecture/transaction-layer.md %}) documentation.
 {{site.data.alerts.end}}
 
+## CockroachDB architecture terms
+
 {% include {{ page.version.version }}/misc/basic-terms.md %}
 
 ## Query execution


### PR DESCRIPTION
This page is our 4th-most-visited page overall, and it needed some attention.

Summary of changes:

- Add more links to terms and things that have docs now.  Most didn't have docs yet when this page was added.

- Move the giant glossaries to the bottom of the page so readers can get through the **Overview** section first (that section is kind of the whole point of this page's existence, and sticking a glossary in the middle was breaking the flow of the page).