### PR TITLE
Precede changefeed tutorials and examples with changefeed privilege note

### DIFF
--- a/src/current/_includes/cockroachcloud/cdc/tutorial-privilege-check.md
+++ b/src/current/_includes/cockroachcloud/cdc/tutorial-privilege-check.md
@@ -1,0 +1,1 @@
+The `CHANGEFEED` privilege in order to create and manage changefeed jobs. Refer to [Required privileges]({% link {{site.current_cloud_version}}/create-changefeed.md %}#required-privileges) for more details.

--- a/src/current/_includes/v23.2/cdc/tutorial-privilege-check.md
+++ b/src/current/_includes/v23.2/cdc/tutorial-privilege-check.md
@@ -1,0 +1,1 @@
+The `CHANGEFEED` privilege in order to create and manage changefeed jobs. Refer to [Required privileges]({% link {{ page.version.version }}/create-changefeed.md %}#required-privileges) for more details.

--- a/src/current/_includes/v24.1/cdc/tutorial-privilege-check.md
+++ b/src/current/_includes/v24.1/cdc/tutorial-privilege-check.md
@@ -1,0 +1,1 @@
+The `CHANGEFEED` privilege in order to create and manage changefeed jobs. Refer to [Required privileges]({% link {{ page.version.version }}/create-changefeed.md %}#required-privileges) for more details.

--- a/src/current/cockroachcloud/stream-changefeed-to-snowflake-aws.md
+++ b/src/current/cockroachcloud/stream-changefeed-to-snowflake-aws.md
@@ -27,6 +27,7 @@ Before you begin, make sure you have:
     {{site.data.alerts.end}}
 
 - [Read and write access](https://docs.snowflake.net/manuals/user-guide/security-access-control-overview.html) to a Snowflake cluster
+- {% include cockroachcloud/cdc/tutorial-privilege-check.md %}
 
 ## Step 1. Create a cluster
 

--- a/src/current/v23.2/changefeed-examples.md
+++ b/src/current/v23.2/changefeed-examples.md
@@ -29,6 +29,8 @@ Use the following filters to show usage examples for either **Enterprise** or **
 
 <section class="filter-content" markdown="1" data-scope="enterprise">
 
+Before you run the examples, verify that you have the `CHANGEFEED` privilege in order to create and manage changefeed jobs. Refer to [Required privileges]({% link {{ page.version.version }}/create-changefeed.md %}#required-privileges) for more details.
+
 {{site.data.alerts.callout_success}}
 {% include {{ page.version.version }}/cdc/sink-URI-external-connection.md %}
 {{site.data.alerts.end}}

--- a/src/current/v23.2/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.md
+++ b/src/current/v23.2/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.md
@@ -25,6 +25,7 @@ Before starting this tutorial, you will need:
     - If you are using CockroachDB {{ site.data.products.serverless }} or CockroachDB {{ site.data.products.dedicated }}, see the [Quickstart with CockroachDB](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) guide. For CockroachDB {{ site.data.products.core }} clusters, see the [install]({% link {{ page.version.version }}/install-cockroachdb-mac.md %}) page.
 - An [Okta Developer account](https://developer.okta.com/signup/).
 - (Optional) A Kafka cluster. This tutorial includes [Kafka cluster setup](#step-3-create-a-kafka-sink). Note that this tutorial was tested with Kafka [version 2.8.2](https://kafka.apache.org/downloads). The Kafka cluster configuration may vary with different versions, but the Okta setup and changefeed creation will be the same.
+- {% include {{ page.version.version }}/cdc/tutorial-privilege-check.md %}
 
 This tutorial uses the Cockroach Labs [`movr`]({% link {{ page.version.version }}/movr.md %}) workload as an example database.
 

--- a/src/current/v23.2/stream-a-changefeed-to-a-confluent-cloud-kafka-cluster.md
+++ b/src/current/v23.2/stream-a-changefeed-to-a-confluent-cloud-kafka-cluster.md
@@ -24,6 +24,7 @@ You will need the following set up before starting this tutorial:
 - A CockroachDB cluster. You can use a CockroachDB {{ site.data.products.cloud }} or CockroachDB {{ site.data.products.core }} cluster. If you are using CockroachDB {{ site.data.products.serverless }} or CockroachDB {{ site.data.products.dedicated }}, see the [Quickstart with CockroachDB](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) guide. For CockroachDB {{ site.data.products.core }} clusters, see the [install]({% link {{ page.version.version }}/install-cockroachdb-mac.md %}) page.
 - A Confluent Cloud account. See Confluent's [Get started](https://www.confluent.io/get-started/) page for details.
 - The Confluent CLI. See [Install Confluent CLI](https://docs.confluent.io/confluent-cli/current/install.html) to set this up. This tutorial uses v3.3.0 of the Confluent CLI. Note that you can also complete the steps in this tutorial in Confluent's Cloud console.
+- {% include {{ page.version.version }}/cdc/tutorial-privilege-check.md %}
 
 This tutorial uses the Cockroach Labs [`movr`]({% link {{ page.version.version }}/movr.md %}) workload as an example database.
 

--- a/src/current/v24.1/changefeed-examples.md
+++ b/src/current/v24.1/changefeed-examples.md
@@ -30,6 +30,8 @@ Use the following filters to show usage examples for either **Enterprise** or **
 
 <section class="filter-content" markdown="1" data-scope="enterprise">
 
+Before you run the examples, verify that you have the `CHANGEFEED` privilege in order to create and manage changefeed jobs. Refer to [Required privileges]({% link {{ page.version.version }}/create-changefeed.md %}#required-privileges) for more details.
+
 {{site.data.alerts.callout_success}}
 {% include {{ page.version.version }}/cdc/sink-URI-external-connection.md %}
 {{site.data.alerts.end}}

--- a/src/current/v24.1/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.md
+++ b/src/current/v24.1/connect-to-a-changefeed-kafka-sink-with-oauth-using-okta.md
@@ -25,6 +25,7 @@ Before starting this tutorial, you will need:
     - If you are using CockroachDB {{ site.data.products.serverless }} or CockroachDB {{ site.data.products.dedicated }}, see the [Quickstart with CockroachDB](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) guide. For CockroachDB {{ site.data.products.core }} clusters, see the [install]({% link {{ page.version.version }}/install-cockroachdb-mac.md %}) page.
 - An [Okta Developer account](https://developer.okta.com/signup/).
 - (Optional) A Kafka cluster. This tutorial includes [Kafka cluster setup](#step-3-create-a-kafka-sink). Note that this tutorial was tested with Kafka [version 2.8.2](https://kafka.apache.org/downloads). The Kafka cluster configuration may vary with different versions, but the Okta setup and changefeed creation will be the same.
+- {% include {{ page.version.version }}/cdc/tutorial-privilege-check.md %}
 
 This tutorial uses the Cockroach Labs [`movr`]({% link {{ page.version.version }}/movr.md %}) workload as an example database.
 

--- a/src/current/v24.1/stream-a-changefeed-to-a-confluent-cloud-kafka-cluster.md
+++ b/src/current/v24.1/stream-a-changefeed-to-a-confluent-cloud-kafka-cluster.md
@@ -24,6 +24,7 @@ You will need the following set up before starting this tutorial:
 - A CockroachDB cluster. You can use a CockroachDB {{ site.data.products.cloud }} or CockroachDB {{ site.data.products.core }} cluster. If you are using CockroachDB {{ site.data.products.serverless }} or CockroachDB {{ site.data.products.dedicated }}, see the [Quickstart with CockroachDB](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) guide. For CockroachDB {{ site.data.products.core }} clusters, see the [install]({% link {{ page.version.version }}/install-cockroachdb-mac.md %}) page.
 - A Confluent Cloud account. See Confluent's [Get started](https://www.confluent.io/get-started/) page for details.
 - The Confluent CLI. See [Install Confluent CLI](https://docs.confluent.io/confluent-cli/current/install.html) to set this up. This tutorial uses v3.3.0 of the Confluent CLI. Note that you can also complete the steps in this tutorial in Confluent's Cloud console.
+- {% include {{ page.version.version }}/cdc/tutorial-privilege-check.md %}
 
 This tutorial uses the Cockroach Labs [`movr`]({% link {{ page.version.version }}/movr.md %}) workload as an example database.
 


### PR DESCRIPTION
Fixes DOC-10247

Added a short sentence before examples and tutorials begin to remind users to check they have the `CHANGEFEED` privilege before running through the steps.