### PR TITLE
Remove recommendation to run SQL stats from v23.2+ Cloud upgrade topics

### DIFF
--- a/src/current/cockroachcloud/upgrade-to-v23.1.md
+++ b/src/current/cockroachcloud/upgrade-to-v23.1.md
@@ -62,7 +62,7 @@ Review the [backward-incompatible changes in {{ page.page_version }}](https://ww
 
 ### Reset SQL statistics
 
-Before upgrading to CockroachDB v23.1, it is recommended to reset the cluster's SQL statistics. Otherwise, it may take longer for the upgrade to complete on a cluster with large statement or transaction statistics tables. This is due to the addition of a new column and a new index to these tables. To reset SQL statistics, issue the following SQL command:
+Before upgrading to CockroachDB v23.1, it is recommended to reset the cluster's [SQL statistics]({% link {{ page.page_version}}/crdb-internal.md %}#statement-statistics). Otherwise, it may take longer for the upgrade to complete on a cluster with large statement or transaction statistics tables. This is due to the addition of a new column and a new index to these tables. To reset SQL statistics, issue the following SQL command:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/cockroachcloud/upgrade-to-v23.2.md
+++ b/src/current/cockroachcloud/upgrade-to-v23.2.md
@@ -86,15 +86,6 @@ Review the backward-incompatible changes and deprecated features announced in ea
 Review the backward-incompatible changes and deprecated features announced in the [{{ page.page_version }} release notes](https://www.cockroachlabs.com/docs/releases/{{ page.page_version }})
 {% endif %}
 
-### Reset SQL statistics
-
-Before upgrading to CockroachDB {{ page.page_version }}, it is recommended to reset the cluster's [SQL statistics]({% link {{ page.page_version }}/cost-based-optimizer.md %}#table-statistics). Otherwise, it may take longer for the upgrade to complete on a cluster with large statement or transaction statistics tables. This is due to the addition of a new column and a new index to these tables. To reset SQL statistics, issue the following SQL command:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT crdb_internal.reset_sql_stats();
-~~~
-
 ## Step 5. Start the upgrade
 
 To start the upgrade process:

--- a/src/current/cockroachcloud/upgrade-to-v24.1.md
+++ b/src/current/cockroachcloud/upgrade-to-v24.1.md
@@ -87,15 +87,6 @@ Review the backward-incompatible changes and deprecated features announced in ea
 Review the backward-incompatible changes and deprecated features announced in the [{{ page.page_version }} release notes](https://www.cockroachlabs.com/docs/releases/{{ page.page_version }})
 {% endif %}
 
-### Reset SQL statistics
-
-Before upgrading to CockroachDB {{ page.page_version }}, it is recommended to reset the cluster's [SQL statistics]({% link {{ page.page_version }}/cost-based-optimizer.md %}#table-statistics). Otherwise, it may take longer for the upgrade to complete on a cluster with large statement or transaction statistics tables. This is due to the addition of a new column and a new index to these tables. To reset SQL statistics, issue the following SQL command:
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-SELECT crdb_internal.reset_sql_stats();
-~~~
-
 ## Step 5. Start the upgrade
 
 To start the upgrade process:

--- a/src/current/v23.1/upgrade-cockroach-version.md
+++ b/src/current/v23.1/upgrade-cockroach-version.md
@@ -112,7 +112,7 @@ See our [support policy for restoring backups across versions]({% link {{ page.v
 
 ### Reset SQL statistics
 
-Before upgrading to CockroachDB v23.1, it is recommended to reset the cluster's SQL statistics. Otherwise, it may take longer for the upgrade to complete on a cluster with large statement or transaction statistics tables. This is due to the addition of a new column and a new index to these tables. To reset SQL statistics, issue the following SQL command:
+Before upgrading to CockroachDB v23.1, it is recommended to reset the cluster's [SQL statistics]({% link {{ page.version.version }}/crdb-internal.md %}#statement-statistics). Otherwise, it may take longer for the upgrade to complete on a cluster with large statement or transaction statistics tables. This is due to the addition of a new column and a new index to these tables. To reset SQL statistics, issue the following SQL command:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql


### PR DESCRIPTION
This was a recommendation specific to upgrading to v23.1, and was removed from the CRDB upgrade topics for v23.2+.

Also add a link for SQL statistics