### PR TITLE
Explain why encryption at rest may not reach 100%

### DIFF
--- a/src/current/v22.1/encryption.md
+++ b/src/current/v22.1/encryption.md
@@ -70,7 +70,12 @@ The report shows encryption status for all stores on the selected node, includin
 - Active data key information.
 - The fraction of files/bytes encrypted using the active data key.
 
-CockroachDB relies on [storage layer](architecture/storage-layer.html) compactions to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped](node-shutdown.html#perform-node-shutdown)).
+CockroachDB relies on [storage layer compactions]({% link {{ page.version.version }}/architecture/storage-layer.md %}#compaction) to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped]({% link {{ page.version.version }}/node-shutdown.md %}#perform-node-shutdown)).
+
+The fraction of files/bytes encrypted on the store may be less than 100% for the following reasons:
+
+- The percentage shown is the percentage encrypted with the **current** data key, which rotates at the configured [`rotation-period`](#starting-a-node-with-encryption). When a data key rotates, the percentage will drop down to zero and slowly climb up as data is compacted.
+- In some cases, it may never reach 100%. This can happen because from the point in time at which encryption is enabled, CockroachDB only encrypts **new** data written to the filesystem. Because it relies entirely on storage layer compactions, there's no mechanism by which dormant on-disk data is encrypted.
 
 Information about keys is written to [the logs](logging-overview.html), including:
 

--- a/src/current/v22.2/encryption.md
+++ b/src/current/v22.2/encryption.md
@@ -70,7 +70,12 @@ The report shows encryption status for all stores on the selected node, includin
 - Active data key information.
 - The fraction of files/bytes encrypted using the active data key.
 
-CockroachDB relies on [storage layer](architecture/storage-layer.html) compactions to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped](node-shutdown.html#perform-node-shutdown)).
+CockroachDB relies on [storage layer compactions]({% link {{ page.version.version }}/architecture/storage-layer.md %}#compaction) to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped]({% link {{ page.version.version }}/node-shutdown.md %}#perform-node-shutdown)).
+
+The fraction of files/bytes encrypted on the store may be less than 100% for the following reasons:
+
+- The percentage shown is the percentage encrypted with the **current** data key, which rotates at the configured [`rotation-period`](#starting-a-node-with-encryption). When a data key rotates, the percentage will drop down to zero and slowly climb up as data is compacted.
+- In some cases, it may never reach 100%. This can happen because from the point in time at which encryption is enabled, CockroachDB only encrypts **new** data written to the filesystem. Because it relies entirely on storage layer compactions, there's no mechanism by which dormant on-disk data is encrypted.
 
 Information about keys is written to [the logs](logging-overview.html), including:
 

--- a/src/current/v23.1/encryption.md
+++ b/src/current/v23.1/encryption.md
@@ -70,7 +70,12 @@ The report shows encryption status for all stores on the selected node, includin
 - Active data key information.
 - The fraction of files/bytes encrypted using the active data key.
 
-CockroachDB relies on [storage layer]({% link {{ page.version.version }}/architecture/storage-layer.md %}) compactions to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped]({% link {{ page.version.version }}/node-shutdown.md %}#perform-node-shutdown)).
+CockroachDB relies on [storage layer compactions]({% link {{ page.version.version }}/architecture/storage-layer.md %}#compaction) to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped]({% link {{ page.version.version }}/node-shutdown.md %}#perform-node-shutdown)).
+
+The fraction of files/bytes encrypted on the store may be less than 100% for the following reasons:
+
+- The percentage shown is the percentage encrypted with the **current** data key, which rotates at the configured [`rotation-period`](#starting-a-node-with-encryption). When a data key rotates, the percentage will drop down to zero and slowly climb up as data is compacted.
+- In some cases, it may never reach 100%. This can happen because from the point in time at which encryption is enabled, CockroachDB only encrypts **new** data written to the filesystem. Because it relies entirely on storage layer compactions, there's no mechanism by which dormant on-disk data is encrypted.
 
 Information about keys is written to [the logs]({% link {{ page.version.version }}/logging-overview.md %}), including:
 

--- a/src/current/v23.2/encryption.md
+++ b/src/current/v23.2/encryption.md
@@ -70,7 +70,12 @@ The report shows encryption status for all stores on the selected node, includin
 - Active data key information.
 - The fraction of files/bytes encrypted using the active data key.
 
-CockroachDB relies on [storage layer]({% link {{ page.version.version }}/architecture/storage-layer.md %}) compactions to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped]({% link {{ page.version.version }}/node-shutdown.md %}#perform-node-shutdown)).
+CockroachDB relies on [storage layer compactions]({% link {{ page.version.version }}/architecture/storage-layer.md %}#compaction) to write new files using the latest encryption key. It may take several days for all files to be replaced. Some files are only rewritten at startup, and some keep older copies around, requiring multiple restarts. You can force storage compaction with the `cockroach debug compact` command (the node must first be [stopped]({% link {{ page.version.version }}/node-shutdown.md %}#perform-node-shutdown)).
+
+The fraction of files/bytes encrypted on the store may be less than 100% for the following reasons:
+
+- The percentage shown is the percentage encrypted with the **current** data key, which rotates at the configured [`rotation-period`](#starting-a-node-with-encryption). When a data key rotates, the percentage will drop down to zero and slowly climb up as data is compacted.
+- In some cases, it may never reach 100%. This can happen because from the point in time at which encryption is enabled, CockroachDB only encrypts **new** data written to the filesystem. Because it relies entirely on storage layer compactions, there's no mechanism by which dormant on-disk data is encrypted.
 
 Information about keys is written to [the logs]({% link {{ page.version.version }}/logging-overview.md %}), including:
 


### PR DESCRIPTION
Fixes DOC-9087

Summary of changes:

- Update the 'Encryption' page to note that because it relies on storage engine compactions, only data that is somehow touched gets encrypted. As a result, in some cases the percentage of files/bytes encrypted may not reach 100%.

- The above is applied to v22.1, v22.2, v23.1, and v23.2 docs