### PR TITLE
[DOC-9458] Update Upgrade Policy page title

### DIFF
--- a/src/current/_includes/v23.1/sidebar-data/cloud-deployments.json
+++ b/src/current/_includes/v23.1/sidebar-data/cloud-deployments.json
@@ -420,7 +420,7 @@
                 "title": "Upgrade",
                 "items": [
                     {
-                        "title": "Upgrade Policy",
+                        "title": "CockroachDB Cloud Upgrade Policy",
                         "urls": [
                             "/cockroachcloud/upgrade-policy.html"
                         ]

--- a/src/current/_includes/v23.2/sidebar-data/cloud-deployments.json
+++ b/src/current/_includes/v23.2/sidebar-data/cloud-deployments.json
@@ -420,7 +420,7 @@
                 "title": "Upgrade",
                 "items": [
                     {
-                        "title": "Upgrade Policy",
+                        "title": "CockroachDB Cloud Upgrade Policy",
                         "urls": [
                             "/cockroachcloud/upgrade-policy.html"
                         ]

--- a/src/current/cockroachcloud/cluster-management.md
+++ b/src/current/cockroachcloud/cluster-management.md
@@ -118,7 +118,7 @@ AWS disks can only be scaled once every six hours.
 
 ## Add or remove regions from a cluster
 
-You can add or remove up to nine regions at a time through the Console. Note that you cannot have a two-region cluster, and it will take about 30 minutes to add or remove each region. See [Planning your cluster]({% link cockroachcloud/plan-your-cluster.md %}) for cluster requirements and recommendations before proceeding. 
+You can add or remove up to nine regions at a time through the Console. Note that you cannot have a two-region cluster, and it will take about 30 minutes to add or remove each region. See [Planning your cluster]({% link cockroachcloud/plan-your-cluster.md %}) for cluster requirements and recommendations before proceeding.
 
 ### Add a region to your cluster
 
@@ -139,7 +139,7 @@ You can add up to nine regions at a time through the Console. See [Planning your
 
 ### Remove a region from your cluster
 
-When you remove a region from a [multi-region]({% link cockroachcloud/plan-your-cluster.md %}#multi-region-clusters) cluster, the node in that region with the highest ordinal will be [decommissioned](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/node-shutdown?filters=decommission#decommission-the-node) first. Any ranges on that node will be [up-replicated](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/ui-replication-dashboard#snapshot-data-received) to other nodes, and once decommission is complete that node will be shut down. This process is then repeated for every other node in the region. 
+When you remove a region from a [multi-region]({% link cockroachcloud/plan-your-cluster.md %}#multi-region-clusters) cluster, the node in that region with the highest ordinal will be [decommissioned](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/node-shutdown?filters=decommission#decommission-the-node) first. Any ranges on that node will be [up-replicated](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/ui-replication-dashboard#snapshot-data-received) to other nodes, and once decommission is complete that node will be shut down. This process is then repeated for every other node in the region.
 
 {{site.data.alerts.callout_info}}
 If your [zone configurations](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-replication-zones) are set to pin range replicas to a specific region, you cannot remove that region.
@@ -161,7 +161,7 @@ To remove a region from your cluster:
 
 ## Set a maintenance window
 
-From your cluster's [**Overview** page]({% link cockroachcloud/cluster-overview-page.md %}), you can view and manage the maintenance and [patch upgrade]({% link cockroachcloud/upgrade-policy.md %}#patch-version-upgrades) window for your cluster. During the window, your cluster may experience restarts, degraded performance, and downtime for single-node clusters. To help keep your clusters updated while minimizing disruptions, set a window of time when your cluster is experiencing the lowest traffic. If no maintenance window is set, your cluster will be automatically upgraded as soon as new patch versions are available, and other cluster maintenance occurs as needed. Refer to [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
+From your cluster's [**Overview** page]({% link cockroachcloud/cluster-overview-page.md %}), you can view and manage the maintenance and [patch upgrade]({% link cockroachcloud/upgrade-policy.md %}#patch-version-upgrades) window for your cluster. During the window, your cluster may experience restarts, degraded performance, and downtime for single-node clusters. To help keep your clusters updated while minimizing disruptions, set a window of time when your cluster is experiencing the lowest traffic. If no maintenance window is set, your cluster will be automatically upgraded as soon as new patch versions are available, and other cluster maintenance occurs as needed. Refer to [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
 
 {{site.data.alerts.callout_info}}
 Maintenance operations that are critical for cluster security or stability may be applied outside of the maintenance window, and upgrades that begin in a maintenance window may not always be completed by the end of the window.

--- a/src/current/cockroachcloud/create-your-cluster.md
+++ b/src/current/cockroachcloud/create-your-cluster.md
@@ -107,7 +107,7 @@ See the [Example](plan-your-cluster.html?filters=dedicated#dedicated-example) fo
 
 ## Step 6. Select the CockroachDB version
 
-When you create a new cluster, it uses the [latest CockroachDB {{ site.data.products.cloud }} production release](https://www.cockroachlabs.com/docs/releases/cloud) by default. All clusters are then upgraded automatically to each subsequent patch release of their major version as it becomes available. To learn more, refer to [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
+When you create a new cluster, it uses the [latest CockroachDB {{ site.data.products.cloud }} production release](https://www.cockroachlabs.com/docs/releases/cloud) by default. All clusters are then upgraded automatically to each subsequent patch release of their major version as it becomes available. To learn more, refer to [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
 
 Prior to the GA release of a new CockroachDB major version, a series of Beta and Release Candidate (RC) releases are made available for CockroachDB {{ site.data.products.dedicated }} as [Pre-Production Preview]({% link cockroachcloud/upgrade-policy.md %}#pre-production-preview-upgrades) releases. If available, the latest Pre-Production Preview release is listed as an option alongside the latest production release.
 

--- a/src/current/cockroachcloud/frequently-asked-questions.md
+++ b/src/current/cockroachcloud/frequently-asked-questions.md
@@ -166,7 +166,7 @@ The following pages can be found in our [Terms & Conditions](https://www.cockroa
 
 ### Am I in control of upgrades for my CockroachDB {{ site.data.products.dedicated }} clusters?
 
-Yes, an [Org Administrator]({% link cockroachcloud/authorization.md %}#org-administrator-legacy) can apply major release upgrades directly [through the CockroachDB {{ site.data.products.cloud }} Console]({% link cockroachcloud/upgrade-to-v21.2.md %}); however, patch version upgrades are automatically applied to all clusters. CockroachDB {{ site.data.products.dedicated }} clusters are restarted one node at a time for patch version upgrades, so previously established connections will need to be [reestablished after the restart](https://www.cockroachlabs.com/docs/v21.2/connection-pooling#validating-connections-in-a-pool). For more information, see the [Upgrade Policy](upgrade-policy.html).
+Yes, an [Org Administrator]({% link cockroachcloud/authorization.md %}#org-administrator-legacy) can apply major release upgrades directly [through the CockroachDB {{ site.data.products.cloud }} Console]({% link cockroachcloud/upgrade-to-v21.2.md %}); however, patch version upgrades are automatically applied to all clusters. CockroachDB {{ site.data.products.dedicated }} clusters are restarted one node at a time for patch version upgrades, so previously established connections will need to be [reestablished after the restart](https://www.cockroachlabs.com/docs/v21.2/connection-pooling#validating-connections-in-a-pool). For more information, see the [CockroachDB Cloud Upgrade Policy](upgrade-policy.html).
 
 ### What is the support policy for older versions of the software?
 

--- a/src/current/cockroachcloud/upgrade-policy.md
+++ b/src/current/cockroachcloud/upgrade-policy.md
@@ -1,6 +1,6 @@
 ---
-title: Upgrade Policy
-summary: Learn about the CockroachDB Cloud upgrade policy.
+title: CockroachDB Cloud Upgrade Policy
+summary: Learn about the upgrade policy for clusters deployed in CockroachDB Cloud.
 toc: true
 docs_area: manage
 ---

--- a/src/current/cockroachcloud/upgrade-to-v23.1.md
+++ b/src/current/cockroachcloud/upgrade-to-v23.1.md
@@ -9,7 +9,7 @@ page_version: v23.1
 Now that [CockroachDB v23.1](https://www.cockroachlabs.com/docs/releases/v23.1) is available, an [Org Administrator]({% link cockroachcloud/authorization.md %}#org-administrator-legacy) can upgrade your CockroachDB {{ site.data.products.dedicated }} cluster from the CockroachDB {{ site.data.products.cloud }} Console. This page guides you through the process for an Admin.
 
 {{site.data.alerts.callout_success}}
-Upgrading a CockroachDB {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the CockroachDB {{ site.data.products.cloud }} [upgrade policy]({% link cockroachcloud/upgrade-policy.md %}).
+Upgrading a CockroachDB {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the CockroachDB {{ site.data.products.cloud }} [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
 {{site.data.alerts.end}}
 
 ## Step 1. Verify that you can upgrade
@@ -137,5 +137,5 @@ After finalization, all [temporary limitations](#expect-temporary-limitations) w
 
 ## See also
 
-- [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %})
+- [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %})
 - [CockroachDB v23.1 Release Notes](https://www.cockroachlabs.com/docs/releases/v23.1)

--- a/src/current/cockroachcloud/upgrade-to-v23.2.md
+++ b/src/current/cockroachcloud/upgrade-to-v23.2.md
@@ -19,11 +19,11 @@ This [testing release]({% link releases/index.md %}#release-naming) is not quali
 An [Org Administrator]({% link cockroachcloud/authorization.md %}#org-administrator-legacy) can upgrade your CockroachDB {{ site.data.products.dedicated }} cluster from the CockroachDB {{ site.data.products.cloud }} Console. This page guides you through the process of upgrading.
 
 {{site.data.alerts.callout_success}}
-Upgrading from {{ page.prev_version }} to {{ page.pre_production_preview_version }} is a major-version upgrade. Upgrading a CockroachDB {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the CockroachDB {{ site.data.products.cloud }} [upgrade policy](https://cockroachlabs.com/docs/cockroachcloud/upgrade-policy#pre-production-preview). After a cluster is upgraded to a Pre-Production Preview release, it is automatically upgraded to all subsequent releases within the same major version—including additional beta and RC releases, the GA release, and subsequent patch releases after GA, as patch version upgrades. To learn more, refer to the [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}#patch-version-upgrades).
+Upgrading from {{ page.prev_version }} to {{ page.pre_production_preview_version }} is a major-version upgrade. Upgrading a CockroachDB {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the CockroachDB {{ site.data.products.cloud }} [CockroachDB Cloud Upgrade Policy](https://cockroachlabs.com/docs/cockroachcloud/upgrade-policy#pre-production-preview). After a cluster is upgraded to a Pre-Production Preview release, it is automatically upgraded to all subsequent releases within the same major version—including additional beta and RC releases, the GA release, and subsequent patch releases after GA, as patch version upgrades. To learn more, refer to [Patch Version Upgrades]({% link cockroachcloud/upgrade-policy.md %}#patch-version-upgrades).
 {{site.data.alerts.end}}
 {% else %}
 {{site.data.alerts.callout_success}}
-Upgrading a CockroachDB {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the CockroachDB {{ site.data.products.cloud }} [upgrade policy](https://cockroachlabs.com/docs/cockroachcloud/upgrade-policy).
+Upgrading a CockroachDB {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the CockroachDB {{ site.data.products.cloud }} [CockroachDB Cloud Upgrade Policy](https://cockroachlabs.com/docs/cockroachcloud/upgrade-policy).
 {{site.data.alerts.end}}
 {% endif %}
 
@@ -55,7 +55,7 @@ Approximately 72 hours after the node has been restarted, the upgrade will be au
 </section>
 
 {{site.data.alerts.callout_danger}}
-If you choose to roll back a major version upgrade, your cluster will be rolled back to the latest patch release of the previous major version, which may differ from the patch release you were running before you initiated the upgrade. To learn more, refer to [Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
+If you choose to roll back a major version upgrade, your cluster will be rolled back to the latest patch release of the previous major version, which may differ from the patch release you were running before you initiated the upgrade. To learn more, refer to [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}).
 {{site.data.alerts.end}}
 
 
@@ -160,5 +160,5 @@ After finalization, all [temporary limitations](#expect-temporary-limitations) w
 
 ## See also
 
-- [Upgrade Policy](https://cockroachlabs.com/docs/cockroachcloud/upgrade-policy)
+- [CockroachDB Cloud Upgrade Policy](https://cockroachlabs.com/docs/cockroachcloud/upgrade-policy)
 - [CockroachDB {{ page.page_version }} Release Notes](https://www.cockroachlabs.com/docs/releases/{{ page.page_version }})

--- a/src/current/v23.1/restoring-backups-across-versions.md
+++ b/src/current/v23.1/restoring-backups-across-versions.md
@@ -14,11 +14,11 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v22.2.x" format. For example, both v22.2.8 and v22.2.14 are considered as v22.2 clusters for backup purposes.
 {{site.data.alerts.end}}
 
-{% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}). 
+{% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 ## Support for restoring backups into a newer version
 
-Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**. 
+Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**.
 
 For example, backups taken on v22.1.x can be restored into v22.2.x. Backups taken on v22.2.x can be restored into v23.1.x. The following table outlines this support:
 
@@ -29,10 +29,10 @@ Backup taken on version   | Restorable into version
 22.1.x                    | 22.1.x, 22.2.x
 22.2.x                    | 22.2.x, 23.1.x
 
-When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [Upgrade Policy](https://www.cockroachlabs.com/docs/cockroachcloud/upgrade-policy) page. 
+When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [CockroachDB Cloud Upgrade Policy](https://www.cockroachlabs.com/docs/cockroachcloud/upgrade-policy) page.
 
 {{site.data.alerts.callout_info}}
-Cockroach Labs does **not** support restoring backups from a higher version into a lower version. 
+Cockroach Labs does **not** support restoring backups from a higher version into a lower version.
 {{site.data.alerts.end}}
 
 ## Support for long-term backup archival

--- a/src/current/v23.2/restoring-backups-across-versions.md
+++ b/src/current/v23.2/restoring-backups-across-versions.md
@@ -14,11 +14,11 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v22.2.x" format. For example, both v22.2.8 and v22.2.14 are considered as v22.2 clusters for backup purposes.
 {{site.data.alerts.end}}
 
-{% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}). 
+{% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 ## Support for restoring backups into a newer version
 
-Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**. 
+Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**.
 
 For example, backups taken on v22.1.x can be restored into v22.2.x. Backups taken on v22.2.x can be restored into v23.1.x. The following table outlines this support:
 
@@ -29,10 +29,10 @@ Backup taken on version   | Restorable into version
 22.1.x                    | 22.1.x, 22.2.x
 22.2.x                    | 22.2.x, 23.1.x
 
-When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [Upgrade Policy](https://www.cockroachlabs.com/docs/cockroachcloud/upgrade-policy) page. 
+When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [CockroachDB Cloud Upgrade Policy](https://www.cockroachlabs.com/docs/cockroachcloud/upgrade-policy) page.
 
 {{site.data.alerts.callout_info}}
-Cockroach Labs does **not** support restoring backups from a higher version into a lower version. 
+Cockroach Labs does **not** support restoring backups from a higher version into a lower version.
 {{site.data.alerts.end}}
 
 ## Support for long-term backup archival


### PR DESCRIPTION
[DOC-9458] Update Upgrade Policy page title

Also updates link text in other CC pages and CRDB v23.1+ pages

### Previews
[src/current/cockroachcloud/cluster-management.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/cockroachcloud/cluster-management.html)
[src/current/cockroachcloud/create-your-cluster.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/cockroachcloud/create-your-cluster.html)
[src/current/cockroachcloud/frequently-asked-questions.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/cockroachcloud/frequently-asked-questions.html)
[src/current/cockroachcloud/upgrade-policy.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/cockroachcloud/upgrade-policy.html)
[src/current/cockroachcloud/upgrade-to-v23.1.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/cockroachcloud/upgrade-to-v23.1.html)
[src/current/cockroachcloud/upgrade-to-v23.2.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/cockroachcloud/upgrade-to-v23.2.html)
[src/current/v23.1/restoring-backups-across-versions.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/v23.1/restoring-backups-across-versions.html)
[src/current/v23.2/restoring-backups-across-versions.md](https://deploy-preview-18192--cockroachdb-docs.netlify.app/docs/v23.2/restoring-backups-across-versions.html)