### PR TITLE
Fix macOS ARM download label on 23.2.0-alpha.2 and 23.2.0-alpha.3

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4932,7 +4932,7 @@
   mac:
     mac_arm: true
     mac_arm_experimental: true
-    mac_arm_limited_access: true
+    mac_arm_limited_access: false
   windows: true
   linux:
     linux_arm: true
@@ -4959,7 +4959,7 @@
   mac:
     mac_arm: true
     mac_arm_experimental: true
-    mac_arm_limited_access: true
+    mac_arm_limited_access: false
   windows: true
   linux:
     linux_arm: true


### PR DESCRIPTION
macOS ARM download links should still be **experimental** rather than **limited access**. In [Prod](https://www.cockroachlabs.com/docs/releases/?filters=mac#testing-releases), they are currently marked as **both**.  It's intended that **both** should be a possibility, but it's not correct here.

Relates to https://github.com/cockroachdb/ed-tools/pull/50
(which fixes the logic bug, hopefully)