### PR TITLE
DOC-9326 Feedback: Statements Page and Transactions Page

### DIFF
--- a/src/current/_includes/v23.1/ui/active-statement-executions.md
+++ b/src/current/_includes/v23.1/ui/active-statement-executions.md
@@ -10,7 +10,7 @@ Statement Execution | The SQL statement that was executed.
 Status | The status of the execution: `Preparing`, `Waiting`, or `Executing`.
 Start Time (UTC) | The timestamp when the execution started.
 Time Spent Waiting | The time the execution spent waiting and experiencing [lock contention]({{ link_prefix }}performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
-Application | The name specified by the [`application_name`]({% link {{ page.version.version }}/show-vars.md %}#supported-variables) session setting.
+Application | The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
 
 To view details of an active statement execution, click an execution ID in the **Statement Execution ID** column to open the [**Statement Execution** details page](#statement-execution-details-page).
 
@@ -25,8 +25,8 @@ The statement execution details page provides the following details on the state
 - **Application Name**: The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
 - **User Name**: The name of the user running the statement.
 - **Client Address**: The IP address and port of the client that opened the session in which the statement is running.
-- **Session ID**: Link to the [session]({% link {{ page.version.version }}/ui-sessions-page.md %}) in which the transaction is running.
-- **Transaction Execution ID**: Link to the ID of the [transaction]({% link {{ page.version.version }}/ui-transactions-page.md %}#active-executions-table) in which the statement is executing.
+- **Session ID**: Link to the [session]({{ link_prefix }}ui-sessions-page.html) in which the transaction is running.
+- **Transaction Execution ID**: Link to the ID of the [transaction]({{ link_prefix }}ui-transactions-page.html#active-executions-table) in which the statement is executing.
 
 If a statement execution is waiting, the statement execution details are followed by Contention Insights and details of the statement execution on which the blocked statement execution is waiting. For more information about contention, see [Understanding and avoiding transaction contention]({{ link_prefix }}performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
 

--- a/src/current/_includes/v23.1/ui/active-transaction-executions.md
+++ b/src/current/_includes/v23.1/ui/active-transaction-executions.md
@@ -14,7 +14,7 @@ Elapsed Time | The time elapsed since the transaction started.
 Time Spent Waiting | The amount of time the execution experienced [lock contention]({{ link_prefix }}performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
 Statements | The number of statements in the transaction.
 Retries | The number of times statements in the transaction were retried.
-Application | The name specified by the [`application_name`]({% link {{ page.version.version }}/show-vars.md %}#supported-variables) session setting.
+Application | The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
 
 To view details of an active transaction execution, click an execution ID in the **Transaction Execution ID** column to open the [**Transaction Execution** details page](#transaction-execution-details-page).
 
@@ -25,13 +25,13 @@ The transaction execution details page provides the following details on the tra
 - **Start Time (UTC)**: The timestamp when the execution started.
 - **Elapsed Time**: The time elapsed since the transaction started.
 - **Status**: The status of the execution: `Preparing`, `Waiting`, or `Executing`.
-- **Priority**: The [priority]({% link {{ page.version.version }}/transactions.md %}#transaction-priorities) of the transaction.
+- **Priority**: The [priority]({{ link_prefix }}transactions.html#transaction-priorities) of the transaction.
 - **Internal Retries**: The number of retries of statements in the transaction.
-- **Last Retry Reason**: The [reason]({% link {{ page.version.version }}/transaction-retry-error-reference.md %}) for the last statement retry.
+- **Last Retry Reason**: The [reason]({{ link_prefix }}transaction-retry-error-reference.html) for the last statement retry.
 - **Number of Statements**: The number of statements in the transaction.
 - **Application Name**: The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
-- **Most Recent Statement Execution ID**: Link to the ID of the most recently [executed statement]({% link {{ page.version.version }}/ui-statements-page.md %}#active-executions-table) in the transaction.
-- **Session ID**: Link to the ID of the [session]({% link {{ page.version.version }}/ui-sessions-page.md %}) in which the transaction is running.
+- **Most Recent Statement Execution ID**: Link to the ID of the most recently [executed statement]({{ page_prefix }}statements-page.html#active-executions-table) in the transaction.
+- **Session ID**: Link to the ID of the [session]({{ page_prefix }}sessions-page.html) in which the transaction is running.
 
 If a transaction execution is waiting, the transaction execution details are followed by Contention Insights and details of the transaction execution on which the blocked transaction execution is waiting. For more information about contention, see [Transaction contention]({{ link_prefix }}performance-best-practices-overview.html#transaction-contention).
 

--- a/src/current/_includes/v23.1/ui/statements-filter.md
+++ b/src/current/_includes/v23.1/ui/statements-filter.md
@@ -1,11 +1,3 @@
-{% if page.cloud == true %}
-  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
-  {% assign page_prefix = "" %}
-{% else %}
-  {% assign link_prefix = "" %}
-  {% assign page_prefix = "ui-" %}
-{% endif %}
-
 ## Statement Fingerprints results
 
 The statement fingerprints returned are determined by the selected **Search Criteria**.

--- a/src/current/_includes/v23.1/ui/statements-views.md
+++ b/src/current/_includes/v23.1/ui/statements-views.md
@@ -1,0 +1,73 @@
+{% if page.cloud == true %}
+  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
+  {% assign page_prefix = "" %}
+{% else %}
+  {% assign link_prefix = "" %}
+  {% assign page_prefix = "ui-" %}
+{% endif %}
+
+The **Statements** page provides information about the execution of SQL statements in your cluster, using data in the cluster's [`crdb_internal` system catalog]({{ link_prefix }}monitoring-and-alerting.html#crdb_internal-system-catalog).
+{%- if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. The **Statements** tab is selected.
+{% else %}
+To view this page, select a cluster from the [**Clusters** page]({% link cockroachcloud/cluster-management.md %}#view-clusters-page), and click **SQL Activity** in the **Monitoring** section of the left side navigation. The **Statements** tab is selected.
+{% endif %}
+
+It offers two views:
+
+- **Statement Fingerprints** show information about completed SQL statements.
+- **Active Executions** show information about SQL statements which are currently executing.
+
+Choose a view by selecting the **Statement Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
+
+{{site.data.alerts.callout_success}}
+If you haven't yet executed any queries in the cluster as a user, this page will be blank.
+{{site.data.alerts.end}}
+
+## Statement Fingerprints view
+
+The **Statements Fingerprints** view helps you:
+
+- Identify frequently executed or high latency [SQL statements]({{ link_prefix}}sql-statements.html).
+- View SQL statement fingerprint [details](#statement-fingerprint-page).
+- Download SQL statement [diagnostics](#diagnostics) for troubleshooting.
+
+{% if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+The **Statements** tab is selected. The **Statement Fingerprints** radio button is selected and the [Statements table](#statements-table) displays.
+
+The following screenshot shows the statement fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({{ link_prefix}}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.1/statement-fingerprint.png' | relative_url }}" alt="Statement fingerprint" style="border:1px solid #eee;max-width:100%" />
+
+If you click the statement fingerprint in the **Statements** column, the [**Statement Fingerprint** page](#statement-fingerprint-page) displays.
+
+<img src="{{ 'images/v23.1/statement-details.png' | relative_url }}" alt="Statement details" style="border:1px solid #eee;max-width:100%" />
+
+## Active Executions view
+
+The **Active Executions** view helps you:
+
+- Understand and tune workload performance, particularly for long-running statements.
+
+{% if page.cloud != true %}
+To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+The **Statements** tab is selected. Click the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
+
+{{site.data.alerts.callout_info}}
+Active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
+{{site.data.alerts.end}}
+
+The following screenshot shows the active statement execution for `SELECT city, id FROM vehicles WHERE city = 'washington dc'` while running the [`movr` workload]({{ link_prefix }}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.1/statement-execution.png' | relative_url }}" alt="Statement execution" style="border:1px solid #eee;max-width:100%" />
+
+If you click the execution ID in the **Statement Execution ID** column, the [**Statement Execution** details page](#statement-execution-details-page) displays.
+
+<img src="{{ 'images/v23.1/statement-execution-details.png' | relative_url }}" alt="Statement execution details" style="border:1px solid #eee;max-width:100%" />

--- a/src/current/_includes/v23.1/ui/transactions-filter.md
+++ b/src/current/_includes/v23.1/ui/transactions-filter.md
@@ -1,11 +1,3 @@
-{% if page.cloud == true %}
-  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
-  {% assign page_prefix = "" %}
-{% else %}
-  {% assign link_prefix = "" %}
-  {% assign page_prefix = "ui-" %}
-{% endif %}
-
 ## Transaction Fingerprints results
 
 The transaction fingerprints returned are determined by the selected **Search Criteria**:

--- a/src/current/_includes/v23.1/ui/transactions-views.md
+++ b/src/current/_includes/v23.1/ui/transactions-views.md
@@ -1,0 +1,73 @@
+{% if page.cloud == true %}
+  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
+  {% assign page_prefix = "" %}
+{% else %}
+  {% assign link_prefix = "" %}
+  {% assign page_prefix = "ui-" %}
+{% endif %}
+
+The **Transactions** page provides information about the execution of SQL transactions in your cluster, using data in the cluster's [`crdb_internal` system catalog]({{ link_prefix }}monitoring-and-alerting.html#crdb_internal-system-catalog).
+{%- if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. Click the **Transactions** tab.
+{% else %}
+To view this page, select a cluster from the [**Clusters** page]({% link cockroachcloud/cluster-management.md %}#view-clusters-page), and click **SQL Activity** in the **Monitoring** section of the left side navigation. Select the **Transactions** tab.
+{% endif %}
+
+It offers two views:
+
+- **Transaction Fingerprints** show information about completed SQL transactions.
+- **Active Executions**, show information about SQL transactions which are currently executing.
+
+Choose a view by selecting the **Transaction Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
+
+{{site.data.alerts.callout_success}}
+In contrast to the [**Statements** page]({{ page_prefix }}statements-page.html), which displays [SQL statement fingerprints]{{ page_prefix }}statements-page.html#sql-statement-fingerprints), the **Transactions** page displays _transaction fingerprints_, which are SQL statement fingerprints grouped by [transaction]({{ link_prefix }}transactions.html).
+{{site.data.alerts.end}}
+
+## Transaction Fingerprints view
+
+The **Transaction Fingerprints** view helps you:
+
+- Identify frequently [retried]({{ link_prefix }}transactions.html#transaction-retries) transactions.
+- [Troubleshoot]({{ link_prefix }}query-behavior-troubleshooting.html) high-latency transactions or execution failures.
+- View transaction [details](#transaction-details-page).
+
+{% if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+Click the **Transactions** tab. The **Transaction Fingerprints** radio button is selected and the [Transactions table](#transactions-table) displays.
+
+The following screenshot shows the transaction fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({{ link_prefix }}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.1/transaction-fingerprint.png' | relative_url }}" alt="Transaction fingerprint" style="border:1px solid #eee;max-width:100%" />
+
+If you click the transaction fingerprint in the **Transactions** column, the [**Transaction Details** page](#transaction-details-page) displays.
+
+<img src="{{ 'images/v23.1/transaction-details.png' | relative_url }}" alt="Transaction details" style="border:1px solid #eee;max-width:100%" />
+
+## Active Executions view
+
+The **Active Executions** view helps you:
+
+- Understand and tune workload performance, particularly for long-running transactions.
+
+{% if page.cloud != true %}
+To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+The **Statements** tab is selected. Click the **Transactions** tab and the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
+
+{{site.data.alerts.callout_info}}
+Active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
+{{site.data.alerts.end}}
+
+The following screenshot shows the active statement execution for `SELECT city, id FROM vehicles WHERE city = 'los angeles'` while running the [`movr` workload]({{ link_prefix }}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.1/transaction-execution.png' | relative_url }}" alt="Transaction execution" style="border:1px solid #eee;max-width:100%" />
+
+If you click the execution ID in the **Transaction Execution ID** column, the [**Transaction Execution** details page](#transaction-execution-details-page) displays.
+
+<img src="{{ 'images/v23.1/transaction-execution-details.png' | relative_url }}" alt="Transaction execution details" style="border:1px solid #eee;max-width:100%" />

--- a/src/current/_includes/v23.2/ui/active-statement-executions.md
+++ b/src/current/_includes/v23.2/ui/active-statement-executions.md
@@ -10,7 +10,7 @@ Statement Execution | The SQL statement that was executed.
 Status | The status of the execution: `Preparing`, `Waiting`, or `Executing`.
 Start Time (UTC) | The timestamp when the execution started.
 Time Spent Waiting | The time the execution spent waiting and experiencing [lock contention]({{ link_prefix }}performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
-Application | The name specified by the [`application_name`]({% link {{ page.version.version }}/show-vars.md %}#supported-variables) session setting.
+Application | The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
 
 To view details of an active statement execution, click an execution ID in the **Statement Execution ID** column to open the [**Statement Execution** details page](#statement-execution-details-page).
 
@@ -25,8 +25,8 @@ The statement execution details page provides the following details on the state
 - **Application Name**: The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
 - **User Name**: The name of the user running the statement.
 - **Client Address**: The IP address and port of the client that opened the session in which the statement is running.
-- **Session ID**: Link to the [session]({% link {{ page.version.version }}/ui-sessions-page.md %}) in which the transaction is running.
-- **Transaction Execution ID**: Link to the ID of the [transaction]({% link {{ page.version.version }}/ui-transactions-page.md %}#active-executions-table) in which the statement is executing.
+- **Session ID**: Link to the [session]({{ link_prefix }}ui-sessions-page.html) in which the transaction is running.
+- **Transaction Execution ID**: Link to the ID of the [transaction]({{ link_prefix }}ui-transactions-page.html#active-executions-table) in which the statement is executing.
 
 If a statement execution is waiting, the statement execution details are followed by Contention Insights and details of the statement execution on which the blocked statement execution is waiting. For more information about contention, see [Understanding and avoiding transaction contention]({{ link_prefix }}performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
 

--- a/src/current/_includes/v23.2/ui/active-transaction-executions.md
+++ b/src/current/_includes/v23.2/ui/active-transaction-executions.md
@@ -14,7 +14,7 @@ Elapsed Time | The time elapsed since the transaction started.
 Time Spent Waiting | The amount of time the execution experienced [lock contention]({{ link_prefix }}performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
 Statements | The number of statements in the transaction.
 Retries | The number of times statements in the transaction were retried.
-Application | The name specified by the [`application_name`]({% link {{ page.version.version }}/show-vars.md %}#supported-variables) session setting.
+Application | The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
 
 To view details of an active transaction execution, click an execution ID in the **Transaction Execution ID** column to open the [**Transaction Execution** details page](#transaction-execution-details-page).
 
@@ -25,13 +25,13 @@ The transaction execution details page provides the following details on the tra
 - **Start Time (UTC)**: The timestamp when the execution started.
 - **Elapsed Time**: The time elapsed since the transaction started.
 - **Status**: The status of the execution: `Preparing`, `Waiting`, or `Executing`.
-- **Priority**: The [priority]({% link {{ page.version.version }}/transactions.md %}#transaction-priorities) of the transaction.
+- **Priority**: The [priority]({{ link_prefix }}transactions.html#transaction-priorities) of the transaction.
 - **Internal Retries**: The number of retries of statements in the transaction.
-- **Last Retry Reason**: The [reason]({% link {{ page.version.version }}/transaction-retry-error-reference.md %}) for the last statement retry.
+- **Last Retry Reason**: The [reason]({{ link_prefix }}transaction-retry-error-reference.html) for the last statement retry.
 - **Number of Statements**: The number of statements in the transaction.
 - **Application Name**: The name specified by the [`application_name`]({{ link_prefix }}show-vars.html#supported-variables) session setting.
-- **Most Recent Statement Execution ID**: Link to the ID of the most recently [executed statement]({% link {{ page.version.version }}/ui-statements-page.md %}#active-executions-table) in the transaction.
-- **Session ID**: Link to the ID of the [session]({% link {{ page.version.version }}/ui-sessions-page.md %}) in which the transaction is running.
+- **Most Recent Statement Execution ID**: Link to the ID of the most recently [executed statement]({{ page_prefix }}statements-page.html#active-executions-table) in the transaction.
+- **Session ID**: Link to the ID of the [session]({{ page_prefix }}sessions-page.html) in which the transaction is running.
 
 If a transaction execution is waiting, the transaction execution details are followed by Contention Insights and details of the transaction execution on which the blocked transaction execution is waiting. For more information about contention, see [Transaction contention]({{ link_prefix }}performance-best-practices-overview.html#transaction-contention).
 

--- a/src/current/_includes/v23.2/ui/statements-filter.md
+++ b/src/current/_includes/v23.2/ui/statements-filter.md
@@ -1,11 +1,3 @@
-{% if page.cloud == true %}
-  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
-  {% assign page_prefix = "" %}
-{% else %}
-  {% assign link_prefix = "" %}
-  {% assign page_prefix = "ui-" %}
-{% endif %}
-
 ## Statement Fingerprints results
 
 The statement fingerprints returned are determined by the selected **Search Criteria**.

--- a/src/current/_includes/v23.2/ui/statements-views.md
+++ b/src/current/_includes/v23.2/ui/statements-views.md
@@ -1,0 +1,79 @@
+{% if page.cloud == true %}
+  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
+  {% assign page_prefix = "" %}
+{% else %}
+  {% assign link_prefix = "" %}
+  {% assign page_prefix = "ui-" %}
+{% endif %}
+
+The **Statements** page provides information about the execution of SQL statements in your cluster, using data in the cluster's [`crdb_internal` system catalog]({{ link_prefix }}monitoring-and-alerting.html#crdb_internal-system-catalog).
+{%- if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. The **Statements** tab is selected.
+{% else %}
+To view this page, select a cluster from the [**Clusters** page]({% link cockroachcloud/cluster-management.md %}#view-clusters-page), and click **SQL Activity** in the **Monitoring** section of the left side navigation. The **Statements** tab is selected.
+{% endif %}
+
+It offers two views:
+
+- **Statement Fingerprints** show information about completed SQL statements.
+- **Active Executions** show information about SQL statements which are currently executing.
+
+Choose a view by selecting the **Statement Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
+
+{{site.data.alerts.callout_success}}
+If you haven't yet executed any queries in the cluster as a user, this page will be blank.
+{{site.data.alerts.end}}
+
+## Statement Fingerprints view
+
+The **Statements Fingerprints** view helps you:
+
+- Identify frequently executed or high latency [SQL statements]({{ link_prefix}}sql-statements.html).
+- View SQL statement fingerprint [details](#statement-fingerprint-page).
+- Download SQL statement [diagnostics](#diagnostics) for troubleshooting.
+
+{% if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+The **Statements** tab is selected. The **Statement Fingerprints** radio button is selected and the [Statements table](#statements-table) displays.
+
+The following screenshot shows the statement fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({{ link_prefix}}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.2/statement-fingerprint.png' | relative_url }}" alt="Statement fingerprint" style="border:1px solid #eee;max-width:100%" />
+
+If you click the statement fingerprint in the **Statements** column, the [**Statement Fingerprint** page](#statement-fingerprint-page) displays.
+
+<img src="{{ 'images/v23.2/statement-details.png' | relative_url }}" alt="Statement details" style="border:1px solid #eee;max-width:100%" />
+
+## Active Executions view
+
+The **Active Executions** view helps you:
+
+- Understand and tune workload performance, particularly for long-running statements.
+
+{% if page.cloud != true %}
+To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+The **Statements** tab is selected. Click the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
+
+{{site.data.alerts.callout_info}}
+When Auto [Refresh](#refresh) is On, active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
+{{site.data.alerts.end}}
+
+The following screenshot shows the active statement execution for `INSERT INTO users VALUES ($1, $2, $3, $4, $5)` while running the [`movr` workload]({{ link_prefix }}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.2/statement-execution.png' | relative_url }}" alt="Statement execution" style="border:1px solid #eee;max-width:100%" />
+
+If you click the execution ID in the **Statement Execution ID** column, the [**Statement Execution** details page](#statement-execution-details-page) displays.
+
+<img src="{{ 'images/v23.2/statement-execution-details.png' | relative_url }}" alt="Statement execution details" style="border:1px solid #eee;max-width:100%" />
+
+{% if page.cloud != true %}
+{% include {{ page.version.version }}/ui/refresh.md %}
+{% else %}
+{% include {{ site.current_cloud_version }}/ui/refresh.md %}
+{% endif %}

--- a/src/current/_includes/v23.2/ui/transactions-filter.md
+++ b/src/current/_includes/v23.2/ui/transactions-filter.md
@@ -1,11 +1,3 @@
-{% if page.cloud == true %}
-  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
-  {% assign page_prefix = "" %}
-{% else %}
-  {% assign link_prefix = "" %}
-  {% assign page_prefix = "ui-" %}
-{% endif %}
-
 ## Transaction Fingerprints results
 
 The transaction fingerprints returned are determined by the selected **Search Criteria**:

--- a/src/current/_includes/v23.2/ui/transactions-views.md
+++ b/src/current/_includes/v23.2/ui/transactions-views.md
@@ -1,0 +1,79 @@
+{% if page.cloud == true %}
+  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
+  {% assign page_prefix = "" %}
+{% else %}
+  {% assign link_prefix = "" %}
+  {% assign page_prefix = "ui-" %}
+{% endif %}
+
+The **Transactions** page provides information about the execution of SQL transactions in your cluster, using data in the cluster's [`crdb_internal` system catalog]({{ link_prefix }}monitoring-and-alerting.html#crdb_internal-system-catalog).
+{%- if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. Click the **Transactions** tab.
+{% else %}
+To view this page, select a cluster from the [**Clusters** page]({% link cockroachcloud/cluster-management.md %}#view-clusters-page), and click **SQL Activity** in the **Monitoring** section of the left side navigation. Select the **Transactions** tab.
+{% endif %}
+
+It offers two views:
+
+- **Transaction Fingerprints** show information about completed SQL transactions.
+- **Active Executions**, show information about SQL transactions which are currently executing.
+
+Choose a view by selecting the **Transaction Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
+
+{{site.data.alerts.callout_success}}
+In contrast to the [**Statements** page]({{ page_prefix }}statements-page.html), which displays [SQL statement fingerprints]({{ page_prefix }}statements-page.html#sql-statement-fingerprints), the **Transactions** page displays _transaction fingerprints_, which are SQL statement fingerprints grouped by [transaction]({{ link_prefix }}transactions.html).
+{{site.data.alerts.end}}
+
+## Transaction Fingerprints view
+
+The **Transaction Fingerprints** view helps you:
+
+- Identify frequently [retried]({{ link_prefix }}transactions.html#transaction-retries) transactions.
+- [Troubleshoot]({{ link_prefix }}query-behavior-troubleshooting.html) high-latency transactions or execution failures.
+- View transaction [details](#transaction-details-page).
+
+{% if page.cloud != true %}
+To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+Click the **Transactions** tab. The **Transaction Fingerprints** radio button is selected and the [Transactions table](#transactions-table) displays.
+
+The following screenshot shows the transaction fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({{ link_prefix }}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.2/transaction-fingerprint.png' | relative_url }}" alt="Transaction fingerprint" style="border:1px solid #eee;max-width:100%" />
+
+If you click the transaction fingerprint in the **Transactions** column, the [**Transaction Details** page](#transaction-details-page) displays.
+
+<img src="{{ 'images/v23.2/transaction-details.png' | relative_url }}" alt="Transaction details" style="border:1px solid #eee;max-width:100%" />
+
+## Active Executions view
+
+The **Active Executions** view helps you:
+
+- Understand and tune workload performance, particularly for long-running transactions.
+
+{% if page.cloud != true %}
+To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
+{% else %}
+To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
+{% endif -%}
+The **Statements** tab is selected. Click the **Transactions** tab and the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
+
+{{site.data.alerts.callout_info}}
+When Auto [Refresh](#refresh) is On, active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
+{{site.data.alerts.end}}
+
+The following screenshot shows the active statement execution for `UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $4, $5)` while running the [`movr` workload]({{ link_prefix }}cockroach-workload.html#run-the-movr-workload):
+
+<img src="{{ 'images/v23.2/transaction-execution.png' | relative_url }}" alt="Transaction execution" style="border:1px solid #eee;max-width:100%" />
+
+If you click the execution ID in the **Transaction Execution ID** column, the [**Transaction Execution** details page](#transaction-execution-details-page) displays.
+
+<img src="{{ 'images/v23.2/transaction-execution-details.png' | relative_url }}" alt="Transaction execution details" style="border:1px solid #eee;max-width:100%" />
+
+{% if page.cloud != true %}
+{% include {{ page.version.version }}/ui/refresh.md %}
+{% else %}
+{% include {{ site.current_cloud_version }}/ui/refresh.md %}
+{% endif %}

--- a/src/current/cockroachcloud/statements-page.md
+++ b/src/current/cockroachcloud/statements-page.md
@@ -8,21 +8,7 @@ docs_area: manage
 
 {% capture version_prefix %}{{site.current_cloud_version}}/{% endcapture %}
 
-The **Statements** page helps you:
-
-- Identify frequently executed or high latency [SQL statements](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/sql-statements).
-- View SQL statement fingerprint [details](#statement-details-page).
-- Download SQL statement [diagnostics](#diagnostics) for troubleshooting.
-
-{% if page.cloud != true %}
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. The **Statements** tab is selected.
-{% else %}
-To view this page, select a cluster from the [**Clusters** page]({% link cockroachcloud/cluster-management.md %}#view-clusters-page), and click **SQL Activity** in the **Monitoring** section of the left side navigation. Select the **Statements** tab.
-{% endif %}
-
-{{site.data.alerts.callout_success}}
-If you haven't yet executed any queries in the cluster as a user, this page will be blank.
-{{site.data.alerts.end}}
+{% include {{version_prefix}}ui/statements-views.md %}
 
 {% include {{version_prefix}}ui/statements-filter.md %}
 
@@ -35,3 +21,5 @@ If you haven't yet executed any queries in the cluster as a user, this page will
 {% include {{version_prefix}}ui/statements-table.md %}
 
 {% include {{version_prefix}}ui/statement-details.md %}
+
+{% include {{version_prefix}}ui/active-statement-executions.md %}

--- a/src/current/cockroachcloud/transactions-page.md
+++ b/src/current/cockroachcloud/transactions-page.md
@@ -8,21 +8,7 @@ docs_area: manage
 
 {% capture version_prefix %}{{site.current_cloud_version}}/{% endcapture %}
 
-The **Transactions** page helps you:
-
-- Identify frequently [retried]({% link {{ version_prefix }}transactions.md %}#transaction-retries) transactions.
-- [Troubleshoot]({% link {{ version_prefix }}query-behavior-troubleshooting.md %}) high latency transactions or execution failures.
-- View transaction [details](#transaction-details-page).
-
-{{site.data.alerts.callout_success}}
-In contrast to the [**Statements** page]({% link cockroachcloud/statements-page.md %}), which displays [SQL statement fingerprints]({% link cockroachcloud/statements-page.md %}#sql-statement-fingerprints), the **Transactions** page displays SQL statement fingerprints grouped by [transaction](https://www.cockroachlabs.com/docs/{{ version_prefix }}transactions).
-{{site.data.alerts.end}}
-
-{% if page.cloud != true %}
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console. Click the **Transactions** tab.
-{% else %}
-To view this page, select a cluster from the [**Clusters** page]({% link cockroachcloud/cluster-management.md %}#view-clusters-page), and click **SQL Activity** in the **Monitoring** section of the left side navigation. Select the **Transactions** tab.
-{% endif %}
+{% include {{version_prefix}}ui/transactions-views.md %}
 
 {% include {{version_prefix}}ui/transactions-filter.md %}
 
@@ -35,3 +21,5 @@ To view this page, select a cluster from the [**Clusters** page]({% link cockroa
 {% include {{version_prefix}}ui/transactions-table.md %}
 
 {% include {{version_prefix}}ui/transaction-details.md %}
+
+{% include {{version_prefix}}ui/active-transaction-executions.md %}

--- a/src/current/v23.1/ui-statements-page.md
+++ b/src/current/v23.1/ui-statements-page.md
@@ -7,68 +7,7 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/admin-access.md %}
 
-The **Statements** page provides information about the execution of SQL statements in your cluster, using data in the cluster's [`crdb_internal` system catalog]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Statements**.
-
-It offers two views:
-
-- **Statement Fingerprints** show information about completed SQL statements.
-- **Active Executions** show information about SQL statements which are currently executing.
-
-Choose a view by selecting the **Statement Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
-
-{{site.data.alerts.callout_success}}
-If you haven't yet executed any queries in the cluster as a user, this page will be blank.
-{{site.data.alerts.end}}
-
-## Statement Fingerprints view
-
-The **Statements Fingerprints** view helps you:
-
-- Identify frequently executed or high latency [SQL statements]({% link {{ page.version.version }}/sql-statements.md %}).
-- View SQL statement fingerprint [details](#statement-fingerprint-page).
-- Download SQL statement [diagnostics](#diagnostics) for troubleshooting.
-
-{% if page.cloud != true %}
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
-{% endif %}
-
-The **Statements** tab is selected. The **Statement Fingerprints** radio button is selected and the [Statements table](#statements-table) displays.
-
-The following screenshot shows the statement fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.1/statement-fingerprint.png' | relative_url }}" alt="Statement fingerprint" style="border:1px solid #eee;max-width:100%" />
-
-If you click the statement fingerprint in the **Statements** column, the [**Statement Fingerprint** page](#statement-fingerprint-page) displays.
-
-<img src="{{ 'images/v23.1/statement-details.png' | relative_url }}" alt="Statement details" style="border:1px solid #eee;max-width:100%" />
-
-## Active Executions view
-
-The **Active Executions** view helps you:
-
-- Understand and tune workload performance, particularly for long-running statements.
-
-{% if page.cloud != true %}
-To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
-{% endif %}
-
-The **Statements** tab is selected. Click the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
-
-{{site.data.alerts.callout_info}}
-Active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
-{{site.data.alerts.end}}
-
-The following screenshot shows the active statement execution for `SELECT city, id FROM vehicles WHERE city = 'washington dc'` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.1/statement-execution.png' | relative_url }}" alt="Statement execution" style="border:1px solid #eee;max-width:100%" />
-
-If you click the execution ID in the **Statement Execution ID** column, the [**Statement Execution** details page](#statement-execution-details-page) displays.
-
-<img src="{{ 'images/v23.1/statement-execution-details.png' | relative_url }}" alt="Statement execution details" style="border:1px solid #eee;max-width:100%" />
+{% include {{ page.version.version }}/ui/statements-views.md %}
 
 {% include {{ page.version.version }}/ui/statements-filter.md %}
 

--- a/src/current/v23.1/ui-transactions-page.md
+++ b/src/current/v23.1/ui-transactions-page.md
@@ -7,68 +7,7 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/admin-access.md %}
 
-The **Transactions** page provides information about the execution of SQL transactions in your cluster, using data in the cluster's [`crdb_internal` system catalog]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Transactions**.
-
-It offers two views:
-
-- **Transaction Fingerprints** show information about completed SQL transactions.
-- **Active Executions**, show information about SQL transactions which are currently executing.
-
-Choose a view by selecting the **Transaction Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
-
-{{site.data.alerts.callout_success}}
-In contrast to the [**Statements** page]({% link {{ page.version.version }}/ui-statements-page.md %}), which displays [SQL statement fingerprints]({% link {{ page.version.version }}/ui-statements-page.md %}#sql-statement-fingerprints), the **Transactions** page displays _transaction fingerprints_, which are SQL statement fingerprints grouped by [transaction]({% link {{ page.version.version }}/transactions.md %}).
-{{site.data.alerts.end}}
-
-## Transaction Fingerprints view
-
-The **Transaction Fingerprints** view helps you:
-
-- Identify frequently [retried]({% link {{ page.version.version }}/{{ link_prefix }}transactions.md %}#transaction-retries) transactions.
-- [Troubleshoot]({% link {{ page.version.version }}/{{ link_prefix }}query-behavior-troubleshooting.md %}) high-latency transactions or execution failures.
-- View transaction [details](#transaction-details-page).
-
-{% if page.cloud != true %}
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console. Click the **Transactions** tab.
-{% endif %}
-
-Click the **Transactions** tab. The **Transaction Fingerprints** radio button is selected and the [Transactions table](#transactions-table) displays.
-
-The following screenshot shows the transaction fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.1/transaction-fingerprint.png' | relative_url }}" alt="Transaction fingerprint" style="border:1px solid #eee;max-width:100%" />
-
-If you click the transaction fingerprint in the **Transactions** column, the [**Transaction Details** page](#transaction-details-page) displays.
-
-<img src="{{ 'images/v23.1/transaction-details.png' | relative_url }}" alt="Transaction details" style="border:1px solid #eee;max-width:100%" />
-
-## Active Executions view
-
-The **Active Executions** view helps you:
-
-- Understand and tune workload performance, particularly for long-running transactions.
-
-{% if page.cloud != true %}
-To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
-{% endif %}
-
-The **Statements** tab is selected. Click the **Transactions** tab and the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
-
-{{site.data.alerts.callout_info}}
-Active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
-{{site.data.alerts.end}}
-
-The following screenshot shows the active statement execution for `SELECT city, id FROM vehicles WHERE city = 'los angeles'` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.1/transaction-execution.png' | relative_url }}" alt="Transaction execution" style="border:1px solid #eee;max-width:100%" />
-
-If you click the execution ID in the **Transaction Execution ID** column, the [**Transaction Execution** details page](#transaction-execution-details-page) displays.
-
-<img src="{{ 'images/v23.1/transaction-execution-details.png' | relative_url }}" alt="Transaction execution details" style="border:1px solid #eee;max-width:100%" />
+{% include {{ page.version.version }}/ui/transactions-views.md %}
 
 {% include {{ page.version.version }}/ui/transactions-filter.md %}
 

--- a/src/current/v23.2/ui-statements-page.md
+++ b/src/current/v23.2/ui-statements-page.md
@@ -7,70 +7,7 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/admin-access.md %}
 
-The **Statements** page provides information about the execution of SQL statements in your cluster, using data in the cluster's [`crdb_internal` system catalog]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Statements**.
-
-It offers two views:
-
-- **Statement Fingerprints** show information about completed SQL statements.
-- **Active Executions** show information about SQL statements which are currently executing.
-
-Choose a view by selecting the **Statement Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
-
-{{site.data.alerts.callout_success}}
-If you haven't yet executed any queries in the cluster as a user, this page will be blank.
-{{site.data.alerts.end}}
-
-## Statement Fingerprints view
-
-The **Statements Fingerprints** view helps you:
-
-- Identify frequently executed or high latency [SQL statements]({% link {{ page.version.version }}/sql-statements.md %}).
-- View SQL statement fingerprint [details](#statement-fingerprint-page).
-- Download SQL statement [diagnostics](#diagnostics) for troubleshooting.
-
-{% if page.cloud != true %}
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
-{% endif %}
-
-The **Statements** tab is selected. The **Statement Fingerprints** radio button is selected and the [Statements table](#statements-table) displays.
-
-The following screenshot shows the statement fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.2/statement-fingerprint.png' | relative_url }}" alt="Statement fingerprint" style="border:1px solid #eee;max-width:100%" />
-
-If you click the statement fingerprint in the **Statements** column, the [**Statement Fingerprint** page](#statement-fingerprint-page) displays.
-
-<img src="{{ 'images/v23.2/statement-details.png' | relative_url }}" alt="Statement details" style="border:1px solid #eee;max-width:100%" />
-
-## Active Executions view
-
-The **Active Executions** view helps you:
-
-- Understand and tune workload performance, particularly for long-running statements.
-
-{% if page.cloud != true %}
-To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
-{% endif %}
-
-The **Statements** tab is selected. Click the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
-
-{{site.data.alerts.callout_info}}
-When Auto [Refresh](#refresh) is On, active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
-{{site.data.alerts.end}}
-
-The following screenshot shows the active statement execution for `INSERT INTO users VALUES ($1, $2, $3, $4, $5)` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.2/statement-execution.png' | relative_url }}" alt="Statement execution" style="border:1px solid #eee;max-width:100%" />
-
-If you click the execution ID in the **Statement Execution ID** column, the [**Statement Execution** details page](#statement-execution-details-page) displays.
-
-<img src="{{ 'images/v23.2/statement-execution-details.png' | relative_url }}" alt="Statement execution details" style="border:1px solid #eee;max-width:100%" />
-
-{% include_cached {{ page.version.version }}/ui/refresh.md %}
+{% include {{ page.version.version }}/ui/statements-views.md %}
 
 {% include {{ page.version.version }}/ui/statements-filter.md %}
 

--- a/src/current/v23.2/ui-transactions-page.md
+++ b/src/current/v23.2/ui-transactions-page.md
@@ -7,70 +7,7 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/admin-access.md %}
 
-The **Transactions** page provides information about the execution of SQL transactions in your cluster, using data in the cluster's [`crdb_internal` system catalog]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#crdb_internal-system-catalog). To view it, click **SQL Activity**, then click **Transactions**.
-
-It offers two views:
-
-- **Transaction Fingerprints** show information about completed SQL transactions.
-- **Active Executions**, show information about SQL transactions which are currently executing.
-
-Choose a view by selecting the **Transaction Fingerprints** or **Active Executions** radio button. The selection is retained when you switch between the **Statements** and **Transactions** tabs on the **SQL Activity** page.
-
-{{site.data.alerts.callout_success}}
-In contrast to the [**Statements** page]({% link {{ page.version.version }}/ui-statements-page.md %}), which displays [SQL statement fingerprints]({% link {{ page.version.version }}/ui-statements-page.md %}#sql-statement-fingerprints), the **Transactions** page displays _transaction fingerprints_, which are SQL statement fingerprints grouped by [transaction]({% link {{ page.version.version }}/transactions.md %}).
-{{site.data.alerts.end}}
-
-## Transaction Fingerprints view
-
-The **Transaction Fingerprints** view helps you:
-
-- Identify frequently [retried]({% link {{ page.version.version }}/{{ link_prefix }}transactions.md %}#transaction-retries) transactions.
-- [Troubleshoot]({% link {{ page.version.version }}/{{ link_prefix }}query-behavior-troubleshooting.md %}) high-latency transactions or execution failures.
-- View transaction [details](#transaction-details-page).
-
-{% if page.cloud != true %}
-To view this page, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To view this page, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console. Click the **Transactions** tab.
-{% endif %}
-
-Click the **Transactions** tab. The **Transaction Fingerprints** radio button is selected and the [Transactions table](#transactions-table) displays.
-
-The following screenshot shows the transaction fingerprint for `SELECT city, id FROM vehicles WHERE city = $1` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.2/transaction-fingerprint.png' | relative_url }}" alt="Transaction fingerprint" style="border:1px solid #eee;max-width:100%" />
-
-If you click the transaction fingerprint in the **Transactions** column, the [**Transaction Details** page](#transaction-details-page) displays.
-
-<img src="{{ 'images/v23.2/transaction-details.png' | relative_url }}" alt="Transaction details" style="border:1px solid #eee;max-width:100%" />
-
-## Active Executions view
-
-The **Active Executions** view helps you:
-
-- Understand and tune workload performance, particularly for long-running transactions.
-
-{% if page.cloud != true %}
-To display this view, click **SQL Activity** in the left-hand navigation of the DB Console.
-{% else %}
-To display this view, click **SQL Activity** in the left-hand navigation of the CockroachDB {{ site.data.products.cloud }} Console.
-{% endif %}
-
-The **Statements** tab is selected. Click the **Transactions** tab and the **Active Executions** radio button. The [Active Executions table](#active-executions-table) displays.
-
-{{site.data.alerts.callout_info}}
-When Auto [Refresh](#refresh) is On, active executions are polled every 10 seconds. Faster-running executions will potentially disappear upon each refresh.
-{{site.data.alerts.end}}
-
-The following screenshot shows the active statement execution for `UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $4, $5)` while running the [`movr` workload]({% link {{ page.version.version }}/cockroach-workload.md %}#run-the-movr-workload):
-
-<img src="{{ 'images/v23.2/transaction-execution.png' | relative_url }}" alt="Transaction execution" style="border:1px solid #eee;max-width:100%" />
-
-If you click the execution ID in the **Transaction Execution ID** column, the [**Transaction Execution** details page](#transaction-execution-details-page) displays.
-
-<img src="{{ 'images/v23.2/transaction-execution-details.png' | relative_url }}" alt="Transaction execution details" style="border:1px solid #eee;max-width:100%" />
-
-{% include_cached {{ page.version.version }}/ui/refresh.md %}
+{% include {{ page.version.version }}/ui/transactions-views.md %}
 
 {% include {{ page.version.version }}/ui/transactions-filter.md %}
 


### PR DESCRIPTION
Fixed DOC-9326

(1) Updated Cloud Statements/Transactions pages to show Active Executions sections similar to Self-Hosted pages, modified pages to only have calls to include files. (2) Moved views sections from Self-Hosted pages into statements/transactions-views include files, updated links to work with Cloud pages. (3) Moved setting of link_prefix variable from statements/transactions-filter include files to statements/transaction-views include files. (4) In active-statement/transaction-executions include files, updated links to work with Cloud pages.