### PR TITLE
DOC-9968 sql: default sql.stats.statement_fingerprint.format_mask to use special flags

### DIFF
--- a/src/current/_includes/v23.2/ui/statement-fingerprints.md
+++ b/src/current/_includes/v23.2/ui/statement-fingerprints.md
@@ -1,0 +1,44 @@
+{% if page.cloud == true %}
+  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
+  {% assign page_prefix = "" %}
+{% else %}
+  {% assign link_prefix = "" %}
+  {% assign page_prefix = "ui-" %}
+{% endif %}
+
+### Example
+
+See [View historical statement statistics and the sampled logical plan per fingerprint]({{ link_prefix }}crdb-internal.html#view-historical-statement-statistics-and-the-sampled-logical-plan-per-fingerprint).
+
+## SQL statement fingerprints
+
+The Statements page displays SQL statement fingerprints.
+
+A _statement fingerprint_ represents one or more SQL statements by replacing literal values (e.g., numbers and strings) with underscores (`_`). This can help you quickly identify frequently executed SQL statements and their latencies.
+
+For multiple SQL statements to be represented by a fingerprint, they must be identical aside from their literal values and placeholders.
+
+These SQL statements:
+
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (380, 11, 11098)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (192, 891, 20)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (784, 452, 78)`
+
+have the fingerprint `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (_, _, _)`
+
+These SQL statements:
+
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, $2, 11098)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($3, $4, 300)`
+
+have the fingerprint `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, $1, _)`.
+
+The following statements are not represented by either fingerprint:
+
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, 11, 11098)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, $2, $3)`
+
+It is possible to see the same fingerprint listed multiple times in the following scenarios:
+
+- Statements with this fingerprint were executed by more than one [`application_name`]({{ link_prefix }}show-vars.html#supported-variables).
+- Statements with this fingerprint were executed both successfully and unsuccessfully.

--- a/src/current/_includes/v24.1/ui/statement-fingerprints.md
+++ b/src/current/_includes/v24.1/ui/statement-fingerprints.md
@@ -1,0 +1,43 @@
+{% if page.cloud == true %}
+  {% capture link_prefix %}../{{site.current_cloud_version}}/{% endcapture %}
+  {% assign page_prefix = "" %}
+{% else %}
+  {% assign link_prefix = "" %}
+  {% assign page_prefix = "ui-" %}
+{% endif %}
+
+### Example
+
+See [View historical statement statistics and the sampled logical plan per fingerprint]({{ link_prefix }}crdb-internal.html#view-historical-statement-statistics-and-the-sampled-logical-plan-per-fingerprint).
+
+## SQL statement fingerprints
+
+The Statements page displays SQL statement fingerprints.
+
+A _statement fingerprint_ represents one or more SQL statements by replacing literal values (e.g., numbers and strings) and placeholders with underscores (`_`). Lists with only literals or placeholders and similar expressions are shortened to their first item followed by `__more__`.
+
+Fingerprints can help you quickly identify frequently executed SQL statements and their latencies.
+
+For multiple SQL statements to be represented by a fingerprint, they must be identical aside from their literal values and placeholders.
+
+These SQL statements:
+
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (380, 11, 11098)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (192, 891, 20)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (784, 452, 78)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, $2, 11098)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($3, $4, 300)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, 11, 11098)`
+- `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES ($1, $2, $3)`
+
+have the fingerprint `INSERT INTO new_order(product_id, customer_id, transaction_id) VALUES (_, __more__)`
+
+The following statements are not represented by the preceding fingerprint:
+
+- INSERT INTO new_order(product_id, customer_id, transaction_id, item_count) VALUES (380, 11, 11098, 1);
+- INSERT INTO new_order(product_id, customer_id, transaction_id, item_count) VALUES (192, 891, 20, 2);
+- INSERT INTO new_order(product_id, customer_id, transaction_id, item_count) VALUES (784, 452, 78, 3);
+
+Instead, they have the fingerprint `INSERT INTO new_order(product_id, customer_id, transaction_id, item_count) VALUES (_, __more__)`
+
+It is possible to see the same fingerprint listed multiple times when statements with this fingerprint were executed by more than one [`application_name`]({{ link_prefix }}show-vars.html#supported-variables).

--- a/src/current/_includes/v24.1/ui/statements-table.md
+++ b/src/current/_includes/v24.1/ui/statements-table.md
@@ -32,7 +32,7 @@ Diagnostics | Activate and download [diagnostics](#diagnostics) for this fingerp
 {{site.data.alerts.callout_info}}
 To obtain the execution statistics, CockroachDB samples a percentage of the executions. If you see `no samples` displayed in the **Contention**, **Max Memory**, or **Network** columns, there are two possibilities:
 - Your statement executed successfully but wasn't sampled because there were too few executions of the statement.
-- Your statement has failed (the most likely case). You can confirm by clicking the statement and viewing the value for **Failed?**.
+- Your statement has failed (the most likely case). You can confirm by clicking the statement and viewing the value for **Failure Count**.
 {{site.data.alerts.end}}
 
 To view statement details, click a SQL statement fingerprint in the **Statements** column to open the **Statement Fingerprint** page.

--- a/src/current/cockroachcloud/statements-page.md
+++ b/src/current/cockroachcloud/statements-page.md
@@ -16,7 +16,7 @@ docs_area: manage
 
 {% include {{version_prefix}}ui/statistics.md %}
 
-{% include common/ui/statements-page.md %}
+{% include {{version_prefix}}ui/statement-fingerprints.md %}
 
 {% include {{version_prefix}}ui/statements-table.md %}
 

--- a/src/current/v23.2/ui-statements-page.md
+++ b/src/current/v23.2/ui-statements-page.md
@@ -15,7 +15,7 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/statistics.md %}
 
-{% include common/ui/statements-page.md %}
+{% include {{ page.version.version }}/ui/statement-fingerprints.md %}
 
 {% include {{ page.version.version }}/ui/statements-table.md %}
 

--- a/src/current/v24.1/ui-statements-page.md
+++ b/src/current/v24.1/ui-statements-page.md
@@ -15,7 +15,7 @@ docs_area: reference.db_console
 
 {% include {{ page.version.version }}/ui/statistics.md %}
 
-{% include common/ui/statements-page.md %}
+{% include {{ page.version.version }}/ui/statement-fingerprints.md %}
 
 {% include {{ page.version.version }}/ui/statements-table.md %}
 


### PR DESCRIPTION
Fixes DOC-9968, DOC-9894

(1) Added _includes/v23.2/ui/statement-fingerprints.md as a copy of ./_includes/common/ui/statements-page.md.
(2) Added _includes/v24.1/ui/statement-fingerprints.md as a copy of ./_includes/common/ui/statements-page.md and modified for this feature.
(3) In v23.2 and v24.1 ui-statements-page.md and ./cockroachcloud/statements-page.md, replace _includes/common/ui/statements-page.md with _includes/VERSION/ui/statement-fingerprints.md.
(4) In ./_includes/v24.1/ui/statements-table.md, replaced Failed? with Failure Count.