### PR TITLE
Clarify incomplete export scenario

### DIFF
--- a/src/current/v23.1/export.md
+++ b/src/current/v23.1/export.md
@@ -71,7 +71,7 @@ You can specify the base directory where you want to store the exported files. C
 
 The `EXPORT` command [returns](#success-responses) the list of files to which the data was exported. You may wish to record these for use in subsequent imports.
 
-If an export encounters some kind of failure or [cancelation](#cancel-a-running-export), it will leave any written files behind in the destination. To run a new export and avoid collision with previously written export files, consider doing the following:
+If an export encounters some kind of failure or [cancellation](#cancel-a-running-export), it will leave any written files behind in the destination. To run a new export and avoid collision with previously written export files, consider doing the following:
 
 - Change the destination (or destination prefix) that you are exporting to.
 - Remove the partial results at the destination from any previously attempted exports.

--- a/src/current/v23.1/export.md
+++ b/src/current/v23.1/export.md
@@ -18,13 +18,11 @@ Using the [CockroachDB distributed execution engine]({% link {{ page.version.ver
 
 If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
-{{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
-{{site.data.alerts.end}}
-
 ## Cancelling export
 
 After the export has been initiated, you can cancel it with [`CANCEL QUERY`]({% link {{ page.version.version }}/cancel-query.md %}).
+
+For detail on handling partially complete exports at the destination, refer to [Export File URL](#export-file-url).
 
 ## Synopsis
 
@@ -49,7 +47,7 @@ Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege]({% link {{ page.v
 - Using the [`cockroach nodelocal upload`]({% link {{ page.version.version }}/cockroach-nodelocal-upload.md %}) command.
 - Using [HTTP]({% link {{ page.version.version }}/use-a-local-file-server.md %}) or HTTPS.
 
-No special privilege is required for: 
+No special privilege is required for:
 
 - Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
 - Using [Userfile]({% link {{ page.version.version }}/use-userfile-storage.md %}) storage.
@@ -72,6 +70,12 @@ No special privilege is required for:
 You can specify the base directory where you want to store the exported files. CockroachDB will create the export file(s) in the specified directory with programmatically generated names (e.g., `exportabc123-n1.1.csv`, `exportabc123-n1.2.csv`, `exportabc123-n2.1.csv`, ...). Each export should use a unique destination directory to avoid collision with other exports.
 
 The `EXPORT` command [returns](#success-responses) the list of files to which the data was exported. You may wish to record these for use in subsequent imports.
+
+If an export encounters some kind of failure or [cancelation](#cancel-a-running-export), it will leave any written files behind in the destination. To run a new export and avoid collision with previously written export files, consider doing the following:
+
+- Change the destination (or destination prefix) that you are exporting to.
+- Remove the partial results at the destination from any previously attempted exports.
+- Use a [changefeed export]({% link {{ page.version.version }}/export-data-with-changefeeds.md %}) instead because it operates as a job, offering more observability into failures.
 
 {{site.data.alerts.callout_info}}
 A hexadecimal hash code (`abc123...` in the file names) uniquely identifies each export **run**; files sharing the same hash are part of the same export. If you see multiple hash codes within a single destination directory, then the directory contains multiple exports, which will likely cause confusion (duplication) on import. We recommend that you manually clean up the directory, to ensure that it contains only a single export run.
@@ -294,6 +298,8 @@ Use [`SHOW STATEMENTS`]({% link {{ page.version.version }}/show-statements.md %}
 ~~~ sql
 > CANCEL QUERY '14dacc1f9a781e3d0000000000000001';
 ~~~
+
+For detail on handling partially complete exports at the destination, refer to [Export File URL](#export-file-url).
 
 ## Known limitation
 

--- a/src/current/v23.2/export.md
+++ b/src/current/v23.2/export.md
@@ -18,13 +18,11 @@ Using the [CockroachDB distributed execution engine]({% link {{ page.version.ver
 
 If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
-{{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
-{{site.data.alerts.end}}
-
 ## Cancelling export
 
 After the export has been initiated, you can cancel it with [`CANCEL QUERY`]({% link {{ page.version.version }}/cancel-query.md %}).
+
+For detail on handling partially complete exports at the destination, refer to [Export File URL](#export-file-url).
 
 ## Synopsis
 
@@ -49,7 +47,7 @@ Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege]({% link {{ page.v
 - Using the [`cockroach nodelocal upload`]({% link {{ page.version.version }}/cockroach-nodelocal-upload.md %}) command.
 - Using [HTTP]({% link {{ page.version.version }}/use-a-local-file-server.md %}) or HTTPS.
 
-No special privilege is required for: 
+No special privilege is required for:
 
 - Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
 - Using [Userfile]({% link {{ page.version.version }}/use-userfile-storage.md %}) storage.
@@ -60,18 +58,24 @@ No special privilege is required for:
 
 ## Parameters
 
- Parameter | Description
+Parameter | Description
 -----------|-------------
- `file_location` | Specify the [URL of the file location](#export-file-url) where you want to store the exported data.<br><br>Note: It is best practice to use a unique destination for each export, to avoid mixing files from different exports in one directory.
- `opt_with_options` | Control your export's behavior with [these options](#export-options).
- `select_stmt` | Specify the query whose result you want to export.
- `table_name` | Specify the name of the table you want to export.
+`file_location` | Specify the [URL of the file location](#export-file-url) where you want to store the exported data.<br><br>Note: It is best practice to use a unique destination for each export, to avoid mixing files from different exports in one directory.
+`opt_with_options` | Control your export's behavior with [these options](#export-options).
+`select_stmt` | Specify the query whose result you want to export.
+`table_name` | Specify the name of the table you want to export.
 
 ### Export file URL
 
 You can specify the base directory where you want to store the exported files. CockroachDB will create the export file(s) in the specified directory with programmatically generated names (e.g., `exportabc123-n1.1.csv`, `exportabc123-n1.2.csv`, `exportabc123-n2.1.csv`, ...). Each export should use a unique destination directory to avoid collision with other exports.
 
 The `EXPORT` command [returns](#success-responses) the list of files to which the data was exported. You may wish to record these for use in subsequent imports.
+
+If an export encounters some kind of failure or [cancelation](#cancel-a-running-export), it will leave any written files behind in the destination. To run a new export and avoid collision with previously written export files, consider doing the following:
+
+- Change the destination (or destination prefix) that you are exporting to.
+- Remove the partial results at the destination from any previously attempted exports.
+- Use a [changefeed export]({% link {{ page.version.version }}/export-data-with-changefeeds.md %}) instead because it operates as a job, offering more observability into failures.
 
 {{site.data.alerts.callout_info}}
 A hexadecimal hash code (`abc123...` in the file names) uniquely identifies each export **run**; files sharing the same hash are part of the same export. If you see multiple hash codes within a single destination directory, then the directory contains multiple exports, which will likely cause confusion (duplication) on import. We recommend that you manually clean up the directory, to ensure that it contains only a single export run.
@@ -294,6 +298,8 @@ Use [`SHOW STATEMENTS`]({% link {{ page.version.version }}/show-statements.md %}
 ~~~ sql
 > CANCEL QUERY '14dacc1f9a781e3d0000000000000001';
 ~~~
+
+For detail on handling partially complete exports at the destination, refer to [Export File URL](#export-file-url).
 
 ## Known limitation
 

--- a/src/current/v23.2/export.md
+++ b/src/current/v23.2/export.md
@@ -71,7 +71,7 @@ You can specify the base directory where you want to store the exported files. C
 
 The `EXPORT` command [returns](#success-responses) the list of files to which the data was exported. You may wish to record these for use in subsequent imports.
 
-If an export encounters some kind of failure or [cancelation](#cancel-a-running-export), it will leave any written files behind in the destination. To run a new export and avoid collision with previously written export files, consider doing the following:
+If an export encounters some kind of failure or [cancellation](#cancel-a-running-export), it will leave any written files behind in the destination. To run a new export and avoid collision with previously written export files, consider doing the following:
 
 - Change the destination (or destination prefix) that you are exporting to.
 - Remove the partial results at the destination from any previously attempted exports.


### PR DESCRIPTION
Fixes DOC-6659

This adds a paragraph to the export docs to let customers know that export will leave partially written files behind if it encounters a cancelation or failure. Also a couple of bullet points to consider alternatives.