### PR TITLE
Correct the syntax on the create schedule for changefeed page

### DIFF
--- a/src/current/v23.1/create-schedule-for-changefeed.md
+++ b/src/current/v23.1/create-schedule-for-changefeed.md
@@ -28,7 +28,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 Parameter | Description
 ----------+------------
 `IF NOT EXISTS` | A scheduled changefeed should not be created if the `schedule_label` already exists. You will receive an error if the schedule label already exists, or if `schedule_label` is not defined when using `IF NOT EXISTS`.
-`schedule_label` | The name for the scheduled changefeed. This is optional and does not need to be unique. If you do not define a name, the label will default to `CHANGEFEED` with the timestamp of when you created the schedule. 
+`schedule_label` | The name for the scheduled changefeed. This is optional and does not need to be unique. If you do not define a name, the label will default to `CHANGEFEED` with the timestamp of when you created the schedule.
 `changefeed_targets` | The tables to target with the changefeed. For example, `movr.users, movr.rides`.
 `changefeed_sink` | The [changefeed sink URI]({% link {{ page.version.version }}/changefeed-sinks.md %}).
 `changefeed_option` | The [options]({% link {{ page.version.version }}/create-changefeed.md %}#options) to control the behavior of your changefeed. For example, `WITH format = csv, full_table_name`. See [Changefeed options](#changefeed-options) for a list of available options.
@@ -54,7 +54,7 @@ Scheduled changefeeds have the [`initial_scan = 'only'`]({% link {{ page.version
 
 Option | Value | Description
 -------+-------+-------------
-`first_run` | [`TIMESTAMP`]({% link {{ page.version.version }}/timestamp.md %}) / `now` | Execute the first run of the schedule at this time. If you do not specify `first_run`, the schedule will execute based on the next `RECURRING` time set by the crontab. 
+`first_run` | [`TIMESTAMP`]({% link {{ page.version.version }}/timestamp.md %}) / `now` | Execute the first run of the schedule at this time. If you do not specify `first_run`, the schedule will execute based on the next `RECURRING` time set by the crontab.
 `on_execution_failure` | `retry` / `reschedule` / `pause` | Determine how the schedule handles an error. <br><br>`retry`: Retry the changefeed immediately.<br><br>`reschedule`: Reschedule the changefeed based on the `RECURRING` expression.<br><br>`pause`: Pause the schedule. This requires that you [resume the schedule]({% link {{ page.version.version }}/resume-schedules.md %}) manually.<br><br>**Default:** `reschedule`
 `on_previous_running` | `start` / `skip` / `wait` | Control whether the changefeed schedule should start a changefeed if the previous scheduled changefeed is still running.<br><br>`start`: Start the new changefeed anyway, even if the previous one is running.<br><br>`skip`: Skip the new changefeed and run the next changefeed based on the `RECURRING` expression.<br><br>`wait`: Wait for the previous changefeed to complete.<br><br>**Default:** `wait`
 
@@ -70,17 +70,28 @@ The following statement sets up a scheduled changefeed named `users_rides_nightl
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE SCHEDULE users_rides_nightly FOR CHANGEFEED INTO 'external://kafka-sink' WITH format=csv RECURRING '1 0 * * *' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=retry, on_previous_running=skip;
+CREATE SCHEDULE users_rides_nightly FOR CHANGEFEED users, rides INTO 'external://kafka-sink' WITH format=csv RECURRING '1 0 * * *' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=retry, on_previous_running=skip;
 ~~~
 
 The [schedule options]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}#schedule-options) control the schedule's behavior:
 
-- If it runs into an error, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately. 
+- If it runs into an error, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately.
 - If the previous scheduled changefeed is still running, `on_previous_running=skip` will skip a new changefeed at the next scheduled time.
+
+The output will confirm that the changefeed has added the `initial_scan = 'only'` option implicitly:
+
+~~~
+     schedule_id     |     label     | status |           first_run           | schedule  |                                                      changefeed_stmt
+---------------------+---------------+--------+-------------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+  947257854259855361 | users_nightly | ACTIVE | 2024-02-28 20:02:35.716699+00 | 1 0 * * * | CREATE CHANGEFEED FOR TABLE movr.public.users, TABLE movr.public.rides INTO 'external://kafka-sink' WITH OPTIONS (format = 'csv', initial_scan = 'only')
+(1 row)
+
+NOTICE: added missing initial_scan='only' option to schedule changefeed
+~~~
 
 ### Create a scheduled changefeed with CDC queries
 
-You can use CDC queries with scheduled changefeeds to define expression syntax that selects columns and applies filters to further restrict or transform the data in your changefeed messages. When you add this expression syntax to your changefeed statement, you can only target one table. 
+You can use CDC queries with scheduled changefeeds to define expression syntax that selects columns and applies filters to further restrict or transform the data in your changefeed messages. When you add this expression syntax to your changefeed statement, you can only target one table.
 
 For guidance on syntax and more example use cases, see [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}).
 
@@ -88,7 +99,7 @@ This scheduled changefeed filters for the usage of promotion codes in the [`movr
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE SCHEDULE FOR CHANGEFEED INTO 'external://kafka-sink' AS SELECT user_id, usage_count FROM movr.user_promo_codes WHERE usage_count > 1 RECURRING '@daily' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=reschedule, on_previous_running=skip;
+CREATE SCHEDULE promo_code FOR CHANGEFEED INTO 'external://kafka-sink' AS SELECT user_id, usage_count FROM movr.user_promo_codes WHERE usage_count > 1 RECURRING '@daily' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=reschedule, on_previous_running=skip;
 ~~~
 
 ### View scheduled changefeed details

--- a/src/current/v23.2/create-schedule-for-changefeed.md
+++ b/src/current/v23.2/create-schedule-for-changefeed.md
@@ -28,7 +28,7 @@ To create a changefeed, the user must be a member of the `admin` role or have th
 Parameter | Description
 ----------+------------
 `IF NOT EXISTS` | A scheduled changefeed should not be created if the `schedule_label` already exists. You will receive an error if the schedule label already exists, or if `schedule_label` is not defined when using `IF NOT EXISTS`.
-`schedule_label` | The name for the scheduled changefeed. This is optional and does not need to be unique. If you do not define a name, the label will default to `CHANGEFEED` with the timestamp of when you created the schedule. 
+`schedule_label` | The name for the scheduled changefeed. This is optional and does not need to be unique. If you do not define a name, the label will default to `CHANGEFEED` with the timestamp of when you created the schedule.
 `changefeed_targets` | The tables to target with the changefeed. For example, `movr.users, movr.rides`.
 `changefeed_sink` | The [changefeed sink URI]({% link {{ page.version.version }}/changefeed-sinks.md %}).
 `changefeed_option` | The [options]({% link {{ page.version.version }}/create-changefeed.md %}#options) to control the behavior of your changefeed. For example, `WITH format = csv, full_table_name`. See [Changefeed options](#changefeed-options) for a list of available options.
@@ -54,7 +54,7 @@ Scheduled changefeeds have the [`initial_scan = 'only'`]({% link {{ page.version
 
 Option | Value | Description
 -------+-------+-------------
-`first_run` | [`TIMESTAMP`]({% link {{ page.version.version }}/timestamp.md %}) / `now` | Execute the first run of the schedule at this time. If you do not specify `first_run`, the schedule will execute based on the next `RECURRING` time set by the crontab. 
+`first_run` | [`TIMESTAMP`]({% link {{ page.version.version }}/timestamp.md %}) / `now` | Execute the first run of the schedule at this time. If you do not specify `first_run`, the schedule will execute based on the next `RECURRING` time set by the crontab.
 `on_execution_failure` | `retry` / `reschedule` / `pause` | Determine how the schedule handles an error. <br><br>`retry`: Retry the changefeed immediately.<br><br>`reschedule`: Reschedule the changefeed based on the `RECURRING` expression.<br><br>`pause`: Pause the schedule. This requires that you [resume the schedule]({% link {{ page.version.version }}/resume-schedules.md %}) manually.<br><br>**Default:** `reschedule`
 `on_previous_running` | `start` / `skip` / `wait` | Control whether the changefeed schedule should start a changefeed if the previous scheduled changefeed is still running.<br><br>`start`: Start the new changefeed anyway, even if the previous one is running.<br><br>`skip`: Skip the new changefeed and run the next changefeed based on the `RECURRING` expression.<br><br>`wait`: Wait for the previous changefeed to complete.<br><br>**Default:** `wait`
 
@@ -70,17 +70,28 @@ The following statement sets up a scheduled changefeed named `users_rides_nightl
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE SCHEDULE users_rides_nightly FOR CHANGEFEED INTO 'external://kafka-sink' WITH format=csv RECURRING '1 0 * * *' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=retry, on_previous_running=skip;
+CREATE SCHEDULE users_rides_nightly FOR CHANGEFEED users, rides INTO 'external://kafka-sink' WITH format=csv RECURRING '1 0 * * *' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=retry, on_previous_running=skip;
 ~~~
 
 The [schedule options]({% link {{ page.version.version }}/create-schedule-for-changefeed.md %}#schedule-options) control the schedule's behavior:
 
-- If it runs into an error, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately. 
+- If it runs into an error, `on_execution_failure=retry` will ensure that the schedule retries the changefeed immediately.
 - If the previous scheduled changefeed is still running, `on_previous_running=skip` will skip a new changefeed at the next scheduled time.
+
+The output will confirm that the changefeed has added the `initial_scan = 'only'` option implicitly:
+
+~~~
+     schedule_id     |     label     | status |           first_run           | schedule  |                                                      changefeed_stmt
+---------------------+---------------+--------+-------------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+  947257854259855361 | users_nightly | ACTIVE | 2024-02-28 20:02:35.716699+00 | 1 0 * * * | CREATE CHANGEFEED FOR TABLE movr.public.users, TABLE movr.public.rides INTO 'external://kafka-sink' WITH OPTIONS (format = 'csv', initial_scan = 'only')
+(1 row)
+
+NOTICE: added missing initial_scan='only' option to schedule changefeed
+~~~
 
 ### Create a scheduled changefeed with CDC queries
 
-You can use CDC queries with scheduled changefeeds to define expression syntax that selects columns and applies filters to further restrict or transform the data in your changefeed messages. When you add this expression syntax to your changefeed statement, you can only target one table. 
+You can use CDC queries with scheduled changefeeds to define expression syntax that selects columns and applies filters to further restrict or transform the data in your changefeed messages. When you add this expression syntax to your changefeed statement, you can only target one table.
 
 For guidance on syntax and more example use cases, see [Change Data Capture Queries]({% link {{ page.version.version }}/cdc-queries.md %}).
 
@@ -88,7 +99,7 @@ This scheduled changefeed filters for the usage of promotion codes in the [`movr
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE SCHEDULE FOR CHANGEFEED INTO 'external://kafka-sink' AS SELECT user_id, usage_count FROM movr.user_promo_codes WHERE usage_count > 1 RECURRING '@daily' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=reschedule, on_previous_running=skip;
+CREATE SCHEDULE promo_code FOR CHANGEFEED INTO 'external://kafka-sink' AS SELECT user_id, usage_count FROM movr.user_promo_codes WHERE usage_count > 1 RECURRING '@daily' WITH SCHEDULE OPTIONS first_run=now, on_execution_failure=reschedule, on_previous_running=skip;
 ~~~
 
 ### View scheduled changefeed details


### PR DESCRIPTION
Fixes DOC-9702

This PR corrects a bug on `CREATE SCHEDULE FOR CHANGEFEED` page where the table name was missing from the statement.

Also, added:
- a schedule label to the CDC query example. (Not incorrect, but preferable)
- output to the first example to show that the `initial_scan = 'only'` option is added to the create statement for scheduled changefeeds without the user needing to include it. 