### PR TITLE
[DOC-10090][DOC-10093] v24.1.0 deprecations, backward-incompatible changes, licensing updates

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.0.md
+++ b/src/current/_includes/releases/v23.1/v23.1.0.md
@@ -224,7 +224,7 @@ Asyncpg is commonly used with ORM libraries such as SQLAlchemy to provide a simp
   </tbody>
 </table>
 
-<h4 id="v23-1-0-recovery-and-io">Recovery and I/O</h4>
+<h4 id="v23-1-0-recovery-and-io" markdown="1">Recovery and I/O</h4>
 
 <h5>Change data capture (Changefeeds)</h5>
 

--- a/src/current/_includes/releases/v24.1/v24.1.0-alpha.1.md
+++ b/src/current/_includes/releases/v24.1/v24.1.0-alpha.1.md
@@ -6,7 +6,7 @@ Release Date: March 7, 2024
 
 <h3 id="v24-1-0-alpha-1-backward-incompatible-changes">Backward-incompatible changes</h3>
 
-- [`AS OF SYSTEM TIME`]({% link v23.2/as-of-system-time.md %}) queries can no longer use a timestamp followed by a question mark to signifiy a future-time value. This was an undocumented syntax. [#116830][#116830]
+- [`AS OF SYSTEM TIME`]({% link v23.2/as-of-system-time.md %}) queries can no longer use a timestamp followed by a question mark to signify a future-time value. This was an undocumented syntax. [#116830][#116830]
 
 <h3 id="v24-1-0-alpha-1-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
 

--- a/src/current/_includes/releases/v24.1/v24.1.0.md
+++ b/src/current/_includes/releases/v24.1/v24.1.0.md
@@ -237,11 +237,21 @@ In CockroachDB Self-Hosted, all available features are free to use unless their 
 
 </div>
 
+<h4 id="v24-1-0-enterprise-features" markdown="1">Enterprise features</h4>
+
+{{site.data.alerts.callout_info}}
+The following are [enterprise-only](https://www.cockroachlabs.com/docs/v24.1/enterprise-licensing) features. [Request a 30-day trial license](https://www.cockroachlabs.com/get-cockroachdb/enterprise/) to try them out.
+{{site.data.alerts.end}}
+
+- The [`READ COMMITTED`]({% link v24.1/read-committed.md %}) isolation level now requires the cluster to have a valid [enterprise license](https://cockroachlabs.com/docs/v24.1/licensing-faqs#obtain-a-license). Otherwise, transactions which are configured to run as `READ COMMITTED` will be upgraded to [`SERIALIZABLE`]({% link v24.1/demo-serializable.md %}), as described in [Backward-incompatible changes](#read-committed-transaction-upgrade). [#120154](https://github.com/cockroachdb/cockroach/pull/120154)
+
 <h4 id="v24-1-0-backward-incompatible-changes">Backward-incompatible changes</h4>
 
 Before [upgrading to CockroachDB v24.1]({% link v24.1/upgrade-cockroach-version.md %}), be sure to review the following backward-incompatible changes, as well as [key cluster setting changes](#v24-1-0-cluster-settings), and adjust your deployment as necessary.
 
-- TBD
+- [`AS OF SYSTEM TIME`]({% link v23.2/as-of-system-time.md %}) queries can no longer use a timestamp followed by a question mark to signify a future-time value. This was an undocumented syntax. [#116830](https://github.com/cockroachdb/cockroach/pull/116830)
+- The [`READ COMMITTED`]({% link v24.1/read-committed.md %}) isolation level now requires the cluster to have a valid [enterprise license](https://cockroachlabs.com/docs/v24.1/licensing-faqs#obtain-a-license). Otherwise, transactions which are configured to run as `READ COMMITTED` will be upgraded to [`SERIALIZABLE`]({% link v24.1/demo-serializable.md %}), as described in the next note. [#120154](https://github.com/cockroachdb/cockroach/pull/120154)
+- <a id="read-committed-transaction-upgrade"></a>The `sql.txn.read_committed_isolation.enabled` [cluster setting]({% link v24.1/cluster-settings.md %}) is now `true` by default. As a result, [`READ COMMITTED`]({% link v24.1/read-committed.md %}) transactions are **not** automatically upgraded to [`SERIALIZABLE`]({% link v24.1/demo-serializable.md %}), and will run as `READ COMMITTED` by default. On v23.2, refer to the [**Upgrades of SQL Transaction Isolation Level**]({% link v24.1/ui-sql-dashboard.md %}#upgrades-of-sql-transaction-isolation-level) graph in the DB Console to check whether any transaction is being upgraded from a weaker isolation level to `SERIALIZABLE`, and could therefore run differently on v24.1. [#118479](https://github.com/cockroachdb/cockroach/pull/118479)
 
 <h4 id="v24-1-0-cluster-settings">Key Cluster Setting Changes</h4>
 
@@ -253,7 +263,8 @@ The following changes should be reviewed prior to upgrading. Default cluster set
 
 {% comment %}TODO: Intro para? Each sibling section has one.{% endcomment %}
 
-- TBD
+- `changefeed.balance_range_distribution.enable` is now deprecated. Instead, use the new [cluster setting]({% link v23.2/cluster-settings.md %}) `changefeed.default_range_distribution_strategy`. `changefeed.default_range_distribution_strategy='balanced_simple'` has the same effect as setting `changefeed.balance_range_distribution.enable=true`. It does not require `initial_scan='only'`, which was required by the old setting. [#115166][#115166]
+- The `cockroach connect` command has been removed. This command was [deprecated]({% link releases/v23.2.md %}#v23-2-0-deprecations) in CockroachDB v23.2. [#113893][#113893]
 
 <h4 id="v24-1-0-known-limitations">Known limitations</h4>
 

--- a/src/current/v24.1/licensing-faqs.md
+++ b/src/current/v24.1/licensing-faqs.md
@@ -36,6 +36,8 @@ For each BSL release all associated alpha, beta, major, and minor (point) releas
 
 CockroachDB version | License | Converts to Apache 2.0
 --------------------|---------|----------------------------
+24.1 | Business Source License | May 20, 2027
+23.1 | Business Source License | Feb 5, 2027
 23.1 | Business Source License | May 16, 2026
 22.2 | Business Source License | Dec 6, 2025
 22.1 | Business Source License | May 24, 2025


### PR DESCRIPTION
[DOC-10090] v24.1.0 deprecations and backward-incompatible changes
[DOC-10093] v24.1.0 licensing updates

- Also fix a display bug in v23.1.0 release notes

Relates to [DOC-10061]

Preview: [releases/v24.1.md](https://deploy-preview-18530--cockroachdb-docs.netlify.app/docs/releases/v24.1.html)