### PR TITLE
[DOC-9251] Clarify Intel and ARM support in the Docker multi-platform image

### DIFF
--- a/src/current/_includes/releases/release-downloads-docker-image.md
+++ b/src/current/_includes/releases/release-downloads-docker-image.md
@@ -25,7 +25,7 @@ This patch release has been withdrawn{% if include.advisory_key %} due to [this 
   {% if release.linux.linux_arm == true %}
     {% capture linux_arm_button_text_addendum %}{% if r.linux.linux_arm_experimental == true %}<br />(Experimental){% endif %}{% if r.linux.linux_arm_limited_access == true %}<br />(Limited Access){% endif %}{% endcapture %}
 
-<a {% if r.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-{{ release.release_name }}.linux-arm64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM{{linux_arm_button_text_addendum}}</button></a>
+<a {% if release.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-{{ release.release_name }}.linux-arm64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM{{linux_arm_button_text_addendum}}</button></a>
 
   {% endif %}
 
@@ -49,7 +49,7 @@ This patch release has been withdrawn{% if include.advisory_key %} due to [this 
 <a href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.release_name }}.linux-amd64.tgz"><button id="linux-intel" class="filter-button" data-scope="linux-intel" data-eventcategory="linux-binary-release-notes">Linux Intel</button></a>
     {% if release.linux.linux_arm == true %}
 
-<a {% if r.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.release_name }}.linux-arm64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM{{linux_arm_button_text_addendum}}</button></a>
+<a {% if release.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-sql-{{ release.release_name }}.linux-arm64.tgz"><button id="linux-arm" class="filter-button" data-scope="linux-arm" data-eventcategory="linux-binary-release-notes">Linux ARM{{linux_arm_button_text_addendum}}</button></a>
 
     {% endif %}
 
@@ -74,14 +74,15 @@ This patch release has been withdrawn{% if include.advisory_key %} due to [this 
   {% if release.docker.docker_arm == true %}
 [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) include support for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.
 
-    {% if r.docker.docker_arm_experimental == true %}
-Support for ARM is **Experimental** and not yet qualified for production use.
-    {% endif %}
-    {% if r.docker.docker_arm_limited_access == true %}
-Support for ARM is in **Limited Access**.
+    {% if release.docker.docker_arm_limited_access == true %}
+Within the multi-platform image:<ul><li>The ARM image is in **Limited Access**.</li><li>The Intel image is **Generally Available** for production use.</li></ul>
+    {% elsif release.docker.docker_arm_experimental == true %}
+Within the multi-platform image:<ul><li>The ARM image is **Experimental** and not yet qualified for production use.</li><li>The Intel image is **Generally Available** for production use.</li></ul>
+    {% else %}
+Within the multi-platform image, both Intel and ARM images are **generally available** for production use.
     {% endif %}
 
-To download the Docker image (multi-platform):
+To download the Docker image:
   {% else %}
 To download the Docker image (Intel-only):
   {% endif %}

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -269,7 +269,7 @@ The following binaries are not suitable for production environments:
                 <span class="badge badge-gray">Withdrawn</span>
             {% else %}
                 {% if r.source == true %}
-                <b>{% if r.docker.docker_arm == false %}Intel{% else %}Multi-platform{% endif %}</b>: <code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
+                <b>{% if r.docker.docker_arm == false %}Intel{% else %}Multi-platform{% endif %}</b>:<br><code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
                 {% else %}
                 N/A
                 {% endif %}
@@ -277,11 +277,11 @@ The following binaries are not suitable for production environments:
             </td>
             <td>
             {% if r.docker.docker_arm_limited_access == true %}
-              **Intel**: Generally available<br />**ARM**: Limited Access
+              **Intel**: GA<br />**ARM**: Limited Access
             {% elsif r.docker.docker_arm_experimental == true %}
-              **Intel**: Generally available<br />**ARM**: Experimental
+              **Intel**: GA<br />**ARM**: Experimental
             {% else %}
-              Generally available
+              GA
             {% endif %}
             </td>
         </tr>

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -60,6 +60,8 @@ The following binaries are not suitable for production environments:
 
         {% assign releases = site.data.releases | where_exp: "releases", "releases.major_version == v.major_version" | where_exp: "releases", "releases.release_type == s" | sort: "release_date" | reverse %} {% comment %} Fetch all releases for that major version based on release type (Production/Testing). {% endcomment %}
 
+{% comment %}Do a separate loop through the releases and for each release, copy some fields into some local v_ variables to use when we are not in a loop below{% endcomment %}
+
         {% assign v_linux_arm = false %}
         {% for r in releases %}
             {% if r.linux.linux_arm == true %}
@@ -97,13 +99,13 @@ The following binaries are not suitable for production environments:
             <td>Version</td>
             <td>Date</td>
             <td>Intel 64-bit Downloads</td>
-        {% if v_linux_arm == true %}
+            {% if v_linux_arm == true %}
             <td>ARM 64-bit Downloads</td>
-        {% endif %}
+            {% endif %}
         </tr>
     </thead>
     <tbody>
-        {% for r in releases %}
+            {% for r in releases %}
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
             <td>
                 <a href="{% link releases/{{ v.major_version }}.md %}#{{ r.release_name | replace: ".", "-" }}">{{ r.release_name }}</a> {% comment %} Add link to each release r. {% endcomment %}
@@ -126,7 +128,7 @@ The following binaries are not suitable for production environments:
                 <td><span class="badge badge-gray">Withdrawn</span></td>
                     {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
                 <td>
-                    {% if r.linux.linux_arm_experimental == true %}<b>Experimental:</b>{% endif %}{% if r.linux.linux_arm_limited_access == true %}<b>Limited Access:</b>{% endif %}
+                        {% if r.linux.linux_arm_experimental == true %}<b>Experimental:</b>{% endif %}
                     <div><a {% if r.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-arm64.tgz">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-arm64.tgz.sha256sum">SHA256</a>{% endif %})</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
                         {% if r.has_sql_only == true %}
                     <div><a {% if r.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.linux-arm64.tgz">SQL shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.linux-arm64.tgz.sha256sum">SHA256</a>{% endif %})</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
@@ -160,26 +162,26 @@ The following binaries are not suitable for production environments:
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
             <td>
                 <a href="{% link releases/{{ v.major_version }}.md %}#{{ r.release_name | replace: ".", "-" }}">{{ r.release_name }}</a> {% comment %} Add link to each release r. {% endcomment %}
-                {% if r.release_name == latest_hotfix.release_name %}
+            {% if r.release_name == latest_hotfix.release_name %}
                 <span class="badge-new">Latest</span> {% comment %} Add "Latest" badge to release if it's the latest release. {% endcomment %}
-                {% endif %}
+            {% endif %}
             </td>
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
-                {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
+            {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
             <td><span class="badge badge-gray">Withdrawn</span></td>
-                {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
+            {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
                 <div><a {% if r.mac.mac_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-10.9-amd64.tgz">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-10.9-amd64.tgz.sha256sum">SHA256</a>){% endif %}</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
                     {% if r.has_sql_only == true %}
                 <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-10.9-amd64.tgz">SQL shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-10.9-amd64.tgz.sha256sum">SHA256</a>){% endif %}</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
                     {% endif %}
-                {% endif %}
-                {% if r.mac.mac_arm == true %}
-                  {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}{% comment %}Version and date columns joined with previous row{% endcomment %}
+            {% endif %}
+            {% if r.mac.mac_arm == true %}
+                {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}{% comment %}Version and date columns joined with previous row{% endcomment %}
             <td><span class="badge badge-gray">Withdrawn</span></td>
-                  {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
+                {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
-                {% if r.mac.mac_arm_experimental == true %}<b>Experimental:</b>{% endif %}{% if r.mac.mac_arm_limited_access == true %}<b>Limited Access:</b>{% endif %}
+                    {% if r.mac.mac_arm_limited_access == true %}<b>Limited Access:</b>{% elsif r.mac.mac_arm_experimental == true %}<b>Experimental:</b>{% endif %}
                 <div><a {% if r.mac.mac_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-11.0-arm64.tgz">Full Binary</a>(<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-11.0-arm64.tgz.sha256sum">SHA256</a>)</div>
                     {% if r.has_sql_only == true %}
                 <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-11.0-arm64.tgz">SQL shell Binary</a>(<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-11.0-arm64.tgz.sha256sum">SHA256</a>)</div>
@@ -230,7 +232,7 @@ The following binaries are not suitable for production environments:
                 {% endif %}
             </td>
         </tr>
-            {% endfor %}
+        {% endfor %}
     </tbody>
 </table>
 </section>
@@ -243,14 +245,13 @@ The following binaries are not suitable for production environments:
     [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) include support for both Intel and ARM.
         {% endif %}
 
-**Experimental** downloads are not yet qualified for production use.
-
     <table class="release-table">
     <thead>
         <tr>
             <td>Version</td>
             <td>Date</td>
             <td>Docker image tag</td>
+            <td>Notes</td>
         </tr>
     </thead>
     <tbody>
@@ -264,18 +265,27 @@ The following binaries are not suitable for production environments:
             </td>
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
             <td>
-                {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
+            {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
                 <span class="badge badge-gray">Withdrawn</span>
+            {% else %}
+                {% if r.source == true %}
+                <b>{% if r.docker.docker_arm == false %}Intel{% else %}Multi-platform{% endif %}</b>: <code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
                 {% else %}
-                    {% if r.source == true %}
-                <b>Intel{% if r.docker.docker_arm == true %}/ARM{% endif %}</b>: <code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>{% if r.docker.docker_arm_experimental == true %} (Experimental){% endif %}{% if r.docker.docker_arm_limited_access == true %} (Limited Access){% endif %}
-                    {% else %}
                 N/A
-                    {% endif %}
+                {% endif %}
+            {% endif %}
             </td>
-        {% endif %}
+            <td>
+            {% if r.docker.docker_arm_limited_access == true %}
+              **Intel**: Generally available<br />**ARM**: Limited Access
+            {% elsif r.docker.docker_arm_experimental == true %}
+              **Intel**: Generally available<br />**ARM**: Experimental
+            {% else %}
+              Generally available
+            {% endif %}
+            </td>
         </tr>
-    {% endfor %}
+        {% endfor %}
     </tbody>
     </table>
 </section>
@@ -291,35 +301,35 @@ The following binaries are not suitable for production environments:
         </tr>
     </thead>
     <tbody>
-    {% for r in releases %}
+        {% for r in releases %}
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
             <td>
                 <a href="{% link releases/{{ v.major_version }}.md %}#{{ r.release_name | replace: ".", "-" }}">{{ r.release_name }}</a> {% comment %} Add link to each release r. {% endcomment %}
-        {% if r.release_name == latest_hotfix.release_name %}
+            {% if r.release_name == latest_hotfix.release_name %}
                 <span class="badge-new">Latest</span> {% comment %} Add "Latest" badge to release if it's the latest release. {% endcomment %}
-        {% endif %}
-            </td>
-            <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
-        {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
-            <td><span class="badge badge-gray">Withdrawn</span></td>
-        {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
-            <td>
-            {% if r.source == true %}
-                <a class="external" href="https://github.com/cockroachdb/cockroach/releases/tag/{{ r.release_name }}">View on Github</a>
-            {% else %}
-                N/A
             {% endif %}
             </td>
-        {% endif %}
+            <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
+            {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
+            <td><span class="badge badge-gray">Withdrawn</span></td>
+            {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
+            <td>
+                {% if r.source == true %}
+                <a class="external" href="https://github.com/cockroachdb/cockroach/releases/tag/{{ r.release_name }}">View on Github</a>
+                {% else %}
+                N/A
+                {% endif %}
+            </td>
+            {% endif %}
         </tr>
-    {% endfor %}
+        {% endfor %}
     </tbody>
     </table>
 </section>
 
 
-{% endif %} {% comment %}if releases[0]{% endcomment %}
-{% endfor %} {% comment %}Sections {% endcomment %}
+        {% endif %} {% comment %}if releases[0]{% endcomment %}
+    {% endfor %} {% comment %}Sections {% endcomment %}
 {% endfor %} {% comment %}Versions{% endcomment %}
 
 ## Release naming


### PR DESCRIPTION
[DOC-9251] Clarify Intel and ARM support in the Docker multi-platform image

This PR adjusts the text shown at the beginning of the Docker section and adds a "Notes" field to the Docker table to document the support level of the Intel and ARM image in each multi-platform image. Also adjusts the logic to prevent the `_limited_access` and `_experimental` fields both displaying as true.

Ref: https://cockroachlabs.slack.com/archives/CHKQGKYEM/p1700107859889549

Related change which I split off from this PR: https://github.com/cockroachdb/docs/pull/18090

Preview: 
[releases/releases.md](https://deploy-preview-18082--cockroachdb-docs.netlify.app/docs/releases/releases.html)
[src/current/releases/index.md](https://deploy-preview-18082--cockroachdb-docs.netlify.app/docs/releases/index.html)