### PR TITLE
Fix typo in compact function

### DIFF
--- a/src/current/_plugins/versions/generator.rb
+++ b/src/current/_plugins/versions/generator.rb
@@ -96,7 +96,7 @@ module JekyllVersions
     end
 
     def versions
-      @versions ||= Set.new(vps.map { |vp| vp.version }).to_a.coddmpact.sort.reverse
+      @versions ||= Set.new(vps.map { |vp| vp.version }).to_a.compact.sort.reverse
     end
 
     def vps_with_key(key)


### PR DESCRIPTION
Fix a change made [here](https://github.com/cockroachdb/docs/pull/17948/files#diff-961682e1b5333c244149ef538764cb6496b45fe3ae780925271e84b2f27797f0R99) where the ruby function `compact` appears to have a typo in it, which may have led to search indexing issues discussed [here](https://cockroachlabs.slack.com/archives/C03TH7EEMAA/p1696635329799879) (private to Cockroach Labs).