### PR TITLE
[DOC-10431] Further LTS improvements

### DIFF
--- a/src/current/_data/alerts.yml
+++ b/src/current/_data/alerts.yml
@@ -2,11 +2,13 @@ tip: '<div class="alert alert-success" role="alert"><i class="fas fa-check-squar
 note: '<div class="alert alert-info" role="alert"><i class="fas fa-info-circle"></i> <b>Note: </b>'
 important: '<div class="alert alert-warning" role="alert"><i class="fas fa-warning"></i> <b>Important: </b>'
 warning: '<div class="alert alert-danger" role="alert"><i class="fas fa-exclamation-circle"></i> <b>Warning: </b>'
+version: '<div class="alert alert-version" role="alert"><i class="fas fa-info-circle"></i>'
 end: '</div>'
 
 callout_danger: '<div class="bs-callout bs-callout--danger"><div class="bs-callout__label">Warning:</div>'
 callout_success: '<div class="bs-callout bs-callout--success"><div class="bs-callout__label">Tip:</div>'
 callout_info: '<div class="bs-callout bs-callout--info"><div class="bs-callout__label">Note:</div>'
+callout_version: '<div class="bs-callout bs-callout--version">'
 
 hr_faded: '<hr class="faded"/>'
 hr_shaded: '<hr class="shaded"/>'

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6187,7 +6187,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.22
-  lts: true
 
 - release_name: v24.2.0-alpha.1
   major_version: v24.2
@@ -6241,7 +6240,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.6
-  lts: true
 
 - release_name: v24.1.2
   major_version: v24.1
@@ -6298,7 +6296,6 @@
   previous_release: v24.2.0-alpha.1
 
 - release_name: v23.2.8
-  lts: true
   major_version: v23.2
   release_date: '2024-07-15'
   release_type: Production
@@ -6356,7 +6353,6 @@
   major_version: v23.1
   release_date: '2024-07-18'
   release_type: Production
-  lts: true
   go_version: go1.22.5
   sha: b9b86f7f30053d86327d80f0bd582af57ffc3020
   has_sql_only: true
@@ -6435,7 +6431,6 @@
   previous_release: v24.2.0-beta.2
 
 - release_name: v23.2.9
-  lts: true
   major_version: v23.2
   release_date: '2024-08-01'
   release_type: Production

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5060,7 +5060,6 @@
   major_version: v23.1
   release_date: '2023-11-13'
   release_type: Production
-  lts: true
   go_version: go1.21
   sha: d7e9824b4cd6ebf7a8548156f2a772ae6648257d
   has_sql_only: true
@@ -5250,7 +5249,6 @@
   major_version: v23.1
   release_date: '2023-12-11'
   release_type: Production
-  lts: true
   go_version: go1.21
   sha: 8d065df26e25a762a1abbbf2b1e475456b341a00
   has_sql_only: true
@@ -5359,7 +5357,6 @@
   major_version: v23.1
   release_date: '2024-01-17'
   release_type: Production
-  lts: true
   go_version: go1.21
   sha: b95f2225b09cf25f9f2be31ef6a6f65c73a1b081
   has_sql_only: true
@@ -5468,7 +5465,6 @@
   major_version: v23.1
   release_date: '2024-02-20'
   release_type: Production
-  lts: true
   go_version: go1.21
   sha: 69a32fafce429e5b75dba8f339ea15922286a0ba
   has_sql_only: true
@@ -5523,7 +5519,6 @@
   major_version: v23.1
   release_date: '2024-02-27'
   release_type: Production
-  lts: true
   go_version: go1.21
   sha: 37f75744ac468fe5a97b343a188ea248bce8fb4a
   has_sql_only: true
@@ -5657,7 +5652,6 @@
   major_version: v23.1
   release_date: '2024-03-19'
   release_type: Production
-  lts: true
   go_version: go1.22.0
   sha: d50ccb5a52cdf5a1f41cbb2fa61ef971c65e1346
   has_sql_only: true
@@ -5766,7 +5760,6 @@
   major_version: v23.1
   release_date: '2024-04-09'
   release_type: Production
-  lts: true
   go_version: go1.22.0
   sha: 84cf36a2a05dcfcf6dfccf4014aad8f703ff6cef
   has_sql_only: true
@@ -5848,7 +5841,6 @@
   major_version: v23.1
   release_date: '2024-04-18'
   release_type: Production
-  lts: true
   go_version: go1.22.0
   sha: 1bca2adcbc1deb23067e28369f8b24c99194f2bb
   has_sql_only: true
@@ -5930,7 +5922,6 @@
   major_version: v23.1
   release_date: '2024-05-01'
   release_type: Production
-  lts: true
   go_version: go1.22.0
   sha: 93a67980ee45391b8ef02d40a6d50ddb0245817b
   has_sql_only: true
@@ -5985,7 +5976,6 @@
   major_version: v23.1
   release_date: '2024-05-07'
   release_type: Production
-  lts: true
   go_version: go1.22.0
   sha: fceb4cf5c378bfb53b3cf12c672716168192f1fe
   has_sql_only: true
@@ -6094,7 +6084,6 @@
   major_version: v23.1
   release_date: '2024-05-23'
   release_type: Production
-  lts: true
   go_version: go1.22.0
   sha: 6ed4ef16634f683adfb7d77b4ebf414e0c1e42a7
   has_sql_only: true

--- a/src/current/_includes/corestyle.scss
+++ b/src/current/_includes/corestyle.scss
@@ -471,6 +471,9 @@ section table tr.warning, table tr.testing, table tr.testing > td.sorting_1  {
 section table tr.danger, table tr.preference, table tr.preference > td.sorting_1  {
   background-color: #f2dede !important;
 }
+section table tr.version {
+  background-color: rgba(105, 51, 255, 0.2);
+}
 
 .orange {
   color: orange;

--- a/src/current/_includes/unsupported-version.md
+++ b/src/current/_includes/unsupported-version.md
@@ -31,6 +31,37 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 
 {% assign x = site.data.versions | where_exp: "m", "m.major_version == include.major_version" | first %}
 
+{% comment %}Save the admonitions into variables {% endcomment %}
+{% capture lts_eol_message %}
+      {{site.data.alerts.callout_danger}}
+      CockroachDB {{ include.major_version }} (LTS) is no longer supported as of {{ x.lts_asst_supp_exp_date | date: "%B %e, %Y"}}. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      {{site.data.alerts.end}}
+{% endcapture %}
+
+{% capture lts_assistance_message %}
+      {{site.data.alerts.callout_danger}}
+      GA releases for CockroachDB {{ include.major_version }} are no longer supported. Cockroach Labs will stop providing <strong>LTS Assistance Support</strong> for {{ include.major_version }} LTS releases on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      {{site.data.alerts.end}}
+{% endcapture %}
+
+{% capture lts_maintenance_message %}
+      {{site.data.alerts.callout_info}}
+      GA releases for CockroachDB {{ include.major_version }} are no longer supported. Cockroach Labs will stop providing <strong>LTS Assistance Support</strong> for {{ include.major_version }} LTS releases on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      {{site.data.alerts.end}}
+{% endcapture %}
+
+{% capture ga_eol_message %}
+      {{site.data.alerts.callout_danger}}
+      CockroachDB {{ include.major_version }} is no longer supported as of {{ x.asst_supp_exp_date | date: "%B %e, %Y"}}. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      {{site.data.alerts.end}}
+{% endcapture %}
+
+{% capture ga_assistance_message %}
+      {{site.data.alerts.callout_danger}}
+      Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} on <strong>{{ x.asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      {{site.data.alerts.end}}
+{% endcapture %}
+
 {% comment %}Continue only if we found an entry for this major version {% endcomment %}
 {% if x %}
 

--- a/src/current/_includes/unsupported-version.md
+++ b/src/current/_includes/unsupported-version.md
@@ -82,7 +82,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 {% capture lts_maintenance_message %}
       {% if today >= lm %}
       {{site.data.alerts.callout_version}}
-      As of {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}, {{ include.major_version }} LTS releases of CockroachDB {{ x.major_version }} releases are in <strong>Maintenance Support</strong>{% if today > a %} and GA releases prior to {{ x.initial_lts_patch }} are no longer supported.{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} LTS on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>
+      As of {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}, LTS releases of CockroachDB {{ x.major_version }} are in <strong>Maintenance Support</strong>{% if today > a %} and GA releases prior to {{ x.initial_lts_patch }} are no longer supported.{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} LTS on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>
       {{site.data.alerts.end}}
       {% endif %}
 {% endcapture %}

--- a/src/current/_includes/unsupported-version.md
+++ b/src/current/_includes/unsupported-version.md
@@ -31,37 +31,6 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 
 {% assign x = site.data.versions | where_exp: "m", "m.major_version == include.major_version" | first %}
 
-{% comment %}Save the admonitions into variables {% endcomment %}
-{% capture lts_eol_message %}
-      {{site.data.alerts.callout_danger}}
-      CockroachDB {{ include.major_version }} (LTS) is no longer supported as of {{ x.lts_asst_supp_exp_date | date: "%B %e, %Y"}}. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
-      {{site.data.alerts.end}}
-{% endcapture %}
-
-{% capture lts_assistance_message %}
-      {{site.data.alerts.callout_danger}}
-      GA releases for CockroachDB {{ include.major_version }} are no longer supported. Cockroach Labs will stop providing <strong>LTS Assistance Support</strong> for {{ include.major_version }} LTS releases on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
-      {{site.data.alerts.end}}
-{% endcapture %}
-
-{% capture lts_maintenance_message %}
-      {{site.data.alerts.callout_info}}
-      GA releases for CockroachDB {{ include.major_version }} are no longer supported. Cockroach Labs will stop providing <strong>LTS Assistance Support</strong> for {{ include.major_version }} LTS releases on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
-      {{site.data.alerts.end}}
-{% endcapture %}
-
-{% capture ga_eol_message %}
-      {{site.data.alerts.callout_danger}}
-      CockroachDB {{ include.major_version }} is no longer supported as of {{ x.asst_supp_exp_date | date: "%B %e, %Y"}}. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
-      {{site.data.alerts.end}}
-{% endcapture %}
-
-{% capture ga_assistance_message %}
-      {{site.data.alerts.callout_danger}}
-      Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} on <strong>{{ x.asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
-      {{site.data.alerts.end}}
-{% endcapture %}
-
 {% comment %}Continue only if we found an entry for this major version {% endcomment %}
 {% if x %}
 
@@ -112,7 +81,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 
 {% capture lts_maintenance_message %}
       {% if today >= lm %}
-      {{site.data.alerts.callout_danger}}
+      {{site.data.alerts.callout_version}}
       As of {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}, LTS releases of CockroachDB {{ x.major_version }} releases are in <strong>Maintenance Support</strong>{% if today > a %} and GA releases of CockroachDB {{ include.major_version }} are no longer supported.{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} LTS on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>
       {{site.data.alerts.end}}
       {% endif %}
@@ -136,7 +105,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 
 {% capture ga_maintenance_message %}
       {% if today <= m and today > a %}
-      {{site.data.alerts.callout_danger}}
+      {{site.data.alerts.callout_version}}
       As of <strong>{{ x.maint_supp_exp_date | date: "%B %e, %Y" }}</strong>, {{ include.major_version }} releases are in <strong>Maintenance Support</strong>. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} on <strong>{{ x.asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
       {{site.data.alerts.end}}
       {% endif %}

--- a/src/current/_includes/unsupported-version.md
+++ b/src/current/_includes/unsupported-version.md
@@ -74,7 +74,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 {% capture lts_assistance_message %}
       {% if today > lm %}
       {{site.data.alerts.callout_danger}}
-      Maintenance Support for LTS releases ended on {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}{% if today >= a %}, and GA releases of CockroachDB are no longer supported{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for LTS releases of {{ include.major_version }} on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      Maintenance Support for {{ include.major_version }} LTS releases ended on {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}{% if today >= a %}, and GA releases prior to {{ x.initial_lts_patch }} are no longer supported{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} LTS on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
       {{site.data.alerts.end}}
       {% endif %}
 {% endcapture %}
@@ -82,7 +82,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 {% capture lts_maintenance_message %}
       {% if today >= lm %}
       {{site.data.alerts.callout_version}}
-      As of {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}, LTS releases of CockroachDB {{ x.major_version }} releases are in <strong>Maintenance Support</strong>{% if today > a %} and GA releases of CockroachDB {{ include.major_version }} are no longer supported.{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} LTS on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>
+      As of {{ x.lts_maint_supp_exp_date | date: "%B %e, %Y" }}, {{ include.major_version }} LTS releases of CockroachDB {{ x.major_version }} releases are in <strong>Maintenance Support</strong>{% if today > a %} and GA releases prior to {{ x.initial_lts_patch }} are no longer supported.{% endif %}. Cockroach Labs will stop providing <strong>Assistance Support</strong> for {{ include.major_version }} LTS on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>
       {{site.data.alerts.end}}
       {% endif %}
 {% endcapture %}

--- a/src/current/_includes/version-switcher.html
+++ b/src/current/_includes/version-switcher.html
@@ -1,10 +1,23 @@
 {% assign DEBUG=false %}
-{% comment %}Get the major version we are currently viewing to see
-             whether it's an LTS version, before we build up the list
-             of available versions of the page later
-{% endcomment %}
-{% assign current_page_major_version_details = site.data.versions | where_exp: "m", "m.major_version == page.version.name" | first %}{% if DEBUG %}<!-- current_page_major_version_details {{ major_version_details }}-->{% endif %}
-{% assign version = site.data.versions | where_exp: "versions", "released_versions contains page.major_version" | sort: "release_date" | reverse  %}
+
+{% comment %}Get the version of the page we are currently viewing{% endcomment %}
+{% assign version = site.data.versions | where_exp: "v", "v.major_version == page.version.version" | sort: "release_date" | first %}
+{% unless version %}Error: Could not get version details for version {{ page.version.version }}. Giving up.{% break %}{% endunless %}
+
+{% comment %}Check whether the current page's version is released and if so, is LTS{% endcomment %}
+{% assign current_version_is_lts = false %}
+{% if version.initial_lts_patch != "N/A" %}
+  {% assign current_version_is_lts = true %}
+{% endif %}
+
+{% if DEBUG %}
+<!-- page.version: {{ page.version }}-->
+
+<!-- version: {{ version }}-->
+
+<!-- current_version_is_lts: {{ current_version_is_lts }}-->
+{% endif %}
+
 <div class="mt-3 mb-4">
 <div id="version-switcher">
   <ul class="nav">
@@ -13,18 +26,40 @@
 
         {% comment %}Display the page version we are currently viewing{% endcomment %}
 
-        Version <span class="version-name">{{ page.version.name }}{% if current_page_major_version_details.release_date != "N/A" and current_page_major_version_details.initial_lts_patch != "N/A" %}&nbsp;LTS&nbsp;{% endif %}</span>
+        Version <span class="version-name">{{ page.version.name }}</span>{% if current_version_is_lts == true %}&nbsp;LTS&nbsp;{% endif %}
         <div class="arrow"></div>
       </a>
       <ul class="list-unstyled"  style="display: none">
         {% comment %}Build the list of versions of the page{% endcomment %}
-        {% for v in page.versions %}{% if DEBUG %}<!-- v: {{ v }}-->{% endif %}
-          {% assign is_lts_version = false %}
+
+        {% for v in page.versions %}
+          {% assign v_is_lts = false %}
           {% comment %}Get major-version details for this version{% endcomment %}
-          {% assign major_version_details = site.data.versions | where_exp: "m", "m.major_version == v.version.version" | first %}{% if DEBUG %}<!-- major_version_details {{ major_version_details }}-->{% endif %}
-          {% if major_version_details.release_date != "N/A" and major_version_details.initial_lts_patch != "N/A" %}
-            {% assign is_lts_version = true %}
+          {% assign major_version_details = site.data.versions | where_exp: "pv", "pv.major_version == v.version.version" | sort: "release_date" | first %}
+          {% unless major_version_details %}Error: Could not get version details for version {{ v.version }}. Giving up.{% break %}{% endunless %}
+
+          {% comment %}Check whether this version is released and if so, and is LTS{% endcomment %}
+
+          {% if major_version_details.major_version == v.version.version and major_version_details.initial_lts_patch != "N/A" %}
+            {% assign v_is_lts = true %}
           {% endif %}
+
+          {% if DEBUG %}
+
+          <!-- major_version_details:  {{ major_version_details }}-->
+
+          <!-- major_version_details.major_version: {{major_version_details.major_version }} -->
+
+            <!-- major_version_details.initial_lts_patch -->
+
+          <!-- page.versions: {{ page.versions }}-->
+
+          <!-- v.version: {{ v.version }}-->
+
+          <!-- v_is_lts: {{ v_is_lts }}-->
+          {% endif %}
+
+
         <li class="tier-2 {% if v.version == page.version %}active{% endif %}">
           <a data-proofer-ignore
           {% if v.url %}
@@ -33,7 +68,7 @@
           {% else %}
             class="version--mobile version--page-dne"
           {% endif %}>
-            {{ v.version.name }}{% if is_lts_version %}&nbsp;LTS{% endif %}
+            {{ v.version.name }}{% if v_is_lts == true %}&nbsp;LTS&nbsp;{% endif %}
             {% unless v.version.tag == "cloud" or v.version.tag == nil %}({% if v.version.version == site.versions["stable"] %}Stable{% elsif v.version.version == site.versions["dev"] %}Dev{% endif %}){% endunless %}
             {% unless v.url %}
               <span class="version-text--page-dne">
@@ -49,7 +84,7 @@
             class="version--desktop version--page-dne"
             data-tooltip data-placement="left" data-container="body" title="This page does not exist in {{ v.version.version }}."
           {% endif %}>
-            {{ v.version.name }}{% if is_lts_version %}&nbsp;LTS{% endif %}
+            {{ v.version.name }}{% if v_is_lts == true %}&nbsp;LTS&nbsp;{% endif %}
             {% if v.version.tag %}({% if v.version.version == site.versions["stable"] %}Stable{% elsif v.version.version == site.versions["dev"] %}Dev{% endif %}){% endif %}
           </a>
         </li>

--- a/src/current/_includes/version-switcher.html
+++ b/src/current/_includes/version-switcher.html
@@ -1,13 +1,30 @@
+{% assign DEBUG=false %}
+{% comment %}Get the major version we are currently viewing to see
+             whether it's an LTS version, before we build up the list
+             of available versions of the page later
+{% endcomment %}
+{% assign current_page_major_version_details = site.data.versions | where_exp: "m", "m.major_version == page.version.name" | first %}{% if DEBUG %}<!-- current_page_major_version_details {{ major_version_details }}-->{% endif %}
+{% assign version = site.data.versions | where_exp: "versions", "released_versions contains page.major_version" | sort: "release_date" | reverse  %}
 <div class="mt-3 mb-4">
 <div id="version-switcher">
   <ul class="nav">
     <li class="tier-1">
       <a href="#">
-        Version <span class="version-name">{{ page.version.name }}</span>
+
+        {% comment %}Display the page version we are currently viewing{% endcomment %}
+
+        Version <span class="version-name">{{ page.version.name }}{% if current_page_major_version_details.release_date != "N/A" and current_page_major_version_details.initial_lts_patch != "N/A" %}&nbsp;LTS&nbsp;{% endif %}</span>
         <div class="arrow"></div>
       </a>
       <ul class="list-unstyled"  style="display: none">
-        {% for v in page.versions %}
+        {% comment %}Build the list of versions of the page{% endcomment %}
+        {% for v in page.versions %}{% if DEBUG %}<!-- v: {{ v }}-->{% endif %}
+          {% assign is_lts_version = false %}
+          {% comment %}Get major-version details for this version{% endcomment %}
+          {% assign major_version_details = site.data.versions | where_exp: "m", "m.major_version == v.version.version" | first %}{% if DEBUG %}<!-- major_version_details {{ major_version_details }}-->{% endif %}
+          {% if major_version_details.release_date != "N/A" and major_version_details.initial_lts_patch != "N/A" %}
+            {% assign is_lts_version = true %}
+          {% endif %}
         <li class="tier-2 {% if v.version == page.version %}active{% endif %}">
           <a data-proofer-ignore
           {% if v.url %}
@@ -16,7 +33,7 @@
           {% else %}
             class="version--mobile version--page-dne"
           {% endif %}>
-            {{ v.version.name }}
+            {{ v.version.name }}{% if is_lts_version %}&nbsp;LTS{% endif %}
             {% unless v.version.tag == "cloud" or v.version.tag == nil %}({% if v.version.version == site.versions["stable"] %}Stable{% elsif v.version.version == site.versions["dev"] %}Dev{% endif %}){% endunless %}
             {% unless v.url %}
               <span class="version-text--page-dne">
@@ -32,7 +49,7 @@
             class="version--desktop version--page-dne"
             data-tooltip data-placement="left" data-container="body" title="This page does not exist in {{ v.version.version }}."
           {% endif %}>
-            {{ v.version.name }}
+            {{ v.version.name }}{% if is_lts_version %}&nbsp;LTS{% endif %}
             {% if v.version.tag %}({% if v.version.version == site.versions["stable"] %}Stable{% elsif v.version.version == site.versions["dev"] %}Dev{% endif %}){% endif %}
           </a>
         </li>

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -8,6 +8,9 @@ pre_production_preview: true
 pre_production_preview_version: v24.1.0-beta.1
 ---
 
+{% comment %}Enable debug to print debug messages {% endcomment %}
+{% assign DEBUG = false %}
+
 {% comment %}
 NOTE TO WRITERS: This file contains interleaved HTML and Liquid. To ease maintenance and readability
 of this file, block-level HTML is indented in relation to the other HTML, and block-level Liquid is
@@ -50,7 +53,16 @@ As of 2024, CockroachDB is released under a staged delivery process. New release
 
 {% for v in versions %} {% comment %} Iterate through all major versions {% endcomment %}
 
+{% assign is_lts_version = false %}
+{% if v.release_date != "N/A" and v.initial_lts_patch != "N/A" %}
+    {% assign is_lts_version = true %}
+{% endif %}
+
 ## {{ v.major_version }}
+
+{% if DEBUG %}
+LTS? {{ is_lts_version }}
+{% endif %}
 
 <div id="os-tabs" class="filters filters-big clearfix">
     <button id="linux" class="filter-button" data-scope="linux">Linux</button>
@@ -109,7 +121,7 @@ As of 2024, CockroachDB is released under a staged delivery process. New release
     <tbody>
             {% for r in releases %}
 
-              {% capture lts_link_linux %}{% if r.lts == true %}&nbsp;([LTS]({% link releases/release-support-policy.md %})){% endif %}{% endcapture %}
+              {% capture lts_link_linux %}{% if is_lts_version != "N/A" %}&nbsp;([LTS]({% link releases/release-support-policy.md %})){% endif %}{% endcapture %}
 
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
             <td>
@@ -272,7 +284,7 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
     <tbody>
         {% for r in releases %}
 
-        {% capture lts_link_docker %}{% if r.lts == true %}&nbsp;([LTS]({% link releases/release-support-policy.md %})){% endif %}{% endcapture %}
+        {% capture lts_link_docker %}{% if is_lts_version %}&nbsp;([LTS]({% link releases/release-support-policy.md %})){% endif %}{% endcapture %}
 
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
             <td>
@@ -325,6 +337,8 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
     </thead>
     <tbody>
         {% for r in releases %}
+        R: <br />{{ r }}<br />
+        V: <br />{{ v }}</br>
 
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
             <td>
@@ -378,5 +392,5 @@ During development of a major version of CockroachDB, releases are produced acco
 ## Licenses
 
 Unless otherwise noted, all binaries available on this page are variously licensed under the Business Source License 1.1 (BSL), the CockroachDB Community License (CCL), and other licenses specified in the source code. To determine whether BSL or CCL applies to a CockroachDB feature, refer to the [Licensing FAQs](https://www.cockroachlabs.com/docs/stable/licensing-faqs) page under Feature Licensing. The default license for any feature that is not listed is the CCL.
- 
+
 To review the CCL, refer to the [CockroachDB Community License](https://www.cockroachlabs.com/cockroachdb-community-license/) page. You can find the applicable Business Source License or third party licenses by reviewing these in the `Licenses` folder for the applicable version of CockroachDB in the GitHub repository [cockroachdb/cockroach](https://github.com/cockroachdb/cockroach). See individual files for details.

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -297,15 +297,19 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
 
 <section class="filter-content" markdown="1" data-scope="docker">
 
+        {% comment %}Prepare to show the Notes column in v22.2 and v23.1{% endcomment %}
+        {% assign show_notes_column = false %}
+        {% if v.major_version == "v23.1" or v.major_version == "v22.2" %}
+            {% assign show_notes_column = true %}
+        {% endif %}
+
         {% if s == "Production" %}{% comment %}Print this only for the Production section{% endcomment %}
     Docker images for CockroachDB are published on [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach/tags).
 
-            {% if v_docker_arm == true %}
-                {% if v.major_version == "v22.2" or v.major_version == "v23.1" %}
-    [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) include support for both Intel and ARM.
-                {% else %}
+            {% if show_notes_column == true %}
+      [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) include support for both Intel and ARM.
+            {% else %}
         All Docker images for {{ v.major_version }} are [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) with support for both Intel and ARM.
-                {% endif %}
             {% endif %}
         {% endif %}
 
@@ -315,7 +319,7 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
             <td>Version</td>
             <td>Date</td>
             <td>Docker image tag</td>
-            {% if s == "Production" %}{% if v.major_version == "v23.1" or v.major_version == "v22.2" %}<td>Notes</td>{% endif %}{% endif %}
+            {% if show_notes_column == true %}<td>Notes</td>{% endif %}
         </tr>
     </thead>
     <tbody>
@@ -338,40 +342,46 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
             {% endif %}
 
         <tr {% if r.release_name == latest_hotfix.release_name %}class="latest"{% endif %}> {% comment %} Add "Latest" class to release if it's the latest release. {% endcomment %}
-            <td>
-                <a href="{% link releases/{{ v.major_version }}.md %}#{{ r.release_name | replace:
-".", "-" }}" class="binary-link">{{ r.release_name }}</a>{% if in_lts == true %}{{ lts_link }}{% endif %}{% comment %} Add link to each release r.
-{% endcomment %}
+
+            {% comment %}Version column{% endcomment %}
+            <td><a href="{% link releases/{{ v.major_version }}.md %}#{{ r.release_name | replace:
+".", "-" }}" class="binary-link">{{ r.release_name }}</a>{% if in_lts == true %}{{ lts_link }}{% endif %}{% comment %} Add link to each release r.{% endcomment %}
             {% if r.release_name == latest_hotfix.release_name %}
                 <span class="badge-new">Latest</span> {% comment %} Add "Latest" badge to release if it's the latest release. {% endcomment %}
             {% endif %}
             </td>
+
+            {% comment %}Release Date column{% endcomment %}
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
+
+            {% comment %}Docker Image Tag column{% endcomment %}
             <td>
-            {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
-                <span class="badge badge-gray">Withdrawn</span>
-            {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
-                <span>{{ r.cloud_only_message_short }}</span>
-                {% continue %}
+            {% if r.withdrawn == true %}
+                <span class="badge badge-gray">Withdrawn</span></td>{% comment %} Suppress download links for withdrawn releases, spans Intel and ARM columns {% endcomment %}
+            {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases, spans Intel and ARM columns {% endcomment %}
+                <span>{{ r.cloud_only_message_short }}</span></td>
             {% else %}
-                {% if r.source == true %}
-                {% if v.major_version == "v22.2" or v.major_version == "v23.1" %}{% if r.docker.docker_arm == false %}<b>Intel</b>:<br />{% else %}<b>Multi-platform</b>:<br />{% endif %}{% endif %}<code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
-                {% else %}
+                {% if r.source == false %}
                 N/A
+                {% else %}
+                    {% if show_notes_column == true %}{% comment %}Show Intel and ARM details only for major versions with a mix{% endcomment %}
+                        {% if r.docker.docker_arm == false %}<b>Intel</b>:<br />{% else %}<b>Multi-platform</b>:<br />{% endif %}
+                    {% endif %}<code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
                 {% endif %}
             {% endif %}
             </td>
-            {% if s == "Production" %}{% if v.major_version == "v23.1" or v.major_version == "v22.2" %}
+            {% if show_notes_column == true %}
+            {% comment %}Notes column{% endcomment %}
             <td>
                 {% if r.docker.docker_arm_limited_access == true %}
-              **Intel**: GA<br />**ARM**: Limited Access
+                **Intel**: Production<br />**ARM**: Limited Access
                 {% elsif r.docker.docker_arm_experimental == true %}
-              **Intel**: GA<br />**ARM**: Experimental
+                **Intel**: Production<br />**ARM**: Experimental
                 {% else %}
-              GA
+                Production
                 {% endif %}
             </td>
-            {% endif %}{% endif %}
+            {% endif %}
         </tr>
         {% endfor %}
     </tbody>
@@ -414,15 +424,15 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
             </td>
             {% endif %}
         </tr>
-        {% endfor %}
+        {% endfor %} {% comment %}for release in releases{% endcomment %}
     </tbody>
     </table>
 </section>
 
 
         {% endif %} {% comment %}if releases[0]{% endcomment %}
-    {% endfor %} {% comment %}Sections {% endcomment %}
-{% endfor %} {% comment %}Versions{% endcomment %}
+    {% endfor %} {% comment %}for s in sections {% endcomment %}
+{% endfor %} {% comment %}for v in versions{% endcomment %}
 
 ## Release naming
 


### PR DESCRIPTION
[DOC-10431] Further LTS improvements

1. Update the logic on the Releases index to get the LTS status from `site.data.versions` instead of `site.data.releases`
2. Update the version switcher to show LTS status both for the currently-viewed page version above the drop-down and in the list of versions in the drop-down
3. Modify the LTS Maintenance admonition from a red warning to a purple note.
4. Fix some LTS logic issues including off-by-one errors on LTS maintenance and assistance dates
5. In the Docker tab, hide the Notes column for all versions except for v23.1 and v22.2.
6. Fix a display bug each in the Source and Docker tabs

Also added some debug messages and the ability to enable or disable debug in the Releases index and the version switcher. The debug info shows in the page source as HTML comments.

### Previews
Description | URL | Description
------------|-----|-------------
Versioned page, not LTS, dev version | https://deploy-preview-18661--cockroachdb-docs.netlify.app/docs/v24.2/diagnostics-reporting (for example) |If the page exists for an LTS version, the entry for that version shows as LTS.
Versioned page, not LTS, stable version, in Assistance Support | https://deploy-preview-18661--cockroachdb-docs.netlify.app/docs/v24.1/diagnostics-reporting (for example) |If the page exists for an LTS version, the entry for that version shows as LTS. Red admonition.
Versioned page, LTS, in LTS Assistance Support | https://deploy-preview-18661--cockroachdb-docs.netlify.app/docs/v23.2/diagnostics-reporting (for example) |If the page exists for an LTS version, the entry for that version shows as LTS. Red admonition.
Versioned page, LTS, EOL | https://deploy-preview-18661--cockroachdb-docs.netlify.app/docs/v23.1/diagnostics-reporting (for example) | If the page exists for v23.1 and another version, v23.1 will be labeled as LTS and other entries do not. Red admonition.
Unversioned page (Release index)| https://deploy-preview-18661--cockroachdb-docs.netlify.app/docs/releases/. | LTS releases have (LTS) with a link to the Release Support Policy.
Unversioned page (Homepage) | https://deploy-preview-18661--cockroachdb-docs.netlify.app/docs/ | Unchanged by this PR.

To test the purple admonition for the terminal maintenance phase, you can set the date to 2024-11-13 and check a 23.1 version of a page.