### PR TITLE
Update cluster setting for bulk oracle cdc in release notes

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.23.md
+++ b/src/current/_includes/releases/v23.1/v23.1.23.md
@@ -11,7 +11,7 @@ Release Date: June 20, 2024
     - There were multiple target tables with significant differences in row counts in one changefeed.
     - The changefeed target tables were large with many ranges.
     - The initial scan took a long time to complete (an hour or longer). [#123970][#123970] [#124759][#124759]
-- [Changefeeds]({% link v23.1/change-data-capture-overview.md %}) now default to evenly distributing their work across all [replicas]({% link v23.1/architecture/glossary.md %}#replica), including [followers]({% link v23.1/architecture/replication-layer.md %}#raft), regardless of [leaseholder]({% link v23.1/architecture/glossary.md %}#leaseholder) placement. To disable this behavior, set the [cluster setting]({% link v23.1/cluster-settings.md %}) `changefeed.balanced_distribution.enabled` to `false`. If disabled, changefeed planning reverts to its previous behavior for distributing work. [#124930][#124930]
+- [Changefeeds]({% link v23.1/change-data-capture-overview.md %}) now default to evenly distributing their work across all [replicas]({% link v23.1/architecture/glossary.md %}#replica), including [followers]({% link v23.1/architecture/replication-layer.md %}#raft), regardless of [leaseholder]({% link v23.1/architecture/glossary.md %}#leaseholder) placement. To disable this behavior, set the [cluster setting]({% link v23.1/cluster-settings.md %}) `changefeed.random_replica_selection.enabled` to `false`. If disabled, changefeed planning reverts to its previous behavior for distributing work. [#124930][#124930]
 
 <h3 id="v23-1-23-sql-language-changes">SQL language changes</h3>
 

--- a/src/current/_includes/releases/v23.1/v23.1.23.md
+++ b/src/current/_includes/releases/v23.1/v23.1.23.md
@@ -11,7 +11,7 @@ Release Date: June 20, 2024
     - There were multiple target tables with significant differences in row counts in one changefeed.
     - The changefeed target tables were large with many ranges.
     - The initial scan took a long time to complete (an hour or longer). [#123970][#123970] [#124759][#124759]
-- [Changefeeds]({% link v23.1/change-data-capture-overview.md %}) now default to evenly distributing their work across all [replicas]({% link v23.1/architecture/glossary.md %}#replica), including [followers]({% link v23.1/architecture/replication-layer.md %}#raft), regardless of [leaseholder]({% link v23.1/architecture/glossary.md %}#leaseholder) placement. To disable this behavior, set the [cluster setting]({% link v23.1/cluster-settings.md %}) `changefeed.random_replica_selection.enabled` to `false`. If disabled, changefeed planning reverts to its previous behavior for distributing work. [#124930][#124930]
+- Introduced the `changefeed.random_replica_selection.enabled` [cluster setting]({% link v23.1/cluster-settings.md %}) that changes the behavior of changefeed planning work distribution. When `changefeed.random_replica_selection.enabled` is set to `true`, [changefeeds]({% link v23.1/change-data-capture-overview.md %}) will evenly distribute their work across all [replicas]({% link v23.1/architecture/glossary.md %}#replica), including [followers]({% link v23.1/architecture/replication-layer.md %}#raft), regardless of [leaseholder]({% link v23.1/architecture/glossary.md %}#leaseholder) placement. `changefeed.random_replica_selection.enabled` is disabled by default. [#124930][#124930]
 
 <h3 id="v23-1-23-sql-language-changes">SQL language changes</h3>
 

--- a/src/current/_includes/releases/v24.1/v24.1.0-alpha.5.md
+++ b/src/current/_includes/releases/v24.1/v24.1.0-alpha.5.md
@@ -6,7 +6,7 @@ Release Date: April 1, 2024
 
 <h3 id="v24-1-0-alpha-5-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
 
-- [Changefeeds]({% link v24.1/change-data-capture-overview.md %}) now default to evenly distributing their work across all replicas, including followers, regardless of leaseholder placement. To disable this behavior, set the [cluster setting]({% link v24.1/cluster-settings.md %}) `changefeed.balanced_distribution.enabled` to `false`. If disabled, changefeed planning reverts to its previous behavior for distributing work. [#120077][#120077]
+- [Changefeeds]({% link v24.1/change-data-capture-overview.md %}) now default to evenly distributing their work across all replicas, including followers, regardless of leaseholder placement. To disable this behavior, set the [cluster setting]({% link v24.1/cluster-settings.md %}) `changefeed.random_replica_selection.enabled ` to `false`. If disabled, changefeed planning reverts to its previous behavior for distributing work. [#120077][#120077]
 - When [physical cluster replication]({% link v24.1/physical-cluster-replication-overview.md %}) is enabled, the output of the `SHOW VIRTUAL CLUSTER ... WITH REPLICATION STATUS` command now displays replication lag. [#120782][#120782]
 - When [physical cluster replication]({% link v24.1/physical-cluster-replication-overview.md %}) is enabled, the output of the `SHOW VIRTUAL CLUSTER WITH REPLICATION STATUS to 1` command has changed:
     - The output no longer displays `replication_job_id` or `service_mode` return fields.


### PR DESCRIPTION
Fixes DOC-10599

This updates v24.1 and v23.1 release notes, looks like the v23.2 release for this setting isn't out yet.