### PR TITLE
Remove heading from UI include file for reuse without heading

### DIFF
--- a/src/current/_includes/v23.2/ui/ui-metrics-navigation.md
+++ b/src/current/_includes/v23.2/ui/ui-metrics-navigation.md
@@ -1,5 +1,3 @@
-## Dashboard navigation
-
 Use the **Graph** menu to display metrics for your entire cluster or for a specific node.
 
 To the right of the Graph and Dashboard menus, a time interval selector allows you to filter the view for a predefined or custom time interval. Use the navigation buttons to move to the previous, next, or current time interval. When you select a time interval, the same interval is selected in the [SQL Activity]({% link {{ page.version.version }}/ui-overview.md %}#sql-activity) pages. However, if you select 10 or 30 minutes, the interval defaults to 1 hour in SQL Activity pages.

--- a/src/current/v23.2/ui-cdc-dashboard.md
+++ b/src/current/v23.2/ui-cdc-dashboard.md
@@ -9,6 +9,8 @@ The **Changefeeds** dashboard in the DB Console lets you monitor the [changefeed
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** on the left-hand navigation bar, and then select **Dashboard** > **Changefeeds**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Changefeeds** dashboard displays the following time series graphs:

--- a/src/current/v23.2/ui-distributed-dashboard.md
+++ b/src/current/v23.2/ui-distributed-dashboard.md
@@ -9,6 +9,8 @@ The **Distributed** dashboard lets you monitor important distribution layer heal
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access) and click **Metrics** on the left-hand navigation, and then select **Dashboard** > **Distributed**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v23.2/ui-hardware-dashboard.md
+++ b/src/current/v23.2/ui-hardware-dashboard.md
@@ -9,6 +9,8 @@ The **Hardware** dashboard lets you monitor the hardware utilization of your clu
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** in the left-hand navigation, and select **Dashboard** > **Hardware**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Hardware** dashboard displays the following time series graphs:

--- a/src/current/v23.2/ui-overload-dashboard.md
+++ b/src/current/v23.2/ui-overload-dashboard.md
@@ -9,6 +9,8 @@ docs_area: reference.db_console
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** in the left-hand navigation, and select **Dashboard** > **Overload**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Overload** dashboard displays the following time series graphs:

--- a/src/current/v23.2/ui-overview-dashboard.md
+++ b/src/current/v23.2/ui-overview-dashboard.md
@@ -11,6 +11,8 @@ To view this dashboard, [access the DB Console]({% link {{ page.version.version 
 
 The time-series data displayed in DB Console graphs is stored within the CockroachDB cluster and steadily increases for the first several days of a cluster's life, before an automatic job begins to prune it. By default, time-series data is stored for at 10-second resolution for 10 days, and at 30-minute resolution for 90 days. For details about managing this process, see this [How Can I Reduce or Disable the Storage of Time-series Data?]({% link {{ page.version.version }}/operational-faqs.md %}#can-i-reduce-or-disable-the-storage-of-time-series-data). In a new cluster, you will observe a steady increase in disk usage and the number of ranges even if you aren't writing data to the cluster.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Overview** dashboard displays the following time series graphs. All timestamps in the DB Console are shown in 24-hour Coordinated Universal Time (UTC).

--- a/src/current/v23.2/ui-queues-dashboard.md
+++ b/src/current/v23.2/ui-queues-dashboard.md
@@ -9,6 +9,8 @@ The **Queues** dashboard lets you monitor the health and performance of various 
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access) and click **Metrics** on the left-hand navigation, and then select **Dashboard** > **Queues**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v23.2/ui-replication-dashboard.md
+++ b/src/current/v23.2/ui-replication-dashboard.md
@@ -19,6 +19,8 @@ To view this dashboard, [access the DB Console]({% link {{ page.version.version 
 
 For more details, see [Scalable SQL Made Easy: How CockroachDB Automates Operations](https://www.cockroachlabs.com/blog/automated-rebalance-and-repair/).
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Replication** dashboard displays the following time series graphs:
@@ -124,7 +126,7 @@ Metric | Description
 
 <img src="{{ 'images/v23.2/ui_replica_circuitbreaker_replicas.png' | relative_url }}" alt="DB Console Circuit Breaker Tripped Replicas" style="border:1px solid #eee;max-width:100%" />
 
-When individual ranges become temporarily unavailable, requests to those ranges are refused by a [per-replica circuit breaker]({% link {{ page.version.version }}/architecture/replication-layer.md %}#per-replica-circuit-breaker-overview) instead of hanging indefinitely. 
+When individual ranges become temporarily unavailable, requests to those ranges are refused by a [per-replica circuit breaker]({% link {{ page.version.version }}/architecture/replication-layer.md %}#per-replica-circuit-breaker-overview) instead of hanging indefinitely.
 
 - In the node view, the graph shows the number of replicas for which the per-replica circuit breaker is currently tripped, for the selected node.
 

--- a/src/current/v23.2/ui-runtime-dashboard.md
+++ b/src/current/v23.2/ui-runtime-dashboard.md
@@ -9,6 +9,8 @@ The **Runtime** dashboard in the DB Console lets you monitor runtime metrics for
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** on the left-hand navigation bar, and select **Dashboard** > **Runtime**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Runtime** dashboard displays the following time series graphs:

--- a/src/current/v23.2/ui-slow-requests-dashboard.md
+++ b/src/current/v23.2/ui-slow-requests-dashboard.md
@@ -9,6 +9,8 @@ The **Slow Requests** dashboard lets you monitor important cluster tasks that ta
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access) and click **Metrics** on the left-hand navigation, and then select **Dashboard** > **Slow Requests**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v23.2/ui-sql-dashboard.md
+++ b/src/current/v23.2/ui-sql-dashboard.md
@@ -9,6 +9,8 @@ The **SQL** dashboard in the DB Console lets you monitor the performance of your
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** in the left-hand navigation, and then select **Dashboard** > **SQL**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 For monitoring CockroachDB, it is sufficient to use the [**Open SQL Sessions**](#open-sql-sessions), [**SQL Byte Traffic**](#sql-byte-traffic), [**SQL Statements**](#sql-statements), [**Service Latency**](#service-latency-sql-99th-percentile), and [**Transactions**](#transactions) graphs.
@@ -28,7 +30,7 @@ The **SQL** dashboard displays the following time series graphs:
 The **SQL Connection Rate** is an average of the number of connection attempts per second over an aggregation window.
 
 - In the node view, the graph shows the rate of SQL connection attempts between clients and the selected node.
-  
+
 - In the cluster view, the graph shows the rate of SQL connection attempts to all nodes, with lines for each node.
 
 ## Open SQL Transactions

--- a/src/current/v23.2/ui-storage-dashboard.md
+++ b/src/current/v23.2/ui-storage-dashboard.md
@@ -9,6 +9,8 @@ The **Storage** dashboard lets you monitor the storage utilization of your clust
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** in the left-hand navigation, and select **Dashboard** > **Storage**.
 
+## Dashboard navigation
+
 {% include {{ page.version.version }}/ui/ui-metrics-navigation.md %}
 
 The **Storage** dashboard displays the following time series graphs:

--- a/src/current/v23.2/ui-ttl-dashboard.md
+++ b/src/current/v23.2/ui-ttl-dashboard.md
@@ -9,6 +9,8 @@ The **TTL** dashboard lets you monitor the progress and performance of [batch de
 
 To view this dashboard, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access), click **Metrics** in the left-hand navigation, and select **Dashboard** > **TTL**.
 
+## Dashboard navigation
+
 {% include {{page.version.version}}/ui/ui-metrics-navigation.md %}
 
 The **TTL** dashboard displays the following time series graphs:


### PR DESCRIPTION
As part of work for the Physical Cluster Replication docs, there will be a monitoring page that includes information on the Physical Replication dashboard. As part of the v23.2 release, we do not want to add a fully fledged dashboard page to the UI section as only as small number of customers will be using this feature. Instead, we are keeping this dashboard info to a new monitoring page in the upcoming Disaster Recovery / Physical Cluster Replication section in the docs (for now).

This PR removes the ## Dashboard Navigation heading that was including in an include file, which provides instructions that would be good to reuse on the PCR monitoring page (without the heading). Ultimately, removing the heading makes this include a little more flexible.