### PR TITLE
Add a callout to the CDC dashboard graph renames

### DIFF
--- a/src/current/_includes/releases/v23.2/v23.2.0-alpha.1.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-alpha.1.md
@@ -414,7 +414,7 @@ When cluster virtualization is enabled:
 - The time window selection for metrics charts is now encoded in the URL via query params. [#101258][#101258]
 - The [Job Details page]({% link v23.2/ui-jobs-page.md %}#job-details) now has a tabbed UI that will allow users to toggle between the Overview and other future views for advanced debugging and observability. [#102737][#102737]
 - Renamed "recent executions" to "active executions" in the UI. [#103784][#103784]
-- The [Changefeed Dashboard]({% link v23.2/ui-cdc-dashboard.md %}) has been updated with new graphs to track backfill progress, protected timestamps age, and the number of schema registry registrations. [#101790][#101790]
+- The [Changefeed Dashboard]({% link v23.2/ui-cdc-dashboard.md %}) has been updated with new graphs to track backfill progress, protected timestamps age, and the number of schema registry registrations. The updates include renaming the **Sink Byte Traffic** graph to **Emitted Bytes** and the **Max Changefeed Latency** graph to **Max Checkpoint Latency**. [#101790][#101790]
 - A new **Networking** tab has been added to the DB Console metrics dashboard. Metrics for network bytes sent and received are now displayed in the **Networking** tab rather than the **Hardware** tab. In addition, the following metrics have been added:
 
   - `cr.node.round-trip-latency-p50`

--- a/src/current/v23.2/ui-cdc-dashboard.md
+++ b/src/current/v23.2/ui-cdc-dashboard.md
@@ -21,7 +21,7 @@ The **Changefeeds** dashboard displays the following time series graphs:
 
 ## Changefeed Status
 
-This graph displays the status of all running changefeeds.
+{% include_cached new-in.html version="v23.2" %} This graph displays the status of all running changefeeds.
 
 <img src="{{ 'images/v23.2/ui-changefeed-status.png' | relative_url }}" alt="DB Console Changefeed Status graph showing running, paused, and failed changefeeds." style="border:1px solid #eee;max-width:100%" />
 
@@ -37,7 +37,7 @@ In the case of a failed changefeed, you may want to use the [`cursor`]({% link {
 
 ## Commit Latency
 
-This graph displays the 99th, 90th, and 50th percentile of commit latency for running changefeeds. This is the difference between an event's MVCC timestamp and the time it was acknowledged as received by the [downstream sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
+{% include_cached new-in.html version="v23.2" %} This graph displays the 99th, 90th, and 50th percentile of commit latency for running changefeeds. This is the difference between an event's MVCC timestamp and the time it was acknowledged as received by the [downstream sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
 
 <img src="{{ 'images/v23.2/ui-commit-latency.png' | relative_url }}" alt="DB Console Commit Latency graph showing the 99th, 90th, and 50th percentile of commit latency." style="border:1px solid #eee;max-width:100%" />
 
@@ -46,6 +46,10 @@ If the sink batches events, then the difference between the oldest event in the 
 ## Emitted Bytes
 
 This graph shows the number of bytes emitted by CockroachDB into the changefeed's [downstream sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
+
+{{site.data.alerts.callout_info}}
+In v23.1 and earlier, the **Emitted Bytes** graph was named **Sink Byte Traffic**. If you want to customize charts, including how metrics are named, use the [**Custom Chart** debug page]({% link {{ page.version.version }}/ui-custom-chart-debug-page.md %}).
+{{site.data.alerts.end}}
 
 <img src="{{ 'images/v23.2/ui-emitted-bytes.png' | relative_url }}" alt="DB Console Emitted Bytes Graph showing the time and emitted bites" style="border:1px solid #eee;max-width:100%" />
 
@@ -71,6 +75,10 @@ Metric | Description
 
 This graph displays the most any changefeed's persisted [checkpoint]({% link {{ page.version.version }}/how-does-an-enterprise-changefeed-work.md %}) is behind the present time. Larger values indicate issues with successfully ingesting or emitting changes. If errors cause a changefeed to restart, or the changefeed is [paused]({% link {{ page.version.version }}/pause-job.md %}) and unpaused, emitted data up to the last checkpoint may be re-emitted.
 
+{{site.data.alerts.callout_info}}
+In v23.1 and earlier, the **Max Checkpoint Latency** graph was named **Max Changefeed Latency**. If you want to customize charts, including how metrics are named, use the [**Custom Chart** debug page]({% link {{ page.version.version }}/ui-custom-chart-debug-page.md %}).
+{{site.data.alerts.end}}
+
 <img src="{{ 'images/v23.2/ui-max-checkpoint-latency.png' | relative_url }}" alt="DB Console Max Checkpoint Latency graph" style="border:1px solid #eee;max-width:100%" />
 
 {{site.data.alerts.callout_info}}
@@ -89,7 +97,7 @@ Metric | Description
 
 ## Oldest Protected Timestamp
 
-This graph displays the oldest [protected timestamp]({% link {{ page.version.version }}/architecture/storage-layer.md %}#protected-timestamps) of any running changefeed on the cluster.
+{% include_cached new-in.html version="v23.2" %} This graph displays the oldest [protected timestamp]({% link {{ page.version.version }}/architecture/storage-layer.md %}#protected-timestamps) of any running changefeed on the cluster.
 
 <img src="{{ 'images/v23.2/ui-oldest-protected-timestamp.png' | relative_url }}" alt="DB Console Oldest Protected Timestamp graph" style="border:1px solid #eee;max-width:100%" />
 
@@ -99,7 +107,7 @@ Metric | Description
 
 ## Backfill Pending Ranges
 
-This graph displays the number of ranges being backfilled that are yet to enter the changefeed pipeline. An [initial scan]({% link {{ page.version.version }}/create-changefeed.md %}#initial-scan) or [schema change]({% link {{ page.version.version }}/online-schema-changes.md %}) can cause a backfill.
+{% include_cached new-in.html version="v23.2" %} This graph displays the number of ranges being backfilled that are yet to enter the changefeed pipeline. An [initial scan]({% link {{ page.version.version }}/create-changefeed.md %}#initial-scan) or [schema change]({% link {{ page.version.version }}/online-schema-changes.md %}) can cause a backfill.
 
 <img src="{{ 'images/v23.2/ui-backfill-pending-ranges.png' | relative_url }}" alt="DB Console Backfill Pending Ranges graph" style="border:1px solid #eee;max-width:100%" />
 
@@ -109,7 +117,7 @@ Metric | Description
 
 ## Schema Registry Registrations
 
-This graph displays the rate of schema registration requests made by CockroachDB nodes to a configured schema registry endpoint. For example, a [Kafka sink]({% link {{ page.version.version }}/changefeed-sinks.md %}#kafka) pointing to a [Confluent Schema Registry]({% link {{ page.version.version }}/stream-a-changefeed-to-a-confluent-cloud-kafka-cluster.md %}).
+{% include_cached new-in.html version="v23.2" %} This graph displays the rate of schema registration requests made by CockroachDB nodes to a configured schema registry endpoint. For example, a [Kafka sink]({% link {{ page.version.version }}/changefeed-sinks.md %}#kafka) pointing to a [Confluent Schema Registry]({% link {{ page.version.version }}/stream-a-changefeed-to-a-confluent-cloud-kafka-cluster.md %}).
 
 <img src="{{ 'images/v23.2/ui-schema-registry-registrations.png' | relative_url }}" alt="DB Console Schema Registry Registrations graph" style="border:1px solid #eee;max-width:100%" />
 


### PR DESCRIPTION
Fixes DOC-9246

Updates include:

- Adds a callout to the Changefeed Dashboard page where the name had changed on two graphs.
- Also, added to "New in v23.2" flags to graphs that are completely new for v23.2 — flags were missed in the original docs page publish
- Included an additional sentence of detail to the release note