### PR TITLE
DOC-7437 PR #99719 - ui: use app name of selected row when fetching fingerprint details

### DIFF
--- a/src/current/_includes/v23.1/ui/statement-details.md
+++ b/src/current/_includes/v23.1/ui/statement-details.md
@@ -2,7 +2,7 @@
 
 ## Statement Fingerprint page
 
-The details displayed on the **Statement Fingerprint** page reflect the [time interval](#time-interval) selected on the **Statements** page.
+The details displayed on the **Statement Fingerprint** page reflect the [time interval](#time-interval) selected on the **Statements** page and the application name and database specified in the selected row of the [Statements table](#statements-table).
 
 ### Overview
 
@@ -26,6 +26,7 @@ The following screenshot shows the statement fingerprint of the query described 
 #### Insights
 
 The **Insights** table is displayed when CockroachDB has detected a problem with the statement fingerprint.
+
 - **Insights**: Provides the [Workload Insight type]({{ link_prefix }}ui-insights-page.html#workload-insight-types).
 - **Details**: Provides a description and possible recommendation.
 - **Latest Execution ID**: The ID of the latest statement execution. To display the details of the [statement execution]({{ link_prefix }}ui-insights-page.html#statement-execution-details), click the ID.

--- a/src/current/_includes/v23.1/ui/statements-table.md
+++ b/src/current/_includes/v23.1/ui/statements-table.md
@@ -6,7 +6,7 @@ The Statements table gives details for each SQL statement fingerprint:
 
 Column | Description
 -----|------------
-Statements | SQL statement [fingerprint](#sql-statement-fingerprints). To view additional details, click the SQL statement fingerprint to open its [Statement Fingerprint page]({{ page_prefix }}statements-page.html#statement-fingerprint-page).
+Statements | SQL statement [fingerprint](#sql-statement-fingerprints). To view additional details, click the SQL statement fingerprint to open its [Statement Fingerprint page]({{ page_prefix }}statements-page.html#statement-fingerprint-page).<br><br>Statement fingerprints are displayed per application rather than grouped into a single fingerprint. This may result in multiple rows for the same statement fingerprint, one per application name.
 Execution Count | Cumulative number of executions of statements with this fingerprint within the [time interval](#time-interval). <br><br>The bar indicates the ratio of runtime success (gray) to [retries]({{ link_prefix }}transactions.html#transaction-retries) (red) for the SQL statement fingerprint.
 Database | The database in which the statement was executed.
 Application Name | The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.

--- a/src/current/_includes/v23.1/ui/transaction-details.md
+++ b/src/current/_includes/v23.1/ui/transaction-details.md
@@ -1,6 +1,6 @@
 ## Transaction Details page
 
-The details displayed on the **Transaction Details** page reflect the [time interval](#time-interval) selected on the **Transactions** page.
+The details displayed on the **Transaction Details** page reflect the [time interval](#time-interval) selected on the **Transactions** page and the application name and database specified in the selected row of the [Transactions table](#transactions-table).
 
 - The _transaction fingerprint_ is displayed as a list of the individual [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints) in the transaction.
 - The **Mean transaction time**: The mean average time it took to execute the transaction within the aggregation interval.

--- a/src/current/_includes/v23.1/ui/transactions-table.md
+++ b/src/current/_includes/v23.1/ui/transactions-table.md
@@ -6,7 +6,7 @@ The Transactions table gives details for each transaction fingerprint in the tra
 
 Column | Description
 -----|------------
-Transactions | The [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints) that make up the transaction. To view the transaction fingerprint and details, click to open the [Transaction Details page](#transaction-details-page).
+Transactions | The [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints) that make up the transaction. To view the transaction fingerprint and details, click to open the [Transaction Details page](#transaction-details-page).<br><br>Transaction fingerprints are displayed per application rather than grouped into a single fingerprint. This may result in multiple rows for the same transaction fingerprint, one per application name.
 Execution Count | Cumulative number of executions of this transaction within the [time interval](#time-interval). <br><br>The bar indicates the ratio of runtime success (gray) to [retries]({{ link_prefix }}transactions.html#transaction-retries) (red) for the transaction.
 Application Name | The name specified by the [`application_name` session setting]({{ link_prefix }}show-vars.html#supported-variables).
 Rows Processed | Average number of rows read and written while executing statements with this fingerprint within the time interval.

--- a/src/current/_includes/v23.2/ui/statement-details.md
+++ b/src/current/_includes/v23.2/ui/statement-details.md
@@ -2,7 +2,7 @@
 
 ## Statement Fingerprint page
 
-The details displayed on the **Statement Fingerprint** page reflect the [time interval](#time-interval) selected on the **Statements** page.
+The details displayed on the **Statement Fingerprint** page reflect the [time interval](#time-interval) selected on the **Statements** page and the application name and database specified in the selected row of the [Statements table](#statements-table).
 
 ### Overview
 

--- a/src/current/_includes/v23.2/ui/statements-table.md
+++ b/src/current/_includes/v23.2/ui/statements-table.md
@@ -6,7 +6,7 @@ The Statements table gives details for each SQL statement fingerprint:
 
 Column | Description
 -----|------------
-Statements | SQL statement [fingerprint](#sql-statement-fingerprints). To view additional details, click the SQL statement fingerprint to open its [Statement Fingerprint page]({{ page_prefix }}statements-page.html#statement-fingerprint-page).
+Statements | SQL statement [fingerprint](#sql-statement-fingerprints). To view additional details, click the SQL statement fingerprint to open its [Statement Fingerprint page]({{ page_prefix }}statements-page.html#statement-fingerprint-page).<br><br>Statement fingerprints are displayed per application rather than grouped into a single fingerprint. This may result in multiple rows for the same statement fingerprint, one per application name.
 Execution Count | Cumulative number of executions of statements with this fingerprint within the [time interval](#time-interval). <br><br>The bar indicates the ratio of runtime success (gray) to [retries]({{ link_prefix }}transactions.html#transaction-retries) (red) for the SQL statement fingerprint.
 Database | The database in which the statement was executed.
 Application Name | The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.

--- a/src/current/_includes/v23.2/ui/transaction-details.md
+++ b/src/current/_includes/v23.2/ui/transaction-details.md
@@ -1,6 +1,6 @@
 ## Transaction Details page
 
-The details displayed on the **Transaction Details** page reflect the [time interval](#time-interval) selected on the **Transactions** page.
+The details displayed on the **Transaction Details** page reflect the [time interval](#time-interval) selected on the **Transactions** page and the application name and database specified in the selected row of the [Transactions table](#transactions-table).
 
 - The _transaction fingerprint_ is displayed as a list of the individual [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints) in the transaction.
 - The **Mean transaction time**: The mean average time it took to execute the transaction within the aggregation interval.

--- a/src/current/_includes/v23.2/ui/transactions-table.md
+++ b/src/current/_includes/v23.2/ui/transactions-table.md
@@ -6,7 +6,7 @@ The Transactions table gives details for each transaction fingerprint in the tra
 
 Column | Description
 -----|------------
-Transactions | The [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints) that make up the transaction. To view the transaction fingerprint and details, click to open the [Transaction Details page](#transaction-details-page).
+Transactions | The [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints) that make up the transaction. To view the transaction fingerprint and details, click to open the [Transaction Details page](#transaction-details-page).<br><br>Transaction fingerprints are displayed per application rather than grouped into a single fingerprint. This may result in multiple rows for the same transaction fingerprint, one per application name.
 Execution Count | Cumulative number of executions of this transaction within the [time interval](#time-interval). <br><br>The bar indicates the ratio of runtime success (gray) to [retries]({{ link_prefix }}transactions.html#transaction-retries) (red) for the transaction.
 Application Name | The name specified by the [`application_name` session setting]({{ link_prefix }}show-vars.html#supported-variables).
 Rows Processed | Average number of rows read and written while executing statements with this fingerprint within the time interval.


### PR DESCRIPTION
Fixes DOC-7437

For Statements and Transactions pages, updated include files to indicate that corresponding fingerprint details page reflects specified application name and database.