### PR TITLE
REL-984 v23.1.23: [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6205,3 +6205,4 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.22
+  lts: true

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6205,10 +6205,3 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.22
-  cloud_only: True
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).


### PR DESCRIPTION
Fixes REL-984

In releases.yml, for v23.1.23, removed cloud fields and added lts:true.

Rendered previews:
- [Releases list](https://deploy-preview-18672--cockroachdb-docs.netlify.app/docs/releases/#v23-1)
- [v23.1.23](https://deploy-preview-18672--cockroachdb-docs.netlify.app/docs/releases/v23.1#v23-1-23)
