### PR TITLE
Add docs for pcr data verification

### DIFF
--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -100,7 +100,7 @@ We recommend tracking the following metrics:
 {{site.data.alerts.callout_info}}
 **This feature is in [preview]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}).** It is in active development and subject to change.
 
-The `SHOW EXPERIMENTAL_FINGERPRINT` statement verifies that the data transmission and ingestion is working as expected while a replication stream is running. Any checksum mismatch likely represents corruption or a bug in CockroachDB. Should you encounter such a mismatch, contact [Support](https://support.cockroachlabs.com/hc/en-us).
+The `SHOW EXPERIMENTAL_FINGERPRINTS` statement verifies that the data transmission and ingestion is working as expected while a replication stream is running. Any checksum mismatch likely represents corruption or a bug in CockroachDB. Should you encounter such a mismatch, contact [Support](https://support.cockroachlabs.com/hc/en-us).
 {{site.data.alerts.end}}
 
 To verify that the data at a certain point in time is correct on the standby cluster, you can use the [current replicated time]({% link {{ page.version.version }}/show-virtual-cluster.md %}#responses) from the replication job information to run a point-in-time fingerprint on both the primary and standby clusters. This will verify that the transmission and ingestion of the data on the standby cluster, at that point in time, is correct.

--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -109,12 +109,12 @@ To verify that the data up to a certain point in time is correct on the standby 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    SHOW VIRTUAL CLUSTER standbyapplication WITH REPLICATION STATUS;
+    SELECT replicated_time FROM [SHOW VIRTUAL CLUSTER standbyapplication WITH REPLICATION STATUS];
     ~~~
     ~~~
-    id |        name        | data_state  | service_mode | source_tenant_name |                                                source_cluster_uri                                                 | replication_job_id |        replicated_time        |         retained_time         | cutover_time
-    ---+--------------------+-------------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------+--------------------+-------------------------------+-------------------------------+---------------
-    3  | standbyapplication | replicating | none         | application        | postgresql://{user}:redacted@{node IP}:26257/?options=-ccluster%3Dsystem&sslmode=verify-full&sslrootcert=redacted | 925475002117849089 | 2023-12-15 19:39:18.321455+00 | 2023-12-14 19:16:07.321456+00 |         NULL
+         replicated_time
+    ----------------------------
+    2023-12-15 19:39:18.321455+00
     (1 row)
     ~~~
 
@@ -124,7 +124,7 @@ To verify that the data up to a certain point in time is correct on the standby 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER application] AS OF SYSTEM TIME '1702669158089558000.0000000000';
+    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER application] AS OF SYSTEM TIME '2023-12-15 19:39:18.321455+00';
     ~~~
     ~~~
     tenant_name |             end_ts             |     fingerprint
@@ -139,7 +139,7 @@ To verify that the data up to a certain point in time is correct on the standby 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER standbyapplication] AS OF SYSTEM TIME '1702669158089558000.0000000000';
+    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER standbyapplication] AS OF SYSTEM TIME '2023-12-15 19:39:18.321455+00';
     ~~~
     ~~~
         tenant_name     |             end_ts             |     fingerprint
@@ -147,19 +147,6 @@ To verify that the data up to a certain point in time is correct on the standby 
     standbyapplication  | 1702669158089558000.0000000000 | 2646132238164576487
     (1 row)
     ~~~
-
-You can also use `SHOW EXPERIMENTAL_FINGERPRINTS` without defining a timestamp to view the fingerprint for the latest replicated timestamp:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER standbyapplication;
-~~~
-~~~
-     tenant_name     |             end_ts             |     fingerprint
----------------------+--------------------------------+----------------------
-  standbyapplication | 1702572059741065000.0000000000 | 5089527880146530165
-(1 row)
-~~~
 
 ## See also
 

--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -100,10 +100,10 @@ We recommend tracking the following metrics:
 {{site.data.alerts.callout_info}}
 **This feature is in [preview]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}).** It is in active development and subject to change.
 
-`SHOW EXPERIMENTAL_FINGERPRINT` allows you to verify that the data transmission and ingestion is working as expected while a replication stream is running. Any checksum mismatch likely represents corruption or a bug in CockroachDB. Should you encounter such a mismatch, contact [Support](https://support.cockroachlabs.com/hc/en-us).
+The `SHOW EXPERIMENTAL_FINGERPRINT` statement verifies that the data transmission and ingestion is working as expected while a replication stream is running. Any checksum mismatch likely represents corruption or a bug in CockroachDB. Should you encounter such a mismatch, contact [Support](https://support.cockroachlabs.com/hc/en-us).
 {{site.data.alerts.end}}
 
-To verify that the data at a certain point in time is correct on the standby cluster, you can use the current replicated time from the replication job information to run a point-in-time fingerprint on both the primary and standby clusters. This will verify that the transmission and ingestion of the data on the standby cluster, at that point in time, is correct.
+To verify that the data at a certain point in time is correct on the standby cluster, you can use the [current replicated time]({% link {{ page.version.version }}/show-virtual-cluster.md %}#responses) from the replication job information to run a point-in-time fingerprint on both the primary and standby clusters. This will verify that the transmission and ingestion of the data on the standby cluster, at that point in time, is correct.
 
 1. Retrieve the current replicated time of the replication job on the standby cluster with [`SHOW VIRTUAL CLUSTER`]({% link {{ page.version.version }}/show-virtual-cluster.md %}):
 
@@ -120,7 +120,7 @@ To verify that the data at a certain point in time is correct on the standby clu
 
     For detail on connecting to the standby cluster, refer to [Set Up Physical Cluster Replication]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#connect-to-the-standby-cluster-system-interface).
 
-1. From the **primary cluster's system interface**, specify a timestamp at or lower than the current `replicated_time` to verify the data:
+1. From the **primary cluster's system interface**, specify a timestamp at or earlier than the current `replicated_time` to retrieve the fingerprint. This example uses the current `replicated_time`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
@@ -135,7 +135,7 @@ To verify that the data at a certain point in time is correct on the standby clu
 
     For detail on connecting to the primary cluster, refer to [Set Up Physical Cluster Replication]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#connect-to-the-primary-cluster-system-interface).
 
-1. From the **standby cluster's system interface**, specify a timestamp at or lower than the current `replicated_time` to verify the data:
+1. From the **standby cluster's system interface**, specify the same timestamp used on the primary cluster to retrieve the standby cluster's fingerprint:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
@@ -147,6 +147,8 @@ To verify that the data at a certain point in time is correct on the standby clu
     standbyapplication  | 1704816945291575000.0000000000 | 2646132238164576487
     (1 row)
     ~~~
+
+1. Compare the fingerprints of the primary and standby clusters to verify the data. The same value for the fingerprints indicates the data is correct.
 
 ## See also
 

--- a/src/current/v23.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v23.2/physical-cluster-replication-monitoring.md
@@ -14,7 +14,7 @@ docs_area: manage
 - [`SHOW VIRTUAL CLUSTER ... WITH REPLICATION STATUS`](#sql-shell) in the SQL shell.
 - The [Physical Replication dashboard](#db-console) on the DB Console.
 - [Prometheus and Alertmanager](#prometheus) to track and alert on replication metrics.
-- [`SHOW EXPERIMENTAL_FINGERPRINTS`](#data-verification) to verify data up to a point in time is correct on the standby cluster.
+- [`SHOW EXPERIMENTAL_FINGERPRINTS`](#data-verification) to verify data at a point in time is correct on the standby cluster.
 
 When you complete a [cutover]({% link {{ page.version.version }}/cutover-replication.md %}), there will be a gap in the primary cluster's metrics whether you are monitoring via the [DB Console](#db-console) or [Prometheus](#prometheus).
 
@@ -103,7 +103,7 @@ We recommend tracking the following metrics:
 `SHOW EXPERIMENTAL_FINGERPRINT` allows you to verify that the data transmission and ingestion is working as expected while a replication stream is running. Any checksum mismatch likely represents corruption or a bug in CockroachDB. Should you encounter such a mismatch, contact [Support](https://support.cockroachlabs.com/hc/en-us).
 {{site.data.alerts.end}}
 
-To verify that the data up to a certain point in time is correct on the standby cluster, you can use the current replicated time from the replication job information to run a point-in-time fingerprint on both the primary and standby clusters. This will verify that the transmission and ingestion of the data on the standby cluster, up to that point in time, is correct.
+To verify that the data at a certain point in time is correct on the standby cluster, you can use the current replicated time from the replication job information to run a point-in-time fingerprint on both the primary and standby clusters. This will verify that the transmission and ingestion of the data on the standby cluster, at that point in time, is correct.
 
 1. Retrieve the current replicated time of the replication job on the standby cluster with [`SHOW VIRTUAL CLUSTER`]({% link {{ page.version.version }}/show-virtual-cluster.md %}):
 
@@ -114,7 +114,7 @@ To verify that the data up to a certain point in time is correct on the standby 
     ~~~
          replicated_time
     ----------------------------
-    2023-12-15 19:39:18.321455+00
+    2024-01-09 16:15:45.291575+00
     (1 row)
     ~~~
 
@@ -124,12 +124,12 @@ To verify that the data up to a certain point in time is correct on the standby 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER application] AS OF SYSTEM TIME '2023-12-15 19:39:18.321455+00';
+    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER application] AS OF SYSTEM TIME '2024-01-09 16:15:45.291575+00';
     ~~~
     ~~~
     tenant_name |             end_ts             |     fingerprint
     ------------+--------------------------------+----------------------
-    application | 1702669158089558000.0000000000 | 2646132238164576487
+    application | 1704816945291575000.0000000000 | 2646132238164576487
     (1 row)
     ~~~
 
@@ -139,12 +139,12 @@ To verify that the data up to a certain point in time is correct on the standby 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER standbyapplication] AS OF SYSTEM TIME '2023-12-15 19:39:18.321455+00';
+    SELECT * FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM VIRTUAL CLUSTER standbyapplication] AS OF SYSTEM TIME '2024-01-09 16:15:45.291575+00';
     ~~~
     ~~~
         tenant_name     |             end_ts             |     fingerprint
     --------------------+--------------------------------+----------------------
-    standbyapplication  | 1702669158089558000.0000000000 | 2646132238164576487
+    standbyapplication  | 1704816945291575000.0000000000 | 2646132238164576487
     (1 row)
     ~~~
 

--- a/src/current/v23.2/physical-cluster-replication-overview.md
+++ b/src/current/v23.2/physical-cluster-replication-overview.md
@@ -31,6 +31,7 @@ You can use physical cluster replication in a disaster recovery plan to:
 - **Maintained/improved RPO and RTO**: Depending on workload and deployment configuration, [replication lag]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}) between the primary and standby is generally in the tens-of-seconds range. The cutover process from the primary cluster to the standby should typically happen within five minutes when completing a cutover to the latest replicated time using `LATEST`.
 - **Cutover to a timestamp in the past or the future**: In the case of logical disasters or mistakes, you can [cut over]({% link {{ page.version.version }}/cutover-replication.md %}) from the primary to the standby cluster to a timestamp in the past. This means that you can return the standby to a timestamp before the mistake was replicated to the standby. You can also configure the [`WITH RETENTION`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}#set-a-retention-window) option to control how far in the past you can cut over to. Furthermore, you can plan a cutover by specifying a timestamp in the future.
 - **Monitoring**: To monitor the replication's initial progress, current status, and performance, you can use metrics available in the [DB Console]({% link {{ page.version.version }}/ui-overview.md %}) and [Prometheus]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %}). For more detail, refer to [Physical Cluster Replication Monitoring]({% link {{ page.version.version }}/physical-cluster-replication-monitoring.md %}).
+- **Data verification on standby**: You can verify that the data on the standby cluster matches that on the primary by checking the fingerprint of the data on each cluster. We recommend running data verification checks regularly as part of your monitoring processes. Refer to [Data verification]({% link {{ page.version.version }}/physical-cluster-replication-monitoring.md %}#data-verification) page for a guide and considerations.
 
 {{site.data.alerts.callout_info}}
 [Cutting over to a timestamp in the past]({% link {{ page.version.version }}/cutover-replication.md %}#cut-over-to-a-point-in-time) involves reverting data on the standby cluster. As a result, this type of cutover takes longer to complete than cutover to the [latest replicated time]({% link {{ page.version.version }}/cutover-replication.md %}#cut-over-to-the-most-recent-replicated-time). The increase in cutover time will correlate to how much data you are reverting from the standby. For more detail, refer to the [Technical Overview]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}) page for physical cluster replication.
@@ -56,7 +57,7 @@ For more comprehensive guides, refer to:
 - [Physical Cluster Replication Monitoring]({% link {{ page.version.version }}/physical-cluster-replication-monitoring.md %}): for detail on metrics and observability into a replication stream.
 - [Cut Over from a Primary Cluster to a Standby Cluster]({% link {{ page.version.version }}/cutover-replication.md %}): for a guide on how to complete a replication stream and cut over to the standby cluster.
 
-### Starting clusters
+### Start clusters
 
 To initiate physical cluster replication on clusters, you must [start]({% link {{ page.version.version }}/cockroach-start.md %}) the primary and standby CockroachDB clusters with the `--config-profile` flag. This enables cluster virtualization {% comment %}link to CV docs{% endcomment %} and sets up each cluster ready for replication.
 
@@ -81,7 +82,7 @@ The node topology of the two clusters does not need to be the same. For example,
 Every node in the standby cluster must be able to make a network connection to every node in the primary cluster to start a replication stream successfully. Refer to [Copy certificates]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#step-3-copy-certificates) for detail.
 {{site.data.alerts.end}}
 
-### Connecting to the system interface and virtual cluster
+### Connect to the system interface and virtual cluster
 
 A cluster with physical cluster replication enabled is a _virtualized cluster_; the primary and standby clusters each contain:
 
@@ -109,7 +110,7 @@ Physical cluster replication requires an [{{ site.data.products.enterprise }} li
 
 To connect to the [DB Console]({% link {{ page.version.version }}/ui-overview.md %}) and view the **Physical Cluster Replication** dashboard, the user must have the correct privileges. Refer to [Create a user for the standby cluster]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#create-a-user-for-the-standby-cluster).
 
-### Managing replication in the SQL shell
+### Manage replication in the SQL shell
 
 To start, manage, and observe physical cluster replication, you can use the following SQL statements:
 

--- a/src/current/v23.2/set-up-physical-cluster-replication.md
+++ b/src/current/v23.2/set-up-physical-cluster-replication.md
@@ -194,13 +194,6 @@ The standby cluster connects to the primary cluster's system interface using an 
 
 Similarly to the primary cluster, each node on the standby cluster must be started with the `--config-profile` flag set to `replication-target`. This creates a _virtualized cluster_ with a system interface and an application virtual cluster, and sets up all the required configuration for starting a replication stream.
 
-To start the standby cluster, run:
-
-{% include_cached copy-clipboard.html %}
-~~~ shell
---config-profile replication-target
-~~~
-
 For example, a `cockroach start` command according to the [prerequisite deployment guide]({% link {{ page.version.version }}/deploy-cockroachdb-on-premises.md %}#step-3-start-nodes):
 
 {% include_cached copy-clipboard.html %}
@@ -369,7 +362,7 @@ The system interface in the standby cluster initiates and controls the replicati
     (1 row)s
     ~~~
 
-    With the replication stream running, you can monitor the job via the DB Console, SQL shell, or Prometheus. You can also verify data up to a point in time is correct on the standby cluster. For more detail, refer to [Physical Cluster Replication Monitoring]({% link {{ page.version.version }}/physical-cluster-replication-monitoring.md %}).
+    With the replication stream running, you can monitor the job via the DB Console, SQL shell, or Prometheus. You can also verify data is correct on the standby cluster at a specific point in time. For more detail, refer to [Physical Cluster Replication Monitoring]({% link {{ page.version.version }}/physical-cluster-replication-monitoring.md %}).
 
 ## Connection reference
 

--- a/src/current/v23.2/set-up-physical-cluster-replication.md
+++ b/src/current/v23.2/set-up-physical-cluster-replication.md
@@ -369,6 +369,8 @@ The system interface in the standby cluster initiates and controls the replicati
     (1 row)s
     ~~~
 
+    With the replication stream running, you can monitor the job via the DB Console, SQL shell, or Prometheus. You can also verify data up to a point in time is correct on the standby cluster. For more detail, refer to [Physical Cluster Replication Monitoring]({% link {{ page.version.version }}/physical-cluster-replication-monitoring.md %}).
+
 ## Connection reference
 
 This table outlines the connection strings you will need for this setup tutorial.


### PR DESCRIPTION
Fixes DOC-8268

This adds a short example to the PCR Monitoring page on verifying data between the primary and standby clusters.

Like the whole of the PCR feature, data verification is very much in preview. Here, we wanted to emphasize that this tool is very much in active development (hence the extended preview message in its section). 

PR includes references across the PCR docs to data verification.