### PR TITLE
Fix "required privileges" for SHOW STATISTICS

### DIFF
--- a/src/current/v22.2/show-statistics.md
+++ b/src/current/v22.2/show-statistics.md
@@ -16,7 +16,7 @@ By default, CockroachDB [automatically generates statistics](cost-based-optimize
 
 ## Required Privileges
 
-No [privileges](security-reference/authorization.html#managing-privileges) are required to list table statistics.
+To list table statistics, the user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table being inspected.
 
 ## Parameters
 

--- a/src/current/v23.1/show-statistics.md
+++ b/src/current/v23.1/show-statistics.md
@@ -16,7 +16,7 @@ By default, CockroachDB [automatically generates statistics]({% link {{ page.ver
 
 ## Required Privileges
 
-No [privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) are required to list table statistics.
+To list table statistics, the user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table being inspected.
 
 ## Parameters
 

--- a/src/current/v23.2/show-statistics.md
+++ b/src/current/v23.2/show-statistics.md
@@ -16,7 +16,7 @@ By default, CockroachDB [automatically generates statistics]({% link {{ page.ver
 
 ## Required Privileges
 
-No [privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) are required to list table statistics.
+To list table statistics, the user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table being inspected.
 
 ## Parameters
 


### PR DESCRIPTION
also see: https://github.com/cockroachdb/cockroach/pull/114166

This sentence in the docs was incorrect. In order to run this command, the user must have any privilege on the table being inspected.