### PR TITLE
Remove reference to webhook and pub/sub performance cluster setting

### DIFF
--- a/src/current/_includes/v23.2/cdc/pubsub-performance-setting.md
+++ b/src/current/_includes/v23.2/cdc/pubsub-performance-setting.md
@@ -1,3 +1,0 @@
-{{site.data.alerts.callout_info}}
-Enable the `changefeed.new_pubsub_sink_enabled` [cluster setting]({% link {{ page.version.version }}/cluster-settings.md %}) to improve the throughput of changefeeds emitting to {% if page.name == "changefeed-sinks.md" %} Pub/Sub sinks. {% else %} [Pub/Sub sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}#google-cloud-pub-sub). {% endif %}
-{{site.data.alerts.end}}

--- a/src/current/_includes/v23.2/cdc/webhook-performance-setting.md
+++ b/src/current/_includes/v23.2/cdc/webhook-performance-setting.md
@@ -1,4 +1,0 @@
-{{site.data.alerts.callout_info}}
-Enable the `changefeed.new_webhook_sink_enabled` [cluster setting]({% link {{ page.version.version }}/cluster-settings.md %}) to improve the throughput of changefeeds emitting to {% if page.name == "changefeed-sinks.md" %} webhook sinks. {% else %} [webhook sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}#webhook-sink). {% endif %}
-{{site.data.alerts.end}}
-

--- a/src/current/v23.2/advanced-changefeed-configuration.md
+++ b/src/current/v23.2/advanced-changefeed-configuration.md
@@ -122,8 +122,6 @@ kafka_sink_config='{'RequiredAcks': 'ALL'}'
 
 Use [Kafka]({% link {{ page.version.version }}/changefeed-sinks.md %}#kafka) or [cloud storage]({% link {{ page.version.version }}/changefeed-sinks.md %}#cloud-storage-sink) sinks when tuning for high durability delivery in changefeeds. Both Kafka and cloud storage sinks offer built-in advanced protocols, whereas the [webhook sink]({% link {{ page.version.version }}/changefeed-sinks.md %}#webhook-sink), while flexible, requires an understanding of how messages are acknowledged and committed by the particular system used for the webhook in order to ensure the durability of message delivery.
 
-{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
-
 ### Defining schema change behavior
 
 Ensure that data is ingested downstream in its new format after a [schema change]({% link {{ page.version.version }}/online-schema-changes.md %}) by using the [`schema_change_events`]({% link {{ page.version.version }}/create-changefeed.md %}#schema-events) and [`schema_schange_policy`]({% link {{ page.version.version }}/create-changefeed.md %}#schema-policy) options. For example, setting `schema_change_events=column_changes` and `schema_change_policy=stop` will trigger an error to the `cockroach.log` file on a [schema change]({% link {{ page.version.version }}/changefeed-messages.md %}#schema-changes-with-column-backfill) and the changefeed to fail.

--- a/src/current/v23.2/changefeed-examples.md
+++ b/src/current/v23.2/changefeed-examples.md
@@ -331,8 +331,6 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
-
 In this example, you'll set up a changefeed for a single-node cluster that is connected to a [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/overview) sink. The changefeed will watch a table and send messages to the sink.
 
 You'll need access to a [Google Cloud Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) to set up a Pub/Sub sink. In this example, the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk) (`gcloud`) is used, but you can also complete each of these steps within your [Google Cloud Console](https://cloud.google.com/storage/docs/cloud-console).
@@ -542,8 +540,6 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 {{site.data.alerts.callout_info}}
 [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) is an [{{ site.data.products.enterprise }}-only]({% link {{ page.version.version }}/enterprise-licensing.md %}) feature. For the Core version, see [the `CHANGEFEED FOR` example](#create-a-core-changefeed).
 {{site.data.alerts.end}}
-
-{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
 
 In this example, you'll set up a changefeed for a single-node cluster that is connected to a local HTTP server via a webhook. For this example, you'll use an [example HTTP server](https://github.com/cockroachlabs/cdc-webhook-sink-test-server/tree/master/go-https-server) to test out the webhook sink.
 

--- a/src/current/v23.2/changefeed-sinks.md
+++ b/src/current/v23.2/changefeed-sinks.md
@@ -192,8 +192,6 @@ See the [Changefeed Examples]({% link {{ page.version.version }}/changefeed-exam
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
-
 Changefeeds can deliver messages to a Google Cloud Pub/Sub sink, which is integrated with Google Cloud Platform.
 
 A Pub/Sub sink URI follows this example:
@@ -384,8 +382,6 @@ The following shows the default JSON messages for a changefeed emitting to a clo
 {% include {{ page.version.version }}/cdc/note-changefeed-message-page.md %}
 
 ## Webhook sink
-
-{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
 
 Use a webhook sink to deliver changefeed messages to an arbitrary HTTP endpoint.
 

--- a/src/current/v23.2/create-changefeed.md
+++ b/src/current/v23.2/create-changefeed.md
@@ -92,8 +92,6 @@ Example of a Google Cloud Pub/Sub sink URI:
 'gcpubsub://{project name}?region={region}&topic_name={topic name}&AUTH=specified&CREDENTIALS={base64-encoded key}'
 ~~~
 
-{% include {{ page.version.version }}/cdc/pubsub-performance-setting.md %}
-
 [Use Cloud Storage for Bulk Operations]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) explains the requirements for the authentication parameter with `specified` or `implicit`. Refer to [Changefeed Sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}#google-cloud-pub-sub) for further consideration.
 
 #### Cloud Storage
@@ -116,8 +114,6 @@ Example of a webhook URI:
 ~~~
 'webhook-https://{your-webhook-endpoint}?insecure_tls_skip_verify=true'
 ~~~
-
-{% include {{ page.version.version }}/cdc/webhook-performance-setting.md %}
 
 Refer to [Changefeed Sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}#webhook-sink) for specifics on webhook sink configuration.
 


### PR DESCRIPTION
Fixes DOC-8670

In v23.1 we added a cluster setting that enables some performances enhancements for webhook & pub/sub. This setting was not enabled by default and customers needed to flip the switch to see the improvements. In the docs, we added notes in all the relevant sink spaces to direct customers to enable this setting. 

For v23.2, we have enabled this setting by default. Because we don't foresee any need for a customer to interact with this setting right now, we're removing mention of this from the docs.