### PR TITLE
Amend A104309 to note that CockroachDB issue #119536 is now fixed

### DIFF
--- a/src/current/advisories/a104309.md
+++ b/src/current/advisories/a104309.md
@@ -1,6 +1,6 @@
 ---
 title: Technical Advisory a104309
-advisory: A-a104309
+advisory: A-104309
 summary: In rare cases, a rangefeed bug may cause a checkpoint to be emitted prematurely, before all writes below the checkpoint timestamp have been emitted.
 toc: true
 affected_versions: v2.1.11 to v22.2.17, v23.1.0 to v23.1.14, v23.2.0
@@ -55,6 +55,14 @@ The fix has been applied to maintenance releases of CockroachDB:
 - [v23.1.15](https://www.cockroachlabs.com/docs/releases/v23.1#v23-1-15)
 - [v23.2.1](https://www.cockroachlabs.com/docs/releases/v23.2#v23-2-1)
 
+However, the initial fix introduced a bug that could cause a rangefeed’s resolved timestamp to stop advancing. For details, diagnostic steps, and mitigations, refer to the [note about the bug](#issue_110536). That bug is fixed in the following versions:
+
+- [v22.2.19](https://www.cockroachlabs.com/docs/releases/v22.2#v22-2-19)
+- [v23.1.16](https://www.cockroachlabs.com/docs/releases/v23.1#v23-1-16)
+- [v23.2.2](https://www.cockroachlabs.com/docs/releases/v23.2#v23-2-2)
+
+Users are encouraged to upgrade to a version that contains both fixes.
+
 This public issue is tracked by [Issue #104309](https://github.com/cockroachdb/cockroach/issues/104309).
 
 ## Mitigation
@@ -80,10 +88,19 @@ If data is found, it can be re-emitted in two ways:
 - By restarting the changefeed with `initial_scan` set to `yes` and without a cursor timestamp. This will perform a full export of all current data across the changefeed.
 - By restarting the changefeed and providing a cursor timestamp. If a cursor timestamp is provided, an initial scan will not be performed. Instead, updates above the cursor timestamp will be emitted. The cursor timestamp can be initialized below the timestamp of omitted writes (refer to the reference documentation for [`CREATE CHANGEFEED`](https://www.cockroachlabs.com/docs/stable/create-changefeed)). However, specifying a cursor timestamp farther in the past than the [`gc.ttlseconds`](https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds) replication zone variable, which defaults to `14400` seconds (4 hours), results in an error.
 
+<a id="issue_110536"></a>
 {{site.data.alerts.callout_info}}
-This fix introduces a [bug](https://github.com/cockroachdb/cockroach/issues/119536) that could cause a rangefeed’s resolved timestamp to stop advancing. The corresponding changefeed will appear to be stalled in `RUNNING` state in certain conditions: If a rangefeed is running on a follower on a recently-merged range, and the rangefeed encounters an aborted transaction, then the resolved timestamp may stall.  Events such as row updates will still be emitted as normal, but new checkpoints will not be emitted.
+This fix introduces a [bug](https://github.com/cockroachdb/cockroach/issues/119536) that could cause a rangefeed’s resolved timestamp to stop advancing. The corresponding changefeed will appear to be stalled in `RUNNING` state in certain conditions: If a rangefeed is running on a follower on a recently-merged range, and the rangefeed encounters an aborted transaction, then the resolved timestamp may stall. Events such as row updates will still be emitted as normal, but new checkpoints will not be emitted.
 
-After upgrading to a version with the fix for this advisory, **a104309**, your cluster may encounter a stalled rangefeed or changefeed even if it was not impacted by the original rangefeed bug. Monitor your cluster using the following mechanisms. For more details, refer to [Monitor and debug changefeeds](https://www.cockroachlabs.com/docs/stable/monitor-and-debug-changefeeds).
+That bug is fixed in the following versions:
+
+- [v22.2.19](https://www.cockroachlabs.com/docs/releases/v22.2#v22-2-19)
+- [v23.1.16](https://www.cockroachlabs.com/docs/releases/v23.1#v23-1-16)
+- [v23.2.2](https://www.cockroachlabs.com/docs/releases/v23.2#v23-2-2)
+
+Users are encouraged to upgrade to a version that contains both fixes. If you are not yet able to upgrade to such a version, refer to the following information to help diagnose and work around rangefeed or changefeed stalls caused by the bug introduced by this advisory's initial fix.
+
+After upgrading to a version with the fix for this advisory, **a104309**, your cluster may encounter a stalled rangefeed or changefeed even if it was not impacted by the original rangefeed bug disclosed in this advisory. Monitor your cluster using the following mechanisms. For more details, refer to [Monitor and debug changefeeds](https://www.cockroachlabs.com/docs/stable/monitor-and-debug-changefeeds).
 
 - Monitor cluster logs for messages like:
 


### PR DESCRIPTION
Amend A104309 to note that CockroachDB issue #119536 is now fixed

Preview: https://deploy-preview-18347--cockroachdb-docs.netlify.app/docs/advisories/a104309