### PR TITLE
Mention that we don't support Advisory Lock Functions

### DIFF
--- a/src/current/_includes/v22.2/sql/unsupported-postgres-features.md
+++ b/src/current/_includes/v22.2/sql/unsupported-postgres-features.md
@@ -15,3 +15,4 @@
 - Creating a database from a template.
 - [Dropping a single partition from a table](partitioning.html#known-limitations).
 - Foreign data wrappers.
+- Advisory Lock Functions (although some functions are defined with no-op implementations).

--- a/src/current/_includes/v23.1/sql/unsupported-postgres-features.md
+++ b/src/current/_includes/v23.1/sql/unsupported-postgres-features.md
@@ -12,3 +12,4 @@
 - Creating a database from a template.
 - [Dropping a single partition from a table]({% link {{ page.version.version }}/partitioning.md %}#known-limitations).
 - Foreign data wrappers.
+- Advisory Lock Functions (although some functions are defined with no-op implementations).

--- a/src/current/_includes/v23.2/sql/unsupported-postgres-features.md
+++ b/src/current/_includes/v23.2/sql/unsupported-postgres-features.md
@@ -12,3 +12,4 @@
 - Creating a database from a template.
 - [Dropping a single partition from a table]({% link {{ page.version.version }}/partitioning.md %}#known-limitations).
 - Foreign data wrappers.
+- Advisory Lock Functions (although some functions are defined with no-op implementations).


### PR DESCRIPTION
We defined some builtins around pg_advisory locks, but they are no-ops, and some functions are not even defined. This commit adds this limitation to unsupported postgres features.

See https://github.com/cockroachdb/cockroach/issues/13546.