### PR TITLE
Update go pgx tutorial to remove `go mod init`

### DIFF
--- a/src/current/v22.2/build-a-go-app-with-cockroachdb.md
+++ b/src/current/v22.2/build-a-go-app-with-cockroachdb.md
@@ -79,7 +79,7 @@ CockroachDB may require the [client to retry a transaction](transactions.html#tr
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ go mod init basic-sample && go mod tidy
+    $ go mod tidy
     ~~~
 
 1. Run the code:

--- a/src/current/v23.1/build-a-go-app-with-cockroachdb.md
+++ b/src/current/v23.1/build-a-go-app-with-cockroachdb.md
@@ -79,7 +79,7 @@ CockroachDB may require the [client to retry a transaction]({% link {{ page.vers
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ go mod init basic-sample && go mod tidy
+    $ go mod tidy
     ~~~
 
 1. Run the code:

--- a/src/current/v23.2/build-a-go-app-with-cockroachdb.md
+++ b/src/current/v23.2/build-a-go-app-with-cockroachdb.md
@@ -79,7 +79,7 @@ CockroachDB may require the [client to retry a transaction]({% link {{ page.vers
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ go mod init basic-sample && go mod tidy
+    $ go mod tidy
     ~~~
 
 1. Run the code:


### PR DESCRIPTION
This step is no longer necessary. Due to changes in

https://github.com/cockroachlabs/example-app-go-pgx/pull/8

it results in the following error message:

    go: /Users/rloveland/work/code/example-app-go-pgx/go.mod already exists

Relates to DOC-9584