### PR TITLE
DOC-9074: Fix Incorrect note on privileges needed to access DB Console pages

### DIFF
--- a/src/current/_includes/v23.1/ui/admin-access-only.md
+++ b/src/current/_includes/v23.1/ui/admin-access-only.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}), you must be an `admin` user to access this area of the DB Console. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
+{{site.data.alerts.end}}

--- a/src/current/_includes/v23.1/ui/admin-access.md
+++ b/src/current/_includes/v23.1/ui/admin-access.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_info}}
-On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}) you must be an `admin` user to access this area of the DB Console. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
+On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}), you must be an `admin` user or a SQL user with the `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWACTIVITY` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) to access this area of the DB Console. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
 {{site.data.alerts.end}}

--- a/src/current/_includes/v23.2/ui/admin-access-only.md
+++ b/src/current/_includes/v23.2/ui/admin-access-only.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}), you must be an `admin` user to access this area of the DB Console. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
+{{site.data.alerts.end}}

--- a/src/current/_includes/v23.2/ui/admin-access.md
+++ b/src/current/_includes/v23.2/ui/admin-access.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_info}}
-On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}) you must be an `admin` user to access this area of the DB Console. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
+On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}), you must be an `admin` user or a SQL user with the `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWACTIVITY` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)) to access this area of the DB Console. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
 {{site.data.alerts.end}}

--- a/src/current/v23.1/enable-node-map.md
+++ b/src/current/v23.1/enable-node-map.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: manage
 ---
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Node Map** is useful for:
 

--- a/src/current/v23.1/ui-databases-page.md
+++ b/src/current/v23.1/ui-databases-page.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.db_console
 ---
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Databases** page of the DB Console provides details of the following:
 

--- a/src/current/v23.1/ui-debug-pages.md
+++ b/src/current/v23.1/ui-debug-pages.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.db_console
 ---
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Advanced Debug** page of the DB Console provides links to advanced monitoring and troubleshooting reports and cluster configuration details. To view this page, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access) and click **Advanced Debug** in the left-hand navigation.
 

--- a/src/current/v23.1/ui-key-visualizer.md
+++ b/src/current/v23.1/ui-key-visualizer.md
@@ -9,7 +9,7 @@ docs_area: reference.db_console
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 {% include_cached new-in.html version="v23.1" %} The **Key Visualizer** page of the DB Console provides access to the Key Visualizer tool, which enables the visualization of current and historical [key-value (KV)]({% link {{ page.version.version }}/architecture/distribution-layer.md %}#table-data-kv-structure) traffic serviced by your cluster.
 

--- a/src/current/v23.1/ui-sessions-page.md
+++ b/src/current/v23.1/ui-sessions-page.md
@@ -6,7 +6,7 @@ docs_area: reference.db_console
 ---
 
 {{site.data.alerts.callout_info}}
-On a secure cluster, you must be an `admin` user or a SQL user with the `VIEWACTIVITY` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWACTIVITY` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)). Other users will see only their own sessions. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
+On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}), you must be an `admin` user or a SQL user with the `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWACTIVITY` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)). Other users will see only their own sessions. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
 {{site.data.alerts.end}}
 
 The **Sessions** page provides information about open SQL sessions in your cluster, using data in the cluster's [`crdb_internal` system catalog]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Sessions**.

--- a/src/current/v23.2/enable-node-map.md
+++ b/src/current/v23.2/enable-node-map.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: manage
 ---
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Node Map** is useful for:
 

--- a/src/current/v23.2/ui-databases-page.md
+++ b/src/current/v23.2/ui-databases-page.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.db_console
 ---
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Databases** page of the DB Console provides details of the following:
 

--- a/src/current/v23.2/ui-debug-pages.md
+++ b/src/current/v23.2/ui-debug-pages.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.db_console
 ---
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Advanced Debug** page of the DB Console provides links to advanced monitoring and troubleshooting reports and cluster configuration details. To view this page, [access the DB Console]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access) and click **Advanced Debug** in the left-hand navigation.
 

--- a/src/current/v23.2/ui-key-visualizer.md
+++ b/src/current/v23.2/ui-key-visualizer.md
@@ -9,7 +9,7 @@ docs_area: reference.db_console
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/ui/admin-access.md %}
+{% include {{ page.version.version }}/ui/admin-access-only.md %}
 
 The **Key Visualizer** page of the DB Console provides access to the Key Visualizer tool, which enables the visualization of current and historical [key-value (KV)]({% link {{ page.version.version }}/architecture/distribution-layer.md %}#table-data-kv-structure) traffic serviced by your cluster.
 

--- a/src/current/v23.2/ui-sessions-page.md
+++ b/src/current/v23.2/ui-sessions-page.md
@@ -6,7 +6,7 @@ docs_area: reference.db_console
 ---
 
 {{site.data.alerts.callout_info}}
-On a secure cluster, you must be an `admin` user or a SQL user with the `VIEWACTIVITY` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWACTIVITY` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)). Other users will see only their own sessions. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
+On a [secure cluster]({% link {{ page.version.version }}/secure-a-cluster.md %}), you must be an `admin` user or a SQL user with the `VIEWACTIVITY` or `VIEWACTIVITYREDACTED` [system privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) (or the legacy `VIEWACTIVITY` [role option]({% link {{ page.version.version }}/security-reference/authorization.md %}#role-options)). Other users will see only their own sessions. Refer to [DB Console security]({% link {{ page.version.version }}/ui-overview.md %}#db-console-access).
 {{site.data.alerts.end}}
 
 The **Sessions** page provides information about open SQL sessions in your cluster, using data in the cluster's [`crdb_internal` system catalog]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Sessions**.


### PR DESCRIPTION
Addresses DOC-9074

(1) Updated Sessions page to mention VIEWREDACTED privilege. (2) Updated admin-access include file to mention VIEWACTIVITY and VIEWREDACTED for Statements, Transactions and Insights pages. (3) Added admin-access-only include file. (4) Updated Databases, Key Visualizer, Debug, Enable NodeMap pages, to use admin-access-only include file.