### PR TITLE
Add release notes for v23.1.13

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5244,3 +5244,30 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0-beta.1
+
+# - release_name: v23.1.13
+#   major_version: v23.1
+#   release_date: '2023-12-11'
+#   release_type: Production
+#   go_version: go1.21
+#   sha: 8d065df26e25a762a1abbbf2b1e475456b341a00
+#   has_sql_only: true
+#   has_sha256sum: true
+#   mac:
+#     mac_arm: true
+#     mac_arm_experimental: true
+#     mac_arm_limited_access: false
+#   windows: true
+#   linux:
+#     linux_arm: true
+#     linux_arm_experimental: true
+#     linux_arm_limited_access: false
+#     linux_intel_fips: true
+#     linux_arm_fips: false
+#   docker:
+#     docker_image: cockroachdb/cockroach
+#     docker_arm: true
+#     docker_arm_experimental: true
+#     docker_arm_limited_access: false
+#   source: true
+#   previous_release: v23.1.12

--- a/src/current/_includes/releases/v23.1/v23.1.13.md
+++ b/src/current/_includes/releases/v23.1/v23.1.13.md
@@ -1,0 +1,89 @@
+v23.1.13
+--------
+
+Release Date: December 5, 2023
+
+{{ site.data.alerts.callout_info }}
+This version is currently available only on select CockroachDB {{ site.data.products.dedicated }} clusters. If you wish to upgrade your cluster to this version, please submit a [support request](https://support.cockroachlabs.com/hc/en-us/requests/new).
+
+This release is currently not available for CockroachDB {{ site.data.products.serverless }} and {{ site.data.products.core }} customers.
+{{ site.data.alerts.end }}
+
+{% comment %}{% include releases/release-downloads-docker-image.md release=include.release %}{% endcomment %}
+
+<h3 id="v23-1-13-sql-language-changes">SQL language changes</h3>
+
+- A new option for the [`RESTORE`](https://www.cockroachlabs.com/docs/v23.1/restore.html) syntax, `strip_localities`, has been added. This can be used to strip the [locality information](https://www.cockroachlabs.com/docs/v23.1/alter-table.html#set-locality) from a backup when there are mismatched [cluster regions](https://www.cockroachlabs.com/docs/v23.1/multiregion-overview.html#cluster-regions) between the backup's cluster and the target cluster. The following are behaviors that will most likely not be encountered with the specific use case that this patch provides, but are documented nonetheless:
+    - Adding a [primary region](https://www.cockroachlabs.com/docs/v23.1/alter-database.html#set-primary-region) to a regionless restore (with or without [regional by row table(s)](https://www.cockroachlabs.com/docs/v23.1/table-localities.html#regional-by-row-tables)) will not work out-of-the-box, but does produce an accurate message instructing a user to [`DROP TYPE {database}.public.crdb_internal_region;`](https://www.cockroachlabs.com/docs/v23.1/drop-type.html) (and for cluster restores, [`ALTER DATABASE {database} CONFIGURE ZONE DISCARD;`](https://www.cockroachlabs.com/docs/v23.1/alter-database.html#remove-a-replication-zone)).
+    - Restoring a cluster/database/table with a [regional by row table](https://www.cockroachlabs.com/docs/v23.1/table-localities.html#regional-by-row-tables) will not work out-of-the box. In particular, when performing writes, the [`crdb_region` column](https://www.cockroachlabs.com/docs/v23.1/alter-table.html#crdb_region) needs to specify the region of the new row(s) being written to the table. The user will need to alter said column and set a default that makes sense, along with discarding the [zone configuration](https://www.cockroachlabs.com/docs/v23.1/configure-replication-zones.html) (this latter is due to the fact that the zone config holds all outdated info related to the [partitions](https://www.cockroachlabs.com/docs/v23.1/partitioning.html), [constraints](https://www.cockroachlabs.com/docs/v23.1/constraints.html), etc.). These are due to a conflict with the `crdb_region` column already being present in the regionless restore. This column specifies each row's home region and is a prefix to the table's primary key. Stripping localities does not touch this column as it would be an expensive operation that includes rewriting the entire table. [#111863][#111863]
+- The [`RESTORE`](https://www.cockroachlabs.com/docs/v23.1/restore.html) option `strip_localities` has been renamed to `remove_regions`. [#111863][#111863]
+- You can no longer perform a [`RESTORE`](https://www.cockroachlabs.com/docs/v23.1/restore.html) with the `remove_regions` option if the object being restored contains a [regional by row table](https://www.cockroachlabs.com/docs/v23.1/table-localities.html#regional-by-row-tables). [#111863][#111863]
+- Added a [builtin function](https://www.cockroachlabs.com/docs/v23.1/functions-and-operators.html) `jsonb_array_to_string_array` that converts a [JSONB](https://www.cockroachlabs.com/docs/v23.1/jsonb.html) array to a string array. [#112864][#112864]
+- Updated the [builtin function](https://www.cockroachlabs.com/docs/v23.1/functions-and-operators.html) `jsonb_array_to_string_array` to return [_NULL_](https://www.cockroachlabs.com/docs/v23.1/null-handling.html) objects. Previously, they were removed from the output. [#112864][#112864]
+- Fixed the [**SQL Activity** page](https://www.cockroachlabs.com/docs/v23.1/monitoring-and-alerting.html#sql-activity-pages) update job to avoid conflicts on update, reduce the amount of data cached to just what the overview page requires, and fix the correctness of the top queries. [#112864][#112864]
+
+<h3 id="v23-1-13-operational-changes">Operational changes</h3>
+
+- Added [metrics](https://www.cockroachlabs.com/docs/v23.1/metrics.html) for [Raft](https://www.cockroachlabs.com/docs/v23.1/architecture/replication-layer.html#raft) proposals and reproposals, specifically:
+    - `raft.commands.proposed`: commands proposed to Raft by [leaseholders](https://www.cockroachlabs.com/docs/v23.1/architecture/overview.html#architecture-leaseholder). (Note that this metric includes both of the reproposed metrics below.)
+    - `raft.commands.reproposed.unchanged`: commands retried/reproposed to Raft because they take too long to apply (so they might be dropped).
+    - `raft.commands.reproposed.new-lai`: commands retried/reproposed to Raft because they were committed to Raft out of order (failed the LAI (lease applied index) or [closed timestamp](https://www.cockroachlabs.com/docs/v23.1/architecture/transaction-layer.html#closed-timestamps) check). [#113153][#113153]
+- Added a new [cluster setting](https://www.cockroachlabs.com/docs/v23.1/cluster-settings.html) `kv.gc.sticky_hint.enabled` that helps expedite [garbage collection](https://www.cockroachlabs.com/docs/v23.1/architecture/storage-layer.html#garbage-collection) after range deletions, such as when a SQL table or index is dropped. This setting is disabled by default. [#110643][#110643]
+
+<h3 id="v23-1-13-db-console-changes">DB Console changes</h3>
+
+- [DB Console](https://www.cockroachlabs.com/docs/v23.1/ui-overview.html) instances proxied at different subpaths that use [OIDC](https://www.cockroachlabs.com/docs/cockroachcloud/configure-cloud-org-sso.html#oidc) will now point to the correct relative path when attempting to use OIDC login. [#111290][#111290]
+
+<h3 id="v23-1-13-bug-fixes">Bug fixes</h3>
+
+- Fixed a bug where the `pg_attribute` could have sparsely populated `attnum`s since dropped columns were not included. Previously, the attribute number generated inside `pg_attribute` could be sparse because there would be gaps after columns were dropped. This could be problematic for ORMs since this would mean that attribute numbers could be sparse, and they may not be designed to handle such gaps. To address this, this patch adds dropped synthetic columns into the `pg_attribute` table, which allows these tools to work correctly. [#111119][#111119]
+- Fixed a bug that could prevent [`RESTORE`](https://www.cockroachlabs.com/docs/v23.1/restore.html) from working if it was performed during a [cluster upgrade](https://www.cockroachlabs.com/docs/v23.1/upgrade-cockroach-version.html). [#112758][#112758]
+- Fixed a bug where queries with the `st_union` [aggregate function](https://www.cockroachlabs.com/docs/v23.1/functions-and-operators.html#aggregate-functions) could produce incorrect results in some cases due to the [query optimizer](https://www.cockroachlabs.com/docs/v23.1/cost-based-optimizer.html) performing invalid optimizations. This bug has been present since the `st_union` function was introduced in v20.2.0. [#112795][#112795]
+- A warning for [technical advisory 99561](https://www.cockroachlabs.com/docs/advisories/a99561) could incorrectly surface when [dropping secondary indexes](https://www.cockroachlabs.com/docs/v23.1/drop-index.html) that store [primary key](https://www.cockroachlabs.com/docs/v23.1/primary-key.html) columns. This is now fixed. [#112906][#112906]
+- Fixed a bug where creating a [trigram index](https://www.cockroachlabs.com/docs/v23.1/trigram-indexes.html) and later displaying it via [`SHOW CREATE TABLE`](https://www.cockroachlabs.com/docs/v23.1/show-create.html), would not show the opclass for this trigram index. [#113077][#113077]
+- Fixed a bug introduced in v22.2 where CockroachDB could incorrectly evaluate [lookup and index joins](https://www.cockroachlabs.com/docs/v23.1/joins.html) into tables with at least 3 [column families](https://www.cockroachlabs.com/docs/v23.1/column-families.html) in some cases (either a `non-nullable column with no value` internal error would occur, or the query would return incorrect results). [#113108][#113108]
+- Fixed a bug that could occasionally cause [schema change jobs](https://www.cockroachlabs.com/docs/v23.1/online-schema-changes.html) (e.g., table/index drops) to appear stuck in state "waiting for MVCC GC" for much longer than expected. This fix only applies to future schema changes. Existing stuck jobs can be processed by manually force-enqueueing the relevant [ranges](https://www.cockroachlabs.com/docs/v23.1/architecture/overview.html#architecture-range) in the MVCC GC queue under the [DB Console's **Advanced Debug** page](https://www.cockroachlabs.com/docs/v23.1/ui-debug-pages.html). [#110643][#110643]
+- Fixed a bug that could cause internal errors or panics while attempting to forecast [statistics](https://www.cockroachlabs.com/docs/v23.1/cost-based-optimizer.html#table-statistics) on a numeric column. [#113798][#113798]
+- Fixed a bug where [`ALTER PRIMARY KEY`](https://www.cockroachlabs.com/docs/v23.1/alter-table.html#alter-primary-key) would incorrectly disable [secondary indexes](https://www.cockroachlabs.com/docs/v23.1/indexes.html) while new secondary indexes were being backfilled when using the [declarative schema changer](https://www.cockroachlabs.com/docs/v23.1/online-schema-changes.html#declarative-schema-changer). [#113183][#113183]
+- Previously, when executing queries with [index / lookup joins](https://www.cockroachlabs.com/docs/v23.1/joins.html) when the ordering needs to be maintained, CockroachDB could in some cases inadvertently increase query latency, possibly by 1 or 2 orders of magnitude. This bug was introduced in v22.2 and is now fixed. [#114143][#114143]
+- Fixed a bug where the [`SHOW STATISTICS`](https://www.cockroachlabs.com/docs/v23.1/show-statistics.html) command would incorrectly require the user to have the [admin role](https://www.cockroachlabs.com/docs/v23.1/security-reference/authorization.html#admin-role). It was intended to only require the user to have any privilege on the table being inspected. [#114479][#114479]
+- Fixed a bug that could cause a query plan to skip scanning rows from the local region when performing a [lookup join](https://www.cockroachlabs.com/docs/v23.1/joins.html) with a [`REGIONAL BY ROW`](https://www.cockroachlabs.com/docs/v23.1/table-localities.html#regional-by-row-tables) table as the input. [#114456][#114456]
+- Fixed a bug that could cause [`ALTER DATABASE ... ADD/DROP REGION`](https://www.cockroachlabs.com/docs/v23.1/alter-database.html#add-region) to hang if node localities were changed after regions were added. [#114197][#114197]
+
+<h3 id="v23-1-13-performance-improvements">Performance improvements</h3>
+
+- Addressed a performance regression that could happen when the [declarative schema changer](https://www.cockroachlabs.com/docs/v23.1/online-schema-changes.html#declarative-schema-changer) is being used to [create an index](https://www.cockroachlabs.com/docs/v23.1/create-index.html) with a concurrent workload. [#113724][#113724]
+- Added an off-by-default [cluster setting](https://www.cockroachlabs.com/docs/v23.1/cluster-settings.html), `kv.dist_sender.follower_reads_unhealthy.enabled`, which when enabled will prevent failed requests from being issued on followers that are [draining](https://www.cockroachlabs.com/docs/v23.1/node-shutdown.html#draining), [decommissioning](https://www.cockroachlabs.com/docs/v23.1/node-shutdown?filters=decommission), or otherwise unhealthy. This will prevent [follower reads](https://www.cockroachlabs.com/docs/v23.1/follower-reads.html) against nodes in such states. This prevents latency spikes if those nodes later go offline. [#114367][#114367]
+- [Query planning](https://www.cockroachlabs.com/docs/v23.1/cost-based-optimizer.html) time has been reduced significantly for some queries in which many tables are [joined](https://www.cockroachlabs.com/docs/v23.1/joins.html). [#114835][#114835]
+
+<div class="release-note-contributors" markdown="1">
+
+<h3 id="v23-1-13-contributors">Contributors</h3>
+
+This release includes 118 merged PRs by 42 authors.
+
+</div>
+
+[#110643]: https://github.com/cockroachdb/cockroach/pull/110643
+[#111119]: https://github.com/cockroachdb/cockroach/pull/111119
+[#111290]: https://github.com/cockroachdb/cockroach/pull/111290
+[#111863]: https://github.com/cockroachdb/cockroach/pull/111863
+[#112758]: https://github.com/cockroachdb/cockroach/pull/112758
+[#112795]: https://github.com/cockroachdb/cockroach/pull/112795
+[#112864]: https://github.com/cockroachdb/cockroach/pull/112864
+[#112906]: https://github.com/cockroachdb/cockroach/pull/112906
+[#113039]: https://github.com/cockroachdb/cockroach/pull/113039
+[#113077]: https://github.com/cockroachdb/cockroach/pull/113077
+[#113108]: https://github.com/cockroachdb/cockroach/pull/113108
+[#113153]: https://github.com/cockroachdb/cockroach/pull/113153
+[#113171]: https://github.com/cockroachdb/cockroach/pull/113171
+[#113183]: https://github.com/cockroachdb/cockroach/pull/113183
+[#113724]: https://github.com/cockroachdb/cockroach/pull/113724
+[#113798]: https://github.com/cockroachdb/cockroach/pull/113798
+[#114143]: https://github.com/cockroachdb/cockroach/pull/114143
+[#114197]: https://github.com/cockroachdb/cockroach/pull/114197
+[#114367]: https://github.com/cockroachdb/cockroach/pull/114367
+[#114456]: https://github.com/cockroachdb/cockroach/pull/114456
+[#114479]: https://github.com/cockroachdb/cockroach/pull/114479
+[#114529]: https://github.com/cockroachdb/cockroach/pull/114529
+[#114835]: https://github.com/cockroachdb/cockroach/pull/114835

--- a/src/current/releases/v23.1.md
+++ b/src/current/releases/v23.1.md
@@ -28,6 +28,10 @@ To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.majo
 
 {% assign release_names = rel | map: "release_name" %}
 
+{% unless release_names contains "v23.1.13" %}
+  {% include releases/{{ page.major_version }}/v23.1.13.md %}
+{% endunless %}
+
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
 {% endfor %}


### PR DESCRIPTION
Touches DOC-8127

NB. This PR is only for the Dedicated rollout targeting 2023-12-04.  Will need to make further PRs for the upcoming Serverless and, later, Self-hosted releases.