### PR TITLE
[DOC-9307] Publish v23.2.0-beta.2 release notes

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5220,10 +5220,10 @@
 
 - release_name: v23.2.0-beta.2
   major_version: v23.2
-  release_date: '2023-12-05'
+  release_date: '2023-12-08'
   release_type: Testing
   go_version: go1.21
-  sha: b5953f20bd644d508d2560387b679f22c9e24f67
+  sha: 8497d5eb24d9ff057fc57346ab21c3d796ba05be
   has_sql_only: true
   has_sha256sum: true
   mac:

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5218,32 +5218,32 @@
   source: true
   previous_release: v23.2.0-alpha.7
 
-# - release_name: v23.2.0-beta.2
-#   major_version: v23.2
-#   release_date: '2023-12-05'
-#   release_type: Testing
-#   go_version: go1.21
-#   sha: b5953f20bd644d508d2560387b679f22c9e24f67
-#   has_sql_only: true
-#   has_sha256sum: true
-#   mac:
-#     mac_arm: true
-#     mac_arm_experimental: true
-#     mac_arm_limited_access: false
-#   windows: true
-#   linux:
-#     linux_arm: true
-#     linux_arm_experimental: true
-#     linux_arm_limited_access: false
-#     linux_intel_fips: true
-#     linux_arm_fips: false
-#   docker:
-#     docker_image: cockroachdb/cockroach-unstable
-#     docker_arm: true
-#     docker_arm_experimental: true
-#     docker_arm_limited_access: false
-#   source: true
-#   previous_release: v23.2.0-beta.1
+- release_name: v23.2.0-beta.2
+  major_version: v23.2
+  release_date: '2023-12-05'
+  release_type: Testing
+  go_version: go1.21
+  sha: b5953f20bd644d508d2560387b679f22c9e24f67
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+    mac_arm_experimental: true
+    mac_arm_limited_access: false
+  windows: true
+  linux:
+    linux_arm: true
+    linux_arm_experimental: true
+    linux_arm_limited_access: false
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach-unstable
+    docker_arm: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
+  source: true
+  previous_release: v23.2.0-beta.1
 
 # - release_name: v23.1.13
 #   major_version: v23.1

--- a/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
@@ -7,14 +7,21 @@ Release Date: December 5, 2023
 <h3 id="v23-2-0-beta-2-general-changes">General changes</h3>
 
 - CockroachDB now periodically dumps the state of its internal memory accounting system into the `heap_profiler/` directory when a heap profile is taken. To disable this behavior, set the `diagnostics.memory_monitoring_dumps.enabled` [cluster setting](https://cockroachlabs.com/docs/v23.2/cluster-settings) to `false`. [#114998][#114998]
+- [#115604][#115604] [d4d8f15d7][d4d8f15d7] release-23.2: Revert "s3: disable content pre-upload checksums" (Aditya Maru <adityamaru@gmail.com>)
+- [#115481][#115481] [69b51a5cd][69b51a5cd] release-23.2: storage: disable multi-level compactions (Nick Travers <travers@cockroachlabs.com>)
 
 <h3 id="v23-2-0-beta-2-enterprise-edition-changes">Enterprise Edition changes</h3>
 
 - When using [Physical Cluster Replication](https://cockroachlabs.com/docs/v23.2/physical-cluster-replication-overview), you can now [initiate a cutover](https://cockroachlabs.com/docs/v23.2/cutover-replication) as of `LATEST` before the initial scan completes. [#115101][#115101]
+- SHOW CHANGEFEED JOB,  SHOW CHANGEFEED JOBS, and SHOW JOBS no longer expose user sensitive infromation(`api_secret`, `sasl_password`, `client_cert`, and `ca_cert`) in the job description and sinkURI output column would reveal sensitive user information (api_secret, sasl_password, client_cert, ca_cert). [#115567][#115567]
+
 
 <h3 id="v23-2-0-beta-2-db-console-changes">DB Console changes</h3>
 
 - In the [Changeeds dashboard](https://www.cockroachlabs.com/docs/v23.2/ui-cdc-dashboard), the **Max Checkpoint Latency** chart title now refers to "Lag" rather than "Latency", to better reflect the intention of the underlying metric, which measures how recently the changefeed was last checkpointed. [#115003][#115003]
+- Time on X-Axis of bar charts on Statement details page display correctly formatted time in UTC. [#115220][#115220]
+- This patch remotes the `physical_replication.frontier_lag_nanos` metric and dbconsole graph is it's sometimes wrong. This patch adds `physical_replication.replicated_time_seconds` metric which users may use for alerting. [#115234][#115234]
+- Proper handling of "Now" button on Time range selector when custom time period was selected before. [#115514][#115514]
 
 <h3 id="v23-2-0-beta-2-bug-fixes">Bug fixes</h3>
 
@@ -23,6 +30,12 @@ Release Date: December 5, 2023
 - Fixed a bug introduced in v23.1 that could cause an internal error when using the text format (as opposed to binary) when [preparing a statement](https://www.cockroachlabs.com/docs/v23.2/sql-grammar#prepare_stmt) with a user-defined composite type. [#115064][#115064]
 - Fixed a bug that could cause a replica to be stuck processing in a queue's replica set when the replica had recently been removed from purgatory for processing but was destroyed, or the replica's ID changed before being processed. These replicas are now removed from the queue when they are encountered. [#115037][#115037]
 - Fixed a bug that could cause a [prepared statement](https://www.cockroachlabs.com/docs/v23.2/sql-grammar#prepare_stmt) to fail if it references both an `enum` and a table that has undergone a schema change. [#115132][#115132]
+- Addressed a bug that could cause cluster version finalization to get starved out by descriptor lease renewals on larger clusters. [#115034][#115034]
+- Backups now evenly distribute work their work across all replicas, including followers, regardless of leaseholder placement. Epic: none. [#115019][#115019]
+- Fixed a bug present only in the 23.2.0-beta.1 version that caused incorrect handling for a single composite-typed variable as the target of a PLpgSQL `INTO` clause. [#115404][#115404]
+- Fixes a bug where replicating from a source cluster that is on an older version (<23.2) than the destination cluster would fail because of an undefined builtin function [#114257][#114257]
+- In the SQL Activity Transaction Details page, users can now view a transaction fingerprint id across  multiple applications. To do so, they can specify the app name in the `appNames` URL search param using a comma separated encoded string  of transaction fingerprint ids. [#115204][#115204]
+- BEGIN statement logs now have correct query `Age` fields. Previously, these fields were being recorded incorrectly which would lead to some statements also appearing erroneously in the slow query logs. [#115259][#115259]
 
 <h3 id="v23-2-0-beta-2-performance-improvements">Performance improvements</h3>
 
@@ -32,7 +45,7 @@ Release Date: December 5, 2023
 
 <h3 id="v23-2-0-beta-2-contributors">Contributors</h3>
 
-This release includes 38 merged PRs by 20 authors.
+This release includes 91 merged PRs by 35 authors.
 
 </div>
 
@@ -47,3 +60,17 @@ This release includes 38 merged PRs by 20 authors.
 [#115132]: https://github.com/cockroachdb/cockroach/pull/115132
 [#115145]: https://github.com/cockroachdb/cockroach/pull/115145
 [#115181]: https://github.com/cockroachdb/cockroach/pull/115181
+[#114257]: https://github.com/cockroachdb/cockroach/pull/114257
+[#115019]: https://github.com/cockroachdb/cockroach/pull/115019
+[#115034]: https://github.com/cockroachdb/cockroach/pull/115034
+[#115204]: https://github.com/cockroachdb/cockroach/pull/115204
+[#115220]: https://github.com/cockroachdb/cockroach/pull/115220
+[#115234]: https://github.com/cockroachdb/cockroach/pull/115234
+[#115259]: https://github.com/cockroachdb/cockroach/pull/115259
+[#115404]: https://github.com/cockroachdb/cockroach/pull/115404
+[#115481]: https://github.com/cockroachdb/cockroach/pull/115481
+[#115514]: https://github.com/cockroachdb/cockroach/pull/115514
+[#115567]: https://github.com/cockroachdb/cockroach/pull/115567
+[#115604]: https://github.com/cockroachdb/cockroach/pull/115604
+[69b51a5cd]: https://github.com/cockroachdb/cockroach/commit/69b51a5cd
+[d4d8f15d7]: https://github.com/cockroachdb/cockroach/commit/d4d8f15d7

--- a/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
@@ -12,14 +12,14 @@ Release Date: December 5, 2023
 <h3 id="v23-2-0-beta-2-enterprise-edition-changes">Enterprise Edition changes</h3>
 
 - When using [Physical Cluster Replication](https://cockroachlabs.com/docs/v23.2/physical-cluster-replication-overview), you can now [initiate a cutover](https://cockroachlabs.com/docs/v23.2/cutover-replication) as of `LATEST` before the initial scan completes. [#115101][#115101]
-- Sensitive information such as `api_secret`, `sasl_password`, `client_cert`, and `ca_cert`, is now redacted in output from commands `SHOW CHANGEFEED JOB``, `SHOW CHANGEFEED JOBS``, and `SHOW JOBS`. [#115567][#115567]
-
+- Sensitive information such as `api_secret`, `sasl_password`, `client_cert`, and `ca_cert`, is now redacted in output from commands `SHOW CHANGEFEED JOB`, `SHOW CHANGEFEED JOBS`, and `SHOW JOBS`. [#115567][#115567]
+- The `physical_replication.frontier_lag_nanos` metric and the related DB Console graph have been removed because they sometimes display incorrect information. For alerting, it is recommended to use the new metric `physical_replication.replicated_time_seconds` metric instead. [#115234][#115234]
+- Fixes a bug in physical cluster replication where replicating from a source cluster that is on a version prior to v23.2.x to a destination cluster running on v23.2.x could fail because of an undefined builtin function in the source cluster. [#114257][#114257]
 
 <h3 id="v23-2-0-beta-2-db-console-changes">DB Console changes</h3>
 
 - In the [Changeeds dashboard](https://www.cockroachlabs.com/docs/v23.2/ui-cdc-dashboard), the **Max Checkpoint Latency** chart title now refers to "Lag" rather than "Latency", to better reflect the intention of the underlying metric, which measures how recently the changefeed was last checkpointed. [#115003][#115003]
 - Times on the X-Axis of bar charts in **Statement details** pages are now correctly formatted in UTC. [#115220][#115220]
-- The `physical_replication.frontier_lag_nanos` metric and the related DB Console graph have been removed because they sometimes display incorrect information. For alerting, it is recommended to use the new metric `physical_replication.replicated_time_seconds` metric instead. [#115234][#115234]
 - In the **SQL Activity** **Transaction Details** page, you can now view a transaction fingerprint ID across multiple applications by specifying the application name name in the `appNames` URL `GET` parameter using a comma separated encoded string of transaction fingerprint IDs. [#115204][#115204]
 
 <h3 id="v23-2-0-beta-2-bug-fixes">Bug fixes</h3>
@@ -33,7 +33,6 @@ Release Date: December 5, 2023
 - Fixed a bug that could cause cluster version finalization to contend with descriptor lease renewals on large clusters. Descriptor lease renewals previously had a higher priority than cluster upgrade finalization. Finalization now always has a higher priority than descriptor lease renewal. [#115034][#115034]
 - Fixed a bug that prevented backups from distributing work evenly across all replicas, including followers, regardless of leaseholder placement. [#115019][#115019]
 - Fixed a bug introduced in v23.2.0-beta.1 that could cause a single composite-typed variable to be incorrectly handled as the target of a PostgreSQL `INTO` clause. [#115404][#115404]
-- Fixes a bug in physical cluster replication where replicating from a source cluster that is on a version prior to v23.2.x to a destination cluster running on v23.2.x could fail because of an undefined builtin function in the source cluster. [#114257][#114257]
 - Fixed a bug that could cause a `BEGIN` statement log to record incorrect information in the `Age` field, which could also cause them to appear erroneously in slow-query logs. [#115259][#115259]
 
 <h3 id="v23-2-0-beta-2-performance-improvements">Performance improvements</h3>

--- a/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
@@ -7,35 +7,34 @@ Release Date: December 5, 2023
 <h3 id="v23-2-0-beta-2-general-changes">General changes</h3>
 
 - CockroachDB now periodically dumps the state of its internal memory accounting system into the `heap_profiler/` directory when a heap profile is taken. To disable this behavior, set the `diagnostics.memory_monitoring_dumps.enabled` [cluster setting](https://cockroachlabs.com/docs/v23.2/cluster-settings) to `false`. [#114998][#114998]
-- [#115604][#115604] [d4d8f15d7][d4d8f15d7] release-23.2: Revert "s3: disable content pre-upload checksums" (Aditya Maru <adityamaru@gmail.com>)
-- [#115481][#115481] [69b51a5cd][69b51a5cd] release-23.2: storage: disable multi-level compactions (Nick Travers <travers@cockroachlabs.com>)
+- Multi-level compactions have been disabled to investigate possible performance issues with foreground throughput and latency. [#115481][#115481]
 
 <h3 id="v23-2-0-beta-2-enterprise-edition-changes">Enterprise Edition changes</h3>
 
 - When using [Physical Cluster Replication](https://cockroachlabs.com/docs/v23.2/physical-cluster-replication-overview), you can now [initiate a cutover](https://cockroachlabs.com/docs/v23.2/cutover-replication) as of `LATEST` before the initial scan completes. [#115101][#115101]
-- SHOW CHANGEFEED JOB,  SHOW CHANGEFEED JOBS, and SHOW JOBS no longer expose user sensitive infromation(`api_secret`, `sasl_password`, `client_cert`, and `ca_cert`) in the job description and sinkURI output column would reveal sensitive user information (api_secret, sasl_password, client_cert, ca_cert). [#115567][#115567]
+- Sensitive information such as `api_secret`, `sasl_password`, `client_cert`, and `ca_cert`, is now redacted in output from commands `SHOW CHANGEFEED JOB``, `SHOW CHANGEFEED JOBS``, and `SHOW JOBS`. [#115567][#115567]
 
 
 <h3 id="v23-2-0-beta-2-db-console-changes">DB Console changes</h3>
 
 - In the [Changeeds dashboard](https://www.cockroachlabs.com/docs/v23.2/ui-cdc-dashboard), the **Max Checkpoint Latency** chart title now refers to "Lag" rather than "Latency", to better reflect the intention of the underlying metric, which measures how recently the changefeed was last checkpointed. [#115003][#115003]
-- Time on X-Axis of bar charts on Statement details page display correctly formatted time in UTC. [#115220][#115220]
-- This patch remotes the `physical_replication.frontier_lag_nanos` metric and dbconsole graph is it's sometimes wrong. This patch adds `physical_replication.replicated_time_seconds` metric which users may use for alerting. [#115234][#115234]
-- Proper handling of "Now" button on Time range selector when custom time period was selected before. [#115514][#115514]
+- Times on the X-Axis of bar charts in **Statement details** pages are now correctly formatted in UTC. [#115220][#115220]
+- The `physical_replication.frontier_lag_nanos` metric and the related DB Console graph have been removed because they sometimes display incorrect information. For alerting, it is recommended to use the new metric `physical_replication.replicated_time_seconds` metric instead. [#115234][#115234]
+- In the **SQL Activity** **Transaction Details** page, you can now view a transaction fingerprint ID across multiple applications by specifying the application name name in the `appNames` URL `GET` parameter using a comma separated encoded string of transaction fingerprint IDs. [#115204][#115204]
 
 <h3 id="v23-2-0-beta-2-bug-fixes">Bug fixes</h3>
 
+- Fixed a bug that prevented the **Now** button on time range selectors from working as expected when a custom time period was previously selected. [#115514][#115514]
 - Fixed a bug that prevented the **SQL Activity** page from showing internal statements when the `sql.stats.response.show_internal.enabled` [cluster setting](https://cockroachlabs.com/docs/v23.2/cluster-settings) was set to `true`. [#114824][#114824]
 - Fixed a bug where an active replication report update could get stuck in a retry loop on clusters with over 10000 ranges. This could prevent a node from shutting down cleanly. [#114178][#114178]
 - Fixed a bug introduced in v23.1 that could cause an internal error when using the text format (as opposed to binary) when [preparing a statement](https://www.cockroachlabs.com/docs/v23.2/sql-grammar#prepare_stmt) with a user-defined composite type. [#115064][#115064]
 - Fixed a bug that could cause a replica to be stuck processing in a queue's replica set when the replica had recently been removed from purgatory for processing but was destroyed, or the replica's ID changed before being processed. These replicas are now removed from the queue when they are encountered. [#115037][#115037]
 - Fixed a bug that could cause a [prepared statement](https://www.cockroachlabs.com/docs/v23.2/sql-grammar#prepare_stmt) to fail if it references both an `enum` and a table that has undergone a schema change. [#115132][#115132]
-- Addressed a bug that could cause cluster version finalization to get starved out by descriptor lease renewals on larger clusters. [#115034][#115034]
-- Backups now evenly distribute work their work across all replicas, including followers, regardless of leaseholder placement. Epic: none. [#115019][#115019]
-- Fixed a bug present only in the 23.2.0-beta.1 version that caused incorrect handling for a single composite-typed variable as the target of a PLpgSQL `INTO` clause. [#115404][#115404]
-- Fixes a bug where replicating from a source cluster that is on an older version (<23.2) than the destination cluster would fail because of an undefined builtin function [#114257][#114257]
-- In the SQL Activity Transaction Details page, users can now view a transaction fingerprint id across  multiple applications. To do so, they can specify the app name in the `appNames` URL search param using a comma separated encoded string  of transaction fingerprint ids. [#115204][#115204]
-- BEGIN statement logs now have correct query `Age` fields. Previously, these fields were being recorded incorrectly which would lead to some statements also appearing erroneously in the slow query logs. [#115259][#115259]
+- Fixed a bug that could cause cluster version finalization to contend with descriptor lease renewals on large clusters. Descriptor lease renewals previously had a higher priority than cluster upgrade finalization. Finalization now always has a higher priority than descriptor lease renewal. [#115034][#115034]
+- Fixed a bug that prevented backups from distributing work evenly across all replicas, including followers, regardless of leaseholder placement. [#115019][#115019]
+- Fixed a bug introduced in v23.2.0-beta.1 that could cause a single composite-typed variable to be incorrectly handled as the target of a PostgreSQL `INTO` clause. [#115404][#115404]
+- Fixes a bug in physical cluster replication where replicating from a source cluster that is on a version prior to v23.2.x to a destination cluster running on v23.2.x could fail because of an undefined builtin function in the source cluster. [#114257][#114257]
+- Fixed a bug that could cause a `BEGIN` statement log to record incorrect information in the `Age` field, which could also cause them to appear erroneously in slow-query logs. [#115259][#115259]
 
 <h3 id="v23-2-0-beta-2-performance-improvements">Performance improvements</h3>
 
@@ -72,5 +71,4 @@ This release includes 91 merged PRs by 35 authors.
 [#115514]: https://github.com/cockroachdb/cockroach/pull/115514
 [#115567]: https://github.com/cockroachdb/cockroach/pull/115567
 [#115604]: https://github.com/cockroachdb/cockroach/pull/115604
-[69b51a5cd]: https://github.com/cockroachdb/cockroach/commit/69b51a5cd
 [d4d8f15d7]: https://github.com/cockroachdb/cockroach/commit/d4d8f15d7

--- a/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
+++ b/src/current/_includes/releases/v23.2/v23.2.0-beta.2.md
@@ -12,26 +12,26 @@ Release Date: December 5, 2023
 <h3 id="v23-2-0-beta-2-enterprise-edition-changes">Enterprise Edition changes</h3>
 
 - When using [Physical Cluster Replication](https://cockroachlabs.com/docs/v23.2/physical-cluster-replication-overview), you can now [initiate a cutover](https://cockroachlabs.com/docs/v23.2/cutover-replication) as of `LATEST` before the initial scan completes. [#115101][#115101]
-- Sensitive information such as `api_secret`, `sasl_password`, `client_cert`, and `ca_cert`, is now redacted in output from commands `SHOW CHANGEFEED JOB`, `SHOW CHANGEFEED JOBS`, and `SHOW JOBS`. [#115567][#115567]
-- The `physical_replication.frontier_lag_nanos` metric and the related DB Console graph have been removed because they sometimes display incorrect information. For alerting, it is recommended to use the new metric `physical_replication.replicated_time_seconds` metric instead. [#115234][#115234]
-- Fixes a bug in physical cluster replication where replicating from a source cluster that is on a version prior to v23.2.x to a destination cluster running on v23.2.x could fail because of an undefined builtin function in the source cluster. [#114257][#114257]
+- Sensitive information such as `api_secret`, `sasl_password`, `client_cert`, and `ca_cert`, is now redacted in output from commands `SHOW CHANGEFEED JOB`, `SHOW CHANGEFEED JOBS`, and [`SHOW JOBS`](https://cockroachlabs.com/docs/v23.2/show-jobs). [#115567][#115567]
+- The `physical_replication.frontier_lag_nanos` metric and the related DB Console graph have been removed because they sometimes display incorrect information. For [alerting](https://cockroachlabs.com/docs/v23.2/physical-cluster-replication-monitoring#prometheus), it is recommended to use the new metric `physical_replication.replicated_time_seconds` metric instead. [#115234][#115234]
+- Fixed a bug in [physical cluster replication](https://cockroachlabs.com/docs/v23.2/physical-cluster-replication-overview) where replicating from a primary cluster that is on a version prior to v23.2.x to a standby cluster running on v23.2.x could fail because of an undefined builtin function in the primary cluster. [#114257][#114257]
 
 <h3 id="v23-2-0-beta-2-db-console-changes">DB Console changes</h3>
 
 - In the [Changeeds dashboard](https://www.cockroachlabs.com/docs/v23.2/ui-cdc-dashboard), the **Max Checkpoint Latency** chart title now refers to "Lag" rather than "Latency", to better reflect the intention of the underlying metric, which measures how recently the changefeed was last checkpointed. [#115003][#115003]
 - Times on the X-Axis of bar charts in **Statement details** pages are now correctly formatted in UTC. [#115220][#115220]
-- In the **SQL Activity** **Transaction Details** page, you can now view a transaction fingerprint ID across multiple applications by specifying the application name name in the `appNames` URL `GET` parameter using a comma separated encoded string of transaction fingerprint IDs. [#115204][#115204]
+- In the **SQL Activity** **Transaction Details** page, you can now view a transaction fingerprint ID across multiple applications by specifying the application name in the `appNames` URL `GET` parameter using a comma-separated encoded string of transaction fingerprint IDs. [#115204][#115204]
 
 <h3 id="v23-2-0-beta-2-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that prevented the **Now** button on time range selectors from working as expected when a custom time period was previously selected. [#115514][#115514]
+- Fixed a bug that prevented the **Now** button on time range selectors in the DB Console from working as expected when a custom time period was previously selected. [#115514][#115514]
 - Fixed a bug that prevented the **SQL Activity** page from showing internal statements when the `sql.stats.response.show_internal.enabled` [cluster setting](https://cockroachlabs.com/docs/v23.2/cluster-settings) was set to `true`. [#114824][#114824]
 - Fixed a bug where an active replication report update could get stuck in a retry loop on clusters with over 10000 ranges. This could prevent a node from shutting down cleanly. [#114178][#114178]
 - Fixed a bug introduced in v23.1 that could cause an internal error when using the text format (as opposed to binary) when [preparing a statement](https://www.cockroachlabs.com/docs/v23.2/sql-grammar#prepare_stmt) with a user-defined composite type. [#115064][#115064]
 - Fixed a bug that could cause a replica to be stuck processing in a queue's replica set when the replica had recently been removed from purgatory for processing but was destroyed, or the replica's ID changed before being processed. These replicas are now removed from the queue when they are encountered. [#115037][#115037]
 - Fixed a bug that could cause a [prepared statement](https://www.cockroachlabs.com/docs/v23.2/sql-grammar#prepare_stmt) to fail if it references both an `enum` and a table that has undergone a schema change. [#115132][#115132]
 - Fixed a bug that could cause cluster version finalization to contend with descriptor lease renewals on large clusters. Descriptor lease renewals previously had a higher priority than cluster upgrade finalization. Finalization now always has a higher priority than descriptor lease renewal. [#115034][#115034]
-- Fixed a bug that prevented backups from distributing work evenly across all replicas, including followers, regardless of leaseholder placement. [#115019][#115019]
+- Fixed a bug that prevented [backups](https://cockroachlabs.com/docs/v23.2/backup) from distributing work evenly across all replicas, including followers, regardless of leaseholder placement. [#115019][#115019]
 - Fixed a bug introduced in v23.2.0-beta.1 that could cause a single composite-typed variable to be incorrectly handled as the target of a PostgreSQL `INTO` clause. [#115404][#115404]
 - Fixed a bug that could cause a `BEGIN` statement log to record incorrect information in the `Age` field, which could also cause them to appear erroneously in slow-query logs. [#115259][#115259]
 
@@ -70,4 +70,3 @@ This release includes 91 merged PRs by 35 authors.
 [#115514]: https://github.com/cockroachdb/cockroach/pull/115514
 [#115567]: https://github.com/cockroachdb/cockroach/pull/115567
 [#115604]: https://github.com/cockroachdb/cockroach/pull/115604
-[d4d8f15d7]: https://github.com/cockroachdb/cockroach/commit/d4d8f15d7


### PR DESCRIPTION
[[DOC-9307](https://cockroachlabs.atlassian.net/browse/DOC-9307)] Publish release notes for v23.2.0-beta.2

Reverts cockroachdb/docs#18126

Adds new notes in SHA `8497d5eb24d9ff057fc57346ab21c3d796ba05be`, then copyedits them.

**Preview**: [releases/v23.2.md](https://deploy-preview-18129--cockroachdb-docs.netlify.app/docs/releases/v23.2.html)
