### PR TITLE
[DOC-9249] Fix ARM Linux metadata for v23.2.x

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -4936,15 +4936,15 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach-unstable
     docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-alpha.1
 
@@ -4963,15 +4963,15 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach-unstable
     docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-alpha.2
 
@@ -4990,15 +4990,15 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach-unstable
     docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-alpha.3
 
@@ -5044,18 +5044,18 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach-unstable
     docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-alpha.4
-  
+
 - release_name: v23.1.12
   major_version: v23.1
   release_date: '2023-11-13'
@@ -5125,15 +5125,15 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach-unstable
     docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-alpha.5
 
@@ -5179,14 +5179,14 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: false
+    linux_arm_experimental: true
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach-unstable
     docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-alpha.6


### PR DESCRIPTION
Fix incorrect ARM metadata for Linux and Docker in v23.2.0-alpha.2+ releases, which erroneously indicated that ARM is GA for these platforms in these versions.

Relates to https://github.com/cockroachdb/ed-tools/pull/52, which adjusts the defaults in `release-notes.py` to hopefully prevent this from happening again.

Previews:
In the below, ARM is experimental for Linux and Docker v23.2.x, v23.1.x, and v22.2.12-. ARM is Limited Access for 22.2.13, and GA for v22.2.14+. ARM did not exist before v22.2.

https://deploy-preview-18090--cockroachdb-docs.netlify.app/docs/releases/ 
https://deploy-preview-18090--cockroachdb-docs.netlify.app/docs/releases/v23.2#v23-2-0-alpha-7
https://deploy-preview-18090--cockroachdb-docs.netlify.app/docs/releases/v23.1#v23-1-12
https://deploy-preview-18090--cockroachdb-docs.netlify.app/docs/releases/v22.2#v22-2-17