### PR TITLE
DOC-9631 Docs for Metric scrape (prometheus-compatible metric endpoint) supported for Dedicated Azure clusters

### DIFF
--- a/src/current/cockroachcloud/export-metrics.md
+++ b/src/current/cockroachcloud/export-metrics.md
@@ -224,6 +224,12 @@ A subset of CockroachDB metrics require that you explicitly [enable percentiles]
 
 <section class="filter-content" markdown="1" data-scope="prometheus-metrics-export">
 
+{{site.data.alerts.callout_info}}
+For CockroachDB {{ site.data.products.dedicated }} clusters hosted on **Azure**:
+{% include_cached feature-phases/preview.md %}
+
+For CockroachDB {{ site.data.products.dedicated }} clusters hosted on AWS and GCP: This feature is in [general availability]({% link {{site.current_cloud_version}}/cockroachdb-feature-availability.md %}).{{site.data.alerts.end}}
+
 1. Find your CockroachDB {{ site.data.products.dedicated }} cluster ID:
 
 	1. Visit the CockroachDB {{ site.data.products.cloud }} console [cluster page](https://cockroachlabs.cloud/clusters).

--- a/src/current/v24.1/cockroachdb-feature-availability.md
+++ b/src/current/v24.1/cockroachdb-feature-availability.md
@@ -65,6 +65,8 @@ The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-
 ### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
 [Exporting metrics from CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/export-metrics.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
 
+[Exporting metrics from CockroachDB {{ site.data.products.dedicated }} to Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
+
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).
 {{site.data.alerts.end}}


### PR DESCRIPTION
Fixes DOC-9631

(1) In export-metrics.md, added preview note for Prometheus for Azure.
(2) In cockroachdb-feature-availability.md, updated Exporting Metrics section for Prometheus for Azure.