### PR TITLE
DOC-8509 display timestamptz for the respective sessions

### DIFF
--- a/src/current/v23.1/show-sessions.md
+++ b/src/current/v23.1/show-sessions.md
@@ -42,8 +42,8 @@ Field | Description
 `application_name` | The [application name]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) specified by the client, if any. For sessions from the [built-in SQL client]({% link {{ page.version.version }}/cockroach-sql.md %}), this will be `cockroach`.
 `active_queries` | The SQL queries currently active in the session.
 `last_active_query` | The most recently completed SQL query in the session.
-`session_start` | The timestamp at which the session started.
-`oldest_query_start` | The timestamp at which the oldest currently active SQL query in the session started.
+`session_start` | The [`timestamptz`]({% link {{ page.version.version }}/timestamp.md %}) at which the session started.
+`oldest_query_start` | The [`timestamptz`]({% link {{ page.version.version }}/timestamp.md %}) at which the oldest currently active SQL query in the session started.
 `kv_txn` | The ID of the current key-value transaction for the session.
 
 ## Examples

--- a/src/current/v23.1/show-statements.md
+++ b/src/current/v23.1/show-statements.md
@@ -49,7 +49,7 @@ Field | Description
 `node_id` | The ID of the node.
 `session_id` | The ID of the session.
 `user_name` | The username of the connected user.
-`start` | The timestamp at which the query started.
+`start` | The [`timestamptz`]({% link {{ page.version.version }}/timestamp.md %}) at which the query started.
 `query` | The SQL query.
 `client_address` | The address and port of the client that issued the SQL query.
 `application_name` | The [application name]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) specified by the client, if any. For queries from the [built-in SQL client]({% link {{ page.version.version }}/cockroach-sql.md %}), this will be `$ cockroach sql`.

--- a/src/current/v23.2/show-sessions.md
+++ b/src/current/v23.2/show-sessions.md
@@ -42,8 +42,8 @@ Field | Description
 `application_name` | The [application name]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) specified by the client, if any. For sessions from the [built-in SQL client]({% link {{ page.version.version }}/cockroach-sql.md %}), this will be `cockroach`.
 `active_queries` | The SQL queries currently active in the session.
 `last_active_query` | The most recently completed SQL query in the session.
-`session_start` | The timestamp at which the session started.
-`oldest_query_start` | The timestamp at which the oldest currently active SQL query in the session started.
+`session_start` | The [`timestamptz`]({% link {{ page.version.version }}/timestamp.md %}) at which the session started.
+`oldest_query_start` | The [`timestamptz`]({% link {{ page.version.version }}/timestamp.md %}) at which the oldest currently active SQL query in the session started.
 `kv_txn` | The ID of the current key-value transaction for the session.
 
 ## Examples

--- a/src/current/v23.2/show-statements.md
+++ b/src/current/v23.2/show-statements.md
@@ -49,7 +49,7 @@ Field | Description
 `node_id` | The ID of the node.
 `session_id` | The ID of the session.
 `user_name` | The username of the connected user.
-`start` | The timestamp at which the query started.
+`start` | The [`timestamptz`]({% link {{ page.version.version }}/timestamp.md %}) at which the query started.
 `query` | The SQL query.
 `client_address` | The address and port of the client that issued the SQL query.
 `application_name` | The [application name]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) specified by the client, if any. For queries from the [built-in SQL client]({% link {{ page.version.version }}/cockroach-sql.md %}), this will be `$ cockroach sql`.


### PR DESCRIPTION
Addresses DOC-8509:
- `SHOW STATEMENTS` and `SHOW SESSIONS` commands now display timestamps using the session's timezone setting

Preview
https://deploy-preview-17985--cockroachdb-docs.netlify.app/docs/dev/show-sessions#response