### PR TITLE
Add YAML field and Liquid logic to better support a Cloud-only release

### DIFF
--- a/src/current/_includes/releases/release-downloads-docker-image.md
+++ b/src/current/_includes/releases/release-downloads-docker-image.md
@@ -9,6 +9,10 @@
 
 {% if release.withdrawn == true %}
 {% include releases/withdrawn.md %}
+{% elsif release.cloud_only == true %} {% comment %}Show the Cloud-first info instead of download links {% endcomment %}
+{{site.data.alerts.callout_info}}
+{{ r.cloud_only_message }}
+{{site.data.alerts.end}}
 {% else %}
 
 {{site.data.alerts.callout_info}}

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -115,6 +115,8 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
                 {% if r.withdrawn == true %} {% comment %} Suppress download links for withdrawn releases. {% endcomment %}
             <td colspan="2"><span class="badge badge-gray">Withdrawn</span></td>{% comment %}covers both Intel and ARM columns {% endcomment %}
+                {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
+            <td colspan="2"><span>{{ r.cloud_only_message_short }}</span></td>
                 {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
                 <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-amd64.tgz">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-amd64.tgz.sha256sum">SHA256</a>){% endif %}</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
@@ -124,7 +126,7 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
                 {% endif %}
                 {% if r.linux.linux_arm == true %}
                 {% comment %}Don't print column because of previous colspan=2{% endcomment %}
-                    {% if r.withdrawn == true %}
+                    {% if r.withdrawn == true or r.cloud_only == true %}
                         {% break %}
                     {% else %}
                 <td>
@@ -169,6 +171,8 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
             {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
             <td colspan="2"><span class="badge badge-gray">Withdrawn</span></td>{% comment %}covers both Intel and ARM columns {% endcomment %}
+            {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
+            <td colspan="2"><span>{{ r.cloud_only_message_short }}</span></td>
             {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
                 <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-10.9-amd64.tgz">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-10.9-amd64.tgz.sha256sum">SHA256</a>){% endif %}</div> {% comment %} If a sha256sum is available for a particular release, we display a link to the file containing the sha256sum alongside the download link of the release. {% endcomment %}
@@ -178,9 +182,9 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
             {% endif %}
             {% if r.mac.mac_arm == true %}
                 {% comment %}Don't print column because of previous colspan=2{% endcomment %}
-                    {% if r.withdrawn == true %}
-                        {% break %}
-                    {% else %}
+                {% if r.withdrawn == true or r.cloud_only == true %}
+                    {% break %}
+                {% else %}
             <td>
                     {% if r.mac.mac_arm_limited_access == true %}<b>Limited Access:</b>{% elsif r.mac.mac_arm_experimental == true %}<b>Experimental:</b>{% endif %}
                 <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-11.0-arm64.tgz">Full Binary</a>(<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-11.0-arm64.tgz.sha256sum">SHA256</a>)</div>
@@ -220,6 +224,8 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
                 {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
             <td colspan="2"><span class="badge badge-gray">Withdrawn</span></td>{% comment %}covers both Intel and ARM columns {% endcomment %}
+                {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
+            <td colspan="2"><span>{{ r.cloud_only_message_short }}</span></td>
                 {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
                     {% if r.windows == true %}
@@ -268,6 +274,8 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
             <td>
             {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
                 <span class="badge badge-gray">Withdrawn</span>
+            {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
+                <span>{{ r.cloud_only_message_short }}</span>
             {% else %}
                 {% if r.source == true %}
                 <b>{% if r.docker.docker_arm == false %}Intel{% else %}Multi-platform{% endif %}</b>:<br><code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
@@ -313,6 +321,8 @@ In CockroachDB v22.2.x and above, a cluster that is upgraded to an alpha binary 
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
             {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
             <td><span class="badge badge-gray">Withdrawn</span></td>
+            {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
+            <td><span>{{ r.cloud_only_message_short }}</span></td>
             {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
                 {% if r.source == true %}


### PR DESCRIPTION
Previously, to suppress download links, you had to remove the release entry from `_data/releases.yml`, which means that the logic that builds the tables in `releases/index.html` can't include Cloud-only releases. Instead, a reader must either be given the direct link or must construct it by going to a different page and manually editing the URL. In addition, the writer must manually add or remove a Liquid include on one line, a  `unless` block in a separate area, and a Liquid admonition. This is all pretty prone to error and. confusing.

This PR introduces three new optional per-release fields in `_data/releases.yml`:
- `cloud_only`: If `true`, suppress download links and show explanatory messaging.
- `cloud_only_message`: If `cloud_only` is `true`, this is displayed at the top of the release notes for the release. This can be multi-line. Markdown is supported but not Liquid.
- `cloud_only_message_short`: If `cloud_only` is `true`, this is displayed in the sections in the release index. This should be only a short sentence. Neither Markdown nor Liquid is supported.

To validate this change, I've set the new field to `true` for a fake v23.1.14 release. Before merging this PR but after you both approve this change, I'll remove the 23.1.14-specific changes from this change. I'll also update the Wiki for creating a Cloud-first release.

This doesn't require an [`ed-tools`](https://github.com/cockroachdb/ed-tools) change to update `release-note.py` because the logic defaults to assuming that `cloud_only` is `false`.

### Previews
[releases/v23.1.md](https://deploy-preview-18122--cockroachdb-docs.netlify.app/docs/releases/v23.1.html#v23.1.14)
[src/current/releases/index.md](https://deploy-preview-18122--cockroachdb-docs.netlify.app/docs/releases/index.html)