### PR TITLE
Revert "Fix typo in compact function"

### DIFF
--- a/src/current/_plugins/versions/generator.rb
+++ b/src/current/_plugins/versions/generator.rb
@@ -96,7 +96,7 @@ module JekyllVersions
     end
 
     def versions
-      @versions ||= Set.new(vps.map { |vp| vp.version }).to_a.compact.sort.reverse
+      @versions ||= Set.new(vps.map { |vp| vp.version }).to_a.coddmpact.sort.reverse
     end
 
     def vps_with_key(key)


### PR DESCRIPTION
Reverting as this did not address the described problem. We now believe the problem may be related to a build timeout caused by #17948, so will revert that next.