### PR TITLE
Updated AWS regions for CockroachDB Cloud

### DIFF
--- a/src/current/cockroachcloud/regions.md
+++ b/src/current/cockroachcloud/regions.md
@@ -66,6 +66,7 @@ Asia Pacific    | `ap-northeast-1` | Tokyo
                 | `ap-southeast-1` | Singapore
                 | `ap-southeast-2` | Sydney
 North America   | `ca-central-1`   | Central Canada
+                | `us-east-1`      | N. Virginia
                 | `us-east-2`      | Ohio
                 | `us-west-2`      | Oregon
 South America   | `sa-east-1`      | Sao Paolo


### PR DESCRIPTION
Added `us-east-1` as an AWS region for Dedicated as per this [Slack comment](https://cockroachlabs.slack.com/archives/C01PHNMUFLN/p1700499556821929)

