### PR TITLE
Update Dedicated AWS IP Allowlist

### DIFF
--- a/src/current/cockroachcloud/network-authorization.md
+++ b/src/current/cockroachcloud/network-authorization.md
@@ -60,7 +60,7 @@ Authorized network access can be managed from the CockroachDB {{ site.data.produ
 
 Cluster Type                | IP allowlist rule max
 ----------------------------|------------
-Dedicated (AWS)             | 7
+Dedicated (AWS)             | 20
 Dedicated (GCP and Azure)   | 200
 Serverless                  | 50
 


### PR DESCRIPTION
Updated the limit on Dedicated AWS IP Allowlist from 7 to 20