### PR TITLE
Update regions.md to include us-east-1 for AWS

### DIFF
--- a/src/current/cockroachcloud/regions.md
+++ b/src/current/cockroachcloud/regions.md
@@ -66,6 +66,7 @@ Asia Pacific    | `ap-northeast-1` | Tokyo
                 | `ap-southeast-1` | Singapore
                 | `ap-southeast-2` | Sydney
 North America   | `ca-central-1`   | Central Canada
+                | `us-east-1`      | Virginia
                 | `us-east-2`      | Ohio
                 | `us-west-2`      | Oregon
 South America   | `sa-east-1`      | Sao Paolo


### PR DESCRIPTION
The docs here were inconsistent with the values shown in the "create cluster" UI for Dedicated.