### PR TITLE
Add logic to avoid treating an internal include as an advisory

### DIFF
--- a/src/current/advisories/index.md
+++ b/src/current/advisories/index.md
@@ -30,6 +30,7 @@ Users are invited to evaluate advisories and consider the recommended mitigation
 <tbody>
 
 {% for advisory in advisories %}
+{% if advisory.summary and advisory.affected_versions and advisory.advisory_date %}
 <tr>
 	<td>
 		<a href="/docs{{ advisory.url }}">{{ advisory.advisory }}</a>
@@ -38,6 +39,7 @@ Users are invited to evaluate advisories and consider the recommended mitigation
 	<td>{{ advisory.affected_versions }}</td>
 	<td>{{ advisory.advisory_date | date: "%B %e, %Y" }}</td>
 </tr>
+{% endif %}
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
This works around an empty row at the end of the table where 'internal/advisories.json' looks like an advisory, but isn't. It also will prevent display of an advisory missing a summary, description, or date, which would be an error.

To test: Check that [src/current/advisories/index.md](https://deploy-preview-18641--cockroachdb-docs.netlify.app/docs/advisories/index.html) has no empty row at the end of the table, and that no advisory is missing when compared to https://www.cockroachlabs.com/docs/advisories/ (there should be 63).