### PR TITLE
[DOC-3439][DOC-6001] Improve recommendations about node per hardware and storage per node

### DIFF
--- a/src/current/_includes/v22.2/prod-deployment/topology-recommendations.md
+++ b/src/current/_includes/v22.2/prod-deployment/topology-recommendations.md
@@ -1,6 +1,13 @@
-- Run each node on a separate machine. Since CockroachDB replicates across nodes, running more than one node per machine increases the risk of data loss if a machine fails. Likewise, if a machine has multiple disks or SSDs, run one node with multiple `--store` flags and not one node per disk. For more details about stores, see [Start a Node](cockroach-start.html#store).
+- Do not run multiple node processes on the same VM or machine. This defeats CockroachDB's replication and causes the system to be a single point of failure. Instead, start each node on a separate VM or machine.
+- To start a node with multiple disks or SSDs, you can use either of these approaches:
+  - Configure the disks or SSDs as a single RAID volume, then pass the RAID volume to the `--store` flag when starting the `cockroach` process on the node.
+  - Provide a separate `--store` flag for each disk when starting the `cockroach` process on the node. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
 
-- When starting each node, use the [`--locality`](cockroach-start.html#locality) flag to describe the node's location, for example, `--locality=region=west,zone=us-west-1`. The key-value pairs should be ordered from most to least inclusive, and the keys and order of key-value pairs must be the same on all nodes.
+      {{site.data.alerts.callout_danger}}
+      If you start a node with multiple `--store` flags, it is not possible to scale back down to only using a single store on the node. Instead, you must decommission the node and start a new node with the updated `--store`.
+      {{site.data.alerts.end}}
+
+- When starting each node, use the [`--locality`]({% link {{ page.version.version }}/cockroach-start.md %}#locality) flag to describe the node's location, for example, `--locality=region=west,zone=us-west-1`. The key-value pairs should be ordered from most to least inclusive, and the keys and order of key-value pairs must be the same on all nodes.
 
 - When deploying in a single availability zone:
 

--- a/src/current/_includes/v23.1/prod-deployment/topology-recommendations.md
+++ b/src/current/_includes/v23.1/prod-deployment/topology-recommendations.md
@@ -1,4 +1,11 @@
-- Run each node on a separate machine. Since CockroachDB replicates across nodes, running more than one node per machine increases the risk of data loss if a machine fails. Likewise, if a machine has multiple disks or SSDs, run one node with multiple `--store` flags and not one node per disk. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+- Do not run multiple node processes on the same VM or machine. This defeats CockroachDB's replication and causes the system to be a single point of failure. Instead, start each node on a separate VM or machine.
+- To start a node with multiple disks or SSDs, you can use either of these approaches:
+  - Configure the disks or SSDs as a single RAID volume, then pass the RAID volume to the `--store` flag when starting the `cockroach` process on the node.
+  - Provide a separate `--store` flag for each disk when starting the `cockroach` process on the node. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+
+      {{site.data.alerts.callout_danger}}
+      If you start a node with multiple `--store` flags, it is not possible to scale back down to only using a single store on the node. Instead, you must decommission the node and start a new node with the updated `--store`.
+      {{site.data.alerts.end}}
 
 - When starting each node, use the [`--locality`]({% link {{ page.version.version }}/cockroach-start.md %}#locality) flag to describe the node's location, for example, `--locality=region=west,zone=us-west-1`. The key-value pairs should be ordered from most to least inclusive, and the keys and order of key-value pairs must be the same on all nodes.
 

--- a/src/current/_includes/v23.2/prod-deployment/topology-recommendations.md
+++ b/src/current/_includes/v23.2/prod-deployment/topology-recommendations.md
@@ -1,4 +1,11 @@
-- Run each node on a separate machine. Since CockroachDB replicates across nodes, running more than one node per machine increases the risk of data loss if a machine fails. Likewise, if a machine has multiple disks or SSDs, run one node with multiple `--store` flags and not one node per disk. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+- Do not run multiple node processes on the same VM or machine. This defeats CockroachDB's replication and causes the system to be a single point of failure. Instead, start each node on a separate VM or machine.
+- To start a node with multiple disks or SSDs, you can use either of these approaches:
+  - Configure the disks or SSDs as a single RAID volume, then pass the RAID volume to the `--store` flag when starting the `cockroach` process on the node.
+  - Provide a separate `--store` flag for each disk when starting the `cockroach` process on the node. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+
+      {{site.data.alerts.callout_danger}}
+      If you start a node with multiple `--store` flags, it is not possible to scale back down to only using a single store on the node. Instead, you must decommission the node and start a new node with the updated `--store`.
+      {{site.data.alerts.end}}
 
 - When starting each node, use the [`--locality`]({% link {{ page.version.version }}/cockroach-start.md %}#locality) flag to describe the node's location, for example, `--locality=region=west,zone=us-west-1`. The key-value pairs should be ordered from most to least inclusive, and the keys and order of key-value pairs must be the same on all nodes.
 

--- a/src/current/v22.2/cockroach-start.md
+++ b/src/current/v22.2/cockroach-start.md
@@ -192,6 +192,17 @@ The `--storage-engine` flag is used to choose the storage engine used by the nod
 
 #### Store
 
+The `--store` flag allows you to specify details about a node's storage.
+
+To start a node with multiple disks or SSDs, you can use either of these approaches:
+
+- Configure the disks or SSDs as a single RAID volume, then pass the RAID volume to the `--store` flag when starting the `cockroach` process on the node.
+- Provide a separate `--store` flag for each disk when starting the `cockroach` process on the node. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+
+  {{site.data.alerts.callout_danger}}
+  If you start a node with multiple `--store` flags, it is not possible to scale back down to only using a single store on the node. Instead, you must decommission the node and start a new node with the updated `--store`.
+  {{site.data.alerts.end}}
+
 The `--store` flag supports the following fields. Note that commas are used to separate fields, and so are forbidden in all field values.
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v23.1/cockroach-start.md
+++ b/src/current/v23.1/cockroach-start.md
@@ -194,6 +194,17 @@ The `--storage-engine` flag is used to choose the storage engine used by the nod
 
 #### Store
 
+The `--store` flag allows you to specify details about a node's storage.
+
+To start a node with multiple disks or SSDs, you can use either of these approaches:
+
+- Configure the disks or SSDs as a single RAID volume, then pass the RAID volume to the `--store` flag when starting the `cockroach` process on the node.
+- Provide a separate `--store` flag for each disk when starting the `cockroach` process on the node. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+
+  {{site.data.alerts.callout_danger}}
+  If you start a node with multiple `--store` flags, it is not possible to scale back down to only using a single store on the node. Instead, you must decommission the node and start a new node with the updated `--store`.
+  {{site.data.alerts.end}}
+
 The `--store` flag supports the following fields. Note that commas are used to separate fields, and so are forbidden in all field values.
 
 {{site.data.alerts.callout_info}}

--- a/src/current/v23.2/cockroach-start.md
+++ b/src/current/v23.2/cockroach-start.md
@@ -194,6 +194,17 @@ The `--storage-engine` flag is used to choose the storage engine used by the nod
 
 #### Store
 
+The `--store` flag allows you to specify details about a node's storage.
+
+To start a node with multiple disks or SSDs, you can use either of these approaches:
+
+- Configure the disks or SSDs as a single RAID volume, then pass the RAID volume to the `--store` flag when starting the `cockroach` process on the node.
+- Provide a separate `--store` flag for each disk when starting the `cockroach` process on the node. For more details about stores, see [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %}#store).
+
+  {{site.data.alerts.callout_danger}}
+  If you start a node with multiple `--store` flags, it is not possible to scale back down to only using a single store on the node. Instead, you must decommission the node and start a new node with the updated `--store`.
+  {{site.data.alerts.end}}
+
 The `--store` flag supports the following fields. Note that commas are used to separate fields, and so are forbidden in all field values.
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
- [DOC-3439] Improve the recommendation against running multiple nodes on the same hardware
  - Change the recommendation against to a "Do not" recommendation
  - Split out the point about multiple disks or SSDs into a separate bullet, and also add using RAID as a possibility
  - Backport to all supported versions 

  This change impacts many different pages that use this include. See https://github.com/cockroachdb/docs/pull/18171#issuecomment-1863629813 for links to preview the changes in context.
- [DOC-6001] Give more context about using multiple stores for a single node