### PR TITLE
Removed mentions of Cloud machine types

### DIFF
--- a/src/current/_includes/releases/cloud/2021-12-06.md
+++ b/src/current/_includes/releases/cloud/2021-12-06.md
@@ -5,7 +5,7 @@
 - New CockroachDB {{ site.data.products.dedicated }} clusters will now run [v21.2.1]({% link releases/v21.2.md %}#v21-2-1).
 - CockroachDB {{ site.data.products.serverless }} clusters will now run CockroachDB [v21.2.0-beta.4]({% link releases/v21.2.md %}#v21-2-0-beta-4).
 - New CockroachDB {{ site.data.products.cloud }} clusters will now have [Admission Control](https://www.cockroachlabs.com/docs/v21.2/architecture/admission-control) enabled by default.
-- CockroachDB {{ site.data.products.dedicated }} clusters will now run on new [machine types and disks](https://www.cockroachlabs.com/docs/cockroachcloud/create-your-cluster#step-2-select-the-cloud-provider). Clusters created before December 1, 2021 will be transitioned to the new hardware configurations by the end of the month, and pricing may change slightly.
+- CockroachDB {{ site.data.products.dedicated }} clusters will now run on new machine types and disks. Clusters created before December 1, 2021 will be transitioned to the new hardware configurations by the end of the month, and pricing may change slightly.
 
 <h3>Console changes</h3>
 

--- a/src/current/_includes/releases/cloud/2021-12-06.md
+++ b/src/current/_includes/releases/cloud/2021-12-06.md
@@ -5,7 +5,6 @@
 - New CockroachDB {{ site.data.products.dedicated }} clusters will now run [v21.2.1]({% link releases/v21.2.md %}#v21-2-1).
 - CockroachDB {{ site.data.products.serverless }} clusters will now run CockroachDB [v21.2.0-beta.4]({% link releases/v21.2.md %}#v21-2-0-beta-4).
 - New CockroachDB {{ site.data.products.cloud }} clusters will now have [Admission Control](https://www.cockroachlabs.com/docs/v21.2/architecture/admission-control) enabled by default.
-- CockroachDB {{ site.data.products.dedicated }} clusters will now run on new machine types and disks. Clusters created before December 1, 2021 will be transitioned to the new hardware configurations by the end of the month, and pricing may change slightly.
 
 <h3>Console changes</h3>
 

--- a/src/current/_includes/releases/cloud/2022-11-07.md
+++ b/src/current/_includes/releases/cloud/2022-11-07.md
@@ -14,7 +14,6 @@
 
 - Added an icon next to a cluster's name on the [**Billing overview**](https://www.cockroachlabs.com/docs/cockroachcloud/billing-management) page to indicate when a cluster has been deleted.
 - The [**Database page**](https://www.cockroachlabs.com/docs/cockroachcloud/databases-page) in the CockroachDB {{ site.data.products.cloud }} Console now shows the last time table statistics were updated.
-- All new AWS clusters now use [`gp3` volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html). Previously created AWS clusters still use `io1` volumes. AWS `gp3` volumes expose three parameters: storage amount, IOPS, and throughput.
 
 <h3> Cloud API changes </h3>
 

--- a/src/current/_includes/releases/cloud/2023-09-08.md
+++ b/src/current/_includes/releases/cloud/2023-09-08.md
@@ -4,8 +4,6 @@
 
 - [Managed-service backups](https://www.cockroachlabs.com/docs/cockroachcloud/use-managed-service-backups?filters=dedicated) are now available for [CockroachDB {{ site.data.products.dedicated }} clusters on Azure (Limited Access)]({% link cockroachcloud/cockroachdb-dedicated-on-azure.md %}).
 
-- New CockroachDB {{ site.data.products.dedicated }} clusters on Azure now use [Dsv4-series VMs](https://learn.microsoft.com/azure/virtual-machines/dv4-dsv4-series).
-
 - You can now create new [multi-region](https://www.cockroachlabs.com/docs/stable/multiregion-overview) CockroachDB {{ site.data.products.dedicated }} clusters on Azure.
 
 {% capture regions_list %}

--- a/src/current/cockroachcloud/architecture.md
+++ b/src/current/cockroachcloud/architecture.md
@@ -22,10 +22,6 @@ If you need a single tenant cluster with no shared resources, we recommend Cockr
 
 We use the Kubernetes offerings in AWS, GCP, and Azure (EKS, GKE, and AKS respectively) to run CockroachDB {{ site.data.products.cloud }} offerings.
 
-- GCP clusters use [N2 standard](https://cloud.google.com/compute/docs/machine-types#n2_machine_types) machine types and [Persistent Disk storage](https://cloud.google.com/compute/docs/disks#pdspecs).
-- AWS clusters use [M6 instance types](https://aws.amazon.com/ec2/instance-types/m6/#Product_Details) and [Elastic Block Store (EBS)](https://aws.amazon.com/ebs/features/).
-- Azure clusters use [Dsv4-series VMs](https://learn.microsoft.com/azure/virtual-machines/dv4-dsv4-series) and [Premium SSDs](https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssds).
-
 Each single-region cluster has a minimum of three nodes spread across three availability zones (AZ) in a cloud provider region. Multi-region clusters are similar to single-region clusters, with nodes spread across three or more AZs in each region.
 
 ### Security and Connection

--- a/src/current/cockroachcloud/create-your-cluster.md
+++ b/src/current/cockroachcloud/create-your-cluster.md
@@ -36,14 +36,6 @@ CockroachDB {{ site.data.products.dedicated }} advanced clusters cannot currentl
 
 You do not need an account in the deployment environment you choose. The cluster is created on infrastructure managed by Cockroach Labs. If you intend to use your CockroachDB {{ site.data.products.dedicated }} cluster with data or services in a cloud tenant, you should select that cloud provider and the region closest to your existing cloud services to maximize performance.
 
-CockroachDB {{ site.data.products.cloud }} clusters use the following machine and storage types:
-
-Cloud | Compute type                                                                          | Storage type
-------|---------------------------------------------------------------------------------------|-------------
-GCP   | [N2 standard](https://cloud.google.com/compute/docs/machine-types#n2_machine_types)   | [Persistent Disk storage](https://cloud.google.com/compute/docs/disks#pdspecs)
-AWS   | [M6](https://aws.amazon.com/ec2/instance-types/m6/#Product_Details)                   | [Elastic Block Store (EBS)](https://aws.amazon.com/ebs/features/)
-Azure | [Dsv4-series VMs](https://learn.microsoft.com/azure/virtual-machines/dv4-dsv4-series) | [Premium SSDs](https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssds)
-
 {% include cockroachcloud/cockroachcloud-pricing.md %}
 
 ## Step 3. Configure region(s) and node(s)


### PR DESCRIPTION
Removed mentions of machine types from CockroachCloud docs and release notes.

Addresses [DOC-9953](https://cockroachlabs.atlassian.net/browse/DOC-9953) and [DOC-10181](https://cockroachlabs.atlassian.net/browse/DOC-10181)