### PR TITLE
Cert manager changes

### DIFF
--- a/src/current/_includes/v22.2/orchestration/kubernetes-limitations.md
+++ b/src/current/_includes/v22.2/orchestration/kubernetes-limitations.md
@@ -17,8 +17,6 @@ The CockroachDB Helm chart requires Helm 3.0 or higher. If you attempt to use an
 Error: UPGRADE FAILED: template: cockroachdb/templates/tests/client.yaml:6:14: executing "cockroachdb/templates/tests/client.yaml" at <.Values.networkPolicy.enabled>: nil pointer evaluating interface {}.enabled
 ~~~
 
-The CockroachDB Helm chart is compatible with Kubernetes versions 1.22 and earlier.
-
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.
@@ -32,7 +30,7 @@ Due to its order of operations, the PostgreSQL wire protocol's implementation of
 
 #### Resources
 
-When starting Kubernetes, select machines with at least **4 vCPUs** and **16 GiB** of memory, and provision at least **2 vCPUs** and **8 Gi** of memory to CockroachDB per pod. These minimum settings are used by default in this deployment guide, and are appropriate for testing purposes only. On a production deployment, you should adjust the resource settings for your workload. For details, see [Resource management](configure-cockroachdb-kubernetes.html#memory-and-cpu).
+When starting Kubernetes, select machines with at least **4 vCPUs** and **16 GiB** of memory, and provision at least **2 vCPUs** and **8 Gi** of memory to CockroachDB per pod. These minimum settings are used by default in this deployment guide, and are appropriate for testing purposes only. On a production deployment, you should adjust the resource settings for your workload. For details, see [Resource management]({% link {{ page.version.version }}/configure-cockroachdb-kubernetes.md %}#memory-and-cpu).
 
 #### Storage
 

--- a/src/current/_includes/v22.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/src/current/_includes/v22.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,7 +1,3 @@
-{{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing maintenance for compatibility with Kubernetes versions 1.17 through 1.21 (the latest version as of this writing). No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
-{{site.data.alerts.end}}
-
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:
 
     {% include_cached copy-clipboard.html %}
@@ -60,7 +56,7 @@ The CockroachDB Helm chart is undergoing maintenance for compatibility with Kube
       enabled: false
     ~~~
 
-    1. You may want to modify `storage.persistentVolume.size` and `storage.persistentVolume.storageClass` for your use case. This chart defaults to 100Gi of disk space per pod. For more details on customizing disks for performance, see [these instructions](kubernetes-performance.html#disk-type).
+    1. You may want to modify `storage.persistentVolume.size` and `storage.persistentVolume.storageClass` for your use case. This chart defaults to 100Gi of disk space per pod. For more details on customizing disks for performance, see [these instructions]({% link {{ page.version.version }}/kubernetes-performance.md %}#disk-type).
 
         {{site.data.alerts.callout_info}}
         If necessary, you can [expand disk size](/docs/{{ page.version.version }}/configure-cockroachdb-kubernetes.html?filters=helm#expand-disk-size) after the cluster is live.

--- a/src/current/_includes/v22.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/src/current/_includes/v22.2/orchestration/start-cockroachdb-helm-secure.md
@@ -1,15 +1,11 @@
-The CockroachDB Helm chart is compatible with Kubernetes versions 1.22 and earlier.
+The CockroachDB Helm chart is compatible with all Kubernetes versions that are [supported by the Kubernetes project](https://kubernetes.io/releases/) when cert-manager is used for mTLS.
 
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#migration-to-self-signer).
-{{site.data.alerts.end}}
-
-{{site.data.alerts.callout_info}}
-Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](https://github.com/cockroachdb/cockroach/issues/38847).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](secure-cockroachdb-kubernetes.html?filters=helm#deploy-cert-manager-for-mtls).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/src/current/_includes/v23.1/orchestration/kubernetes-limitations.md
+++ b/src/current/_includes/v23.1/orchestration/kubernetes-limitations.md
@@ -17,8 +17,6 @@ The CockroachDB Helm chart requires Helm 3.0 or higher. If you attempt to use an
 Error: UPGRADE FAILED: template: cockroachdb/templates/tests/client.yaml:6:14: executing "cockroachdb/templates/tests/client.yaml" at <.Values.networkPolicy.enabled>: nil pointer evaluating interface {}.enabled
 ~~~
 
-The CockroachDB Helm chart is compatible with Kubernetes versions 1.22 and earlier.
-
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,7 +1,3 @@
-{{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing maintenance for compatibility with Kubernetes versions 1.17 through 1.21 (the latest version as of this writing). No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
-{{site.data.alerts.end}}
-
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
@@ -5,7 +5,7 @@ The CockroachDB Helm chart is currently not under active development, and no new
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use cert-manager for certificate management. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#migration-to-cert-manager).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use cert-manager for certificate management. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#deploy-cert-manager-for-mtls).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
@@ -5,7 +5,7 @@ The CockroachDB Helm chart is currently not under active development, and no new
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use cert-manager for certificate management. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#deploy-cert-manager-for-mtls).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](secure-cockroachdb-kubernetes.html?filters=helm#deploy-cert-manager-for-mtls).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,15 +1,11 @@
-The CockroachDB Helm chart is compatible with Kubernetes versions 1.22 and earlier.
+The CockroachDB Helm chart is compatible with all Kubernetes versions when cert-manager is used for mTLS.
 
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#migration-to-self-signer).
-{{site.data.alerts.end}}
-
-{{site.data.alerts.callout_info}}
-Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](https://github.com/cockroachdb/cockroach/issues/38847).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use cert-manager for certificate management. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#migration-to-cert-manager).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,4 +1,4 @@
-The CockroachDB Helm chart is compatible with all Kubernetes versions when cert-manager is used for mTLS.
+The CockroachDB Helm chart is compatible with all Kubernetes versions that are [supported by the Kubernetes project](https://kubernetes.io/releases/) when cert-manager is used for mTLS.
 
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 

--- a/src/current/_includes/v23.2/orchestration/kubernetes-limitations.md
+++ b/src/current/_includes/v23.2/orchestration/kubernetes-limitations.md
@@ -4,7 +4,9 @@ To deploy CockroachDB {{page.version.version}}, Kubernetes 1.18 or higher is req
 
 #### Kubernetes Operator
 
-The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}).
+- The CockroachDB Kubernetes Operator currently deploys clusters in a single region. For multi-region deployments using manual configs, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}).
+
+- Using the Operator, you can give a new cluster an arbitrary number of [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). However, a cluster's labels cannot be modified after it is deployed. To track the status of this limitation, refer to [#993](https://github.com/cockroachdb/cockroach-operator/issues/993) in the Operator project's issue tracker.
 
 {% unless page.name == "orchestrate-cockroachdb-with-kubernetes-multi-cluster.md" %}
 #### Helm version
@@ -14,8 +16,6 @@ The CockroachDB Helm chart requires Helm 3.0 or higher. If you attempt to use an
 ~~~ shell
 Error: UPGRADE FAILED: template: cockroachdb/templates/tests/client.yaml:6:14: executing "cockroachdb/templates/tests/client.yaml" at <.Values.networkPolicy.enabled>: nil pointer evaluating interface {}.enabled
 ~~~
-
-The CockroachDB Helm chart is compatible with Kubernetes versions 1.22 and earlier.
 
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 

--- a/src/current/_includes/v23.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/src/current/_includes/v23.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,7 +1,3 @@
-{{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing maintenance for compatibility with Kubernetes versions 1.17 through 1.21 (the latest version as of this writing). No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
-{{site.data.alerts.end}}
-
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/_includes/v23.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/src/current/_includes/v23.2/orchestration/start-cockroachdb-helm-secure.md
@@ -1,15 +1,11 @@
-The CockroachDB Helm chart is compatible with Kubernetes versions 1.22 and earlier.
+The CockroachDB Helm chart is compatible with all Kubernetes versions that are [supported by the Kubernetes project](https://kubernetes.io/releases/) when cert-manager is used for mTLS.
 
 The CockroachDB Helm chart is currently not under active development, and no new features are planned. However, Cockroach Labs remains committed to fully supporting the Helm chart by addressing defects, providing security patches, and addressing breaking changes due to deprecations in Kubernetes APIs.
 
 A deprecation notice for the Helm chart will be provided to customers a minimum of 6 months in advance of actual deprecation.
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. For details, see [Certificate management](secure-cockroachdb-kubernetes.html?filters=helm#migration-to-self-signer).
-{{site.data.alerts.end}}
-
-{{site.data.alerts.callout_info}}
-Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](https://github.com/cockroachdb/cockroach/issues/38847).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](secure-cockroachdb-kubernetes.html?filters=helm#deploy-cert-manager-for-mtls).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/src/current/v22.2/secure-cockroachdb-kubernetes.md
+++ b/src/current/v22.2/secure-cockroachdb-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Certificate management
+title: Certificate Management
 summary: How to authenticate a secure 3-node CockroachDB cluster with Kubernetes.
 toc: true
 toc_not_nested: true
@@ -8,10 +8,10 @@ docs_area: deploy
 ---
 
 {{site.data.alerts.callout_info}}
-This article assumes you have already [deployed CockroachDB securely on a single Kubernetes cluster](deploy-cockroachdb-with-kubernetes.html) using the Operator or Helm. However, it's possible to configure these settings before starting CockroachDB on Kubernetes.
+This article assumes you have already [deployed CockroachDB securely on a single Kubernetes cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}) using the Operator or Helm. However, it's possible to configure these settings before starting CockroachDB on Kubernetes.
 {{site.data.alerts.end}}
 
-By default, self-signed certificates are used when using the Operator or Helm to securely [deploy CockroachDB on Kubernetes](deploy-cockroachdb-with-kubernetes.html).
+By default, self-signed certificates are used when using the Operator or Helm to securely [deploy CockroachDB on Kubernetes]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}). However, the recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
 
 This page explains how to:
 
@@ -20,7 +20,7 @@ This page explains how to:
 - [Secure the webhooks](#secure-the-webhooks) (Operator)
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. For details, see [Migration to self-signer](#migration-to-self-signer).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
 {{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">
@@ -35,7 +35,7 @@ If you are running a secure Helm deployment on Kubernetes 1.22 and later, you mu
 <section class="filter-content" markdown="1" data-scope="operator">
 By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster.
 
-To use your own certificate authority instead, add the following to the Operator's custom resource **before** [initializing the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster):
+To use your own certificate authority instead, add the following to the Operator's custom resource **before** [initializing the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster):
 
 ~~~ yaml
 spec:
@@ -56,9 +56,9 @@ Currently, the Operator requires that the client and node secrets each contain t
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
-By default on secure deployments, the Helm chart will generate and sign 1 client and 1 node certificate to secure the cluster. 
+By default on secure deployments, the Helm chart will generate and sign 1 client and 1 node certificate to secure the cluster.
 
-To use your own certificate authority instead, specify the following in the custom values file you created when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html?filters=helm#step-2-start-cockroachdb):
+To use your own certificate authority instead, specify the following in the custom values file you created when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}?filters=helm#step-2-start-cockroachdb):
 
 {% include_cached copy-clipboard.html %}
 ~~~ yaml
@@ -81,12 +81,12 @@ tls:
 ### Example: Authenticating with `cockroach cert`
 
 {{site.data.alerts.callout_info}}
-The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly generate and sign the CockroachDB node and client certificates. Read our [Authentication](authentication.html#using-digital-certificates-with-cockroachdb) docs to learn about other methods of signing certificates.
+The below steps use [`cockroach cert` commands]({% link {{ page.version.version }}/cockroach-cert.md %}) to quickly generate and sign the CockroachDB node and client certificates. Read our [Authentication]({% link {{ page.version.version }}/authentication.md %}#using-digital-certificates-with-cockroachdb) docs to learn about other methods of signing certificates.
 {{site.data.alerts.end}}
 
 <section class="filter-content" markdown="1" data-scope="operator">
 {{site.data.alerts.callout_info}}
-Complete the following steps **before** [initializing the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster).
+Complete the following steps **before** [initializing the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster).
 {{site.data.alerts.end}}
 
 1. Create two directories:
@@ -135,7 +135,7 @@ Complete the following steps **before** [initializing the cluster](deploy-cockro
     secret/cockroachdb.client.root created
     ~~~
 
-1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
+1. Create the certificate and key pair for your CockroachDB nodes, specifying the namespace you used when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -180,7 +180,7 @@ Complete the following steps **before** [initializing the cluster](deploy-cockro
     default-token-6js7b       kubernetes.io/service-account-token   3      9h
     ~~~
 
-1. Add `nodeTLSSecret` and `clientTLSSecret` to the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster), specifying the generated secret names:
+1. Add `nodeTLSSecret` and `clientTLSSecret` to the Operator's [custom resource]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster), specifying the generated secret names:
 
     ~~~ yaml
     spec:
@@ -251,7 +251,7 @@ Complete the following steps **before** [initializing the cluster](deploy-cockro
     ~~~
 
     {{site.data.alerts.callout_info}}
-    This example assumes that you followed our [deployment example](deploy-cockroachdb-with-kubernetes.html?filters=helm), which uses `my-release` as the release name. If you used a different value, be sure to adjust the release name in this command.
+    This example assumes that you followed our [deployment example]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}?filters=helm), which uses `my-release` as the release name. If you used a different value, be sure to adjust the release name in this command.
     {{site.data.alerts.end}}
 
 1. Upload the node certificate and key to the Kubernetes cluster as a secret:
@@ -281,7 +281,7 @@ Complete the following steps **before** [initializing the cluster](deploy-cockro
     default-token-6qjdb       kubernetes.io/service-account-token   3      4m
     ~~~
 
-1. Specify the following in the custom values file you created when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html?filters=helm#step-2-start-cockroachdb), using the generated secret names:
+1. Specify the following in the custom values file you created when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}?filters=helm#step-2-start-cockroachdb), using the generated secret names:
 
     {% include_cached copy-clipboard.html %}
     ~~~
@@ -341,7 +341,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.client.root.2 created
     ~~~
 
-1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
+1. Create a new certificate and key pair for your CockroachDB nodes, overwriting the previous certificate and key. Specify the namespace you used when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster). This example uses the Operator's default namespace (`cockroach-operator-system`):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -373,7 +373,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.node.2 created
     ~~~
 
-1. Add `nodeTLSSecret` and `clientTLSSecret` to the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster), specifying the new secret names:
+1. Add `nodeTLSSecret` and `clientTLSSecret` to the Operator's [custom resource]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster), specifying the new secret names:
 
     ~~~ yaml
     spec:
@@ -396,7 +396,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     ~~~
 
     {{site.data.alerts.callout_info}}
-    Remember that `nodeTLSSecret` and `clientTLSSecret` in the Operator's [custom resource](deploy-cockroachdb-with-kubernetes.html#initialize-the-cluster) must specify these secret names. For details, see [Use a custom CA](#use-a-custom-ca).
+    Remember that `nodeTLSSecret` and `clientTLSSecret` in the Operator's [custom resource]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#initialize-the-cluster) must specify these secret names. For details, see [Use a custom CA](#use-a-custom-ca).
     {{site.data.alerts.end}}
 
 1. Apply the new settings to the cluster:
@@ -464,7 +464,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     secret/cockroachdb.ca created
     ~~~
 
-1. Specify the following in the custom values file you created when [deploying the cluster](deploy-cockroachdb-with-kubernetes.html?filters=helm#step-2-start-cockroachdb), using the generated secret name:
+1. Specify the following in the custom values file you created when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}?filters=helm#step-2-start-cockroachdb), using the generated secret name:
 
     {% include_cached copy-clipboard.html %}
     ~~~ yaml
@@ -503,7 +503,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
             </ul>
     </ul>
 
-    Certificate duration is configured when running [`cockroach cert`](cockroach-cert.html#general). You can check the expiration dates of the `cockroach cert` certificates by running:
+    Certificate duration is configured when running [`cockroach cert`]({% link {{ page.version.version }}/cockroach-cert.md %}#general). You can check the expiration dates of the `cockroach cert` certificates by running:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -528,64 +528,63 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
     The certificates will be rotated during the specified expiry windows.
 
-## Migration to self-signer
+## Deploy `cert-manager` for mTLS
 
-Previous versions of the Helm chart used the Kubernetes CA to sign certificates. However, the Kubernetes CA is deprecated from Kubernetes 1.22 and later. The Helm chart now uses a self-signer for cluster authentication.
+Cockroach Labs recommends using `cert-manager` to sign certificates for cluster authentication. `cert-manager` manages certificates and certificate issuers as resource types in Kubernetes clusters, to simplify the process of obtaining, renewing and using those certificates.
 
-To migrate your Helm deployment to use the self-signer:
+{{site.data.alerts.callout_info}}
+Previously, the Helm chart used a self-signer for cluster authentication. This approach is no longer recommended.
+{{site.data.alerts.end}}
 
-1. Set the cluster's upgrade strategy to `OnDelete`, which specifies that only pods deleted by the user will be upgraded.
+1. Install a [supported version of `cert-manger`](https://cert-manager.io/docs/releases/). For a new cluster, Cockroach Labs recommends using the latest supported version. Refer to installed you will find it [`cert-manager` Installation](https://cert-manager.io/docs/installation/) in the `cert-manager` project's documentation.
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    helm upgrade {release-name} cockroachdb/cockroachdb --set statefulset.updateStrategy.type="OnDelete"
-    ~~~
-
-1. Confirm that the `init` pod has been created:
+1. Create a file named `issuer.yaml` that configures an `Issuer`, which represents a certificate authority that can sign certificates. This example creates an issuer that can sign self-signed CA certificates. To customize your issuer, refer to [Issuer Configuration](https://cert-manager.io/docs/configuration/) in the `cert-manager` project's documentation.
 
     {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl get pods
-    ~~~
+    ~~~yaml
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+    name: cockroachdb
+    spec:
+    selfSigned: {}
 
-    ~~~
-    NAME                                READY     STATUS     RESTARTS   AGE
-    my-release-cockroachdb-0            1/1       Running    0          6m
-    my-release-cockroachdb-1            1/1       Running    0          6m
-    my-release-cockroachdb-2            1/1       Running    0          6m
-    my-release-cockroachdb-init-59ndf   0/1       Completed  0          8s
-    ~~~
-
-1. Delete the cluster pods to start the upgrade process.
+1. Use `kubectl apply` to create the issuer from the YAML file:
 
     {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    kubectl delete pods -l app.kubernetes.io/component=cockroachdb
+    ~~~shell
+    kubectl apply -f issuer.yaml
     ~~~
 
-    ~~~
-    pod "my-release-cockroachdb-0" deleted
-    pod "my-release-cockroachdb-1" deleted
-    pod "my-release-cockroachdb-2" deleted
-    ~~~
 
-    All pods will be restarted with new certificates generated by the self-signer. Note that this is not a rolling upgrade, so the cluster will experience some downtime. You can monitor this process:
+1. Enable and configure `cert-manager` in the Helm chart's `values.yaml` file. The following options are required. For more options, refer to [`cert-manager`](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb#cert-manager) in the CockroachDB Helm chart documentation.
 
     {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl get pods
+    ~~~yaml
+    tls.certs.selfSigner.enabled: false
+    tls.certs.certManager: true
+    tls.certs.certManagerIssuer.kind: Issuer
+    tls.certs.certManagerIssuer.name: cockroachdb
     ~~~
 
+    - To disable signing self-signed certificates, set `tls.certs.selfSigner.enabled` to `false`.
+    - Set `tls.certs.certManagerIssuer.kind` to either `Issuer` or `ClusterIssuer`. To get started, `Issuer` is recommended. `ClusterIssuer` is cluster-scoped; when referencing a secret via the `secretName` field, only secrets in the `cluster-resource` namespace (`cert-manager` by default) are searched. To learn more, refer to [Cluster Resource Namespace](https://cert-manager.io/v1.6-docs/faq/cluster-resource/) in the `cert-manager` project's documentation.
+    - Set `certManagerIssuer.name` to the name of the issuer you created in the previous step.
+
+1. Apply the updated Helm chart:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    helm install my-release --values values.yaml cockroachdb/cockroachdb
     ~~~
-    NAME                       READY   STATUS              RESTARTS   AGE
-    my-release-cockroachdb-0   0/1     ContainerCreating   0          14s
-    my-release-cockroachdb-1   0/1     ContainerCreating   0          4s
-    my-release-cockroachdb-2   0/1     Terminating         0          7m16s
-    ~~~
+
+Replace `values.yaml` with the name of your Helm chart's values file.
+
 </section>
 
 <section class="filter-content" markdown="1" data-scope="operator">
-## Secure the webhooks
+
+##  Secure the webhooks
 
 The Operator ships with both [mutating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) and [validating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) webhooks. Communication between the Kubernetes API server and the webhook service must be secured with TLS.
 
@@ -613,7 +612,7 @@ These steps demonstrate how to use the [`openssl genrsa`](https://www.openssl.or
     openssl req -x509 -new -nodes -key tls.key -sha256 -days 3650 -out tls.crt
     ~~~
 
-1. Create the secret, making sure that [you are in the correct namespace](deploy-cockroachdb-with-kubernetes.html#install-the-operator):
+1. Create the secret, making sure that [you are in the correct namespace]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}#install-the-operator):
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -20,7 +20,7 @@ This page explains how to:
 - [Secure the webhooks](#secure-the-webhooks) (Operator)
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, see [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS].
 {{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -574,6 +574,7 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
     helm install my-release --values values.yaml cockroachdb/cockroachdb
     ~~~
 
+Replace `values.yaml` with the name of your Helm chart's values file.
 
 ## Migration to self-signer
 

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -532,7 +532,7 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
 The recommended approach for cluster authentication is to use cert-manger to sign certificates. cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.
 
-1. Make sure you have the latest version of cert-manger installed you will find it here.
+1. Make sure you have the latest version of cert-manger installed you will find it [here](https://cert-manager.io/docs/installation/).
 
 2. The first thing you will need to do is to create an `Issuer` these are the resources that represent certificate authorities and are able to sign certificates. Using cert-manger create an `Issuer` for signing self-signed CA certificate.
 

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -11,7 +11,7 @@ docs_area: deploy
 This article assumes you have already [deployed CockroachDB securely on a single Kubernetes cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}) using the Operator or Helm. However, it's possible to configure these settings before starting CockroachDB on Kubernetes.
 {{site.data.alerts.end}}
 
-By default, self-signed certificates are used when using the Operator or Helm to securely [deploy CockroachDB on Kubernetes]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}).
+By default, self-signed certificates are used when using the Operator or Helm to securely [deploy CockroachDB on Kubernetes]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}). However, the recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
 
 This page explains how to:
 
@@ -20,7 +20,7 @@ This page explains how to:
 - [Secure the webhooks](#secure-the-webhooks) (Operator)
 
 {{site.data.alerts.callout_danger}}
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS].
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
 {{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">
@@ -56,7 +56,7 @@ Currently, the Operator requires that the client and node secrets each contain t
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
-By default on secure deployments, the Helm chart will generate and sign 1 client and 1 node certificate to secure the cluster. 
+By default on secure deployments, the Helm chart will generate and sign 1 client and 1 node certificate to secure the cluster.
 
 To use your own certificate authority instead, specify the following in the custom values file you created when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}?filters=helm#step-2-start-cockroachdb):
 
@@ -532,9 +532,13 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
 Cockroach Labs recommends using `cert-manager` to sign certificates for cluster authentication. `cert-manager` manages certificates and certificate issuers as resource types in Kubernetes clusters, to simplify the process of obtaining, renewing and using those certificates.
 
+{{site.data.alerts.callout_info}}
+Previously, the Helm chart used a self-signer for cluster authentication. This approach is no longer recommended.
+{{site.data.alerts.end}}
+
 1. Install a [supported version of `cert-manger`](https://cert-manager.io/docs/releases/). For a new cluster, Cockroach Labs recommends using the latest supported version. Refer to installed you will find it [`cert-manager` Installation](https://cert-manager.io/docs/installation/) in the `cert-manager` project's documentation.
 
-2. Create a file named `issuer.yaml` that configures an `Issuer`, which represents a certificate authority that can sign certificates. This example creates an issuer that can sign self-signed CA certificates. To customize your issuer, refer to [Issuer Configuration](https://cert-manager.io/docs/configuration/) in the `cert-manager` project's documentation.
+1. Create a file named `issuer.yaml` that configures an `Issuer`, which represents a certificate authority that can sign certificates. This example creates an issuer that can sign self-signed CA certificates. To customize your issuer, refer to [Issuer Configuration](https://cert-manager.io/docs/configuration/) in the `cert-manager` project's documentation.
 
     {% include_cached copy-clipboard.html %}
     ~~~yaml
@@ -545,7 +549,7 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
     spec:
     selfSigned: {}
 
-3. Use `kubectl apply` to create the issuer from the YAML file:
+1. Use `kubectl apply` to create the issuer from the YAML file:
 
     {% include_cached copy-clipboard.html %}
     ~~~shell
@@ -553,7 +557,7 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
     ~~~
 
 
-4. Enable and configure `cert-manager` in the Helm chart's `values.yaml` file. The following options are required. For more options, refer to [`cert-manager`](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb#cert-manager) in the CockroachDB Helm chart documentation.
+1. Enable and configure `cert-manager` in the Helm chart's `values.yaml` file. The following options are required. For more options, refer to [`cert-manager`](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb#cert-manager) in the CockroachDB Helm chart documentation.
 
     {% include_cached copy-clipboard.html %}
     ~~~yaml
@@ -565,9 +569,9 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
 
     - To disable signing self-signed certificates, set `tls.certs.selfSigner.enabled` to `false`.
     - Set `tls.certs.certManagerIssuer.kind` to either `Issuer` or `ClusterIssuer`. To get started, `Issuer` is recommended. `ClusterIssuer` is cluster-scoped; when referencing a secret via the `secretName` field, only secrets in the `cluster-resource` namespace (`cert-manager` by default) are searched. To learn more, refer to [Cluster Resource Namespace](https://cert-manager.io/v1.6-docs/faq/cluster-resource/) in the `cert-manager` project's documentation.
-    - Set `certManagerIssuer.name` to the name of the issuer you created in the previous step. 
+    - Set `certManagerIssuer.name` to the name of the issuer you created in the previous step.
 
-5. Apply the updated Helm chart:
+1. Apply the updated Helm chart:
 
     {% include_cached copy-clipboard.html %}
     ~~~shell
@@ -576,60 +580,6 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
 
 Replace `values.yaml` with the name of your Helm chart's values file.
 
-## Migration to self-signer
-
-Previous versions of the Helm chart used the Kubernetes CA to sign certificates. However, the Kubernetes CA is deprecated from Kubernetes 1.22 and later. The Helm chart now uses a self-signer for cluster authentication.
-
-To migrate your Helm deployment to use the self-signer:
-
-1. Set the cluster's upgrade strategy to `OnDelete`, which specifies that only pods deleted by the user will be upgraded.
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    helm upgrade {release-name} cockroachdb/cockroachdb --set statefulset.updateStrategy.type="OnDelete"
-    ~~~
-
-1. Confirm that the `init` pod has been created:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl get pods
-    ~~~
-
-    ~~~
-    NAME                                READY     STATUS     RESTARTS   AGE
-    my-release-cockroachdb-0            1/1       Running    0          6m
-    my-release-cockroachdb-1            1/1       Running    0          6m
-    my-release-cockroachdb-2            1/1       Running    0          6m
-    my-release-cockroachdb-init-59ndf   0/1       Completed  0          8s
-    ~~~
-
-1. Delete the cluster pods to start the upgrade process.
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    kubectl delete pods -l app.kubernetes.io/component=cockroachdb
-    ~~~
-
-    ~~~
-    pod "my-release-cockroachdb-0" deleted
-    pod "my-release-cockroachdb-1" deleted
-    pod "my-release-cockroachdb-2" deleted
-    ~~~
-
-    All pods will be restarted with new certificates generated by the self-signer. Note that this is not a rolling upgrade, so the cluster will experience some downtime. You can monitor this process:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl get pods
-    ~~~
-
-    ~~~
-    NAME                       READY   STATUS              RESTARTS   AGE
-    my-release-cockroachdb-0   0/1     ContainerCreating   0          14s
-    my-release-cockroachdb-1   0/1     ContainerCreating   0          4s
-    my-release-cockroachdb-2   0/1     Terminating         0          7m16s
-    ~~~
 </section>
 
 <section class="filter-content" markdown="1" data-scope="operator">

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -547,7 +547,7 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
 
 3. Apply this to your Kubernetes cluster using `kubectl`
 
-4. To enable `cert-manager` you will need to have the following settings in the values.yaml file.
+4. Enable and configure `cert-manager` in the Helm chart's `values.yaml` file. The following options are required. For more options, refer to [`cert-manager`](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb#cert-manager) in the CockroachDB Helm chart documentation.
 
     {% include_cached copy-clipboard.html %}
     ~~~yaml

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -563,10 +563,9 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
     tls.certs.certManagerIssuer.name: cockroachdb
     ~~~
 
-- Setting `tls.certs.selfSigner.enabled` to `false` will disable the self signing certificates for cockroachdb.
-- By enabling the`tls.certs.certManager:` setting to true this will enable cert-manager for certificate signing.
-- Specify the ‘Issuer` kind here either `Issuer` or `ClusterIssuer` under the setting `certManagerIssuer.kind`.
-- `certManagerIssuer.name` Provide the Issuer you have created in previous step. In this example it was `cockroachdb`.
+    - To disable signing self-signed certificates, set `tls.certs.selfSigner.enabled` to `false`.
+    - Set `tls.certs.certManagerIssuer.kind` to either `Issuer` or `ClusterIssuer`. To get started, `Issuer` is recommended. `ClusterIssuer` is cluster-scoped; when referencing a secret via the `secretName` field, only secrets in the `cluster-resource` namespace (`cert-manager` by default) are searched. To learn more, refer to [Cluster Resource Namespace](https://cert-manager.io/v1.6-docs/faq/cluster-resource/) in the `cert-manager` project's documentation.
+    - Set `certManagerIssuer.name` to the name of the issuer you created in the previous step. 
 
 5. Once the values.yaml file has been updated you can then deploy CockroachDB via the Helm Chart with the following command.
 

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -528,13 +528,13 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
     The certificates will be rotated during the specified expiry windows.
 
-## Deploy cert-manager for mTLS
+## Deploy `cert-manager` for mTLS
 
-The recommended approach for cluster authentication is to use cert-manger to sign certificates. cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.
+Cockroach Labs recommends using `cert-manager` to sign certificates for cluster authentication. `cert-manager` manages certificates and certificate issuers as resource types in Kubernetes clusters, to simplify the process of obtaining, renewing and using those certificates.
 
-1. Make sure you have the latest version of cert-manger installed you will find it [here](https://cert-manager.io/docs/installation/).
+1. Install a [supported version of `cert-manger`](https://cert-manager.io/docs/releases/). For a new cluster, Cockroach Labs recommends using the latest supported version. Refer to installed you will find it [`cert-manager` Installation](https://cert-manager.io/docs/installation/) in the `cert-manager` project's documentation.
 
-2. The first thing you will need to do is to create an `Issuer` these are the resources that represent certificate authorities and are able to sign certificates. Using cert-manger create an `Issuer` for signing self-signed CA certificate.
+2. Create a file named `issuer.yaml` that configures an `Issuer`, which represents a certificate authority that can sign certificates. This example creates an issuer that can sign self-signed CA certificates. To customize your issuer, refer to [Issuer Configuration](https://cert-manager.io/docs/configuration/) in the `cert-manager` project's documentation.
 
     {% include_cached copy-clipboard.html %}
     ~~~yaml

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -571,7 +571,7 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
 
     {% include_cached copy-clipboard.html %}
     ~~~shell
-    helm install my-release --values {custom-values}.yaml cockroachdb/cockroachdb
+    helm install my-release --values values.yaml cockroachdb/cockroachdb
     ~~~
 
 

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -545,7 +545,13 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
     spec:
     selfSigned: {}
 
-3. Apply this to your Kubernetes cluster using `kubectl`
+3. Use `kubectl apply` to create the issuer from the YAML file:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    kubectl apply -f issuer.yaml
+    ~~~
+
 
 4. Enable and configure `cert-manager` in the Helm chart's `values.yaml` file. The following options are required. For more options, refer to [`cert-manager`](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb#cert-manager) in the CockroachDB Helm chart documentation.
 

--- a/src/current/v23.1/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.1/secure-cockroachdb-kubernetes.md
@@ -567,7 +567,7 @@ Cockroach Labs recommends using `cert-manager` to sign certificates for cluster 
     - Set `tls.certs.certManagerIssuer.kind` to either `Issuer` or `ClusterIssuer`. To get started, `Issuer` is recommended. `ClusterIssuer` is cluster-scoped; when referencing a secret via the `secretName` field, only secrets in the `cluster-resource` namespace (`cert-manager` by default) are searched. To learn more, refer to [Cluster Resource Namespace](https://cert-manager.io/v1.6-docs/faq/cluster-resource/) in the `cert-manager` project's documentation.
     - Set `certManagerIssuer.name` to the name of the issuer you created in the previous step. 
 
-5. Once the values.yaml file has been updated you can then deploy CockroachDB via the Helm Chart with the following command.
+5. Apply the updated Helm chart:
 
     {% include_cached copy-clipboard.html %}
     ~~~shell

--- a/src/current/v23.2/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.2/secure-cockroachdb-kubernetes.md
@@ -11,7 +11,7 @@ docs_area: deploy
 This article assumes you have already [deployed CockroachDB securely on a single Kubernetes cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}) using the Operator or Helm. However, it's possible to configure these settings before starting CockroachDB on Kubernetes.
 {{site.data.alerts.end}}
 
-By default, self-signed certificates are used when using the Operator or Helm to securely [deploy CockroachDB on Kubernetes]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}).
+By default, self-signed certificates are used when using the Operator or Helm to securely [deploy CockroachDB on Kubernetes]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}). However, the recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
 
 This page explains how to:
 
@@ -20,7 +20,15 @@ This page explains how to:
 - [Secure the webhooks](#secure-the-webhooks) (Operator)
 
 {{site.data.alerts.callout_danger}}
+<<<<<<< Updated upstream
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS].
+=======
+<<<<<<< Updated upstream
 If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. For details, see [Migration to self-signer](#migration-to-self-signer).
+=======
+If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 {{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">
@@ -56,7 +64,7 @@ Currently, the Operator requires that the client and node secrets each contain t
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
-By default on secure deployments, the Helm chart will generate and sign 1 client and 1 node certificate to secure the cluster. 
+By default on secure deployments, the Helm chart will generate and sign 1 client and 1 node certificate to secure the cluster.
 
 To use your own certificate authority instead, specify the following in the custom values file you created when [deploying the cluster]({% link {{ page.version.version }}/deploy-cockroachdb-with-kubernetes.md %}?filters=helm#step-2-start-cockroachdb):
 
@@ -528,64 +536,63 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
 
     The certificates will be rotated during the specified expiry windows.
 
-## Migration to self-signer
+## Deploy `cert-manager` for mTLS
 
-Previous versions of the Helm chart used the Kubernetes CA to sign certificates. However, the Kubernetes CA is deprecated from Kubernetes 1.22 and later. The Helm chart now uses a self-signer for cluster authentication.
+Cockroach Labs recommends using `cert-manager` to sign certificates for cluster authentication. `cert-manager` manages certificates and certificate issuers as resource types in Kubernetes clusters, to simplify the process of obtaining, renewing and using those certificates.
 
-To migrate your Helm deployment to use the self-signer:
+{{site.data.alerts.callout_info}}
+Previously, the Helm chart used a self-signer for cluster authentication. This approach is no longer recommended.
+{{site.data.alerts.end}}
 
-1. Set the cluster's upgrade strategy to `OnDelete`, which specifies that only pods deleted by the user will be upgraded.
+1. Install a [supported version of `cert-manger`](https://cert-manager.io/docs/releases/). For a new cluster, Cockroach Labs recommends using the latest supported version. Refer to installed you will find it [`cert-manager` Installation](https://cert-manager.io/docs/installation/) in the `cert-manager` project's documentation.
 
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    helm upgrade {release-name} cockroachdb/cockroachdb --set statefulset.updateStrategy.type="OnDelete"
-    ~~~
-
-1. Confirm that the `init` pod has been created:
+1. Create a file named `issuer.yaml` that configures an `Issuer`, which represents a certificate authority that can sign certificates. This example creates an issuer that can sign self-signed CA certificates. To customize your issuer, refer to [Issuer Configuration](https://cert-manager.io/docs/configuration/) in the `cert-manager` project's documentation.
 
     {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl get pods
-    ~~~
+    ~~~yaml
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+    name: cockroachdb
+    spec:
+    selfSigned: {}
 
-    ~~~
-    NAME                                READY     STATUS     RESTARTS   AGE
-    my-release-cockroachdb-0            1/1       Running    0          6m
-    my-release-cockroachdb-1            1/1       Running    0          6m
-    my-release-cockroachdb-2            1/1       Running    0          6m
-    my-release-cockroachdb-init-59ndf   0/1       Completed  0          8s
-    ~~~
-
-1. Delete the cluster pods to start the upgrade process.
+1. Use `kubectl apply` to create the issuer from the YAML file:
 
     {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    kubectl delete pods -l app.kubernetes.io/component=cockroachdb
+    ~~~shell
+    kubectl apply -f issuer.yaml
     ~~~
 
-    ~~~
-    pod "my-release-cockroachdb-0" deleted
-    pod "my-release-cockroachdb-1" deleted
-    pod "my-release-cockroachdb-2" deleted
-    ~~~
 
-    All pods will be restarted with new certificates generated by the self-signer. Note that this is not a rolling upgrade, so the cluster will experience some downtime. You can monitor this process:
+1. Enable and configure `cert-manager` in the Helm chart's `values.yaml` file. The following options are required. For more options, refer to [`cert-manager`](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb#cert-manager) in the CockroachDB Helm chart documentation.
 
     {% include_cached copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl get pods
+    ~~~yaml
+    tls.certs.selfSigner.enabled: false
+    tls.certs.certManager: true
+    tls.certs.certManagerIssuer.kind: Issuer
+    tls.certs.certManagerIssuer.name: cockroachdb
     ~~~
 
+    - To disable signing self-signed certificates, set `tls.certs.selfSigner.enabled` to `false`.
+    - Set `tls.certs.certManagerIssuer.kind` to either `Issuer` or `ClusterIssuer`. To get started, `Issuer` is recommended. `ClusterIssuer` is cluster-scoped; when referencing a secret via the `secretName` field, only secrets in the `cluster-resource` namespace (`cert-manager` by default) are searched. To learn more, refer to [Cluster Resource Namespace](https://cert-manager.io/v1.6-docs/faq/cluster-resource/) in the `cert-manager` project's documentation.
+    - Set `certManagerIssuer.name` to the name of the issuer you created in the previous step.
+
+1. Apply the updated Helm chart:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    helm install my-release --values values.yaml cockroachdb/cockroachdb
     ~~~
-    NAME                       READY   STATUS              RESTARTS   AGE
-    my-release-cockroachdb-0   0/1     ContainerCreating   0          14s
-    my-release-cockroachdb-1   0/1     ContainerCreating   0          4s
-    my-release-cockroachdb-2   0/1     Terminating         0          7m16s
-    ~~~
+
+Replace `values.yaml` with the name of your Helm chart's values file.
+
 </section>
 
 <section class="filter-content" markdown="1" data-scope="operator">
-## Secure the webhooks
+
+##  Secure the webhooks
 
 The Operator ships with both [mutating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) and [validating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) webhooks. Communication between the Kubernetes API server and the webhook service must be secured with TLS.
 

--- a/src/current/v23.2/secure-cockroachdb-kubernetes.md
+++ b/src/current/v23.2/secure-cockroachdb-kubernetes.md
@@ -20,15 +20,10 @@ This page explains how to:
 - [Secure the webhooks](#secure-the-webhooks) (Operator)
 
 {{site.data.alerts.callout_danger}}
-<<<<<<< Updated upstream
 If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS].
-=======
-<<<<<<< Updated upstream
-If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. For details, see [Migration to self-signer](#migration-to-self-signer).
-=======
+
 If you are running a secure Helm deployment on Kubernetes 1.22 and later, you must migrate away from using the Kubernetes CA for cluster authentication. The recommended approach is to use `cert-manager` for certificate management. For details, refer to [Deploy cert-manager for mTLS](#deploy-cert-manager-for-mtls).
->>>>>>> Stashed changes
->>>>>>> Stashed changes
+
 {{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">


### PR DESCRIPTION
Updating documentation to include cert-manager as an option and option of choice for Certificate Management in Kubernetes using Helm, further updating the documents as this now brings support for all versions of k8s including 1.22 and later.