### PR TITLE
Edit release notes for v23.1.0-alpha.8 for clarity on mux rangefeed

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.0-alpha.8.md
+++ b/src/current/_includes/releases/v23.1/v23.1.0-alpha.8.md
@@ -14,7 +14,7 @@ Release Date: March 27, 2023
 
 <h3 id="v23-1-0-alpha-8-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
 
-- Enabled the `changefeed.mux_rangefeed.enabled` [cluster setting](https://www.cockroachlabs.com/docs/v23.1/cluster-settings) for MuxRangeFeed clients to increase the efficiency when running against large-scale workloads. [#97957][#97957]
+- The MuxRangefeed client, which is enabled with the `changefeed.mux_rangefeed.enabled` [cluster setting](https://www.cockroachlabs.com/docs/v23.1/cluster-settings), is now more efficient when running against large-scale workloads. [#97957][#97957]
 - The `server.oidc_authentication.claim_json_key` [cluster setting](https://www.cockroachlabs.com/docs/v23.1/cluster-settings) for DB Console SSO now accepts list-valued token claims. [#98522][#98522]
 - Added the `WITH` key_column option to override the message metadata key for [changefeeds](https://www.cockroachlabs.com/docs/v23.1/changefeed-examples). This changes the key hashed to determine Kafka partitions. It does not affect the output of `key_in_value` or the domain of the per-key ordering guarantee. [#98806][#98806]
 - The [Node Map](https://www.cockroachlabs.com/docs/v23.1/ui-cluster-overview-page#node-map-enterprise) now shows normalized CPU usage. [#98225][#98225]


### PR DESCRIPTION
Edited a release note that referred to mux rangefeeds being "enabled", which may have caused confusion as they are no longer enabled by default. The original release note was edited "too much" and moved away from the meaning.