### PR TITLE
Add the pause resume cancel all job syntax to diagram

### DIFF
--- a/src/current/v23.1/cancel-job.md
+++ b/src/current/v23.1/cancel-job.md
@@ -32,6 +32,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/cancel_job.html %}
 </div>
 
+### Cancel all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/cancel_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -39,6 +45,7 @@ Parameter | Description
 `job_id` | The ID of the job you want to cancel, which can be found with [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %}).
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to cancel.
 `for_schedules_clause` |  The schedule you want to cancel jobs for. You can cancel jobs for a specific schedule (`FOR SCHEDULE id`) or cancel jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#cancel-jobs-for-a-schedule) below.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to cancel.
 
 ## Examples
 
@@ -69,6 +76,15 @@ To cancel multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.versio
 ~~~
 
 All jobs created by `maxroach` will be cancelled.
+
+### Cancel by job type
+
+To cancel all jobs by the type of job, use the `CANCEL ALL {job} JOBS` statement. You can cancel all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CANCEL ALL BACKUP JOBS;
+~~~
 
 ### Cancel automatic table statistics jobs
 

--- a/src/current/v23.1/pause-job.md
+++ b/src/current/v23.1/pause-job.md
@@ -33,6 +33,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/pause_job.html %}
 </div>
 
+### Pause all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/pause_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -41,6 +47,7 @@ Parameter | Description
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to pause.
 `for_schedules_clause` |  The schedule you want to pause jobs for. You can pause jobs for a specific schedule (`FOR SCHEDULE id`) or pause jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#pause-jobs-for-a-schedule) below.
 `WITH REASON = ...` |  The reason to pause the job. CockroachDB stores the reason in the job's metadata, but there is no way to display it.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to pause.
 
 ## Monitoring paused jobs
 
@@ -95,6 +102,15 @@ To pause multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.version
 ~~~
 
 All jobs created by `maxroach` will be paused.
+
+### Pause by job type
+
+To pause all jobs by the type of job, use the `PAUSE ALL {job} JOBS` statement. You can pause all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+PAUSE ALL BACKUP JOBS;
+~~~
 
 ### Pause automatic table statistics jobs
 

--- a/src/current/v23.1/resume-job.md
+++ b/src/current/v23.1/resume-job.md
@@ -27,6 +27,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/resume_job.html %}
 </div>
 
+### Resume all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/resume_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -34,6 +40,7 @@ Parameter | Description
 `job_id` | The ID of the job you want to resume, which can be found with [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %}).
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to resume.
 `for_schedules_clause` |  The schedule you want to resume jobs for. You can resume jobs for a specific schedule (`FOR SCHEDULE id`) or resume jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#resume-jobs-for-a-schedule) below.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to resume.
 
 ## Examples
 
@@ -73,6 +80,15 @@ To resume multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.versio
 ~~~
 
 All jobs created by `maxroach` will be resumed.
+
+### Resume by job type
+
+To resume all jobs by the type of job, use the `RESUME ALL {job} JOBS` statement. You can resume all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+RESUME ALL BACKUP JOBS;
+~~~
 
 ### Resume jobs for a schedule
 

--- a/src/current/v23.2/cancel-job.md
+++ b/src/current/v23.2/cancel-job.md
@@ -32,6 +32,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/cancel_job.html %}
 </div>
 
+### Cancel all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/cancel_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -39,6 +45,7 @@ Parameter | Description
 `job_id` | The ID of the job you want to cancel, which can be found with [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %}).
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to cancel.
 `for_schedules_clause` |  The schedule you want to cancel jobs for. You can cancel jobs for a specific schedule (`FOR SCHEDULE id`) or cancel jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#cancel-jobs-for-a-schedule) below.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to cancel.
 
 ## Examples
 
@@ -69,6 +76,15 @@ To cancel multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.versio
 ~~~
 
 All jobs created by `maxroach` will be cancelled.
+
+### Cancel by job type
+
+To cancel all jobs by the type of job, use the `CANCEL ALL {job} JOBS` statement. You can cancel all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CANCEL ALL BACKUP JOBS;
+~~~
 
 ### Cancel automatic table statistics jobs
 

--- a/src/current/v23.2/pause-job.md
+++ b/src/current/v23.2/pause-job.md
@@ -33,6 +33,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/pause_job.html %}
 </div>
 
+### Pause all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/pause_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -41,6 +47,7 @@ Parameter | Description
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to pause.
 `for_schedules_clause` |  The schedule you want to pause jobs for. You can pause jobs for a specific schedule (`FOR SCHEDULE id`) or pause jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#pause-jobs-for-a-schedule) below.
 `WITH REASON = ...` |  The reason to pause the job. CockroachDB stores the reason in the job's metadata, but there is no way to display it.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to pause.
 
 ## Monitoring paused jobs
 
@@ -95,6 +102,15 @@ To pause multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.version
 ~~~
 
 All jobs created by `maxroach` will be paused.
+
+### Pause by job type
+
+To pause all jobs by the type of job, use the `PAUSE ALL {job} JOBS` statement. You can pause all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+PAUSE ALL BACKUP JOBS;
+~~~
 
 ### Pause automatic table statistics jobs
 

--- a/src/current/v23.2/resume-job.md
+++ b/src/current/v23.2/resume-job.md
@@ -27,6 +27,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/resume_job.html %}
 </div>
 
+### Resume all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/resume_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -34,6 +40,7 @@ Parameter | Description
 `job_id` | The ID of the job you want to resume, which can be found with [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %}).
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to resume.
 `for_schedules_clause` |  The schedule you want to resume jobs for. You can resume jobs for a specific schedule (`FOR SCHEDULE id`) or resume jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#resume-jobs-for-a-schedule) below.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to resume.
 
 ## Examples
 
@@ -73,6 +80,15 @@ To resume multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.versio
 ~~~
 
 All jobs created by `maxroach` will be resumed.
+
+### Resume by job type
+
+To resume all jobs by the type of job, use the `RESUME ALL {job} JOBS` statement. You can resume all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+RESUME ALL BACKUP JOBS;
+~~~
 
 ### Resume jobs for a schedule
 

--- a/src/current/v24.1/cancel-job.md
+++ b/src/current/v24.1/cancel-job.md
@@ -31,6 +31,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/cancel_job.html %}
 </div>
 
+### Cancel all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/cancel_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -38,6 +44,7 @@ Parameter | Description
 `job_id` | The ID of the job you want to cancel, which can be found with [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %}).
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to cancel.
 `for_schedules_clause` |  The schedule you want to cancel jobs for. You can cancel jobs for a specific schedule (`FOR SCHEDULE id`) or cancel jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#cancel-jobs-for-a-schedule) below.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to cancel.
 
 ## Examples
 
@@ -68,6 +75,15 @@ To cancel multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.versio
 ~~~
 
 All jobs created by `maxroach` will be cancelled.
+
+### Cancel by job type
+
+To cancel all jobs by the type of job, use the `CANCEL ALL {job} JOBS` statement. You can cancel all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CANCEL ALL BACKUP JOBS;
+~~~
 
 ### Cancel automatic table statistics jobs
 

--- a/src/current/v24.1/pause-job.md
+++ b/src/current/v24.1/pause-job.md
@@ -33,6 +33,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/pause_job.html %}
 </div>
 
+### Pause all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/pause_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -41,6 +47,7 @@ Parameter | Description
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to pause.
 `for_schedules_clause` |  The schedule you want to pause jobs for. You can pause jobs for a specific schedule (`FOR SCHEDULE id`) or pause jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#pause-jobs-for-a-schedule) below.
 `WITH REASON = ...` |  The reason to pause the job. CockroachDB stores the reason in the job's metadata, but there is no way to display it.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to pause.
 
 ## Monitoring paused jobs
 
@@ -95,6 +102,15 @@ To pause multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.version
 ~~~
 
 All jobs created by `maxroach` will be paused.
+
+### Pause by job type
+
+To pause all jobs by the type of job, use the `PAUSE ALL {job} JOBS` statement. You can pause all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+PAUSE ALL BACKUP JOBS;
+~~~
 
 ### Pause automatic table statistics jobs
 

--- a/src/current/v24.1/resume-job.md
+++ b/src/current/v24.1/resume-job.md
@@ -27,6 +27,12 @@ For changefeeds, users with the [`CHANGEFEED`]({% link {{ page.version.version }
 {% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/resume_job.html %}
 </div>
 
+### Resume all jobs by type
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/resume_all_jobs.html %}
+</div>
+
 ## Parameters
 
 Parameter | Description
@@ -34,6 +40,7 @@ Parameter | Description
 `job_id` | The ID of the job you want to resume, which can be found with [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %}).
 `select_stmt` | A [selection query]({% link {{ page.version.version }}/selection-queries.md %}) that returns `job_id`(s) to resume.
 `for_schedules_clause` |  The schedule you want to resume jobs for. You can resume jobs for a specific schedule (`FOR SCHEDULE id`) or resume jobs for multiple schedules by nesting a [`SELECT` clause]({% link {{ page.version.version }}/select-clause.md %}) in the statement (`FOR SCHEDULES <select_clause>`). See the [examples](#resume-jobs-for-a-schedule) below.
+`BACKUP`, `CHANGEFEED`, `RESTORE`, `IMPORT` | The job type to resume.
 
 ## Examples
 
@@ -73,6 +80,15 @@ To resume multiple jobs, nest a [`SELECT` clause]({% link {{ page.version.versio
 ~~~
 
 All jobs created by `maxroach` will be resumed.
+
+### Resume by job type
+
+To resume all jobs by the type of job, use the `RESUME ALL {job} JOBS` statement. You can resume all `BACKUP`, `RESTORE`, `CHANGEFEED`, `IMPORT` jobs using this statement, for example:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+RESUME ALL BACKUP JOBS;
+~~~
 
 ### Resume jobs for a schedule
 


### PR DESCRIPTION
Fixes DOC-5624

This adds the pause/resume/cancel all diagram and syntax to the v24.1+ docs.

Refer to the Files changed box below for a rendered preview.