### PR TITLE
DOC-9636 PR #118787 - ui: take non-negative derivative of full scan chart

### DIFF
--- a/src/current/v24.1/ui-sql-dashboard.md
+++ b/src/current/v24.1/ui-sql-dashboard.md
@@ -83,11 +83,11 @@ The statement contention metric is a counter that represents the number of state
 
 ## Full Table/Index Scans
 
-- In the node view, the graph shows the total number of full table and index scans on that node.
+- In the node view, the graph shows the total number of full table and index scans per second on that node. This is a non-negative rate.
 
-- In the cluster view, the graph shows the total number of full table and index scans across all nodes in the cluster.
+- In the cluster view, the graph shows the total number of full table and index scans per second across all nodes in the cluster. This is a non-negative rate.
 
-[Examine the statements]({% link {{ page.version.version }}/sql-tuning-with-explain.md %}) that result in full table scans and consider adding [secondary indexes]({% link {{ page.version.version }}/schema-design-indexes.md %}#create-a-secondary-index).
+You can [identify the specific statements]({% link {{ page.version.version }}/ui-statements-page.md %}#filter) that result in full table scans by filtering for them on the **Statements** page. [Examine these statements]({% link {{ page.version.version }}/sql-tuning-with-explain.md %}) that result in full table scans and consider adding [secondary indexes]({% link {{ page.version.version }}/schema-design-indexes.md %}#create-a-secondary-index).
 
 ## Active Flows for Distributed SQL Statements
 
@@ -101,7 +101,7 @@ Connection latency is calculated as the time in nanoseconds between when the clu
 
 - In the node view, the graph shows the 99th [percentile](https://wikipedia.org/wiki/Percentile#The_normal_distribution_and_percentiles) of connection latency for the node. Over the last minute this node established 99% of connections within this time, not including network latency between the node and the client.
 
-- In the cluster view, the graph shows the 99th [percentile](https://wikipedia.org/wiki/Percentile#The_normal_distribution_and_percentiles) of service latency across all nodes in the cluster. There are lines for each node in the cluster. Over the last minute the cluster established 99% of connections within this time, not including network latency between the node and the client.
+- In the cluster view, the graph shows the 99th [percentile](https://wikipedia.org/wiki/Percentile#The_normal_distribution_and_percentiles) of connection latency across all nodes in the cluster. There are lines for each node in the cluster. Over the last minute the cluster established 99% of connections within this time, not including network latency between the node and the client.
 
 ## Connection Latency: 90th Percentile
 


### PR DESCRIPTION
Fixes DOC-9636

(1) In ui-sql-dashboard.md, (a) modified description of Full Table/Index Scans to specify non-negative rate, (b) added link to Statements page filter, (c) fixed typo in description for the Connection Latency.

rendered preview: [SQL Dashboard page](https://deploy-preview-18491--cockroachdb-docs.netlify.app/docs/v24.1/ui-sql-dashboard.html)