### PR TITLE
Add reference to metrics on primary and standby during cutover

### DIFF
--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -15,13 +15,17 @@ docs_area: manage
 - The [Physical Replication dashboard](#db-console) on the DB Console.
 - [Prometheus and Alertmanager](#prometheus) to track and alert on replication metrics.
 
+When you complete a [cutover]({% link {{ page.version.version }}/cutover-replication.md %}) to the primary cluster, there will be a gap in the primary cluster's metrics whether you are monitoring via the [DB Console](#db-console) or [Prometheus](#prometheus).
+
+The standby cluster will also require separate monitoring to ensure observability during the cutover period. You can use the DB console to track the relevant metrics, or you can use a tool like [Grafana]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %}#step-5-visualize-metrics-in-grafana) to create two separate dashboards, one for each cluster, or a single dashboard with data from both clusters.
+
 ## SQL Shell
 
 In the standby cluster's SQL shell, you can query `SHOW VIRTUAL CLUSTER ... WITH REPLICATION STATUS` for detail on status and timestamps for planning [cutover]({% link {{ page.version.version }}/cutover-replication.md %}):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
- SHOW VIRTUAL CLUSTER standbyapplication WITH REPLICATION STATUS;
+SHOW VIRTUAL CLUSTER standbyapplication WITH REPLICATION STATUS;
 ~~~
 
 Refer to [Responses](#responses) for a description of each field.

--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -15,7 +15,7 @@ docs_area: manage
 - The [Physical Replication dashboard](#db-console) on the DB Console.
 - [Prometheus and Alertmanager](#prometheus) to track and alert on replication metrics.
 
-When you complete a [cutover]({% link {{ page.version.version }}/cutover-replication.md %}) to the primary cluster, there will be a gap in the primary cluster's metrics whether you are monitoring via the [DB Console](#db-console) or [Prometheus](#prometheus).
+When you complete a [cutover]({% link {{ page.version.version }}/cutover-replication.md %}), there will be a gap in the primary cluster's metrics whether you are monitoring via the [DB Console](#db-console) or [Prometheus](#prometheus).
 
 The standby cluster will also require separate monitoring to ensure observability during the cutover period. You can use the DB console to track the relevant metrics, or you can use a tool like [Grafana]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %}#step-5-visualize-metrics-in-grafana) to create two separate dashboards, one for each cluster, or a single dashboard with data from both clusters.
 


### PR DESCRIPTION
Fixes DOC-9168

This PR adds a reference (on the physical cluster replication page) to metrics during the cutover period for the primary and standby clusters.

This came about after a customer asked what happens to metrics in the case where they fail over and then fail back to the primary cluster.