### PR TITLE
DOC-9690 Docs for General Availability: Prometheus/Grafana metrics integration for Dedicated/Advanced clusters

### DIFF
--- a/src/current/cockroachcloud/export-metrics.md
+++ b/src/current/cockroachcloud/export-metrics.md
@@ -224,10 +224,6 @@ A subset of CockroachDB metrics require that you explicitly [enable percentiles]
 
 <section class="filter-content" markdown="1" data-scope="prometheus-metrics-export">
 
-{{site.data.alerts.callout_info}}
-{% include_cached feature-phases/preview.md %}
-{{site.data.alerts.end}}
-
 1. Find your CockroachDB {{ site.data.products.dedicated }} cluster ID:
 
 	1. Visit the CockroachDB {{ site.data.products.cloud }} console [cluster page](https://cockroachlabs.cloud/clusters).


### PR DESCRIPTION
Fixes DOC-9690

In export-metrics.md, removed Preview note for Prometheus.

Rendered preview: [Enable metrics export for Prometheus](https://deploy-preview-18585--cockroachdb-docs.netlify.app/docs/cockroachcloud/export-metrics.html?filters=prometheus-metrics-export#enable-metrics-export)