### PR TITLE
Add missing changefeed release notes to v23.1 & v23.2

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.7.md
+++ b/src/current/_includes/releases/v23.1/v23.1.7.md
@@ -29,6 +29,7 @@ Release Date: July 31, 2023
 - Fixed a bug where [changefeeds](https://www.cockroachlabs.com/docs/v23.1/change-data-capture-overview) would fail when upgrading to version [v23.1.5](#v23-1-5) because the job record did not have a `clusterID` field set. [#106399][#106399]
 - Fixed a bug where `UPDATE`, `UPSERT`, `DELETE` statements running concurrently with [`ALTER TABLE..ADD COLUMN`](https://www.cockroachlabs.com/docs/v23.1/alter-table#add-column) of a virtual computed column on the same table would fail. [#107403][#107403]
 - Fixed a bug where [SQL statistics compaction jobs](https://www.cockroachlabs.com/docs/v23.1/show-jobs#show-automatic-jobs) would fail. This is now fixed by reducing the contention on the `system.statement_statistics` table. [#107573][#107573]
+- Fixed a bug where running a [changefeed]({% link v23.2/change-data-capture-overview.md %}) that targets a table with a user-defined type column and with the [`envelope` option]({% link v23.2/create-changefeed.md %}#envelope) set to any value other than `wrapped` would cause a node panic due to a nil dereference. [#119746][119746]
 
 <div class="release-note-contributors" markdown="1">
 
@@ -54,3 +55,4 @@ This release includes 16 merged PRs by 11 authors.
 [#107403]: https://github.com/cockroachdb/cockroach/pull/107403
 [#107497]: https://github.com/cockroachdb/cockroach/pull/107497
 [#107573]: https://github.com/cockroachdb/cockroach/pull/107573
+[#119746]: https://github.com/cockroachdb/cockroach/pull/119746

--- a/src/current/_includes/releases/v23.2/v23.2.3.md
+++ b/src/current/_includes/releases/v23.2/v23.2.3.md
@@ -59,6 +59,7 @@ Release Date: March 20, 2024
 - Previously, in certain cases, using virtual tables such as `crdb_internal.system_jobs` could result in the internal error `attempting to append refresh spans after the tracked timestamp has moved forward`. This is now fixed. The bug was introduced in CockroachDB v23.1. [#119184][#119184]
 - Fixed a bug where operations on the `crdb_internal.leases` table could cause a node to become unavailable due to a deadlock in the leasing subsystem. [#119341][#119341]
 - Fixed a bug where rangefeed resolved timestamps could get stuck, continually emitting the log message `pushing old intents failed: range barrier failed, range split`, typically following a [range merge](../v23.2/architecture/distribution-layer.html#range-merges). [#119541][#119541]
+- Fixed a bug where running a [changefeed]({% link v23.2/change-data-capture-overview.md %}) that targets a table with a user-defined type column and with the [`envelope` option]({% link v23.2/create-changefeed.md %}#envelope) set to any value other than `wrapped` would cause a node panic due to a nil dereference. [#119738][#119738]
 - Fixed a rare panic that could happen during a `pg_dump` import that contains a function that has a subquery in one of its arguments, like `SELECT addgeometrycolumn(...)`. Now, attempting to import a `pg_dump` with such a function results in an expected error. [#118612][#118612]
 - Users with the [VIEWACTIVITY](../v23.2/security-reference/authorization.html#supported-privileges) privilege can now request statement bundles using `crdb_internal.request_statement_bundle` or through the DB Console [SQL Activity](../v23.2/security-reference/authorization.html#supported-privileges) page. [#118809][#118809]
 - Fixed a bug in changefeed [webhook sinks](../v23.2/changefeed-sinks.html#webhook-sink) where the HTTP request body may not be initialized on retries, resulting in the error `http: ContentLength=... with Body length 0`. [#119496][#119496]
@@ -106,6 +107,7 @@ This release includes 118 merged PRs by 42 authors.
 [#119601]: https://github.com/cockroachdb/cockroach/pull/119601
 [#119702]: https://github.com/cockroachdb/cockroach/pull/119702
 [#119711]: https://github.com/cockroachdb/cockroach/pull/119711
+[#119738]: https://github.com/cockroachdb/cockroach/pull/119738
 [#119768]: https://github.com/cockroachdb/cockroach/pull/119768
 [#120076]: https://github.com/cockroachdb/cockroach/pull/120076
 [#120245]: https://github.com/cockroachdb/cockroach/pull/120245


### PR DESCRIPTION
Fixes DOC-9805

A couple of release notes relating to changefeeds were missed from the original eng PR, adding them to the release note pages manually.