### PR TITLE
Small fix to prompt note on standby v24.1 virtualized-empty PCR

### DIFF
--- a/src/current/v24.1/set-up-physical-cluster-replication.md
+++ b/src/current/v24.1/set-up-physical-cluster-replication.md
@@ -206,8 +206,6 @@ Connect to your standby cluster's system virtual cluster using [`cockroach sql`]
     --certs-dir "certs"
     ~~~
 
-    The prompt will include `system` when you are connected to the system virtual cluster.
-
 1. Add your cluster organization and [{{ site.data.products.enterprise }} license]({% link {{ page.version.version }}/enterprise-licensing.md %}) to the cluster:
 
     {% include_cached copy-clipboard.html %}


### PR DESCRIPTION
Quick fix to the standby cluster creation portion. The setup page noted that the sql prompt would include the word `system` on the standby cluster. This is no longer true when a user first initializes a cluster with `--virtualized-empty`, it will look more like `root@{node IP}:26257/defaultdb>`

To avoid confusion, this PR removes that line from the tutorial. (Note that this line still exists in the docs for the primary cluster started with `virtualized` as the prompt includes `system` still in v24.1