### PR TITLE
DOC-10153 Fix release note formatting in v24.1.0-alpha.5

### DIFF
--- a/src/current/_includes/releases/v24.1/v24.1.0-alpha.5.md
+++ b/src/current/_includes/releases/v24.1/v24.1.0-alpha.5.md
@@ -51,7 +51,8 @@ Release Date: April 1, 2024
     - `distsender.rpc.proxy.forward.sent`
     - `distsender.rpc.proxy.forward.err`
 
-  Cockroach Labs recommends monitoring and alerting on `distsender.rpc.proxy.sent`, because it indicates a possible network partition. [#120239][#120239]
+    Cockroach Labs recommends monitoring and alerting on `distsender.rpc.proxy.sent`, because it indicates a possible network partition. [#120239][#120239]
+
 - The `provisioned-rate` field of a node's store specification can no longer be used to add constraints for the disk name or bandwidth. By default, bandwidth is constrained according to the [cluster setting]({% link v24.1/cluster-settings.md %}) `kv.store.admission.provisioned_bandwidth`. To override this setting for a specific node, the storage specification must contain `provisioned-rate=bandwidth={bandwidth-bytes/s}`. [#120895][#120895]
 - Removal of the [cluster setting]({% link v24.1/cluster-settings.md %}) `kv.rangefeed.scheduler.enabled`, which was announced in [v24.1.0-alpha.1](https://www.cockroachlabs.com/docs/releases/v24.1.html#v24-1-0-alpha-1), has been reverted, and the cluster setting is reinstated. [#121164][#121164]
 


### PR DESCRIPTION
Fixes DOC-10153

In v24.1.0-alpha.5.md, fixed formatting of 2 release notes.