### PR TITLE
ARM on Linux and Docker is GA for 23.1.16

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5433,7 +5433,7 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v22.2.17
-  
+
 - release_name: v23.2.1
   major_version: v23.2
   release_date: '2024-02-20'
@@ -5467,7 +5467,7 @@
       CockroachDB Cloud clusters. To request to upgrade
       a CockroachDB Self-Hosted cluster to this version,
       [contact Support](https://support.cockroachlabs.com/hc/en-us/requests/new).
-      
+
 - release_name: v23.1.15
   major_version: v23.1
   release_date: '2024-02-20'
@@ -5537,14 +5537,14 @@
   windows: true
   linux:
     linux_arm: true
-    linux_arm_experimental: true
+    linux_arm_experimental: false
     linux_arm_limited_access: false
     linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach
     docker_arm: true
-    docker_arm_experimental: true
+    docker_arm_experimental: false
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.15


### PR DESCRIPTION
ARM on Linux and Docker is GA for 23.1.16

Relates to https://github.com/cockroachdb/ed-tools/pull/54 which updates the release-note script defaults
Ref: [DOC-8595] 

### Previews
https://deploy-preview-18330--cockroachdb-docs.netlify.app/docs/releases/#v23-1
https://deploy-preview-18330--cockroachdb-docs.netlify.app/docs/releases/v23.1#v23-1-16