### PR TITLE
Extend redirect to more versions

### DIFF
--- a/src/current/_data/redirects.yml
+++ b/src/current/_data/redirects.yml
@@ -167,7 +167,7 @@
 
 - destination: cockroach-sql.md
   sources: ['use-the-built-in-sql-client.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1', 'v22.2', 'v23.1', 'v23.2']
 
 - destination: cockroach-sqlfmt.md
   sources: ['use-the-query-formatter.md']
@@ -943,7 +943,7 @@
 - destination: movr-flask-use-case.md
   sources: ['multi-region-use-case.md']
   versions: ['v21.1', 'v21.2', 'v22.1', 'v22.2']
-  
+
 - destination: serverless-resource-usage.md
   sources: ['optimize-serverless-workload.md']
   versions: ['cockroachcloud']


### PR DESCRIPTION
This link is used in the CLI help text. This redirect will be needed until the help text is updated.