### PR TITLE
Fix typo in authentication.md

### DIFF
--- a/src/current/v23.2/security-reference/authentication.md
+++ b/src/current/v23.2/security-reference/authentication.md
@@ -37,7 +37,7 @@ GSS                   |      &nbsp;         |           &nbsp;               |  
 All options also support the following no-op 'authentication methods' (authentication is not actually performed):
 
 - `reject`: unconditionally rejects the connection attempt.
-- `trust`: unconditionally rejects the connection attempt.
+- `trust`: unconditionally allows the connection attempt.
 
 ### HBA configuration syntax
 


### PR DESCRIPTION
https://www.cockroachlabs.com/docs/stable/security-reference/authentication

It says that both `trust` and `reject` will unconditionally reject the connection attempt. This is not correct.