### PR TITLE
Add PCR from non-virtualized cluster to virtualized standby docs

### DIFF
--- a/src/current/_includes/releases/v24.1/v24.1.0-alpha.5.md
+++ b/src/current/_includes/releases/v24.1/v24.1.0-alpha.5.md
@@ -12,6 +12,7 @@ Release Date: April 1, 2024
     - The output no longer displays `replication_job_id` or `service_mode` return fields.
     - The `data_state` field has been renamed to `status`.
     - The fields that are displayed are now ordered as follows: `retained_time`, `replicated_time`, `replication_lag`, `cutover_time`, `status`. [#120782][#120782]
+- You can now run [physical cluster replication]({% link v24.1/physical-cluster-replication-overview.md %}) from an [existing CockroachDB cluster]({% link v24.1/set-up-physical-cluster-replication.md %}#set-up-pcr-from-an-existing-cluster), without [cluster virtualization]({% link v24.1/cluster-virtualization-overview.md %}) enabled, to a standby cluster with cluster virtualization enabled. [#122001][#122001]
 
 <h3 id="v24-1-0-alpha-5-sql-language-changes">SQL language changes</h3>
 
@@ -115,3 +116,4 @@ We would like to thank the following contributors from the CockroachDB community
 [#121023]: https://github.com/cockroachdb/cockroach/pull/121023
 [#121160]: https://github.com/cockroachdb/cockroach/pull/121160
 [#121164]: https://github.com/cockroachdb/cockroach/pull/121164
+[#122001]: https://github.com/cockroachdb/cockroach/pull/122001

--- a/src/current/_includes/v24.1/sql/privileges.md
+++ b/src/current/_includes/v24.1/sql/privileges.md
@@ -19,6 +19,7 @@ Privilege | Levels | Description
 <a id="modifyclustersetting"></a>`MODIFYCLUSTERSETTING` | System | Grants the ability to modify [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}).
 `MODIFYSQLCLUSTERSETTING` | System | Grants the ability to modify SQL [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) (cluster settings prefixed with `sql.`).
 `NOSQLLOGIN` | System | Prevents roles from connecting to the SQL interface of a cluster.
+`REPLICATION` | System | Grants the ability to create a [physical cluster replication]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}) stream.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/query-data.md %}) at the table or sequence level.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update-data.md %}) at the table or sequence level.


### PR DESCRIPTION
Fixes DOC-10381

Add shortened guide on replicating from a non-virtualized cluster to a standby cluster that has been initialized with `--virtualized-empty`. 

Added the release note for the same.