### PR TITLE
[DOC-10557] Fix LTS date logic bug and 23.1 TOC

### DIFF
--- a/src/current/_includes/sidebar-data-v23.1.json
+++ b/src/current/_includes/sidebar-data-v23.1.json
@@ -7,7 +7,7 @@
     ]
   },
   {% include_cached v23.1/sidebar-data/get-started.json %},
-  {% include_cached v23.1/sidebar-data/latest-releases.json %},
+  {% include_cached v23.1/sidebar-data/releases.json %},
   {% include_cached v23.1/sidebar-data/feature-overview.json %},
   {% include_cached v23.1/sidebar-data/connect-to-cockroachdb.json %},
   {% include_cached v23.1/sidebar-data/migrate.json %},
@@ -22,6 +22,5 @@
   {% include_cached v23.1/sidebar-data/sql.json %},
   {% include_cached v23.1/sidebar-data/reference.json %},
   {% include_cached v23.1/sidebar-data/faqs.json %},
-  {% include_cached v23.1/sidebar-data/releases.json %},
   {% include_cached sidebar-data-cockroach-university.json %}
 ]

--- a/src/current/_includes/unsupported-version.md
+++ b/src/current/_includes/unsupported-version.md
@@ -40,6 +40,12 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
       {{site.data.alerts.end}}
 {% endcapture %}
 
+{% capture lts_maintenance_message %}
+      {{site.data.alerts.callout_danger}}
+      GA releases for CockroachDB {{ include.major_version }} are no longer supported. Cockroach Labs will stop providing <strong>LTS Assistance Support</strong> for {{ include.major_version }} LTS releases on <strong>{{ x.lts_asst_supp_exp_date | date: "%B %e, %Y" }}</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+      {{site.data.alerts.end}}
+{% endcapture %}
+
 {% capture ga_eol_message %}
       {{site.data.alerts.callout_danger}}
       CockroachDB {{ include.major_version }} is no longer supported as of {{ x.asst_supp_exp_date | date: "%B %e, %Y"}}. For more details, refer to the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
@@ -55,9 +61,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
 {% comment %}Continue only if we found an entry for this major version {% endcomment %}
 {% if x %}
 
-  {% if DEBUG %}
-  Major version object: {{ x }}<br />
-  {% endif %}
+  {% if DEBUG %}Major version object: {{ x }}<br />{% endif %}
 
   {% assign production = false %}
   {% assign lts = false %}
@@ -87,14 +91,7 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
     {% comment %}Show LTS admonitions only for versions with LTS releases {% endcomment %}
     {% if lts == true %}
 
-      {% if DEBUG %}
-    lts: {{ lts }}<br />
-    production: {{ production }}<br />
-    lm: {{ lm }}<br />
-    la: {{ la }}<br />
-    m: {{ m }}<br />
-    a: {{ a }}<br />
-      {% endif %}
+      {% if DEBUG %}lts: {{ lts }}<br />production: {{ production }}<br />lm: {{ lm }}<br />la: {{ la }}<br />m: {{ m }}<br />a: {{ a }}<br />{% endif %}
 
       {% comment %} LTS date validation will stop processing the include early {% endcomment %}
       {% if la <= lm %}
@@ -109,12 +106,11 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
       {% comment %}Show LTS Assistance message from the start of LTS maintance until EOL{% endcomment %}
       {% if today > la %} {% comment %}LTS assistance has passed, EOL{% endcomment %}
           {{ lts_eol_message }}
-      {% elsif today <= la %}
-        {% if today >= lm %} {% comment %}LTS maintenance has passed, in LTS assistance{% endcomment %}
+      {% elsif today <= la %}{% comment %}LTS assistance has not passed {% endcomment %}
+        {% if today > lm %} {% comment %}In LTS maintenance{% endcomment %}
           {{ lts_assistance_message }}
-          {% break %}
-        {% else %}
-          {{ lts_assistance_message }}
+        {% else %}{% comment %}In LTS GA, where only LTS patches are supported{% endcomment %}
+          {{ lts_maintenance_message }}
         {% endif %}
       {% endif %}
 
@@ -131,7 +127,6 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
       {% comment %}Show Assistance message from the start of maintance until EOL{% endcomment %}
       {% if today > a %} {% comment %}assistance has passed, EOL{% endcomment %}
         {{ ga_eol_message }}
-        {% break %}
       {% elsif today <= a %}
         {% if today >= m %} {% comment %}maintenance has begun{% endcomment %}
         {{ ga_assistance_message }}
@@ -140,8 +135,6 @@ Today date: {{ today | date: "%Y-%m-%d" }} <br />
           {% if DEBUG %}As of today {{ today }}, release is GA{% endif %}
         {% endif %}
       {% endif %}
-
-      {
     {% endif %}
 
   {% endif %}

--- a/src/current/_includes/unsupported-version.md
+++ b/src/current/_includes/unsupported-version.md
@@ -1,9 +1,29 @@
+{% assign DEBUG=false %}
 {% unless include.major_version %}
 Missing include.major_version. Usage: <code>{% raw %}{% include unsupported-version.md major_version=page.major_version %}{% endraw %}</code>
 {% break %}
 {% endunless %}
+{% if DEBUG %}Major version: {{ include.major_version }}<br />{% endif %}
 
-{% assign today = "today" | date: "%s" %} {% comment %} Fetch today's date and format it in seconds. {% endcomment %}
+{% comment %}To test, comment this line and uncomment the today and actual_today variables below{% endcomment %}
+{% assign today = "today" | date: "%s" %}{% comment %} Simulate future date and format it in seconds. {% endcomment %}
+
+{% comment %} Some dates to test:
+2025-11-14: 23.1 LTS EOL (LTS EOL message)
+2025-11-13: 23.1 LTS Assistance (LTS Assistance message)
+2024-11-13: 23.1 LTS Maintenance (LTS Assistance message)
+2024-11-12: 23.1 LTS GA (no message)
+{% endcomment %}
+
+{% comment %}Uncomment the following two lines and comment the third to test a specific date{% endcomment %}
+{% comment %}{% assign today = '2024-11-12' | date: "%s" %}{% endcomment %}
+{% comment %}{% assign actual_today = "today" | date: "%s" %}{% endcomment %}
+
+{% if DEBUG %}
+  {% if actual_today %}Actual today: {{ actual_today }}<br />{% endif %}
+Today: {{ today }}<br />
+Today date: {{ today | date: "%Y-%m-%d" }} <br />
+{% endif %}
 
 {% assign x = site.data.versions | where_exp: "m", "m.major_version == include.major_version" | first %}
 
@@ -35,15 +55,14 @@ Missing include.major_version. Usage: <code>{% raw %}{% include unsupported-vers
 {% comment %}Continue only if we found an entry for this major version {% endcomment %}
 {% if x %}
 
-  {% assign lts = false %}
-  {% comment %}Is it an LTS?{% endcomment %}
-  {% if x.initial_lts_patch != "N/A" %}
-    {% assign lts = true %}
-    {% assign lm = x.lts_maint_supp_exp_date | date: "%s" %} {% comment %} Format m_raw in seconds. {% endcomment %}
-    {% assign la = x.lts_asst_supp_exp_date | date: "%s" %} {% comment %} Format a_raw in seconds. {% endcomment %}
+  {% if DEBUG %}
+  Major version object: {{ x }}<br />
   {% endif %}
 
   {% assign production = false %}
+  {% assign lts = false %}
+  {% if DEBUG %}GA Maintenance support date: {{ x.maint_supp_exp_date }}<br />GA Assistance support date: {{ x.asst_supp_exp_date }}<br />{% endif %}
+
   {% comment %}Is it GA?{% endcomment %}
   {% if x.asst_supp_exp_date != "N/A" and x.asst_supp_exp_date != "N/A" %}
     {% assign production = true %}
@@ -51,25 +70,78 @@ Missing include.major_version. Usage: <code>{% raw %}{% include unsupported-vers
     {% assign a = x.asst_supp_exp_date | date: "%s" %} {% comment %} Format a_raw in seconds. {% endcomment %}
   {% endif %}
 
+  {% if production == true %}
+    {% comment %}Is it an LTS?{% endcomment %}
+    {% if x.initial_lts_patch != "N/A" %}
+      {% assign lts = true %}
+      {% assign lm = x.lts_maint_supp_exp_date | date: "%s" %} {% comment %} Format m_raw in seconds. {% endcomment %}
+      {% assign la = x.lts_asst_supp_exp_date | date: "%s" %} {% comment %} Format a_raw in seconds. {% endcomment %}
+    {% endif %}
+  {% endif %}
+
+  {% if DEBUG %}LTS maintenance support date: {{ x.lts_maint_supp_exp_date }}<br />LTS assistance support date: {{ x.lts_asst_supp_exp_date }}<br />
+  {% endif %}
+
   {% comment %}Show unsupported admonitions only for production releases {% endcomment %}
   {% if production == true %}
     {% comment %}Show LTS admonitions only for versions with LTS releases {% endcomment %}
     {% if lts == true %}
 
-      {% if la < today %} {% comment %}LTS assistance has passed, EOL{% endcomment %}
-        {{ lts_eol_message }}
-      {% elsif lm < today %} {% comment %}LTS maintenance has passed, in LTS assistance{% endcomment %}
-        {{ lts_assistance_message }}
+      {% if DEBUG %}
+    lts: {{ lts }}<br />
+    production: {{ production }}<br />
+    lm: {{ lm }}<br />
+    la: {{ la }}<br />
+    m: {{ m }}<br />
+    a: {{ a }}<br />
+      {% endif %}
+
+      {% comment %} LTS date validation will stop processing the include early {% endcomment %}
+      {% if la <= lm %}
+        Error: LTS assistance date must be after LTS maintenance date. Giving up.
+        {% break %}
+      {% endif %}
+      {% if la <= a or la <= m %}
+        Error: LTS assistance date must be after GA assistance and maintenance dates. Giving up.
+        {% break %}
+      {% endif %}
+
+      {% comment %}Show LTS Assistance message from the start of LTS maintance until EOL{% endcomment %}
+      {% if today > la %} {% comment %}LTS assistance has passed, EOL{% endcomment %}
+          {{ lts_eol_message }}
+      {% elsif today <= la %}
+        {% if today >= lm %} {% comment %}LTS maintenance has passed, in LTS assistance{% endcomment %}
+          {{ lts_assistance_message }}
+          {% break %}
+        {% else %}
+          {{ lts_assistance_message }}
+        {% endif %}
       {% endif %}
 
     {% comment %}Show non-LTS admonitions only releases without LTS {% endcomment %}
     {% else %}
 
-      {% if a < today %} {% comment %}assistance has passed, EOL{% endcomment %}
-        {{ ga_eol_message }}
-      {% elsif m < today %} {% comment %}maintenance has passed{% endcomment %}
-        {{ ga_assistance_message }}
+      {% comment %} GA date validation will stop processing the include early {% endcomment %}
+      {% if a <= m %}
+        Error: Assistance date must be after Maintenance date. Check _data/versions.csv. Giving up.
+        {% break %}
       {% endif %}
+      {% if DEBUG %}production: {{ production }}<br />m: {{ m }}<br />a: {{ a }}<br />{% endif %}
+
+      {% comment %}Show Assistance message from the start of maintance until EOL{% endcomment %}
+      {% if today > a %} {% comment %}assistance has passed, EOL{% endcomment %}
+        {{ ga_eol_message }}
+        {% break %}
+      {% elsif today <= a %}
+        {% if today >= m %} {% comment %}maintenance has begun{% endcomment %}
+        {{ ga_assistance_message }}
+          {% break %}
+        {% else %}
+          {% if DEBUG %}As of today {{ today }}, release is GA{% endif %}
+        {% endif %}
+      {% endif %}
+
+      {
     {% endif %}
 
   {% endif %}

--- a/src/current/_includes/v23.1/sidebar-data/latest-releases.json
+++ b/src/current/_includes/v23.1/sidebar-data/latest-releases.json
@@ -1,7 +1,0 @@
-{
-    "title": "Latest Releases",
-    "is_top_level": true,
-    "items": [
-      {% include_cached sidebar-latest-releases.json %}
-    ]
-  }

--- a/src/current/_layouts/page.html
+++ b/src/current/_layouts/page.html
@@ -46,10 +46,14 @@ front-matter.
   </div>
   <div id="toc" class="d-none"></div>
 {% endif %}
-{% if page.major_version %}{% comment %}Show unsupported version details only if a page is versioned{% endcomment %}
-  {% capture majorversion %}{{ page.major_version }}{% endcapture %}
-  {% include unsupported-version.md major_version=majorversion %}
+{% comment %}Release pages and normal versioned pages store their major version differently{% endcomment %}
+{% assign majorversion = 0 %}
+{% if page.version.version %}
+  {% assign majorversion = page.version.version %}
+{% elsif page.major_version %}
+  {% assign majorversion = page.major_version %}
 {% endif %}
+{% if majorversion and majorversion != 0 %}{% include unsupported-version.md major_version=majorversion %}{% endif %}
 {{content}}
 
 {% if page.feedback != false %}


### PR DESCRIPTION
[DOC-10557] Fix LTS date logic bug and 23.1 TOC

These bugs are causing the unsupported-version admonition to show up only on Release pages and not in versioned pages for any version (including EOL).

- Also add debug capability (disabled by default)
- Also propagate the combined Releases TOC entry to 23.1

This PR takes over https://github.com/cockroachdb/docs/pull/18615 (which already had review) and implements its fixes, as well as fixing a regression I somehow introduced there and making the logic just a bit more safe. I keep missing the "In LTS maintenance or LTS assistance, just show the LTS assistance" message in the logic.

### Previews
**Versioned release pages**:
GA: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/releases/v24.1 (No admonition)
GA: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/releases/v23.2 (No admonition)
LTS: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/releases/v23.1 (LTS admonition)
EOL: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/releases/v21.1 (EOL admonition)

**Versioned non-release pages**:
GA: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/v24.1/authentication (No admonition)
GA: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/v23.2/authentication (No admonition)
LTS: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/v23.1/authentication (LTS admonition)
EOL: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/v21.1/authentication (EOL admonition)

**Unversioned pages**:
Homepage: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/ (No admonition)
Releases index: https://deploy-preview-18667--cockroachdb-docs.netlify.app/docs/releases/ (No admonition, LTS link in 23.1 table rows)