### PR TITLE
Revert v23.2.0-beta.2 by commenting out releases.yml block

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5218,32 +5218,32 @@
   source: true
   previous_release: v23.2.0-alpha.7
 
-- release_name: v23.2.0-beta.2
-  major_version: v23.2
-  release_date: '2023-12-05'
-  release_type: Testing
-  go_version: go1.21
-  sha: b5953f20bd644d508d2560387b679f22c9e24f67
-  has_sql_only: true
-  has_sha256sum: true
-  mac:
-    mac_arm: true
-    mac_arm_experimental: true
-    mac_arm_limited_access: false
-  windows: true
-  linux:
-    linux_arm: true
-    linux_arm_experimental: true
-    linux_arm_limited_access: false
-    linux_intel_fips: true
-    linux_arm_fips: false
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-    docker_arm: true
-    docker_arm_experimental: true
-    docker_arm_limited_access: false
-  source: true
-  previous_release: v23.2.0-beta.1
+# - release_name: v23.2.0-beta.2
+#   major_version: v23.2
+#   release_date: '2023-12-05'
+#   release_type: Testing
+#   go_version: go1.21
+#   sha: b5953f20bd644d508d2560387b679f22c9e24f67
+#   has_sql_only: true
+#   has_sha256sum: true
+#   mac:
+#     mac_arm: true
+#     mac_arm_experimental: true
+#     mac_arm_limited_access: false
+#   windows: true
+#   linux:
+#     linux_arm: true
+#     linux_arm_experimental: true
+#     linux_arm_limited_access: false
+#     linux_intel_fips: true
+#     linux_arm_fips: false
+#   docker:
+#     docker_image: cockroachdb/cockroach-unstable
+#     docker_arm: true
+#     docker_arm_experimental: true
+#     docker_arm_limited_access: false
+#   source: true
+#   previous_release: v23.2.0-beta.1
 
 # - release_name: v23.1.13
 #   major_version: v23.1


### PR DESCRIPTION
Published release notes a bit too soon. We'll bring this back shortly. 