### PR TITLE
[DOC-8898] Document new role capabilities

### DIFF
--- a/src/current/cockroachcloud/alerts-page.md
+++ b/src/current/cockroachcloud/alerts-page.md
@@ -14,6 +14,11 @@ The **Alerts** page is applicable for CockroachDB {{ site.data.products.dedicate
 
 If alerts are enabled, CockroachDB {{ site.data.products.cloud }} sends alerts to [specified email recipients](#configure-alerts) when the following usage metrics are detected:
 
+**Cluster Maintenance:**
+
+- When a cluster is scheduled for [maintenance or a patch upgrade]({% link cockroachcloud/cluster-management.md %}#set-a-maintenance-window) that could temporarily impact the cluster's performance.
+- When a cluster's CockroachDB version is nearing [end of life](https://www.cockroachlabs.com/docs/releases/release-support-policy#support-cycle) and must be upgraded to maintain support.
+
 **Storage Utilization:**
 
 - Cluster-wide available disk capacity is **20% or less**.

--- a/src/current/cockroachcloud/authorization.md
+++ b/src/current/cockroachcloud/authorization.md
@@ -58,6 +58,8 @@ Org Administrators can:
 - [Create service accounts]({% link cockroachcloud/managing-access.md %}#create-a-service-account).
 - Grant and revoke roles for both [users]({% link cockroachcloud/managing-access.md %}#manage-an-organizations-users) and [service accounts]({% link cockroachcloud/managing-access.md %}#manage-service-accounts).
 
+Org Administrators automatically receive [email alerts]({% link cockroachcloud/alerts-page.md %}) about planned cluster maintenance and when CockroachDB {{ site.data.products.cloud }} detects that a cluster is overloaded or experiencing issues. In addition, Org Administrators can subscribe other members to the email alerts, and can configure how alerts work for the organization.
+
 This role can be granted only at the scope of the organization.
 
 This role replaces the [Org Administrator (legacy)](#org-administrator-legacy) role, which is considered deprecated.
@@ -72,29 +74,30 @@ Cluster Operators can perform a variety of cluster functions:
 
 - *Users* with this role can perform the following *console operations*:
 
-	- View a cluster's [Overview page]({% link cockroachcloud/cluster-overview-page.md %}), which displays its configuration, attributes and statistics, including cloud provider, region topography, and available and maximum storage and request units.
-	- Manage a cluster's databases from the [Databases Page]({% link cockroachcloud/databases-page.md %}).
-	- [Scale a cluster's nodes]({% link cockroachcloud/cluster-management.md %}#scale-your-cluster).
-	- View and configure a cluster's authorized networks from the [Networking Page]({% link cockroachcloud/network-authorization.md %}).
-	- View backups in a cluster's [Backup and Restore Page]({% link cockroachcloud/use-managed-service-backups.md %}#backups-tab).
-	- [Restore a cluster from a backup]({% link cockroachcloud/use-managed-service-backups.md %}#restore-a-cluster).
-	- View a cluster's Jobs from the [Jobs page]({% link cockroachcloud/jobs-page.md %}).
-	- View a cluster's Metrics from the [Metrics page]({% link cockroachcloud/metrics-page.md %}).
-	- View a cluster's Insights from the [Insights page]({% link cockroachcloud/insights-page.md %}).
-	- [Upgrade]({% link cockroachcloud/upgrade-to-v23.1.md %}#step-5-start-the-upgrade) a cluster's CRDB version.
-	- View a cluster's [PCI-readiness status (Dedicated Advanced clusters only)]({% link cockroachcloud/cluster-overview-page.md %}?filters=dedicated#pci-ready-dedicated-advanced).
-	- Send a test alert from the [Alerts Page]({% link cockroachcloud/alerts-page.md %}).
-	- Configure single sign-on (SSO) enforcement.
-	- Access the [DB Console]({% link cockroachcloud/network-authorization.md %}#db-console).
+  - View a cluster's [Overview page]({% link cockroachcloud/cluster-overview-page.md %}), which displays its configuration, attributes and statistics, including cloud provider, region topography, and available and maximum storage and request units.
+  - Manage a cluster's databases from the [Databases Page]({% link cockroachcloud/databases-page.md %}).
+  - [Scale a cluster's nodes]({% link cockroachcloud/cluster-management.md %}#scale-your-cluster).
+  - View and configure a cluster's authorized networks from the [Networking Page]({% link cockroachcloud/network-authorization.md %}).
+  - View backups in a cluster's [Backup and Restore Page]({% link cockroachcloud/use-managed-service-backups.md %}#backups-tab).
+  - [Restore a cluster from a backup]({% link cockroachcloud/use-managed-service-backups.md %}#restore-a-cluster).
+  - View a cluster's Jobs from the [Jobs page]({% link cockroachcloud/jobs-page.md %}).
+  - View a cluster's Metrics from the [Metrics page]({% link cockroachcloud/metrics-page.md %}).
+  - View a cluster's Insights from the [Insights page]({% link cockroachcloud/insights-page.md %}).
+  - [Upgrade]({% link cockroachcloud/upgrade-to-v23.1.md %}#step-5-start-the-upgrade) a cluster's CRDB version.
+  - View a cluster's [PCI-readiness status (Dedicated Advanced clusters only)]({% link cockroachcloud/cluster-overview-page.md %}?filters=dedicated#pci-ready-dedicated-advanced).
+  - Send a test alert from the [Alerts Page]({% link cockroachcloud/alerts-page.md %}).
+  - Configure single sign-on (SSO) enforcement.
+  - Access the [DB Console]({% link cockroachcloud/network-authorization.md %}#db-console).
+  - Configure a cluster's [maintenance window]({% link cockroachcloud/cluster-management.md %}#set-a-maintenance-window).
 
 - *Service accounts* with this role can perform the following *API operations*:
 
-	- [Read a cluster summary]({% link cockroachcloud/cloud-api.md %}#get-information-about-a-specific-cluster).
-	- [Manage Customer-Managed Encryption Keys (CMEK) for Dedicated Clusters]({% link cockroachcloud/managing-cmek.md %})
-	- [Export a cluster's logs]({% link cockroachcloud/export-logs.md %}).
-	- [Export a cluster's metrics]({% link cockroachcloud/export-metrics.md %}).
-	- [View and configure a cluster's Egress Rules]({% link cockroachcloud/egress-perimeter-controls.md %}).
-	- [Configure the export of metrics to DataDog or AWS CloudWatch]({% link cockroachcloud/export-metrics.md %}).
+  - [Read a cluster summary]({% link cockroachcloud/cloud-api.md %}#get-information-about-a-specific-cluster).
+  - [Manage Customer-Managed Encryption Keys (CMEK) for Dedicated Clusters]({% link cockroachcloud/managing-cmek.md %})
+  - [Export a cluster's logs]({% link cockroachcloud/export-logs.md %}).
+  - [Export a cluster's metrics]({% link cockroachcloud/export-metrics.md %}).
+  - [View and configure a cluster's Egress Rules]({% link cockroachcloud/egress-perimeter-controls.md %}).
+  - [Configure the export of metrics to DataDog or AWS CloudWatch]({% link cockroachcloud/export-metrics.md %}).
 
 This role can be considered a more restricted alternative to [Cluster Administrator](#cluster-administrator), as it grants all of the permissions of that role, except that it does **not** allow users to:
 
@@ -114,6 +117,7 @@ Cluster Administrators can perform all of the [Cluster Operator actions](#cluste
 - [Edit or delete a cluster]({% link cockroachcloud/cluster-management.md %}).
 - Cluster Administrators for the whole organization (rather than scoped to a single cluster) can [create new clusters]({% link cockroachcloud/create-your-cluster.md %}).
 - Access the [DB Console]({% link cockroachcloud/network-authorization.md %}#db-console).
+- Configure a cluster's [maintenance window]({% link cockroachcloud/cluster-management.md %}#set-a-maintenance-window).
 
 This role can be granted at the scope of the organization, on an individual cluster, or on a folder. If granted on a folder, it is inherited on the folder's clusters, descendent folders, and their descendants.
 

--- a/src/current/cockroachcloud/cluster-management.md
+++ b/src/current/cockroachcloud/cluster-management.md
@@ -163,15 +163,17 @@ When you remove a region from a [multi-region]({% link cockroachcloud/plan-your-
 
 ## Set a maintenance window
 
-From your cluster's [**Overview** page]({% link cockroachcloud/cluster-overview-page.md %}), you can view and manage the maintenance and [patch upgrade]({% link cockroachcloud/upgrade-policy.md %}#patch-version-upgrades) window for your cluster. During the window, your cluster may experience restarts, degraded performance, and downtime for single-node clusters. To help keep your clusters updated while minimizing disruptions, set a window of time when your cluster is experiencing the lowest traffic. If no upgrade window is set, your cluster will be automatically upgraded as soon as new patch versions are available. Refer to [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
+From your cluster's [**Overview** page]({% link cockroachcloud/cluster-overview-page.md %}), you can view and manage the maintenance and [patch upgrade]({% link cockroachcloud/upgrade-policy.md %}#patch-version-upgrades) window for your cluster. During the window, your cluster may experience restarts, degraded performance, and downtime for single-node clusters. To help keep your clusters updated while minimizing disruptions, set a window of time when your cluster is experiencing the lowest traffic. If no maintenance window is set, your cluster will be automatically upgraded as soon as new patch versions are available, and other cluster maintenance occurs as needed. Refer to [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
+
+ [Org Administrators]({% link cockroachcloud/authorization.md%}#org-administrator) automatically receive [email alerts]({% link cockroachcloud/alerts-page.md %}) about scheduled upgrades and cluster maintenance, and can subscribe other members to the email alerts.
 
 {{site.data.alerts.callout_info}}
-Maintenance operations that are critical for cluster security or stability may be applied outside of the upgrade window, and upgrades that begin in a maintenance window may not always be completed by the end of the window.
+Maintenance operations that are critical for cluster security or stability may be applied outside of the maintenance window, and upgrades that begin in a maintenance window may not always be completed by the end of the window.
 {{site.data.alerts.end}}
 
-To set an upgrade window:
+To set a maintenance window:
 
-1. Click the pencil icon next to **Cluster maintenance** to edit the upgrade window.
+1. Click the pencil icon next to **Cluster maintenance** to edit the maintenance window.
 1. From the **Day** dropdown, select the day of the week during which maintenance may be applied.
 1. From the **Start of window** dropdown, select a start time for your maintenance window in UTC.
 


### PR DESCRIPTION
[DOC-8898] Document new role capabilities:

- Org Admins receive email notifications about patch upgrades
- Cluster admins and cluster operators can set maintenance windows

Also convert tabs to spaces and add some cross-references

### Previews
[src/current/cockroachcloud/alerts-page.md](https://deploy-preview-18005--cockroachdb-docs.netlify.app/docs/cockroachcloud/alerts-page.html)
[src/current/cockroachcloud/authorization.md](https://deploy-preview-18005--cockroachdb-docs.netlify.app/docs/cockroachcloud/authorization.html)
[src/current/cockroachcloud/cluster-management.md](https://deploy-preview-18005--cockroachdb-docs.netlify.app/docs/cockroachcloud/cluster-management.html)
