### PR TITLE
v23.2.4 self-hosted binary release

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5823,10 +5823,3 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.3
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-    This version is currently available only for select
-    CockroachDB Cloud clusters. To request to upgrade
-    a CockroachDB self-hosted cluster to this version,
-    [contact support](https://support.cockroachlabs.com/hc/en-us/requests/new).


### PR DESCRIPTION
Fixes DOC-9904

In releases.yml, removed cloud lines from v23.2.4 to enable download of self-hosted binaries.

rendered preview: https://deploy-preview-18471--cockroachdb-docs.netlify.app/docs/releases/v23.2#v23-2-4