### PR TITLE
[DOC-7783] Release notes for v23.2.0-alpha.2

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4920,3 +4920,30 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.10
+
+- release_name: v23.2.0-alpha.2
+  major_version: v23.2
+  release_date: '2023-10-02'
+  release_type: Testing
+  go_version: go1.20
+  sha: 10d282dc9045ebb8b3faaf891706a13b08177949
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+    mac_arm_experimental: true
+    mac_arm_limited_access: true
+  windows: true
+  linux:
+    linux_arm: true
+    linux_arm_experimental: false
+    linux_arm_limited_access: false
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach-unstable
+    docker_arm: true
+    docker_arm_experimental: false
+    docker_arm_limited_access: true
+  source: true
+  previous_release: v23.2.0-alpha.1

--- a/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
@@ -6,61 +6,44 @@ Release Date: October 2, 2023
 
 <h3 id="v23-2-0-alpha-2-security-updates">Security updates</h3>
 
-- The SIGHUP signal will now clear the cached expiration times for client certificates that are reported by the security.certificate.expiration.client metric. [#110726][#110726]
-- Endpoints in the admin and status server that previously required the admin role now can be used by users with the VIEWCLUSTERMETADATA or REPAIRCLUSTERMETADATA system privilege, depending on whether the endpoint is read-only or can modify state. [#110609][#110609]
+- The `SIGHUP` signal now clears the cached expiration times for [client certificates](https://www.cockroachlabs.com/docs/v23.2/cockroach-cert#how-security-certificates-work) that are reported by the `security.certificate.expiration.client` metric. [#110726][#110726]
 
 <h3 id="v23-2-0-alpha-2-sql-language-changes">SQL language changes</h3>
 
-- The discard log message is now limited to once per minute by default. The message was also changed to have both the number of transactions and the number of statements that were discarded. [#110805][#110805]
-- It is not possible any more to control access to the RANGEFEED SQL syntax by modifying the cluster setting `kv.rangefeed.enabled`. Instead use `feature.changefeed.enabled`. [#110676][#110676]
-- SQL commands that were previously only usable by users with the admin role can now be used by users with the VIEWCLUSTERMETADATA or REPAIRCLUSTERMETADATA system privilege, depending on whether the operation is read-only or modifies state. [#110084][#110084]
-- Adds `last_error` column to the `[cluster|node]_execution_insights` and `[cluster|node]_txn_execution_insights` tables which keeps track of the error message for failed executions. [#110565][#110565]
+- The `discard` [log message](https://www.cockroachlabs.com/docs/v23.2/logging-overview) is now limited to once per minute by default. The message now includes both the number of transactions and the number of statements that were discarded. [#110805][#110805]
+- The [cluster setting](https://www.cockroachlabs.com/docs/v23.2/cluster-settings) `kv.rangefeed.enabled` no longer controls access to `RANGEFEED SQL` commands. Instead, use `feature.changefeed.enabled`. [#110676][#110676]
+- SQL commands that were previously limited to the `admin` [system privilege](https://www.cockroachlabs.com/docs/v23.2/security-reference/authorization#supported-privileges) can now be used by users with the `VIEWCLUSTERMETADATA` or `REPAIRCLUSTERMETADATA` system privilege, depending on whether the operation is read-only or modifies state. [#110084][#110084]
+- Added a `last_error` column to the `cluster_execution_insights`, `node_execution_insights`, `cluster_txn_execution_insights`, and `node_txn_execution_insights` tables. These columns contain error messages for failed executions. [#110565][#110565]
 
 <h3 id="v23-2-0-alpha-2-operational-changes">Operational changes</h3>
 
-- Removed node-level `engine.stalls` timeseries metric. This metric has not been updated for several releases. [#110936][#110936]
+- Removed the node-level `engine.stalls` timeseries metric. This metric has not been updated for several releases. [#110936][#110936]
 
 <h3 id="v23-2-0-alpha-2-db-console-changes">DB Console changes</h3>
 
-- Always show the legend on Metrics charts, allowing single lines to be selected. [#110809][#110809]
-- Add option to filter out by specific plan gist when collecting a statement bundle. [#110931][#110931]
-- Added a tooltip to the ranges chart on the replication dashboard, describing the metric in single vs cluster view. [#111115][#111115]
-- Adds "Error message" row to the statement and transaction insights details pages. If the user has VIEWACTIVITY, they are able to view the full error message. If they have VIEWACTIVTYREDACTED, they are given a redacted error message. If they have both, VIEWACTIVITYTREDACTED  takes precedence. [#110849][#110849]
-- An additional dashboard has been added to SQL metrics page. It tracks the number of times distributed queries that resulted in errors were rerun as local as well as when those reruns failed. This "rerun as local" mechanism is new in 23.2 and is enabled by default but could be disabled by updating the undocumented cluster setting `sql.distsql.distributed_query_rerun_locally.enabled` to `false`. [#110619][#110619]
+- The legend is now always displayed on charts in DB Console Metrics pages. In addition, when you select an item from the legend that represents a single line in the chart, that line is selected in the chart. [#110809][#110809]
+- When collecting a [statement bundle](https://www.cockroachlabs.com/docs/v23.2/cockroach-statement-diag), you can now filter by a specific [plan gist](https://www.cockroachlabs.com/docs/v23.2/ui-statements-page#explain-plans) or collect diagnostics for all plan gists. [#110931][#110931]
+- [Statement](https://www.cockroachlabs.com/docs/v23.2/ui-statements-page) and [Transaction](https://www.cockroachlabs.com/docs/v23.2/ui-transactions-page) detail pages now include an **Error Message** row. Users with the `VIEWACTIVITY` [system privilege](https://www.cockroachlabs.com/docs/v23.2/security-reference/authorization#supported-privileges) can view the full error message, and users with the `VIEWACTIVTYREDACTED` system privilege can view the redacted error message. If a user has both privileges, `VIEWACTIVITYTREDACTED`` takes precedence. [#110849][#110849]
+- A new dashboard in the [SQL Dashboard page](https://www.cockroachlabs.com/docs/v23.2/ui-sql-dashboard) tracks how often distributed queries with errors were rerun using the "rerun as local" mechanism, as well as how often those reruns failed. the number of times distributed queries that resulted in errors were rerun as local as well as when those reruns failed. The "rerun as local" mechanism is new in v23.2 and is enabled by default. For more information, contact your Cockroach Labs account representative. [#110619][#110619]
 
 <h3 id="v23-2-0-alpha-2-bug-fixes">Bug fixes</h3>
 
-- Fixed a race condition in Replica lifecycle which could result in a failed SQL request in cases where it could be successfully retried.  Epic: none [#110806][#110806]
-- CREATE TABLE with IDENTITY columns did not properly propagate the type of the column into the sequence. [#110621][#110621]
-- Fixed panic when decoding gist in DB without the table referred to by the gist. [#110966][#110966]
-- Pg_attribute could have sparsely populated attnum's since dropped columns were not included. [#111019][#111019]
-- Fixed an edge case in the `unnest` and `information_schema._pg_expandarray` builtin functions that could cause an internal error when passed string arguments that could be cast to an array. [#110956][#110956]
-- Fixes azure schemes in storage, kms and external conns. [#111217][#111217]
-
-<h3 id="v23-2-0-alpha-2-performance-improvements">Performance improvements</h3>
-
-- Performance of large stores using encryption-at-rest with many files is improved by removing a pathological behavior where every file creation, rename or removal could result in a rewrite of a 128MB file. [#111069][#111069]
-
-<h3 id="v23-2-0-alpha-2-doc-updates">Doc updates</h3>
-
-{% comment %}Docs team: Please add these manually.{% endcomment %}
-
-<div class="release-note-contributors" markdown="1">
+- Fixed a race condition in the [Replica lifecycle](https://www.cockroachlabs.com/docs/v23.2/architecture/replication-layer) that could result in a failed SQL request when the request could have been successfully retried. [#110806][#110806]
+- Fixed a bug where a [`CREATE TABLE`](https://www.cockroachlabs.com/docs/v23.2/create-table) command with an `IDENTITY` column did not properly propagate the type of the column into the sequence. [#110621][#110621]
+- Fixed a panic when decoding a gist in a foreign database that does not contain a table referred to by the gist. [#110966][#110966]
+- A synthetic `dropped` column have been added to the `pg_attribute` table. This column tracks the attribution numbers for dropped attributions, to work around issues with ORMs that are not designed to handle gaps in attribution numbering in the `pg_attribute` table. [#111019][#111019]
+- Fixed a rare internal error in the `unnest` and `information_schema._pg_expandarray` [built-in functions](https://www.cockroachlabs.com/docs/v23.2/functions-and-operators) where passed string arguments could be cast to an array. [#110956][#110956]
+- External connection URLs now accept the scheme `azure-blob` for connections to Azure Blob Storage and the scheme `azure-kms` for connections to Azure KMS. For backward compatibility, schemes `azure` and `azure-storage` schemes continue to work for connections to Azure Blob Storage. [#111217][#111217]
+- Fixed a performance bug that could result in rewriting a 128-MB file each time a store file is created, renamed, or removed when [Encryption At Rest](https://www.cockroachlabs.com/docs/v23.2/security-reference/encryption#encryption-at-rest) is enabled on a large store with many small files. [#111069][#111069]
 
 <h3 id="v23-2-0-alpha-2-contributors">Contributors</h3>
 
 This release includes 102 merged PRs by 43 authors.
-We would like to thank the following contributors from the CockroachDB community:
-
-- Wenyi Hu (first-time contributor, CockroachDB team member)
-- Xhesika Malecaj (first-time contributor, CockroachDB team member)
-- rharding6373
 
 </div>
 
 [#110084]: https://github.com/cockroachdb/cockroach/pull/110084
 [#110565]: https://github.com/cockroachdb/cockroach/pull/110565
-[#110609]: https://github.com/cockroachdb/cockroach/pull/110609
 [#110619]: https://github.com/cockroachdb/cockroach/pull/110619
 [#110621]: https://github.com/cockroachdb/cockroach/pull/110621
 [#110676]: https://github.com/cockroachdb/cockroach/pull/110676
@@ -75,5 +58,4 @@ We would like to thank the following contributors from the CockroachDB community
 [#110966]: https://github.com/cockroachdb/cockroach/pull/110966
 [#111019]: https://github.com/cockroachdb/cockroach/pull/111019
 [#111069]: https://github.com/cockroachdb/cockroach/pull/111069
-[#111115]: https://github.com/cockroachdb/cockroach/pull/111115
 [#111217]: https://github.com/cockroachdb/cockroach/pull/111217

--- a/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
@@ -1,0 +1,79 @@
+## v23.2.0-alpha.2
+
+Release Date: October 2, 2023
+
+{% include releases/release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-2-0-alpha-2-security-updates">Security updates</h3>
+
+- The SIGHUP signal will now clear the cached expiration times for client certificates that are reported by the security.certificate.expiration.client metric. [#110726][#110726]
+- Endpoints in the admin and status server that previously required the admin role now can be used by users with the VIEWCLUSTERMETADATA or REPAIRCLUSTERMETADATA system privilege, depending on whether the endpoint is read-only or can modify state. [#110609][#110609]
+
+<h3 id="v23-2-0-alpha-2-sql-language-changes">SQL language changes</h3>
+
+- The discard log message is now limited to once per minute by default. The message was also changed to have both the number of transactions and the number of statements that were discarded. [#110805][#110805]
+- It is not possible any more to control access to the RANGEFEED SQL syntax by modifying the cluster setting `kv.rangefeed.enabled`. Instead use `feature.changefeed.enabled`. [#110676][#110676]
+- SQL commands that were previously only usable by users with the admin role can now be used by users with the VIEWCLUSTERMETADATA or REPAIRCLUSTERMETADATA system privilege, depending on whether the operation is read-only or modifies state. [#110084][#110084]
+- Adds `last_error` column to the `[cluster|node]_execution_insights` and `[cluster|node]_txn_execution_insights` tables which keeps track of the error message for failed executions. [#110565][#110565]
+
+<h3 id="v23-2-0-alpha-2-operational-changes">Operational changes</h3>
+
+- Removed node-level `engine.stalls` timeseries metric. This metric has not been updated for several releases. [#110936][#110936]
+
+<h3 id="v23-2-0-alpha-2-db-console-changes">DB Console changes</h3>
+
+- Always show the legend on Metrics charts, allowing single lines to be selected. [#110809][#110809]
+- Add option to filter out by specific plan gist when collecting a statement bundle. [#110931][#110931]
+- Added a tooltip to the ranges chart on the replication dashboard, describing the metric in single vs cluster view. [#111115][#111115]
+- Adds "Error message" row to the statement and transaction insights details pages. If the user has VIEWACTIVITY, they are able to view the full error message. If they have VIEWACTIVTYREDACTED, they are given a redacted error message. If they have both, VIEWACTIVITYTREDACTED  takes precedence. [#110849][#110849]
+- An additional dashboard has been added to SQL metrics page. It tracks the number of times distributed queries that resulted in errors were rerun as local as well as when those reruns failed. This "rerun as local" mechanism is new in 23.2 and is enabled by default but could be disabled by updating the undocumented cluster setting `sql.distsql.distributed_query_rerun_locally.enabled` to `false`. [#110619][#110619]
+
+<h3 id="v23-2-0-alpha-2-bug-fixes">Bug fixes</h3>
+
+- Fixed a race condition in Replica lifecycle which could result in a failed SQL request in cases where it could be successfully retried.  Epic: none [#110806][#110806]
+- CREATE TABLE with IDENTITY columns did not properly propagate the type of the column into the sequence. [#110621][#110621]
+- Fixed panic when decoding gist in DB without the table referred to by the gist. [#110966][#110966]
+- Pg_attribute could have sparsely populated attnum's since dropped columns were not included. [#111019][#111019]
+- Fixed an edge case in the `unnest` and `information_schema._pg_expandarray` builtin functions that could cause an internal error when passed string arguments that could be cast to an array. [#110956][#110956]
+- Fixes azure schemes in storage, kms and external conns. [#111217][#111217]
+
+<h3 id="v23-2-0-alpha-2-performance-improvements">Performance improvements</h3>
+
+- Performance of large stores using encryption-at-rest with many files is improved by removing a pathological behavior where every file creation, rename or removal could result in a rewrite of a 128MB file. [#111069][#111069]
+
+<h3 id="v23-2-0-alpha-2-doc-updates">Doc updates</h3>
+
+{% comment %}Docs team: Please add these manually.{% endcomment %}
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-2-0-alpha-2-contributors">Contributors</h3>
+
+This release includes 102 merged PRs by 43 authors.
+We would like to thank the following contributors from the CockroachDB community:
+
+- Wenyi Hu (first-time contributor, CockroachDB team member)
+- Xhesika Malecaj (first-time contributor, CockroachDB team member)
+- rharding6373
+
+</div>
+
+[#110084]: https://github.com/cockroachdb/cockroach/pull/110084
+[#110565]: https://github.com/cockroachdb/cockroach/pull/110565
+[#110609]: https://github.com/cockroachdb/cockroach/pull/110609
+[#110619]: https://github.com/cockroachdb/cockroach/pull/110619
+[#110621]: https://github.com/cockroachdb/cockroach/pull/110621
+[#110676]: https://github.com/cockroachdb/cockroach/pull/110676
+[#110726]: https://github.com/cockroachdb/cockroach/pull/110726
+[#110805]: https://github.com/cockroachdb/cockroach/pull/110805
+[#110806]: https://github.com/cockroachdb/cockroach/pull/110806
+[#110809]: https://github.com/cockroachdb/cockroach/pull/110809
+[#110849]: https://github.com/cockroachdb/cockroach/pull/110849
+[#110931]: https://github.com/cockroachdb/cockroach/pull/110931
+[#110936]: https://github.com/cockroachdb/cockroach/pull/110936
+[#110956]: https://github.com/cockroachdb/cockroach/pull/110956
+[#110966]: https://github.com/cockroachdb/cockroach/pull/110966
+[#111019]: https://github.com/cockroachdb/cockroach/pull/111019
+[#111069]: https://github.com/cockroachdb/cockroach/pull/111069
+[#111115]: https://github.com/cockroachdb/cockroach/pull/111115
+[#111217]: https://github.com/cockroachdb/cockroach/pull/111217

--- a/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
@@ -21,9 +21,14 @@ Release Date: October 2, 2023
 - The new backup option `updates_cluster_monitoring_metrics` tracks the timestamp of the last backup failure due to a KMS error. This option is disabled by default. [#104634][#104634]
 - The new restore option `strip_localities` optionally strips the locality information from a backup when restoring to a cluster with different regions than the source cluster.
 
-  Adding a primary region to a regionless restore (with or without regional by row tables) will not work without modifying the database. However, the attempt will produce an error message that provides instructions to alter the restored database.
+  Restoring a cluster or database that contains regional-by-row tables, or restoring a regional-by-row table, requires you to modify the database:
 
-  Restoring a cluster, database, or table with a regional-by-row table will not work without modifications. In particular, you must alter the `crdb_region` column needs to specify the region of the new rows being written to the table by setting a default region, and also discard the zone config, which contains outdated information, such as that related to the partitions and constraints after the restore. This column specifies each row's home region and is a prefix to the table's primary key. Stripping localities does not modify this column, because it would require the entire table to be written.
+  - To restore a cluster with regional-by-row tables, you must drop the zone config of the database, then drop the type `d.public.crdb_internal_region`.
+  - To restore a database that contains regional-by-row tables, or to restore a regional-by-row table, you must drop the type `d.public.crdb_internal_region`.
+  - You must alter the `crdb_region` column to set the default region for newly-written rows.
+  - You must discard the previous zone config, which contains outdated information, such as that related to the partitions and constraints after the restore. This column specifies each row's home region and is a prefix to the table's primary key. Stripping localities does not modify this column, because it would require the entire table to be written.
+
+  This change is part of a larger effort, and this feature is subject to change.
 
   [#110606][#110606]
 

--- a/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
@@ -8,12 +8,35 @@ Release Date: October 2, 2023
 
 - The `SIGHUP` signal now clears the cached expiration times for [client certificates](https://www.cockroachlabs.com/docs/v23.2/cockroach-cert#how-security-certificates-work) that are reported by the `security.certificate.expiration.client` metric. [#110726][#110726]
 
+<h3 id="v23-2-0-alpha-2-general-changes">General changes</h3>
+
+- Increased the maximum permitted value of the `COCKROACH_RPC_INITIAL_WINDOW_SIZE` environment variable to 64MB. In conjunction with tuning your operating system's maximum TCP window size, this can increase the throughput that Raft replication can sustain over high latency network links. [#111255][#111255]
+
 <h3 id="v23-2-0-alpha-2-sql-language-changes">SQL language changes</h3>
 
 - The `discard` [log message](https://www.cockroachlabs.com/docs/v23.2/logging-overview) is now limited to once per minute by default. The message now includes both the number of transactions and the number of statements that were discarded. [#110805][#110805]
 - The [cluster setting](https://www.cockroachlabs.com/docs/v23.2/cluster-settings) `kv.rangefeed.enabled` no longer controls access to `RANGEFEED SQL` commands. Instead, use `feature.changefeed.enabled`. [#110676][#110676]
 - SQL commands that were previously limited to the `admin` [system privilege](https://www.cockroachlabs.com/docs/v23.2/security-reference/authorization#supported-privileges) can now be used by users with the `VIEWCLUSTERMETADATA` or `REPAIRCLUSTERMETADATA` system privilege, depending on whether the operation is read-only or modifies state. [#110084][#110084]
 - Added a `last_error` column to the `cluster_execution_insights`, `node_execution_insights`, `cluster_txn_execution_insights`, and `node_txn_execution_insights` tables. These columns contain error messages for failed executions. [#110565][#110565]
+- The new backup option `updates_cluster_monitoring_metrics` tracks the timestamp of the last backup failure due to a KMS error. This option is disabled by default. [#104634][#104634]
+- The new restore option `strip_localities` optionally strips the locality information from a backup when restoring to a cluster with different regions than the source cluster.
+
+  Adding a primary region to a regionless restore (with or without regional by row tables) will not work without modifying the database. However, the attempt will produce an error message that provides instructions to alter the restored database.
+
+  Restoring a cluster, database, or table with a regional-by-row table will not work without modifications. In particular, you must alter the `crdb_region` column needs to specify the region of the new rows being written to the table by setting a default region, and also discard the zone config, which contains outdated information, such as that related to the partitions and constraints after the restore. This column specifies each row's home region and is a prefix to the table's primary key. Stripping localities does not modify this column, because it would require the entire table to be written.
+
+  [#110606][#110606]
+
+- Added a check to disallow queries that use predicate locking, since explicit uniqueness checks are not yet supported under Read Committed isolation. `INSERT`, `UPDATE`, and `UPSERT` statements against some `REGIONAL BY ROW` tables will fail under Read Committed isolation with the following error:
+
+  ~~~ shell
+  unimplemented: explicit unique checks are not yet supported under read committed isolation SQLSTATE: 0A000
+  ~~~
+
+    For more details about which `REGIONAL BY ROW` tables are affected, refer to [Issue #110873](https://github.com/cockroachdb/cockroach/issues/110873).
+
+    [#110879][#110879]
+- The `created` field produced by `SHOW STATISTICS` has been updated from `TIMESTAMP` to `TIMESTAMPTZ`. Statistic creation times are now displayed in the session time zone if it is set. [#110753][#110753]
 
 <h3 id="v23-2-0-alpha-2-operational-changes">Operational changes</h3>
 
@@ -25,6 +48,7 @@ Release Date: October 2, 2023
 - When collecting a [statement bundle](https://www.cockroachlabs.com/docs/v23.2/cockroach-statement-diag), you can now filter by a specific [plan gist](https://www.cockroachlabs.com/docs/v23.2/ui-statements-page#explain-plans) or collect diagnostics for all plan gists. [#110931][#110931]
 - [Statement](https://www.cockroachlabs.com/docs/v23.2/ui-statements-page) and [Transaction](https://www.cockroachlabs.com/docs/v23.2/ui-transactions-page) detail pages now include an **Error Message** row. Users with the `VIEWACTIVITY` [system privilege](https://www.cockroachlabs.com/docs/v23.2/security-reference/authorization#supported-privileges) can view the full error message, and users with the `VIEWACTIVTYREDACTED` system privilege can view the redacted error message. If a user has both privileges, `VIEWACTIVITYTREDACTED`` takes precedence. [#110849][#110849]
 - A new dashboard in the [SQL Dashboard page](https://www.cockroachlabs.com/docs/v23.2/ui-sql-dashboard) tracks how often distributed queries with errors were rerun using the "rerun as local" mechanism, as well as how often those reruns failed. the number of times distributed queries that resulted in errors were rerun as local as well as when those reruns failed. The "rerun as local" mechanism is new in v23.2 and is enabled by default. For more information, contact your Cockroach Labs account representative. [#110619][#110619]
+- The DB Console [Insights page](https://cockroachlabs.com/docs/v23.2/ui-insights-page) now shows the error message when a transaction fails at the the `COMMIT` stage. [#110898][#110898]
 
 <h3 id="v23-2-0-alpha-2-bug-fixes">Bug fixes</h3>
 
@@ -34,28 +58,49 @@ Release Date: October 2, 2023
 - A synthetic `dropped` column have been added to the `pg_attribute` table. This column tracks the attribution numbers for dropped attributions, to work around issues with ORMs that are not designed to handle gaps in attribution numbering in the `pg_attribute` table. [#111019][#111019]
 - Fixed a rare internal error in the `unnest` and `information_schema._pg_expandarray` [built-in functions](https://www.cockroachlabs.com/docs/v23.2/functions-and-operators) where passed string arguments could be cast to an array. [#110956][#110956]
 - External connection URLs now accept the scheme `azure-blob` for connections to Azure Blob Storage and the scheme `azure-kms` for connections to Azure KMS. For backward compatibility, schemes `azure` and `azure-storage` schemes continue to work for connections to Azure Blob Storage. [#111217][#111217]
+- Fixed a bug where vectorized `COPY FROM` could produce a plan with more than one RenderNodes, when only zero or one should be allowed. This could result in multiple render nodes in a table with a hash shareded primary key. [#111284][#111284]
+- Fixed a bug in DB Console's Statement Diagnostic page that could cause the page to crash if the response was larger than 50 KB. The page now keeps pulling results until no maximum size errors are encountered. [#111128][#111128]
+- Fixed a bug where DB Console instances proxied at different subpaths that use OIDC pointed to an incorrect relative OIDC login path. [#111240][#111240]
+- Fixed a bug where changing the setting `server.telemetry.hot_ranges_stats.interval` had no effect. [#111305][#111305]
+
+<h3 id="v23-2-0-alpha-2-performance-improvements">Performance improvements</h3>
+
 - Fixed a performance bug that could result in rewriting a 128-MB file each time a store file is created, renamed, or removed when [Encryption At Rest](https://www.cockroachlabs.com/docs/v23.2/security-reference/encryption#encryption-at-rest) is enabled on a large store with many small files. [#111069][#111069]
+- Improved compaction heuristics to mitigate read amplification growth and admission control throttling when processing large deletes, such as during node decommissioning, replica rebalancing, or hen dropping tables. [#111277][#111277]
 
 <h3 id="v23-2-0-alpha-2-contributors">Contributors</h3>
 
-This release includes 102 merged PRs by 43 authors.
+This release includes [157 merged PRs by 54 authors](https://github.com/cockroachdb/cockroach/compare/v23.2.0-alpha.1...2111b61b2d7c789bc03b1e9392062df80c779075).
 
 </div>
 
+[#104634]: https://github.com/cockroachdb/cockroach/pull/104634
 [#110084]: https://github.com/cockroachdb/cockroach/pull/110084
 [#110565]: https://github.com/cockroachdb/cockroach/pull/110565
+[#110606]: https://github.com/cockroachdb/cockroach/pull/110606
+[#110609]: https://github.com/cockroachdb/cockroach/pull/110609
 [#110619]: https://github.com/cockroachdb/cockroach/pull/110619
 [#110621]: https://github.com/cockroachdb/cockroach/pull/110621
 [#110676]: https://github.com/cockroachdb/cockroach/pull/110676
 [#110726]: https://github.com/cockroachdb/cockroach/pull/110726
+[#110753]: https://github.com/cockroachdb/cockroach/pull/110753
 [#110805]: https://github.com/cockroachdb/cockroach/pull/110805
 [#110806]: https://github.com/cockroachdb/cockroach/pull/110806
 [#110809]: https://github.com/cockroachdb/cockroach/pull/110809
 [#110849]: https://github.com/cockroachdb/cockroach/pull/110849
+[#110879]: https://github.com/cockroachdb/cockroach/pull/110879
+[#110898]: https://github.com/cockroachdb/cockroach/pull/110898
 [#110931]: https://github.com/cockroachdb/cockroach/pull/110931
 [#110936]: https://github.com/cockroachdb/cockroach/pull/110936
 [#110956]: https://github.com/cockroachdb/cockroach/pull/110956
 [#110966]: https://github.com/cockroachdb/cockroach/pull/110966
 [#111019]: https://github.com/cockroachdb/cockroach/pull/111019
 [#111069]: https://github.com/cockroachdb/cockroach/pull/111069
+[#111115]: https://github.com/cockroachdb/cockroach/pull/111115
+[#111128]: https://github.com/cockroachdb/cockroach/pull/111128
 [#111217]: https://github.com/cockroachdb/cockroach/pull/111217
+[#111240]: https://github.com/cockroachdb/cockroach/pull/111240
+[#111255]: https://github.com/cockroachdb/cockroach/pull/111255
+[#111277]: https://github.com/cockroachdb/cockroach/pull/111277
+[#111284]: https://github.com/cockroachdb/cockroach/pull/111284
+[#111305]: https://github.com/cockroachdb/cockroach/pull/111305

--- a/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-alpha.2.md
@@ -71,7 +71,7 @@ Release Date: October 2, 2023
 <h3 id="v23-2-0-alpha-2-performance-improvements">Performance improvements</h3>
 
 - Fixed a performance bug that could result in rewriting a 128-MB file each time a store file is created, renamed, or removed when [Encryption At Rest](https://www.cockroachlabs.com/docs/v23.2/security-reference/encryption#encryption-at-rest) is enabled on a large store with many small files. [#111069][#111069]
-- Improved compaction heuristics to mitigate read amplification growth and admission control throttling when processing large deletes, such as during node decommissioning, replica rebalancing, or hen dropping tables. [#111277][#111277]
+- Improved compaction heuristics to mitigate read amplification growth and admission control throttling when processing large deletes, such as during node decommissioning, replica rebalancing, or when dropping tables. [#111277][#111277]
 
 <h3 id="v23-2-0-alpha-2-contributors">Contributors</h3>
 


### PR DESCRIPTION
[DOC-7783] Release notes for v23.2.0-alpha.2

Initial commit represents the generated notes for SHA `10d282dc9045ebb8b3faaf891706a13b08177949` before edits

Latest commit updates the hash to `2111b61b2d7c789bc03b1e9392062df80c779075` with a copyedit for the new notes.

Preview: [releases/v23.2.md](https://deploy-preview-17929--cockroachdb-docs.netlify.app/docs/releases/v23.2.html)