### PR TITLE
Correct the sidebar data typo for back and restore overview

### DIFF
--- a/src/current/_includes/v23.2/sidebar-data/self-hosted-deployments.json
+++ b/src/current/_includes/v23.2/sidebar-data/self-hosted-deployments.json
@@ -542,7 +542,7 @@
                 "title": "Backups and Restores",
                 "items": [
                   {
-                    "titles": "Overview",
+                    "title": "Overview",
                     "urls": [
                       "/${VERSION}/backup-and-restore-overview.html"
                     ]


### PR DESCRIPTION
The Backup and Restore Overview page was not showing in the nav, this was due to a typo in the sidebar data file.