### PR TITLE
[DOC-10653] Update logic in What's New intro

### DIFF
--- a/src/current/_includes/releases/whats-new-intro.md
+++ b/src/current/_includes/releases/whats-new-intro.md
@@ -1,10 +1,49 @@
+{% comment %}Early in development, a new major-version directory may not
+             yet exist. Adapt some links in this situation.{% endcomment %}
+{% assign branched = false %}
+{% assign ancient = false %}
+{% assign install_links = '' %}
+
+{% for file in site.pages %}
+  {% unless branched == true %}
+    {% capture fpath %}{{ file.dir | remove:'/' }}{% endcapture %}
+    {% if fpath == page.major_version %}
+      {% assign branched = true %}
+    {% endif %}
+  {% endunless %}
+{% endfor %}
+
+{% comment %}Some old pages need different links to install and upgrade pages{% endcomment %}
+{% if page.major_version == 'v1.0' or page.major_version == 'v1.1' or page.major_version == 'v2.0' or page.major_version == 'v2.1' or page.major_version == 'v21.1' %}
+  {% assign branched = true %}
+  {% assign ancient = true %}
+  {% capture install_link %}[install CockroachDB](https://cockroachlabs.com/docs/{{ page.major_version}}/install-cockroachdb.html){% endcapture %}
+  {% capture install_sentence %}After downloading a supported CockroachDB binary, learn how to {{ install_link }}.{% endcapture %}
+{% elsif page.major_version == 'v19.1' or page.major_version == 'v19.2' or page.major_version == 'v20.1' or page.major_version == 'v20.2' %}
+  {% assign branched = true %}
+  {% capture install_link %}[install CockroachDB](https://cockroachlabs.com/docs/{{ page.major_version}}/install-cockroachdb.html){% endcapture %}
+  {% capture upgrade_link %}[upgrade your cluster](https://cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version.html){% endcapture %}
+  {% capture install_sentence %}After downloading a supported CockroachDB binary, learn how to {{ install_link }} or {{ upgrade_link }}.{% endcapture %}
+{% else %}
+  {% if branched %}
+    {% capture install_link %}[install CockroachDB](/docs/{{ page.major_version }}/install-cockroachdb.html){% endcapture %}
+    {% capture upgrade_link %}[upgrade your cluster](/docs/{{ page.major_version }}/upgrade-cockroach-version.html){% endcapture %}
+  {% else %}
+    {% capture install_link %}[install CockroachDB](/docs/dev/install-cockroachdb.html){% endcapture %}
+    {% capture upgrade_link %}[upgrade your cluster](/docs/dev/upgrade-cockroach-version.html){% endcapture %}
+  {% endif %}
+  {% capture install_sentence %}After downloading a supported CockroachDB binary, learn how to {{ install_link }} or {{ upgrade_link }}.{% endcapture %}
+{% endif %}
+
 On this page, you can read about changes and find downloads for all production and testing releases of CockroachDB {{ page.major_version }}.
 
-- For key feature enhancements in {{ page.major_version }} and other upgrade considerations, refer to the notes for {% if page.release_type == 'Production' and page.major_version != 'v1.0' %}[{{ page.major_version }}.0](#{{ page.major_version | replace: '.', '-' }}-0){% else %}{{ page.major_version }} on this page.{% endif %}
+{% comment %}v1.0 has no #v1-0-0 anchor, and before GA other releases also do not.{% endcomment %}
+- For key feature enhancements in {{ page.major_version }} and other upgrade considerations, refer to the notes for {% if include.major_version.release_date != 'N/A' and page.major_version != 'v1.0' %}[{{ page.major_version }}.0](#{{ page.major_version | replace: '.', '-' }}-0){% else %}{{ page.major_version }} on this page{% endif %}.
 - For details about release types, naming, and licensing, refer to the [Releases]({% link releases/index.md %}) page.
 - Be sure to also review the [Release Support Policy]({% link releases/release-support-policy.md %}).
-- After downloading a supported CockroachDB binary, learn how to [install CockroachDB]{% if static_file.path == '{{ page.major_version }}/install-cockroachdb.md' %}(../{{ page.major_version }}/install-cockroachdb.html) or [upgrade your cluster](../{{ page.major_version }}/upgrade-cockroach-version.html){% else %}(../dev/install-cockroachdb.html) or [upgrade your cluster](../dev/upgrade-cockroach-version.html){% endif %}.
+- {{ install_sentence | strip_newlines }}
 
+{% comment %}The strip_newlines is needed here because otherwise Jekyll inserts <p> tags around the install and ugrade links{% endcomment %}
 Get future release notes emailed to you:
 
 {% include_cached marketo.html formId=1083 %}

--- a/src/current/releases/v1.0.md
+++ b/src/current/releases/v1.0.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v1.1.md
+++ b/src/current/releases/v1.1.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name release_date=r.release_date %}

--- a/src/current/releases/v19.1.md
+++ b/src/current/releases/v19.1.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name release_date=r.release_date %}

--- a/src/current/releases/v19.2.md
+++ b/src/current/releases/v19.2.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name release_date=r.release_date %}

--- a/src/current/releases/v2.0.md
+++ b/src/current/releases/v2.0.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name release_date=r.release_date %}

--- a/src/current/releases/v2.1.md
+++ b/src/current/releases/v2.1.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name release_date=r.release_date %}

--- a/src/current/releases/v20.1.md
+++ b/src/current/releases/v20.1.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name release_date=r.release_date %}

--- a/src/current/releases/v20.2.md
+++ b/src/current/releases/v20.2.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v21.1.md
+++ b/src/current/releases/v21.1.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v21.2.md
+++ b/src/current/releases/v21.2.md
@@ -16,11 +16,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v22.1.md
+++ b/src/current/releases/v22.1.md
@@ -17,11 +17,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v22.2.md
+++ b/src/current/releases/v22.2.md
@@ -21,11 +21,7 @@ keywords: gin, gin index, gin indexes, inverted index, inverted indexes, acceler
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v23.1.md
+++ b/src/current/releases/v23.1.md
@@ -20,11 +20,7 @@ docs_area: releases
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% assign release_names = rel | map: "release_name" %}
 

--- a/src/current/releases/v23.2.md
+++ b/src/current/releases/v23.2.md
@@ -20,13 +20,7 @@ docs_area: releases
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% comment %}
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, see [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
-{% endcomment %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v24.1.md
+++ b/src/current/releases/v24.1.md
@@ -22,13 +22,7 @@ docs_area: releases
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% comment %}
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-To upgrade to {{ page.major_version }}, refer to [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-{% endunless %}
-{% endcomment %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}

--- a/src/current/releases/v24.2.md
+++ b/src/current/releases/v24.2.md
@@ -22,16 +22,7 @@ docs_area: releases
 
 {% include releases/testing-release-notice.md major_version=vers %}
 
-{% include releases/whats-new-intro.md %}
-
-{% unless vers.release_date == "N/A" or vers.release_date > today %}
-{% comment %}In early testing releases, the new version of the docs may not yet exist{% endcomment %}
-  {% if static_file.path == '{{ page.major_version }}/upgrade-cockroach-version.md' %}
-To upgrade to {{ page.major_version }}, refer to [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/{{ page.major_version }}/upgrade-cockroach-version).
-  {% else %}
-To upgrade to {{ page.version.version }}, refer to [Upgrade to CockroachDB {{ page.major_version }}](https://www.cockroachlabs.com/docs/dev/upgrade-cockroach-version).
-  {% endif %}
-{% endunless %}
+{% include releases/whats-new-intro.md major_version=vers %}
 
 {% for r in rel %}
 {% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}


### PR DESCRIPTION
[DOC-10653] Update logic in What's New intro:

- Evaluate the page directory to see whether a major version has been branched, rather than using `static_files`, which does not include files with frontmatter. The logic is not the most efficient but it does bail early as soon as it finds a file in the directory.
- Keep track of some older versions that need different links or anchors. (The release notes Python script refers to this as "the singularity")
- Parameterize the What's New intro to require the major version, adjust all What's New pages to pass it.
- Remove duplicate content about upgrading from some What's New pages since it's in the What's New intro 

To see the problem @mikeCRL originally reported, go to the v24.1 live release notes and notice that the third bullet point in the intro points to `/docs//dev/` instead of `/docs/v24.1/`.

### Tests I have run
- Local build succeeds
- Local linkcheck passes
- Review each What's New intro to be sure it uses the correct links
- Add a mock v24.3-alpha.1 release to test unbranched logic (this commit was removed before merge)

### Previews
Branched, different install link, no upgrade link: [src/current/releases/v1.0.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v1.0.html)
Branched, different install link, no upgrade link: [src/current/releases/v1.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v1.1.html)
Branched, different install link: [src/current/releases/v19.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v19.1.html)
Branched, different install link: [src/current/releases/v19.2.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v19.2.html)
Branched, versioned links: [src/current/releases/v2.0.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v2.0.html)
Branched, versioned links: [src/current/releases/v2.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v2.1.html)
Branched, versioned links: [src/current/releases/v20.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v20.1.html)
Branched, versioned links: [src/current/releases/v20.2.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v20.2.html)
Branched, versioned links: [src/current/releases/v21.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v21.1.html)
Branched, versioned links: [src/current/releases/v21.2.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v21.2.html)
Branched, versioned links: [src/current/releases/v22.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v22.1.html)
Branched, versioned links: [src/current/releases/v22.2.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v22.2.html)
Branched, versioned links: [src/current/releases/v23.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v23.1.html)
Branched, versioned links: [src/current/releases/v23.2.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v23.2.html)
Branched, versioned links: [src/current/releases/v24.1.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v24.1.html)
Branched, versioned links: [src/current/releases/v24.2.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v24.2.html)
~Unbranched, `/dev/` links: [src/current/releases/v24.3.md](https://deploy-preview-18720--cockroachdb-docs.netlify.app/docs/releases/v24.3.html)~