### PR TITLE
Add jekyll-diagrams plugin and svgbob

### DIFF
--- a/src/current/Cargo.toml
+++ b/src/current/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "CockroachDB docs"
+version = "1.0"
+edition = "2023"
+
+[dependencies]
+svgbob_cli = "0.7.2"

--- a/src/current/Gemfile
+++ b/src/current/Gemfile
@@ -20,4 +20,5 @@ group :jekyll_plugins do
     gem "jekyll-last-modified-at"
     gem "jekyll-get-json"
     gem 'jekyll-sass-converter', '~> 3.0'
+    gem 'jekyll-diagrams'
   end

--- a/src/current/_config_base.yml
+++ b/src/current/_config_base.yml
@@ -70,8 +70,12 @@ plugins:
 - jekyll-last-modified-at
 - jekyll-minifier
 - jekyll-get-json
+- jekyll-diagrams
 sass:
   quiet_deps: 'true'
   sass_dir: css
   style: compressed
 site_title: CockroachDB Docs
+jekyll-diagrams:
+  font-family: 'Source Sans Pro'
+  font-size: '14'

--- a/src/current/v23.2/live-migration-service.md
+++ b/src/current/v23.2/live-migration-service.md
@@ -13,6 +13,55 @@ MOLT LMS (Live Migration Service) is used to perform a [live migration]({% link 
 
 The LMS is a self-hosted, horizontally scalable proxy that routes traffic between an application, a source database, and a target CockroachDB database. You use the LMS to control which database, as the "source of truth", is serving reads and writes to an application. You can optionally configure the LMS to [shadow production traffic](#shadowing-modes) from the source database and validate the query results on CockroachDB. When you have sufficiently tested your application and are confident with its consistency and performance on CockroachDB, you use the LMS to [perform the cutover](#perform-a-cutover) to CockroachDB.
 
+{% svgbob %}
+
+ Using MOLT LMS
+ 
+                     .--------------.
+                     |              |
+                     | CockroachDB  |
+                     | {t}          |
+                     '--------------'
+                            ^
+                            |
+
+                           ____
++--------------+         .'    `.
+|              |        /        \
+| Application  | <-->  (   LMS    )
+|{a}           |        \ {lms}  /
++--------------+         `.____.'
+
+                            |
+                            V
+                     .--------------.
+                     |              |
+                     |  Source DB.  |
+                     | {s}          |
+                     '--------------'
+
+# Legend:
+t = {
+    stroke: #6933ff;
+    fill: #b59cf9;
+}
+s = {
+    stroke: green;
+    fill: lightgreen;
+}
+a = {
+    fill: lightblue;
+}
+lms = {
+    fill: #afc8fb;
+    stroke: #05f;
+}
+crdb = {
+    fill: #6933ff;
+    color: white;
+}
+{% endsvgbob %}
+
 MOLT LMS is self-hosted on [Kubernetes](https://kubernetes.io/) and [configured using Helm](#configuration). At a high level, the LMS consists of the following:
 
 - A number of proxy [instances](#lms-instances) (running in separate Kubernetes pods) across which application traffic is distributed and routed to the source and target databases.


### PR DESCRIPTION
This PR adds the jekyll-diagrams plugin and the svgbob utility for generating SVG graphics from embedded text.

It's used to create simple diagrams embedded within the Markdown files as ASCII text.

jekyll-diagrams supports other graphics formats as well (e.g. PlantUML) if we decide to use them within our docs.