### PR TITLE
DOC-9073 Update our documentation to include sql.mem.root.current metric

### DIFF
--- a/src/current/_includes/v23.1/metric-names.md
+++ b/src/current/_includes/v23.1/metric-names.md
@@ -251,6 +251,8 @@ Name | Description
 `sql.mem.distsql.current` | Current sql statement memory usage for distsql
 `sql.mem.distsql.max` | Memory usage per sql statement for distsql
 `sql.mem.max` | Memory usage per sql statement
+`sql.mem.root.current` | Current sql statement memory usage for root
+`sql.mem.root.max` | Memory usage per sql statement for root
 `sql.mem.session.current` | Current sql session memory usage
 `sql.mem.session.max` | Memory usage per sql session
 `sql.mem.txn.current` | Current sql transaction memory usage

--- a/src/current/_includes/v23.2/metric-names.md
+++ b/src/current/_includes/v23.2/metric-names.md
@@ -251,6 +251,8 @@ Name | Description
 `sql.mem.distsql.current` | Current sql statement memory usage for distsql
 `sql.mem.distsql.max` | Memory usage per sql statement for distsql
 `sql.mem.max` | Memory usage per sql statement
+`sql.mem.root.current` | Current sql statement memory usage for root
+`sql.mem.root.max` | Memory usage per sql statement for root
 `sql.mem.session.current` | Current sql session memory usage
 `sql.mem.session.max` | Memory usage per sql session
 `sql.mem.txn.current` | Current sql transaction memory usage


### PR DESCRIPTION
Fixes DOC-9073

On Metrics page, added sql.mem.root.current and sql.mem.root.max