### PR TITLE
Phase 2 admonition for v23.1.11

### DIFF
--- a/src/current/_config_cockroachdb.yml
+++ b/src/current/_config_cockroachdb.yml
@@ -2,7 +2,7 @@ baseurl: /docs
 current_cloud_date: '2023-09-26'
 current_cloud_version: v23.1
 current_dedicated_hotfix: v23.1.10
-current_serverless_hotfix: v23.1.10
+current_serverless_hotfix: v23.1.11
 destination: _site/docs
 homepage_title: CockroachDB Docs
 versions:

--- a/src/current/_includes/releases/current-cloud-version.md
+++ b/src/current/_includes/releases/current-cloud-version.md
@@ -1,6 +1,8 @@
 {% assign smv = site.data.releases | where_exp: "smv", "smv.release_name == site.current_serverless_hotfix" | map: "major_version" %}
 {% assign dmv = site.data.releases | where_exp: "dmv", "dmv.release_name == site.current_dedicated_hotfix" | map: "major_version" %}
 
+{% assign smv = "v23.1" %}
+
 {{site.data.alerts.callout_version}}
 As of {{ site.current_cloud_date | date: "%B %e, %Y" }}, CockroachDB {{ site.data.products.serverless }} clusters are running CockroachDB [{{ site.current_serverless_hotfix }}]({% link releases/{{ smv }}.md %}#{{ site.current_serverless_hotfix | replace: ".", "-" }}) and new CockroachDB {{ site.data.products.dedicated }} clusters are running CockroachDB [{{ site.current_dedicated_hotfix }}]({% link releases/{{ dmv }}.md %}#{{ site.current_dedicated_hotfix | replace: ".", "-" }}).
 {{site.data.alerts.end}}

--- a/src/current/_includes/releases/v23.1/v23.1.11.md
+++ b/src/current/_includes/releases/v23.1/v23.1.11.md
@@ -1,9 +1,9 @@
 ## v23.1.11
 
 {{ site.data.alerts.callout_info }}
-v23.1.11 is currently available only on select CockroachDB {{ site.data.products.dedicated }} clusters. If you wish to upgrade your {{ site.data.products.dedicated }} cluster to v23.1.11, please submit a [support request](https://support.cockroachlabs.com/hc/en-us/requests/new).
+v23.1.11 is currently available only for CockroachDB {{ site.data.products.serverless }} customers and select {{ site.data.products.dedicated }} clusters. If you wish to upgrade your {{ site.data.products.dedicated }} cluster to v23.1.11, please [submit a support request](https://support.cockroachlabs.com/hc/en-us/requests/new?).
 
-This release is currently not available for CockroachDB {{ site.data.products.serverless }} or {{ site.data.products.core }} customers.
+This release is currently not available for CockroachDB {{ site.data.products.core }} customers.
 {{ site.data.alerts.end }}
 
 Release Date: September 25, 2023

--- a/src/current/_includes/releases/v23.1/v23.1.11.md
+++ b/src/current/_includes/releases/v23.1/v23.1.11.md
@@ -1,7 +1,7 @@
 ## v23.1.11
 
 {{ site.data.alerts.callout_info }}
-v23.1.11 is currently available only for CockroachDB {{ site.data.products.serverless }} customers and select {{ site.data.products.dedicated }} clusters. If you wish to upgrade your {{ site.data.products.dedicated }} cluster to v23.1.11, please [submit a support request](https://support.cockroachlabs.com/hc/en-us/requests/new?).
+v23.1.11 is currently available for CockroachDB {{ site.data.products.serverless }} customers and select {{ site.data.products.dedicated }} clusters. If you wish to upgrade your {{ site.data.products.dedicated }} cluster to v23.1.11, please [submit a support request](https://support.cockroachlabs.com/hc/en-us/requests/new?).
 
 This release is currently not available for CockroachDB {{ site.data.products.core }} customers.
 {{ site.data.alerts.end }}


### PR DESCRIPTION
This release will now be available on all Serverless clusters and select Dedicated clusters.

Build preview links:

- https://deploy-preview-17922--cockroachdb-docs.netlify.app/docs/releases/cloud
- https://deploy-preview-17922--cockroachdb-docs.netlify.app/docs/releases/v23.1