### PR TITLE
fix typos on why-cockroachdb

### DIFF
--- a/src/current/v23.1/why-cockroachdb.md
+++ b/src/current/v23.1/why-cockroachdb.md
@@ -15,7 +15,7 @@ There are many reasons to use CockroachDB, including:
 - [Resiliency](#resiliency)
 - [Scalability](#scalability)
 - [Strong consistency](#strong-consistency)
-- [Geo-partioning and multi-region features](#geo-partitioning-and-multi-region-features)
+- [Geo-partitioning and multi-region features](#geo-partitioning-and-multi-region-features)
 - [PostgreSQL-compatibility](#postgresql-compatibility)
 
 ### Resiliency

--- a/src/current/v23.2/why-cockroachdb.md
+++ b/src/current/v23.2/why-cockroachdb.md
@@ -15,7 +15,7 @@ There are many reasons to use CockroachDB, including:
 - [Resiliency](#resiliency)
 - [Scalability](#scalability)
 - [Strong consistency](#strong-consistency)
-- [Geo-partioning and multi-region features](#geo-partitioning-and-multi-region-features)
+- [Geo-partitioning and multi-region features](#geo-partitioning-and-multi-region-features)
 - [PostgreSQL-compatibility](#postgresql-compatibility)
 
 ### Resiliency


### PR DESCRIPTION
Hi, just fixes a typo in the index name from 'geo-partioning' to 'geo-partitioning' on the 'why-cockroachdb' page.
