### PR TITLE
Update manage-certs-vault.md

### DIFF
--- a/src/current/v24.1/manage-certs-vault.md
+++ b/src/current/v24.1/manage-certs-vault.md
@@ -369,7 +369,7 @@ The operations in this section are performed by the`ca-admin` persona, and there
     {% include_cached copy-clipboard.html %}
     ```shell
     # for example...
-    openssl x509 -in "${secrets_dir}/node1/ca.crt" -text | less
+    openssl x509 -in "${secrets_dir}/node1/certs/ca.crt" -text | less
     ```
     ~~~txt
     Certificate:


### PR DESCRIPTION
From a few lines above, we're copying the `ca.crt` to `node1/certs`. I presume we'd want to check the cert at the right path.