### PR TITLE
DOC-9265: Feedback: Configure CockroachDB Dedicated Logs

### DIFF
--- a/src/current/v23.1/configure-logs.md
+++ b/src/current/v23.1/configure-logs.md
@@ -509,12 +509,14 @@ http-defaults:
 In addition, the `DEV` channel should be output to a separate logging directory, since it is likely to contain sensitive data. See [`DEV` channel](#dev-channel).
 {{site.data.alerts.end}}
 
-External log collectors can misinterpret the `cockroach debug` redaction markers, since they are specific to CockroachDB. To prevent this issue when using network sinks, disable `redactable`:
+External log collectors can misinterpret the `cockroach debug` redaction markers (`< >`), since they are specific to CockroachDB. To prevent this issue when using network sinks, disable `redactable`:
 
 ~~~ yaml
 fluent-defaults:
   redactable: false
 ~~~
+
+If the default redaction behavior and policies do not meet redaction requirements, we recommend using the external log collectors with the redaction markers (`< >`) to redact. In this case, enable `redactable`.
 
 ### DEV channel
 

--- a/src/current/v23.2/configure-logs.md
+++ b/src/current/v23.2/configure-logs.md
@@ -576,12 +576,14 @@ http-defaults:
 In addition, the `DEV` channel should be output to a separate logging directory, since it is likely to contain sensitive data. See [`DEV` channel](#dev-channel).
 {{site.data.alerts.end}}
 
-External log collectors can misinterpret the `cockroach debug` redaction markers, since they are specific to CockroachDB. To prevent this issue when using network sinks, disable `redactable`:
+External log collectors can misinterpret the `cockroach debug` redaction markers (`< >`), since they are specific to CockroachDB. To prevent this issue when using network sinks, disable `redactable`:
 
 ~~~ yaml
 fluent-defaults:
   redactable: false
 ~~~
+
+If the default redaction behavior and policies do not meet redaction requirements, we recommend using the external log collectors with the redaction markers (`< >`) to redact. In this case, enable `redactable`.
 
 ### DEV channel
 


### PR DESCRIPTION
Addresses DOC-9265

(1) Updated Configure Logs page, Redact Logs section with recommendation to use external log collector to redact logs.