### PR TITLE
Add .bundle/config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules
 /src/*/bootstrap
 /src/*/vendor/
 spec_30_enriched.json
+.bundle/config


### PR DESCRIPTION
With recent macOS and Xcode and our toolchain, you now need to run this command before `bundle install`:

```
bundle config build.cbor --with-cflags="-Wno-incompatible-function-pointer-types"
bundle config build.posix-spawn --with-cflags="-Wno-incompatible-function-pointer-types"
```

After you run that plus `bundle install`, a new file is created in the repo, `.bundle/config`. This is a local configuration file that should not make it into the repo, I guess.