### PR TITLE
DOC-8678: Feedback: Logging Overview - Document the KV_DISTRIBUTION channel

### DIFF
--- a/src/current/v23.1/configure-logs.md
+++ b/src/current/v23.1/configure-logs.md
@@ -645,6 +645,8 @@ sinks:
         WARNING: all except [DEV, OPS]
     health:
       channels: [HEALTH]
+    kv-distribution:
+      channels: [KV_DISTRIBUTION]
     pebble:
       channels: [STORAGE]
     security:

--- a/src/current/v23.1/logging-overview.md
+++ b/src/current/v23.1/logging-overview.md
@@ -40,6 +40,7 @@ This allows you to group channels that log related information (e.g., operationa
 | [`SQL_EXEC`]({% link {{ page.version.version }}/logging.md %}#sql_exec)                 | SQL statement executions (when enabled via the `sql.trace.log_statement_execute` [cluster setting]({% link {{ page.version.version }}/cluster-settings.md %})) and uncaught Go panic errors during SQL statement execution.                                                                                                                                    |
 | [`SQL_PERF`]({% link {{ page.version.version }}/logging.md %}#sql_perf)                 | SQL executions that impact performance, such as slow queries (when enabled via the `sql.log.slow_query.latency_threshold` and/or `sql.log.slow_query.experimental_full_table_scans.enabled` [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %})).                                                                                    |
 | [`TELEMETRY`]({% link {{ page.version.version }}/logging.md %}#telemetry)               | Telemetry events for internal usage, except for [`sampled_query` events]({% link {{ page.version.version }}/eventlog.md %}#sampled_query) which may be [logged externally to Datadog]({% link {{ page.version.version }}/log-sql-statistics-to-datadog.md %}). |
+| [`KV_DISTRIBUTION`]({% link {{ page.version.version }}/logging.md %}#kv_distribution)   | Data distribution events, such as moving [replicas]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-replica) between [stores]({% link {{ page.version.version }}/cockroach-start.md %}#store) in a cluster, adding replicas to [ranges]({% link {{ page.version.version }}/architecture/overview.md %}#range), and removing replicas from ranges. |
 
 Logging channels are analogous to [logging facilities in Syslog](https://wikipedia.org/wiki/Syslog) or [logging services in Datadog](https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes). For more details on the contents of each logging channel, see the [Logging reference]({% link {{ page.version.version }}/logging.md %}#logging-channels).
 
@@ -51,6 +52,7 @@ When using the [default logging configuration]({% link {{ page.version.version }
 |----------------------------+-------------------------+-----------------------------|
 | `cockroach.log`            | General CockroachDB log | `DEV`                       |
 | `cockroach-health.log`     | Health log              | `HEALTH`                    |
+| `cockroach-kv-distribution.log` | Data distribution log | `KV_DISTRIBUTION`        |
 | `cockroach-security.log`   | SQL security log        | `PRIVILEGES` + `USER_ADMIN` |
 | `cockroach-sql-audit.log`  | SQL access audit log    | `SENSITIVE_ACCESS`          |
 | `cockroach-sql-auth.log`   | SQL authentication log  | `SESSIONS`                  |

--- a/src/current/v23.2/configure-logs.md
+++ b/src/current/v23.2/configure-logs.md
@@ -670,6 +670,8 @@ sinks:
         WARNING: all except [DEV, OPS]
     health:
       channels: [HEALTH]
+    kv-distribution:
+      channels: [KV_DISTRIBUTION]
     pebble:
       channels: [STORAGE]
     security:

--- a/src/current/v23.2/logging-overview.md
+++ b/src/current/v23.2/logging-overview.md
@@ -40,6 +40,7 @@ This allows you to group channels that log related information (e.g., operationa
 | [`SQL_EXEC`]({% link {{ page.version.version }}/logging.md %}#sql_exec)                 | SQL statement executions (when enabled via the `sql.trace.log_statement_execute` [cluster setting]({% link {{ page.version.version }}/cluster-settings.md %})) and uncaught Go panic errors during SQL statement execution.                                                                                                                                    |
 | [`SQL_PERF`]({% link {{ page.version.version }}/logging.md %}#sql_perf)                 | SQL executions that impact performance, such as slow queries (when enabled via the `sql.log.slow_query.latency_threshold` and/or `sql.log.slow_query.experimental_full_table_scans.enabled` [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %})).                                                                                    |
 | [`TELEMETRY`]({% link {{ page.version.version }}/logging.md %}#telemetry)               | Telemetry events for internal usage, except for [`sampled_query` events]({% link {{ page.version.version }}/eventlog.md %}#sampled_query) which may be [logged externally to Datadog]({% link {{ page.version.version }}/log-sql-statistics-to-datadog.md %}). |
+| [`KV_DISTRIBUTION`]({% link {{ page.version.version }}/logging.md %}#kv_distribution)   | Data distribution events, such as moving [replicas]({% link {{ page.version.version }}/architecture/overview.md %}#architecture-replica) between [stores]({% link {{ page.version.version }}/cockroach-start.md %}#store) in a cluster, adding replicas to [ranges]({% link {{ page.version.version }}/architecture/overview.md %}#range), and removing replicas from ranges. |
 
 Logging channels are analogous to [logging facilities in Syslog](https://wikipedia.org/wiki/Syslog) or [logging services in Datadog](https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes). For more details on the contents of each logging channel, see the [Logging reference]({% link {{ page.version.version }}/logging.md %}#logging-channels).
 
@@ -51,6 +52,7 @@ When using the [default logging configuration]({% link {{ page.version.version }
 |----------------------------+-------------------------+-----------------------------|
 | `cockroach.log`            | General CockroachDB log | `DEV`                       |
 | `cockroach-health.log`     | Health log              | `HEALTH`                    |
+| `cockroach-kv-distribution.log` | Data distribution log | `KV_DISTRIBUTION`        |
 | `cockroach-security.log`   | SQL security log        | `PRIVILEGES` + `USER_ADMIN` |
 | `cockroach-sql-audit.log`  | SQL access audit log    | `SENSITIVE_ACCESS`          |
 | `cockroach-sql-auth.log`   | SQL authentication log  | `SESSIONS`                  |


### PR DESCRIPTION
Addresses DOC-8678

(1) Updated Logging Overview page, added KV_DISTRIBUTION channel and cockroach-kv-distribution.log destination. (2) Updated Configure Logs page, added kv-distribution file-group to default configuration.