### PR TITLE
Remove the preview label from changefeed metrics labels

### DIFF
--- a/src/current/v24.1/cockroachdb-feature-availability.md
+++ b/src/current/v24.1/cockroachdb-feature-availability.md
@@ -198,12 +198,6 @@ $ cockroach sql --user=jpointsman --insecure
 
 The [`EXPERIMENTAL CHANGEFEED FOR`]({% link {{ page.version.version }}/changefeed-for.md %}) statement creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
-### Changefeed metrics labels
-
-{% include {{ page.version.version }}/cdc/metrics-labels.md %}
-
-For usage details, see the [Monitor and Debug Changefeeds]({% link {{ page.version.version }}/monitor-and-debug-changefeeds.md %}) page.
-
 ### Multiple active portals
 
 The multiple active portals feature of the Postgres wire protocol (pgwire) is available, with limitations.  For more information, see [Multiple active portals]({% link {{ page.version.version }}/postgresql-compatibility.md %}#multiple-active-portals).

--- a/src/current/v24.1/monitor-and-debug-changefeeds.md
+++ b/src/current/v24.1/monitor-and-debug-changefeeds.md
@@ -77,10 +77,6 @@ If you are running a changefeed with the [`confluent_schema_registry`]({% link {
 ### Using changefeed metrics labels
 
 {{site.data.alerts.callout_info}}
-{% include feature-phases/preview.md %}
-{{site.data.alerts.end}}
-
-{{site.data.alerts.callout_info}}
 An {{ site.data.products.enterprise }} license is required to use metrics labels in changefeeds.
 {{site.data.alerts.end}}
 


### PR DESCRIPTION
Fixes DOC-10016

This removes the preview label from changefeed metrics labels in v24.1.