### PR TITLE
DOC-9195: Differences in Metrics Between Datadog & DB Console follow-up

### DIFF
--- a/src/current/cockroachcloud/export-metrics.md
+++ b/src/current/cockroachcloud/export-metrics.md
@@ -206,6 +206,12 @@ To enable metrics export for your CockroachDB {{ site.data.products.dedicated }}
 
 1. Once metrics export has been enabled, you can access metrics from your CockroachDB {{ site.data.products.dedicated }} cluster directly in Datadog's [Metrics Explorer](https://docs.datadoghq.com/metrics/explorer/), or via Datadog's [notebook](https://docs.datadoghq.com/notebooks/) or [dashboard](https://docs.datadoghq.com/dashboards/) features.
 
+1. Review [enable percentiles for selected metrics]({% link cockroachcloud/tools-page.md %}#enable-percentiles-for-selected-metrics). Configure metrics as necessary.
+
+{{site.data.alerts.callout_info}}
+A subset of CockroachDB metrics require that you explicitly [enable percentiles]({% link cockroachcloud/tools-page.md %}#enable-percentiles-for-selected-metrics) for them in the Datadog interface. Graphs that display data for these metrics will fail to render properly otherwise.
+{{site.data.alerts.end}}
+
 </section>
 
 ## Monitor the status of a metrics export configuration

--- a/src/current/v23.1/differences-in-metrics-between-third-party-monitoring-integrations-and-db-console.md
+++ b/src/current/v23.1/differences-in-metrics-between-third-party-monitoring-integrations-and-db-console.md
@@ -35,7 +35,7 @@ Since Cockroach Labs does not own the third-party systems, we can not be expecte
 
 The [metrics export feature](https://www.cockroachlabs.com/docs/cockroachcloud/export-metrics) scrapes the `/_status/vars` endpoint every 30 seconds, and forwards the data along to the third-party system. The metrics export does no intermediate aggregation, downsampling, or modification of the timeseries values at any point. The raw metrics export data is at a 30-second resolution, but how that data is processed once received by the third party system is unknown to us.
 
-It is within our scope to understand and support our own timeseries database. If you have problems receiving metrics in your third-party system, [our support]({% link {{ page.version.version }}/support-resources.md %}) can help troubleshoot those problems. However, once the data is ingested into the third-party system, please contact your representative at that third-party company to support issues found on those systems.
+It is within our scope to understand and support our own timeseries database. If you have problems receiving metrics in your third-party system, [our support]({% link {{ page.version.version }}/support-resources.md %}) can help troubleshoot those problems. However, once the data is ingested into the third-party system, please contact your representative at that third-party company to support issues found on those systems. For example, assuming the raw metric data has been ingested as expected, Cockroach Labs does not support writing queries in third-party systems, such as using Datadog's Metrics Explorer or Datadog Query Language (DQL).
 
 ## See Also
 

--- a/src/current/v23.2/differences-in-metrics-between-third-party-monitoring-integrations-and-db-console.md
+++ b/src/current/v23.2/differences-in-metrics-between-third-party-monitoring-integrations-and-db-console.md
@@ -35,7 +35,7 @@ Since Cockroach Labs does not own the third-party systems, we can not be expecte
 
 The [metrics export feature](https://www.cockroachlabs.com/docs/cockroachcloud/export-metrics) scrapes the `/_status/vars` endpoint every 30 seconds, and forwards the data along to the third-party system. The metrics export does no intermediate aggregation, downsampling, or modification of the timeseries values at any point. The raw metrics export data is at a 30-second resolution, but how that data is processed once received by the third party system is unknown to us.
 
-It is within our scope to understand and support our own timeseries database. If you have problems receiving metrics in your third-party system, [our support]({% link {{ page.version.version }}/support-resources.md %}) can help troubleshoot those problems. However, once the data is ingested into the third-party system, please contact your representative at that third-party company to support issues found on those systems.
+It is within our scope to understand and support our own timeseries database. If you have problems receiving metrics in your third-party system, [our support]({% link {{ page.version.version }}/support-resources.md %}) can help troubleshoot those problems. However, once the data is ingested into the third-party system, please contact your representative at that third-party company to support issues found on those systems. For example, assuming the raw metric data has been ingested as expected, Cockroach Labs does not support writing queries in third-party systems, such as using Datadog's Metrics Explorer or Datadog Query Language (DQL).
 
 ## See Also
 


### PR DESCRIPTION
Addresses: DOC-9195

(1) Updated Export Metrics page, added step and callout to enable percentiles. (2) Updated Differences in Metrics page, added that writing queries is not supported.