### PR TITLE
Use the new download table include for 23.1.20

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.20.md
+++ b/src/current/_includes/releases/v23.1/v23.1.20.md
@@ -2,7 +2,7 @@
 
 Release Date: May 1, 2024
 
-{% include releases/release-downloads-docker-image.md release=include.release %}
+{% include releases/new-release-downloads-docker-image.md release=include.release %}
 
 <h3 id="v23-1-20-sql-language-changes">SQL language changes</h3>
 


### PR DESCRIPTION
23.1.20 landed simultaneous to recent changes to the display of downloads, and missed being updated to use the new include, causing the old download buttons to look ugly instead of using the new table.