### PR TITLE
Add new limitation for ALTER COLUMN TYPE

### DIFF
--- a/src/current/v22.2/alter-table.md
+++ b/src/current/v22.2/alter-table.md
@@ -181,6 +181,7 @@ You cannot alter the data type of a column if:
 - The column is part of an [index](indexes.html).
 - The column has [`CHECK` constraints](check.html).
 - The column owns a [sequence](create-sequence.html).
+- The column has a [`DEFAULT` expression]({% link {{ page.version.version }}/default-value.md %}). This will result in an `ERROR: ... column ... cannot also have a DEFAULT expression` with `SQLSTATE: 42P16`.
 - The `ALTER COLUMN TYPE` statement is part of a combined `ALTER TABLE` statement.
 - The `ALTER COLUMN TYPE` statement is inside an [explicit transaction](begin-transaction.html).
 

--- a/src/current/v23.1/alter-table.md
+++ b/src/current/v23.1/alter-table.md
@@ -181,6 +181,7 @@ You cannot alter the data type of a column if:
 - The column is part of an [index]({% link {{ page.version.version }}/indexes.md %}).
 - The column has [`CHECK` constraints]({% link {{ page.version.version }}/check.md %}).
 - The column owns a [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
+- The column has a [`DEFAULT` expression]({% link {{ page.version.version }}/default-value.md %}). This will result in an `ERROR: ... column ... cannot also have a DEFAULT expression` with `SQLSTATE: 42P16`.
 - The `ALTER COLUMN TYPE` statement is part of a combined `ALTER TABLE` statement.
 - The `ALTER COLUMN TYPE` statement is inside an [explicit transaction]({% link {{ page.version.version }}/begin-transaction.md %}).
 

--- a/src/current/v23.2/alter-table.md
+++ b/src/current/v23.2/alter-table.md
@@ -181,6 +181,7 @@ You cannot alter the data type of a column if:
 - The column is part of an [index]({% link {{ page.version.version }}/indexes.md %}).
 - The column has [`CHECK` constraints]({% link {{ page.version.version }}/check.md %}).
 - The column owns a [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
+- The column has a [`DEFAULT` expression]({% link {{ page.version.version }}/default-value.md %}). This will result in an `ERROR: ... column ... cannot also have a DEFAULT expression` with `SQLSTATE: 42P16`.
 - The `ALTER COLUMN TYPE` statement is part of a combined `ALTER TABLE` statement.
 - The `ALTER COLUMN TYPE` statement is inside an [explicit transaction]({% link {{ page.version.version }}/begin-transaction.md %}).
 


### PR DESCRIPTION
Fixes DOC-9537

NB. This limitation applies to v22.2, v23.1, and v23.2