### PR TITLE
Replace the lag nanos metric pcr

### DIFF
--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -99,7 +99,7 @@ We recommend tracking the following metrics:
 
 - `physical_replication.logical_bytes`: The logical bytes (the sum of all keys and values) ingested by all physical cluster replication jobs.
 - `physical_replication.sst_bytes`: The [SST]({% link {{ page.version.version }}/architecture/storage-layer.md %}#ssts) bytes (compressed) sent to the KV layer by all physical cluster replication jobs.
-- `physical_replication.frontier_lag_nanos`: The time between the actual time (now) and `replicated_time` of the replication stream. That is, this metric tracks how far behind the replication stream is relative to now.
+- `physical_replication.replicated_time_seconds`: The [replicated time]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#cutover-and-promotion-process) of the physical replication stream in seconds since the Unix epoch.
 
 ## See also
 


### PR DESCRIPTION
Fixes DOC-9304

Replaces the `physical_replication.frontier_lag_nanos` metric for `physical_replication.replicated_time_seconds` in the physical cluster replication docs.