### PR TITLE
Add sentence to export docs on nullable columns

### DIFF
--- a/src/current/v23.1/export.md
+++ b/src/current/v23.1/export.md
@@ -112,7 +112,7 @@ Successful `EXPORT` returns a table of (perhaps multiple) files to which the dat
 
 ## Parquet types
 
-CockroachDB types map to [Parquet types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) as per the following:
+CockroachDB types map to [Parquet types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) listed in the following table. All columns witten to Parquet files will be nullable, therefore the Parquet repetition level is `optional`.
 
 | CockroachDB Type    | Parquet Type | Parquet Logical Type |
 --------------------|--------------|----------------------

--- a/src/current/v23.2/export.md
+++ b/src/current/v23.2/export.md
@@ -112,7 +112,7 @@ Successful `EXPORT` returns a table of (perhaps multiple) files to which the dat
 
 ## Parquet types
 
-CockroachDB types map to [Parquet types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) as per the following:
+CockroachDB types map to [Parquet types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) listed in the following table. All columns witten to Parquet files will be nullable, therefore the Parquet repetition level is `optional`.
 
 | CockroachDB Type    | Parquet Type | Parquet Logical Type |
 --------------------|--------------|----------------------


### PR DESCRIPTION
Fixes DOC-7861

This PR adds a brief sentence to the `EXPORT` docs following a new internal implementation which results in all columns being written as nullable.