### PR TITLE
DOC-10138 v23.1.21 release notes SH download links

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6021,13 +6021,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.20
-  cloud_only: True
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-    This version is currently available only for select
-    CockroachDB Cloud clusters. To request to upgrade
-    a CockroachDB self-hosted cluster to this version,
-    [contact support](https://support.cockroachlabs.com/hc/en-us/requests/new).
 
 - release_name: v24.1.0-rc.1
   major_version: v24.1


### PR DESCRIPTION
Fixes DOC-10138

In releases.yml for v23.1.21, removed 3 cloud fields to show download links

Rendered preview [releases/v23.1.html#v23.1.21](https://deploy-preview-18546--cockroachdb-docs.netlify.app/docs/releases/v23.1.html#v23-1-21)