### PR TITLE
Add warning for __crdb__ Avro schema field

### DIFF
--- a/src/current/v22.2/changefeed-messages.md
+++ b/src/current/v22.2/changefeed-messages.md
@@ -135,7 +135,7 @@ To ensure that the Avro schemas that CockroachDB publishes will work with the sc
 The original CockroachDB column definition is also included within a doc field `__crdb__` in the schema. This allows CockroachDB to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
 
 {{site.data.alerts.callout_danger}}
-Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between versions of CockroachDB versions.
+Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between CockroachDB versions.
 {{site.data.alerts.end}}
 
 ### Schema changes with column backfill

--- a/src/current/v22.2/changefeed-messages.md
+++ b/src/current/v22.2/changefeed-messages.md
@@ -130,9 +130,13 @@ In v22.1, CockroachDB introduced the [declarative schema changer](online-schema-
 
 ### Avro schema changes
 
-To ensure that the Avro schemas that CockroachDB publishes will work with the schema compatibility rules used by the Confluent schema registry, CockroachDB emits all fields in Avro as nullable unions. This ensures that Avro and Confluent consider the schemas to be both backward- and forward-compatible, since the Confluent Schema Registry has a different set of rules than Avro for schemas to be backward- and forward-compatible.
+To ensure that the Avro schemas that CockroachDB publishes will work with the schema compatibility rules used by the Confluent schema registry, CockroachDB emits all fields in Avro as nullable unions. This ensures that Avro and Confluent consider the schemas to be both backward- and forward-compatible, because the Confluent Schema Registry has a different set of rules than Avro for schemas to be backward- and forward-compatible.
 
-Note that the original CockroachDB column definition is also included in the schema as a doc field, so it's still possible to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
+The original CockroachDB column definition is also included within a doc field `__crdb__` in the schema. This allows CockroachDB to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
+
+{{site.data.alerts.callout_danger}}
+Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between versions of CockroachDB versions.
+{{site.data.alerts.end}}
 
 ### Schema changes with column backfill
 

--- a/src/current/v23.1/changefeed-messages.md
+++ b/src/current/v23.1/changefeed-messages.md
@@ -330,9 +330,13 @@ In v22.1, CockroachDB introduced the [declarative schema changer]({% link {{ pag
 
 ### Avro schema changes
 
-To ensure that the Avro schemas that CockroachDB publishes will work with the schema compatibility rules used by the Confluent schema registry, CockroachDB emits all fields in Avro as nullable unions. This ensures that Avro and Confluent consider the schemas to be both backward- and forward-compatible, since the Confluent Schema Registry has a different set of rules than Avro for schemas to be backward- and forward-compatible.
+To ensure that the Avro schemas that CockroachDB publishes will work with the schema compatibility rules used by the Confluent schema registry, CockroachDB emits all fields in Avro as nullable unions. This ensures that Avro and Confluent consider the schemas to be both backward- and forward-compatible, because the Confluent Schema Registry has a different set of rules than Avro for schemas to be backward- and forward-compatible.
 
-Note that the original CockroachDB column definition is also included in the schema as a doc field, so it's still possible to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
+The original CockroachDB column definition is also included within a doc field `__crdb__` in the schema. This allows CockroachDB to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
+
+{{site.data.alerts.callout_danger}}
+Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between versions of CockroachDB versions.
+{{site.data.alerts.end}}
 
 ### Schema changes with column backfill
 

--- a/src/current/v23.1/changefeed-messages.md
+++ b/src/current/v23.1/changefeed-messages.md
@@ -335,7 +335,7 @@ To ensure that the Avro schemas that CockroachDB publishes will work with the sc
 The original CockroachDB column definition is also included within a doc field `__crdb__` in the schema. This allows CockroachDB to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
 
 {{site.data.alerts.callout_danger}}
-Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between versions of CockroachDB versions.
+Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between CockroachDB versions.
 {{site.data.alerts.end}}
 
 ### Schema changes with column backfill

--- a/src/current/v23.2/changefeed-messages.md
+++ b/src/current/v23.2/changefeed-messages.md
@@ -327,9 +327,13 @@ In v22.1, CockroachDB introduced the [declarative schema changer]({% link {{ pag
 
 ### Avro schema changes
 
-To ensure that the Avro schemas that CockroachDB publishes will work with the schema compatibility rules used by the Confluent schema registry, CockroachDB emits all fields in Avro as nullable unions. This ensures that Avro and Confluent consider the schemas to be both backward- and forward-compatible, since the Confluent Schema Registry has a different set of rules than Avro for schemas to be backward- and forward-compatible.
+To ensure that the Avro schemas that CockroachDB publishes will work with the schema compatibility rules used by the Confluent schema registry, CockroachDB emits all fields in Avro as nullable unions. This ensures that Avro and Confluent consider the schemas to be both backward- and forward-compatible, because the Confluent Schema Registry has a different set of rules than Avro for schemas to be backward- and forward-compatible.
 
-Note that the original CockroachDB column definition is also included in the schema as a doc field, so it's still possible to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
+The original CockroachDB column definition is also included within a doc field `__crdb__` in the schema. This allows CockroachDB to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
+
+{{site.data.alerts.callout_danger}}
+Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between versions of CockroachDB versions.
+{{site.data.alerts.end}}
 
 ### Schema changes with column backfill
 

--- a/src/current/v23.2/changefeed-messages.md
+++ b/src/current/v23.2/changefeed-messages.md
@@ -332,7 +332,7 @@ To ensure that the Avro schemas that CockroachDB publishes will work with the sc
 The original CockroachDB column definition is also included within a doc field `__crdb__` in the schema. This allows CockroachDB to distinguish between a `NOT NULL` CockroachDB column and a `NULL` CockroachDB column.
 
 {{site.data.alerts.callout_danger}}
-Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between versions of CockroachDB versions.
+Schema validation tools should ignore the `__crdb__` field. This is an internal CockroachDB schema type description that may change between CockroachDB versions.
 {{site.data.alerts.end}}
 
 ### Schema changes with column backfill


### PR DESCRIPTION
Fixes DOC-9221, DOC-9247

Adds a warning regarding the `__crdb__` field that is emitted in changefeed messages in Avro format. 