### PR TITLE
[REL-1004] Followup to add Cloud-first messages to v23.2.7

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -5463,13 +5463,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.0
-  cloud_only: false
-  cloud_only_message_short: 'Available only to select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only to select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB Self-Hosted cluster to this version,
-      [contact Support](https://support.cockroachlabs.com/hc/requests/new).
 
 - release_name: v23.1.15
   major_version: v23.1
@@ -6260,3 +6253,10 @@
   source: true
   previous_release: v23.2.6
   lts: true
+  cloud_only: true
+  cloud_only_message_short: 'Available only to select CockroachDB Cloud clusters'
+  cloud_only_message: >
+      This version is currently available only to select
+      CockroachDB Cloud clusters. To request to upgrade
+      a CockroachDB Self-Hosted cluster to this version,
+      [contact Support](https://support.cockroachlabs.com/hc/requests/new).


### PR DESCRIPTION
[REL-1004] Followup to add Cloud-first messages to v23.2.7

Also remove an extraneous entry in a prior version