### PR TITLE
Remove stray slash from Dockerfile

### DIFF
--- a/src/current/v23.2/debezium.md
+++ b/src/current/v23.2/debezium.md
@@ -40,7 +40,7 @@ Once all of the [prerequisite steps](#before-you-begin) are completed, you can u
     {% include_cached copy-clipboard.html %}
     ~~~
     FROM quay.io/debezium/connect:latest
-    ENV KAFKA_CONNECT_JDBC_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-jdbc \
+    ENV KAFKA_CONNECT_JDBC_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-jdbc
 
 
     ARG POSTGRES_VERSION=latest


### PR DESCRIPTION
This Dockerfile isn't working currently. The extraneous `\` needs to be removed in order for the file to work.