### PR TITLE
remove `self` nodelocal examples

### DIFF
--- a/src/current/v23.1/use-cloud-storage.md
+++ b/src/current/v23.1/use-cloud-storage.md
@@ -66,7 +66,7 @@ Location     | Example
 Amazon S3 | `s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`
 Azure Blob Storage | `azure://acme-co/employees?AUTH=specified&AZURE_ACCOUNT_NAME={account name}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_TENANT_ID={tenant ID}`
 Google Cloud Storage | `gs://acme-co/employees?AUTH=specified&CREDENTIALS=encoded-123`
-NFS/Local | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>2</sup>](#considerations)
+NFS/Local | `nodelocal://1/path/employees`
 
 {{site.data.alerts.callout_info}}
 [Cloud storage sinks (for changefeeds)]({% link {{ page.version.version }}/create-and-configure-changefeeds.md %}#known-limitations) only work with `JSON` and emits newline-delimited `JSON` files.
@@ -80,7 +80,7 @@ Amazon S3 | `s3://acme-co/employees.sql?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_
 Azure Blob Storage | `azure://acme-co/employees.sql?AUTH=specified&AZURE_ACCOUNT_NAME={account name}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_TENANT_ID={tenant ID}`
 Google Cloud Storage | `gs://acme-co/employees.sql?AUTH=specified&CREDENTIALS=encoded-123`
 HTTP | `http://localhost:8080/employees.sql`
-NFS/Local | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>2</sup>](#considerations)
+NFS/Local | `nodelocal://1/path/employees`
 
 {{site.data.alerts.callout_info}}
 HTTP storage can only be used for [`IMPORT`]({% link {{ page.version.version }}/import.md %}) and [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}).

--- a/src/current/v23.2/use-cloud-storage.md
+++ b/src/current/v23.2/use-cloud-storage.md
@@ -66,7 +66,7 @@ Location     | Example
 Amazon S3 | `s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`
 Azure Blob Storage | `azure://acme-co/employees?AUTH=specified&AZURE_ACCOUNT_NAME={account name}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_TENANT_ID={tenant ID}`
 Google Cloud Storage | `gs://acme-co/employees?AUTH=specified&CREDENTIALS=encoded-123`
-NFS/Local | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>2</sup>](#considerations)
+NFS/Local | `nodelocal://1/path/employees`
 
 Example URLs for [`IMPORT`]({% link {{ page.version.version }}/import.md %}) and given a bucket or container name of `acme-co` and a filename of `employees`:
 
@@ -76,7 +76,7 @@ Amazon S3 | `s3://acme-co/employees.sql?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_
 Azure Blob Storage | `azure://acme-co/employees.sql?AUTH=specified&AZURE_ACCOUNT_NAME={account name}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_TENANT_ID={tenant ID}`
 Google Cloud Storage | `gs://acme-co/employees.sql?AUTH=specified&CREDENTIALS=encoded-123`
 HTTP | `http://localhost:8080/employees.sql`
-NFS/Local | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>2</sup>](#considerations)
+NFS/Local | `nodelocal://1/path/employees`
 
 Example URLs for [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}):
 


### PR DESCRIPTION
We do not recommend `self` in most cases and showing it as an example gives it more exposure than we really desire.

We especially want to be sure that anyone using "self" has read and understood the footnote under "considerations". This note was previously linked after the example but that relied on one clicking it and reading it, so a user could presumably discover and start using `self` without reading the note.

After this change, the only mention of `self` is in the footnote, so only users who read the note should be aware it is an option, specifically in the configuration where it is a valid option.