### PR TITLE
Add docs for show backup connection

### DIFF
--- a/src/current/_includes/v23.1/backups/show-backup-replace-diagram.html
+++ b/src/current/_includes/v23.1/backups/show-backup-replace-diagram.html
@@ -1,50 +1,141 @@
-<div style="overflow-x:auto;"><svg width="1171" height="223">
-    <polygon points="11 17 3 13 3 21"/>
-    <polygon points="19 17 11 13 11 21"/>
-    <rect x="33" y="3" width="64" height="32" rx="10"/>
-    <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="41" y="21">SHOW</text>
-    <rect x="45" y="69" width="84" height="32" rx="10"/>
-    <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="87">BACKUPS</text>
-    <rect x="149" y="69" width="36" height="32" rx="10"/>
-    <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="157" y="87">IN</text>
-    <rect x="205" y="69" width="102" height="32"/>
-    <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="213" y="87">collectionURI</text>
-    <rect x="45" y="113" width="74" height="32" rx="10"/>
-    <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="131">BACKUP</text>
-    <rect x="159" y="145" width="86" height="32" rx="10"/>
-    <rect x="157" y="143" width="86" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="167" y="163">SCHEMAS</text>
-    <rect x="285" y="113" width="60" height="32" rx="10"/>
-    <rect x="283" y="111" width="60" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="293" y="131">FROM</text>
-    <rect x="365" y="113" width="98" height="32"/>
-    <rect x="363" y="111" width="98" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="373" y="131">subdirectory</text><rect x="483" y="113" width="36" height="32" rx="10"/>
-    <rect x="481" y="111" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="491" y="131">IN</text>
-    <rect x="539" y="113" width="102" height="32"/>
-    <rect x="537" y="111" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="547" y="131">collectionURI</text><rect x="681" y="145" width="58" height="32" rx="10"/>
-    <rect x="679" y="143" width="58" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="689" y="163">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="779" y="145" width="108" height="32"/>
-    <rect x="777" y="143" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="787" y="163">kv_option_list</text></a><rect x="779" y="189" width="84" height="32" rx="10"/>
-    <rect x="777" y="187" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="787" y="207">OPTIONS</text>
-    <rect x="883" y="189" width="26" height="32" rx="10"/>
-    <rect x="881" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="891" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="929" y="189" width="108" height="32"/>
-    <rect x="927" y="187" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="937" y="207">kv_option_list</text></a><rect x="1057" y="189" width="26" height="32" rx="10"/>
-    <rect x="1055" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="1065" y="207">)</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h816 m-1118 0 h20 m1098 0 h20 m-1138 0 q10 0 10 10 m1118 0 q0 -10 10 -10 m-1128 10 v24 m1118 0 v-24 m-1118 24 q0 10 10 10 m1098 0 q10 0 10 -10 m-1108 10 h10 m74 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m63 -120 h-3"/>
-    <polygon points="1161 83 1169 79 1169 87"/>
-    <polygon points="1161 83 1153 79 1153 87"/></svg></div>
+<?xml version="1.0" encoding="UTF-8"?>
+<div style="overflow-x:auto;">
+<svg xmlns="http://www.w3.org/2000/svg" width="1127" height="299">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="45" y="69" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="67"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="87">BACKUPS</text>
+   <rect x="149" y="69" width="36" height="32" rx="10"/>
+   <rect x="147"
+         y="67"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="87">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="205" y="69" width="102" height="32"/>
+      <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="213" y="87">collectionURI</text>
+   </a>
+   <rect x="45" y="113" width="74" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">BACKUP</text>
+   <rect x="179" y="145" width="86" height="32" rx="10"/>
+   <rect x="177"
+         y="143"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="163">SCHEMAS</text>
+   <rect x="305" y="113" width="60" height="32" rx="10"/>
+   <rect x="303"
+         y="111"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="313" y="131">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="subdirectory">
+      <rect x="385" y="113" width="98" height="32"/>
+      <rect x="383" y="111" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="393" y="131">subdirectory</text>
+   </a>
+   <rect x="503" y="113" width="36" height="32" rx="10"/>
+   <rect x="501"
+         y="111"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="131">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="559" y="113" width="102" height="32"/>
+      <rect x="557" y="111" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="567" y="131">collectionURI</text>
+   </a>
+   <rect x="701" y="145" width="58" height="32" rx="10"/>
+   <rect x="699"
+         y="143"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="709" y="163">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_option_list">
+      <rect x="799" y="145" width="108" height="32"/>
+      <rect x="797" y="143" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="807" y="163">kv_option_list</text>
+   </a>
+   <rect x="799" y="189" width="84" height="32" rx="10"/>
+   <rect x="797"
+         y="187"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="807" y="207">OPTIONS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_options_list">
+      <rect x="903" y="189" width="116" height="32"/>
+      <rect x="901" y="187" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="911" y="207">kv_options_list</text>
+   </a>
+   <rect x="159" y="233" width="112" height="32" rx="10"/>
+   <rect x="157"
+         y="231"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="251">CONNECTION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="291" y="233" width="102" height="32"/>
+      <rect x="289" y="231" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="299" y="251">collectionURI</text>
+   </a>
+   <rect x="433" y="265" width="58" height="32" rx="10"/>
+   <rect x="431"
+         y="263"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="441" y="283">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="connection_options_list">
+      <rect x="511" y="265" width="170" height="32"/>
+      <rect x="509" y="263" width="170" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="519" y="283">connection_options_list</text>
+   </a>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h772 m-1074 0 h20 m1054 0 h20 m-1094 0 q10 0 10 10 m1074 0 q0 -10 10 -10 m-1084 10 v24 m1074 0 v-24 m-1074 24 q0 10 10 10 m1054 0 q10 0 10 -10 m-1064 10 h10 m74 0 h10 m40 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h348 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v12 m378 0 v-12 m-378 12 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h112 m-260 0 h20 m240 0 h20 m-280 0 q10 0 10 10 m260 0 q0 -10 10 -10 m-270 10 v24 m260 0 v-24 m-260 24 q0 10 10 10 m240 0 q10 0 10 -10 m-250 10 h10 m84 0 h10 m0 0 h10 m116 0 h10 m-900 -76 h20 m920 0 h20 m-960 0 q10 0 10 10 m940 0 q0 -10 10 -10 m-950 10 v100 m940 0 v-100 m-940 100 q0 10 10 10 m920 0 q10 0 10 -10 m-930 10 h10 m112 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h258 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v12 m288 0 v-12 m-288 12 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m58 0 h10 m0 0 h10 m170 0 h10 m20 -32 h358 m43 -164 h-3"/>
+   <polygon points="1117 83 1125 79 1125 87"/>
+   <polygon points="1117 83 1109 79 1109 87"/>
+</svg>
+</div>

--- a/src/current/_includes/v23.2/backups/show-backup-replace-diagram.html
+++ b/src/current/_includes/v23.2/backups/show-backup-replace-diagram.html
@@ -1,50 +1,141 @@
-<div style="overflow-x:auto;"><svg width="1171" height="223">
-    <polygon points="11 17 3 13 3 21"/>
-    <polygon points="19 17 11 13 11 21"/>
-    <rect x="33" y="3" width="64" height="32" rx="10"/>
-    <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="41" y="21">SHOW</text>
-    <rect x="45" y="69" width="84" height="32" rx="10"/>
-    <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="87">BACKUPS</text>
-    <rect x="149" y="69" width="36" height="32" rx="10"/>
-    <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="157" y="87">IN</text>
-    <rect x="205" y="69" width="102" height="32"/>
-    <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="213" y="87">collectionURI</text>
-    <rect x="45" y="113" width="74" height="32" rx="10"/>
-    <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="131">BACKUP</text>
-    <rect x="159" y="145" width="86" height="32" rx="10"/>
-    <rect x="157" y="143" width="86" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="167" y="163">SCHEMAS</text>
-    <rect x="285" y="113" width="60" height="32" rx="10"/>
-    <rect x="283" y="111" width="60" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="293" y="131">FROM</text>
-    <rect x="365" y="113" width="98" height="32"/>
-    <rect x="363" y="111" width="98" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="373" y="131">subdirectory</text><rect x="483" y="113" width="36" height="32" rx="10"/>
-    <rect x="481" y="111" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="491" y="131">IN</text>
-    <rect x="539" y="113" width="102" height="32"/>
-    <rect x="537" y="111" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="547" y="131">collectionURI</text><rect x="681" y="145" width="58" height="32" rx="10"/>
-    <rect x="679" y="143" width="58" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="689" y="163">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="779" y="145" width="108" height="32"/>
-    <rect x="777" y="143" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="787" y="163">kv_option_list</text></a><rect x="779" y="189" width="84" height="32" rx="10"/>
-    <rect x="777" y="187" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="787" y="207">OPTIONS</text>
-    <rect x="883" y="189" width="26" height="32" rx="10"/>
-    <rect x="881" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="891" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="929" y="189" width="108" height="32"/>
-    <rect x="927" y="187" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="937" y="207">kv_option_list</text></a><rect x="1057" y="189" width="26" height="32" rx="10"/>
-    <rect x="1055" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="1065" y="207">)</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h816 m-1118 0 h20 m1098 0 h20 m-1138 0 q10 0 10 10 m1118 0 q0 -10 10 -10 m-1128 10 v24 m1118 0 v-24 m-1118 24 q0 10 10 10 m1098 0 q10 0 10 -10 m-1108 10 h10 m74 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m63 -120 h-3"/>
-    <polygon points="1161 83 1169 79 1169 87"/>
-    <polygon points="1161 83 1153 79 1153 87"/></svg></div>
+<?xml version="1.0" encoding="UTF-8"?>
+<div style="overflow-x:auto;">
+<svg xmlns="http://www.w3.org/2000/svg" width="1127" height="299">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="45" y="69" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="67"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="87">BACKUPS</text>
+   <rect x="149" y="69" width="36" height="32" rx="10"/>
+   <rect x="147"
+         y="67"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="87">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="205" y="69" width="102" height="32"/>
+      <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="213" y="87">collectionURI</text>
+   </a>
+   <rect x="45" y="113" width="74" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">BACKUP</text>
+   <rect x="179" y="145" width="86" height="32" rx="10"/>
+   <rect x="177"
+         y="143"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="163">SCHEMAS</text>
+   <rect x="305" y="113" width="60" height="32" rx="10"/>
+   <rect x="303"
+         y="111"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="313" y="131">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="subdirectory">
+      <rect x="385" y="113" width="98" height="32"/>
+      <rect x="383" y="111" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="393" y="131">subdirectory</text>
+   </a>
+   <rect x="503" y="113" width="36" height="32" rx="10"/>
+   <rect x="501"
+         y="111"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="131">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="559" y="113" width="102" height="32"/>
+      <rect x="557" y="111" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="567" y="131">collectionURI</text>
+   </a>
+   <rect x="701" y="145" width="58" height="32" rx="10"/>
+   <rect x="699"
+         y="143"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="709" y="163">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_option_list">
+      <rect x="799" y="145" width="108" height="32"/>
+      <rect x="797" y="143" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="807" y="163">kv_option_list</text>
+   </a>
+   <rect x="799" y="189" width="84" height="32" rx="10"/>
+   <rect x="797"
+         y="187"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="807" y="207">OPTIONS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_options_list">
+      <rect x="903" y="189" width="116" height="32"/>
+      <rect x="901" y="187" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="911" y="207">kv_options_list</text>
+   </a>
+   <rect x="159" y="233" width="112" height="32" rx="10"/>
+   <rect x="157"
+         y="231"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="251">CONNECTION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="291" y="233" width="102" height="32"/>
+      <rect x="289" y="231" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="299" y="251">collectionURI</text>
+   </a>
+   <rect x="433" y="265" width="58" height="32" rx="10"/>
+   <rect x="431"
+         y="263"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="441" y="283">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="connection_options_list">
+      <rect x="511" y="265" width="170" height="32"/>
+      <rect x="509" y="263" width="170" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="519" y="283">connection_options_list</text>
+   </a>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h772 m-1074 0 h20 m1054 0 h20 m-1094 0 q10 0 10 10 m1074 0 q0 -10 10 -10 m-1084 10 v24 m1074 0 v-24 m-1074 24 q0 10 10 10 m1054 0 q10 0 10 -10 m-1064 10 h10 m74 0 h10 m40 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h348 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v12 m378 0 v-12 m-378 12 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h112 m-260 0 h20 m240 0 h20 m-280 0 q10 0 10 10 m260 0 q0 -10 10 -10 m-270 10 v24 m260 0 v-24 m-260 24 q0 10 10 10 m240 0 q10 0 10 -10 m-250 10 h10 m84 0 h10 m0 0 h10 m116 0 h10 m-900 -76 h20 m920 0 h20 m-960 0 q10 0 10 10 m940 0 q0 -10 10 -10 m-950 10 v100 m940 0 v-100 m-940 100 q0 10 10 10 m920 0 q10 0 10 -10 m-930 10 h10 m112 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h258 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v12 m288 0 v-12 m-288 12 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m58 0 h10 m0 0 h10 m170 0 h10 m20 -32 h358 m43 -164 h-3"/>
+   <polygon points="1117 83 1125 79 1125 87"/>
+   <polygon points="1117 83 1109 79 1109 87"/>
+</svg>
+</div>

--- a/src/current/_includes/v24.1/backups/show-backup-replace-diagram.html
+++ b/src/current/_includes/v24.1/backups/show-backup-replace-diagram.html
@@ -1,50 +1,141 @@
-<div style="overflow-x:auto;"><svg width="1171" height="223">
-    <polygon points="11 17 3 13 3 21"/>
-    <polygon points="19 17 11 13 11 21"/>
-    <rect x="33" y="3" width="64" height="32" rx="10"/>
-    <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="41" y="21">SHOW</text>
-    <rect x="45" y="69" width="84" height="32" rx="10"/>
-    <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="87">BACKUPS</text>
-    <rect x="149" y="69" width="36" height="32" rx="10"/>
-    <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="157" y="87">IN</text>
-    <rect x="205" y="69" width="102" height="32"/>
-    <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="213" y="87">collectionURI</text>
-    <rect x="45" y="113" width="74" height="32" rx="10"/>
-    <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="131">BACKUP</text>
-    <rect x="159" y="145" width="86" height="32" rx="10"/>
-    <rect x="157" y="143" width="86" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="167" y="163">SCHEMAS</text>
-    <rect x="285" y="113" width="60" height="32" rx="10"/>
-    <rect x="283" y="111" width="60" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="293" y="131">FROM</text>
-    <rect x="365" y="113" width="98" height="32"/>
-    <rect x="363" y="111" width="98" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="373" y="131">subdirectory</text><rect x="483" y="113" width="36" height="32" rx="10"/>
-    <rect x="481" y="111" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="491" y="131">IN</text>
-    <rect x="539" y="113" width="102" height="32"/>
-    <rect x="537" y="111" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="547" y="131">collectionURI</text><rect x="681" y="145" width="58" height="32" rx="10"/>
-    <rect x="679" y="143" width="58" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="689" y="163">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="779" y="145" width="108" height="32"/>
-    <rect x="777" y="143" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="787" y="163">kv_option_list</text></a><rect x="779" y="189" width="84" height="32" rx="10"/>
-    <rect x="777" y="187" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="787" y="207">OPTIONS</text>
-    <rect x="883" y="189" width="26" height="32" rx="10"/>
-    <rect x="881" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="891" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="929" y="189" width="108" height="32"/>
-    <rect x="927" y="187" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="937" y="207">kv_option_list</text></a><rect x="1057" y="189" width="26" height="32" rx="10"/>
-    <rect x="1055" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="1065" y="207">)</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h816 m-1118 0 h20 m1098 0 h20 m-1138 0 q10 0 10 10 m1118 0 q0 -10 10 -10 m-1128 10 v24 m1118 0 v-24 m-1118 24 q0 10 10 10 m1098 0 q10 0 10 -10 m-1108 10 h10 m74 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m63 -120 h-3"/>
-    <polygon points="1161 83 1169 79 1169 87"/>
-    <polygon points="1161 83 1153 79 1153 87"/></svg></div>
+<?xml version="1.0" encoding="UTF-8"?>
+<div style="overflow-x:auto;">
+<svg xmlns="http://www.w3.org/2000/svg" width="1127" height="299">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="45" y="69" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="67"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="87">BACKUPS</text>
+   <rect x="149" y="69" width="36" height="32" rx="10"/>
+   <rect x="147"
+         y="67"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="87">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="205" y="69" width="102" height="32"/>
+      <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="213" y="87">collectionURI</text>
+   </a>
+   <rect x="45" y="113" width="74" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">BACKUP</text>
+   <rect x="179" y="145" width="86" height="32" rx="10"/>
+   <rect x="177"
+         y="143"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="163">SCHEMAS</text>
+   <rect x="305" y="113" width="60" height="32" rx="10"/>
+   <rect x="303"
+         y="111"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="313" y="131">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="subdirectory">
+      <rect x="385" y="113" width="98" height="32"/>
+      <rect x="383" y="111" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="393" y="131">subdirectory</text>
+   </a>
+   <rect x="503" y="113" width="36" height="32" rx="10"/>
+   <rect x="501"
+         y="111"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="131">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="559" y="113" width="102" height="32"/>
+      <rect x="557" y="111" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="567" y="131">collectionURI</text>
+   </a>
+   <rect x="701" y="145" width="58" height="32" rx="10"/>
+   <rect x="699"
+         y="143"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="709" y="163">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_option_list">
+      <rect x="799" y="145" width="108" height="32"/>
+      <rect x="797" y="143" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="807" y="163">kv_option_list</text>
+   </a>
+   <rect x="799" y="189" width="84" height="32" rx="10"/>
+   <rect x="797"
+         y="187"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="807" y="207">OPTIONS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_options_list">
+      <rect x="903" y="189" width="116" height="32"/>
+      <rect x="901" y="187" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="911" y="207">kv_options_list</text>
+   </a>
+   <rect x="159" y="233" width="112" height="32" rx="10"/>
+   <rect x="157"
+         y="231"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="251">CONNECTION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="291" y="233" width="102" height="32"/>
+      <rect x="289" y="231" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="299" y="251">collectionURI</text>
+   </a>
+   <rect x="433" y="265" width="58" height="32" rx="10"/>
+   <rect x="431"
+         y="263"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="441" y="283">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="connection_options_list">
+      <rect x="511" y="265" width="170" height="32"/>
+      <rect x="509" y="263" width="170" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="519" y="283">connection_options_list</text>
+   </a>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h772 m-1074 0 h20 m1054 0 h20 m-1094 0 q10 0 10 10 m1074 0 q0 -10 10 -10 m-1084 10 v24 m1074 0 v-24 m-1074 24 q0 10 10 10 m1054 0 q10 0 10 -10 m-1064 10 h10 m74 0 h10 m40 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h348 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v12 m378 0 v-12 m-378 12 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h112 m-260 0 h20 m240 0 h20 m-280 0 q10 0 10 10 m260 0 q0 -10 10 -10 m-270 10 v24 m260 0 v-24 m-260 24 q0 10 10 10 m240 0 q10 0 10 -10 m-250 10 h10 m84 0 h10 m0 0 h10 m116 0 h10 m-900 -76 h20 m920 0 h20 m-960 0 q10 0 10 10 m940 0 q0 -10 10 -10 m-950 10 v100 m940 0 v-100 m-940 100 q0 10 10 10 m920 0 q10 0 10 -10 m-930 10 h10 m112 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h258 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v12 m288 0 v-12 m-288 12 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m58 0 h10 m0 0 h10 m170 0 h10 m20 -32 h358 m43 -164 h-3"/>
+   <polygon points="1117 83 1125 79 1125 87"/>
+   <polygon points="1117 83 1109 79 1109 87"/>
+</svg>
+</div>

--- a/src/current/_includes/v24.2/backups/show-backup-replace-diagram.html
+++ b/src/current/_includes/v24.2/backups/show-backup-replace-diagram.html
@@ -1,50 +1,141 @@
-<div style="overflow-x:auto;"><svg width="1171" height="223">
-    <polygon points="11 17 3 13 3 21"/>
-    <polygon points="19 17 11 13 11 21"/>
-    <rect x="33" y="3" width="64" height="32" rx="10"/>
-    <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="41" y="21">SHOW</text>
-    <rect x="45" y="69" width="84" height="32" rx="10"/>
-    <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="87">BACKUPS</text>
-    <rect x="149" y="69" width="36" height="32" rx="10"/>
-    <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="157" y="87">IN</text>
-    <rect x="205" y="69" width="102" height="32"/>
-    <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="213" y="87">collectionURI</text>
-    <rect x="45" y="113" width="74" height="32" rx="10"/>
-    <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="53" y="131">BACKUP</text>
-    <rect x="159" y="145" width="86" height="32" rx="10"/>
-    <rect x="157" y="143" width="86" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="167" y="163">SCHEMAS</text>
-    <rect x="285" y="113" width="60" height="32" rx="10"/>
-    <rect x="283" y="111" width="60" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="293" y="131">FROM</text>
-    <rect x="365" y="113" width="98" height="32"/>
-    <rect x="363" y="111" width="98" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="373" y="131">subdirectory</text><rect x="483" y="113" width="36" height="32" rx="10"/>
-    <rect x="481" y="111" width="36" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="491" y="131">IN</text>
-    <rect x="539" y="113" width="102" height="32"/>
-    <rect x="537" y="111" width="102" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="547" y="131">collectionURI</text><rect x="681" y="145" width="58" height="32" rx="10"/>
-    <rect x="679" y="143" width="58" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="689" y="163">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="779" y="145" width="108" height="32"/>
-    <rect x="777" y="143" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="787" y="163">kv_option_list</text></a><rect x="779" y="189" width="84" height="32" rx="10"/>
-    <rect x="777" y="187" width="84" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="787" y="207">OPTIONS</text>
-    <rect x="883" y="189" width="26" height="32" rx="10"/>
-    <rect x="881" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="891" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-    <rect x="929" y="189" width="108" height="32"/>
-    <rect x="927" y="187" width="108" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="937" y="207">kv_option_list</text></a><rect x="1057" y="189" width="26" height="32" rx="10"/>
-    <rect x="1055" y="187" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="1065" y="207">)</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h816 m-1118 0 h20 m1098 0 h20 m-1138 0 q10 0 10 10 m1118 0 q0 -10 10 -10 m-1128 10 v24 m1118 0 v-24 m-1118 24 q0 10 10 10 m1098 0 q10 0 10 -10 m-1108 10 h10 m74 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m63 -120 h-3"/>
-    <polygon points="1161 83 1169 79 1169 87"/>
-    <polygon points="1161 83 1153 79 1153 87"/></svg></div>
+<?xml version="1.0" encoding="UTF-8"?>
+<div style="overflow-x:auto;">
+<svg xmlns="http://www.w3.org/2000/svg" width="1127" height="299">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="45" y="69" width="84" height="32" rx="10"/>
+   <rect x="43"
+         y="67"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="87">BACKUPS</text>
+   <rect x="149" y="69" width="36" height="32" rx="10"/>
+   <rect x="147"
+         y="67"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="87">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="205" y="69" width="102" height="32"/>
+      <rect x="203" y="67" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="213" y="87">collectionURI</text>
+   </a>
+   <rect x="45" y="113" width="74" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">BACKUP</text>
+   <rect x="179" y="145" width="86" height="32" rx="10"/>
+   <rect x="177"
+         y="143"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="163">SCHEMAS</text>
+   <rect x="305" y="113" width="60" height="32" rx="10"/>
+   <rect x="303"
+         y="111"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="313" y="131">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="subdirectory">
+      <rect x="385" y="113" width="98" height="32"/>
+      <rect x="383" y="111" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="393" y="131">subdirectory</text>
+   </a>
+   <rect x="503" y="113" width="36" height="32" rx="10"/>
+   <rect x="501"
+         y="111"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="131">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="559" y="113" width="102" height="32"/>
+      <rect x="557" y="111" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="567" y="131">collectionURI</text>
+   </a>
+   <rect x="701" y="145" width="58" height="32" rx="10"/>
+   <rect x="699"
+         y="143"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="709" y="163">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_option_list">
+      <rect x="799" y="145" width="108" height="32"/>
+      <rect x="797" y="143" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="807" y="163">kv_option_list</text>
+   </a>
+   <rect x="799" y="189" width="84" height="32" rx="10"/>
+   <rect x="797"
+         y="187"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="807" y="207">OPTIONS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="kv_options_list">
+      <rect x="903" y="189" width="116" height="32"/>
+      <rect x="901" y="187" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="911" y="207">kv_options_list</text>
+   </a>
+   <rect x="159" y="233" width="112" height="32" rx="10"/>
+   <rect x="157"
+         y="231"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="251">CONNECTION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="collectionURI">
+      <rect x="291" y="233" width="102" height="32"/>
+      <rect x="289" y="231" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="299" y="251">collectionURI</text>
+   </a>
+   <rect x="433" y="265" width="58" height="32" rx="10"/>
+   <rect x="431"
+         y="263"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="441" y="283">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:title="connection_options_list">
+      <rect x="511" y="265" width="170" height="32"/>
+      <rect x="509" y="263" width="170" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="519" y="283">connection_options_list</text>
+   </a>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h772 m-1074 0 h20 m1054 0 h20 m-1094 0 q10 0 10 10 m1074 0 q0 -10 10 -10 m-1084 10 v24 m1074 0 v-24 m-1074 24 q0 10 10 10 m1054 0 q10 0 10 -10 m-1064 10 h10 m74 0 h10 m40 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h348 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v12 m378 0 v-12 m-378 12 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h112 m-260 0 h20 m240 0 h20 m-280 0 q10 0 10 10 m260 0 q0 -10 10 -10 m-270 10 v24 m260 0 v-24 m-260 24 q0 10 10 10 m240 0 q10 0 10 -10 m-250 10 h10 m84 0 h10 m0 0 h10 m116 0 h10 m-900 -76 h20 m920 0 h20 m-960 0 q10 0 10 10 m940 0 q0 -10 10 -10 m-950 10 v100 m940 0 v-100 m-940 100 q0 10 10 10 m920 0 q10 0 10 -10 m-930 10 h10 m112 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h258 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v12 m288 0 v-12 m-288 12 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m58 0 h10 m0 0 h10 m170 0 h10 m20 -32 h358 m43 -164 h-3"/>
+   <polygon points="1117 83 1125 79 1125 87"/>
+   <polygon points="1117 83 1109 79 1109 87"/>
+</svg>
+</div>

--- a/src/current/v23.1/cockroachdb-feature-availability.md
+++ b/src/current/v23.1/cockroachdb-feature-availability.md
@@ -224,6 +224,10 @@ Command                                     | Description
 [`cockroach demo`]({% link {{ page.version.version }}/cockroach-demo.md %})     | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach sqlfmt`]({% link {{ page.version.version }}/cockroach-sqlfmt.md %}) | Reformat SQL queries for enhanced clarity.
 
+### Test the connection to cloud storage
+
+Test the connection to a cloud storage location from each node in your cluster. [`SHOW BACKUP CONNECTION`]({% link {{ page.version.version }}/show-backup.md %}#test-the-connection-to-cloud-storage) will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location.
+
 ## See Also
 
 - [`SHOW {session variable}`]({% link {{ page.version.version }}/show-vars.md %})

--- a/src/current/v23.1/show-backup.md
+++ b/src/current/v23.1/show-backup.md
@@ -48,8 +48,8 @@ Parameter | Description
 `SHOW BACKUP FROM subdirectory IN collectionURI` | Show the details of backups in the subdirectory at the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). Also, use `FROM LATEST in collectionURI` to show the most recent backup. [See the example](#show-the-most-recent-backup).
 `SHOW BACKUP SCHEMAS FROM subdirectory IN collectionURI` | Show the schema details of the backup in the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). [See the example](#show-a-backup-with-schemas).
 `kv_option_list` | Control the behavior of `SHOW BACKUP` with a comma-separated list of [these options](#options).
-`SHOW BACKUP CONNECTION collectionURI` | Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
-`connection_options_list` | Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
+`SHOW BACKUP CONNECTION collectionURI` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
+`connection_options_list` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
 
 ### Options
 
@@ -66,6 +66,10 @@ Option        | Value | Description
 `privileges`  | N/A   |  List which users and roles had which privileges on each table in the backup. Displays original ownership of the backup.
 
 #### Show backup connection options
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Option  | Value | Description
 --------+-------+------------
@@ -99,6 +103,10 @@ Field | Description
 See [Show a backup with descriptor IDs](#show-a-backup-with-descriptor-ids) for the responses displayed when the `WITH debug_ids` option is specified.
 
 ### Show backup connection responses
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Field | Value | Description
 ------|-------|------------
@@ -329,6 +337,10 @@ SHOW BACKUP FROM '2020/09/24-190540.54' IN 's3://test/backups/test_explicit_kms?
 ~~~
 
 ### Test the connection to cloud storage
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Test the connection to a cloud storage location from each node in your cluster. `SHOW BACKUP CONNECTION` will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location:
 

--- a/src/current/v23.1/show-backup.md
+++ b/src/current/v23.1/show-backup.md
@@ -27,7 +27,7 @@ Either the `EXTERNALIOIMPLICITACCESS` [system-level privilege]({% link {{ page.v
 - Using a [custom endpoint](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) on S3.
 - Using the [`cockroach nodelocal upload`]({% link {{ page.version.version }}/cockroach-nodelocal-upload.md %}) command.
 
-No special privilege is required for: 
+No special privilege is required for:
 
 - Interacting with an Amazon S3 and Google Cloud Storage resource using `SPECIFIED` credentials. Azure Storage is always `SPECIFIED` by default.
 - Using [Userfile]({% link {{ page.version.version }}/use-userfile-storage.md %}) storage.
@@ -48,8 +48,12 @@ Parameter | Description
 `SHOW BACKUP FROM subdirectory IN collectionURI` | Show the details of backups in the subdirectory at the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). Also, use `FROM LATEST in collectionURI` to show the most recent backup. [See the example](#show-the-most-recent-backup).
 `SHOW BACKUP SCHEMAS FROM subdirectory IN collectionURI` | Show the schema details of the backup in the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). [See the example](#show-a-backup-with-schemas).
 `kv_option_list` | Control the behavior of `SHOW BACKUP` with a comma-separated list of [these options](#options).
+`SHOW BACKUP CONNECTION collectionURI` | Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
+`connection_options_list` | Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
 
 ### Options
+
+#### Show backup options
 
 Option        | Value | Description
 --------------+-------+-----------------------------------------------------
@@ -57,9 +61,19 @@ Option        | Value | Description
 `check_files` |  N/A  | Validate that all files belonging to a backup are in the expected location in storage. See [Validate a backup's files](#validate-a-backups-files) for an example.
 `debug_ids` |  N/A  |  [Display descriptor IDs](#show-a-backup-with-descriptor-ids) of every object in the backup, including the object's database and parent schema.
 `encryption_passphrase`<a name="with-encryption-passphrase"></a> | [`STRING`]({% link {{ page.version.version }}/string.md %}) |  The passphrase used to [encrypt the files]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}) that the `BACKUP` statement generates (the data files and its manifest, containing the backup's metadata).
-`kms`                                                            | [`STRING`]({% link {{ page.version.version }}/string.md %}) |  The URI of the cryptographic key stored in a key management service (KMS), or a comma-separated list of key URIs, used to [take and restore encrypted backups]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}#examples). Refer to [URI Formats]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}#uri-formats). 
+`kms`                                                            | [`STRING`]({% link {{ page.version.version }}/string.md %}) |  The URI of the cryptographic key stored in a key management service (KMS), or a comma-separated list of key URIs, used to [take and restore encrypted backups]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}#examples). Refer to [URI Formats]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}#uri-formats).
 `incremental_location` | [`STRING`]({% link {{ page.version.version }}/string.md %}) | [List the details of an incremental backup](#show-a-backup-taken-with-the-incremental-location-option) taken with the [`incremental_location` option]({% link {{ page.version.version }}/backup.md %}#incr-location).
 `privileges`  | N/A   |  List which users and roles had which privileges on each table in the backup. Displays original ownership of the backup.
+
+#### Show backup connection options
+
+Option  | Value | Description
+--------+-------+------------
+`concurrently` | `INT` | Run multiple connection tests concurrently. If you also set the `time` option, it will run the specified number of concurrent tests until the time has elapsed. By default, only `1` connection test will run.
+`time` | `STRING` | Run the test repeatedly until the duration has elapsed.
+`transfer` | `STRING` | The size of the file that is written and read during each iteration of the connection test. By default, this will transfer a `32MiB` file.
+
+Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
 
 ## Response
 
@@ -84,13 +98,26 @@ Field | Description
 
 See [Show a backup with descriptor IDs](#show-a-backup-with-descriptor-ids) for the responses displayed when the `WITH debug_ids` option is specified.
 
+### Show backup connection responses
+
+Field | Value | Description
+------|-------|------------
+`node` | `INT` | The node ID.
+`locality` | `STRING` | The locality of the node.
+`ok` | `BOOL` | The success of the test run.
+`error` | `STRING` | Errors encountered during the test run.
+`transferred` | `STRING` | The size of the file transferred during the test.
+`read_speed` | `STRING` | The speed at which the node read the test file.
+`write_speed` | `STRING` | The speed at which the node wrote the test file.
+`can_delete` | `BOOL` | The success of file deletion.
+
 ## Examples
 
 {% include {{ page.version.version }}/backups/bulk-auth-options.md %}
 
 ### View a list of the available full backup subdirectories
 
-<a name="show-backups-in"></a>To view a list of the available [full backups]({% link {{ page.version.version }}/take-full-and-incremental-backups.md %}#full-backups) subdirectories, use the following command: 
+<a name="show-backups-in"></a>To view a list of the available [full backups]({% link {{ page.version.version }}/take-full-and-incremental-backups.md %}#full-backups) subdirectories, use the following command:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -300,6 +327,51 @@ SHOW BACKUP FROM '2020/09/24-190540.54' IN 's3://test/backups/test_explicit_kms?
   defaultdb     | NULL               | org_one                    | schema      | full        |  NULL       | 2020-09-24 19:05:40.542168+00:00 |       NULL | NULL |      true
 (20 rows)
 ~~~
+
+### Test the connection to cloud storage
+
+Test the connection to a cloud storage location from each node in your cluster. `SHOW BACKUP CONNECTION` will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW BACKUP CONNECTION 'external://cloud_storage';
+~~~
+
+~~~
+  node |                 locality                  | ok | error | transferred | read_speed  | write_speed | can_delete
+-------+-------------------------------------------+----+-------+-------------+-------------+-------------+-------------
+     1 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 32 MiB      | 66.17 MiB/s | 37.52 MiB/s |     t
+     3 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 32 MiB      | 41.77 MiB/s | 33.55 MiB/s |     t
+     2 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 32 MiB      | 14.23 MiB/s | 37.12 MiB/s |     t
+~~~
+
+To modify the testing parameters, use one or a combination of the options: `concurrently`, `time`, and `transfer`. For details on each, refer to [Show backup connection options](#show-backup-connection-options).
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW BACKUP CONNECTION 'external://cloud_storage' WITH transfer = '50MiB', concurrently = 5, time = '1ms';
+~~~
+~~~
+  node |                 locality                  | ok | error | transferred | read_speed  | write_speed | can_delete
+-------+-------------------------------------------+----+-------+-------------+-------------+-------------+-------------
+     2 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 59.85 MiB/s | 34.99 MiB/s |     t
+     1 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 58.26 MiB/s | 34.91 MiB/s |     t
+     1 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 57.69 MiB/s | 32.30 MiB/s |     t
+     2 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 55.51 MiB/s | 33.02 MiB/s |     t
+     3 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 59.29 MiB/s | 31.45 MiB/s |     t
+     3 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 55.61 MiB/s | 32.58 MiB/s |     t
+     3 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 61.04 MiB/s | 29.63 MiB/s |     t
+     1 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 47.69 MiB/s | 34.04 MiB/s |     t
+     1 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 55.66 MiB/s | 30.39 MiB/s |     t
+     1 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 57.77 MiB/s | 29.64 MiB/s |     t
+     2 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 44.95 MiB/s | 34.41 MiB/s |     t
+     2 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 46.77 MiB/s | 33.31 MiB/s |     t
+     2 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 57.64 MiB/s | 28.96 MiB/s |     t
+     3 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 58.99 MiB/s | 26.65 MiB/s |     t
+     3 | cloud=gce,region=us-east1,zone=us-east1-b | t  |       | 50 MiB      | 15.14 MiB/s | 33.45 MiB/s |     t
+~~~
+
+For details on the output columns, refer to [Show backup connection responses](#show-backup-connection-responses).
 
 ### Show a backup with descriptor IDs
 

--- a/src/current/v23.2/cockroachdb-feature-availability.md
+++ b/src/current/v23.2/cockroachdb-feature-availability.md
@@ -251,6 +251,10 @@ Command                                     | Description
 [`cockroach demo`]({% link {{ page.version.version }}/cockroach-demo.md %})     | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach sqlfmt`]({% link {{ page.version.version }}/cockroach-sqlfmt.md %}) | Reformat SQL queries for enhanced clarity.
 
+### Test the connection to cloud storage
+
+Test the connection to a cloud storage location from each node in your cluster. [`SHOW BACKUP CONNECTION`]({% link {{ page.version.version }}/show-backup.md %}#test-the-connection-to-cloud-storage) will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location.
+
 ## See Also
 
 - [`SHOW {session variable}`]({% link {{ page.version.version }}/show-vars.md %})

--- a/src/current/v23.2/show-backup.md
+++ b/src/current/v23.2/show-backup.md
@@ -48,8 +48,8 @@ Parameter | Description
 `SHOW BACKUP FROM subdirectory IN collectionURI` | Show the details of backups in the subdirectory at the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). Also, use `FROM LATEST in collectionURI` to show the most recent backup. [See the example](#show-the-most-recent-backup).
 `SHOW BACKUP SCHEMAS FROM subdirectory IN collectionURI` | Show the schema details of the backup in the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). [See the example](#show-a-backup-with-schemas).
 `kv_option_list` | Control the behavior of `SHOW BACKUP` with a comma-separated list of [these options](#options).
-`SHOW BACKUP CONNECTION collectionURI` | Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
-`connection_options_list` | Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
+`SHOW BACKUP CONNECTION collectionURI` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
+`connection_options_list` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
 
 ### Options
 
@@ -66,6 +66,10 @@ Option        | Value | Description
 `privileges`  | N/A   |  List which users and roles had which privileges on each table in the backup. Displays original ownership of the backup.
 
 #### Show backup connection options
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Option  | Value | Description
 --------+-------+------------
@@ -99,6 +103,10 @@ Field | Value | Description
 See [Show a backup with descriptor IDs](#show-a-backup-with-descriptor-ids) for the responses displayed when the `WITH debug_ids` option is specified.
 
 ### Show backup connection responses
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Field | Value | Description
 ------|-------|------------
@@ -329,6 +337,10 @@ SHOW BACKUP FROM '2020/09/24-190540.54' IN 's3://test/backups/test_explicit_kms?
 ~~~
 
 ### Test the connection to cloud storage
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Test the connection to a cloud storage location from each node in your cluster. `SHOW BACKUP CONNECTION` will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location:
 

--- a/src/current/v24.1/cockroachdb-feature-availability.md
+++ b/src/current/v24.1/cockroachdb-feature-availability.md
@@ -251,6 +251,9 @@ Command                                     | Description
 [`cockroach demo`]({% link {{ page.version.version }}/cockroach-demo.md %})     | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach sqlfmt`]({% link {{ page.version.version }}/cockroach-sqlfmt.md %}) | Reformat SQL queries for enhanced clarity.
 
+### Test the connection to cloud storage
+
+Test the connection to a cloud storage location from each node in your cluster. [`SHOW BACKUP CONNECTION`]({% link {{ page.version.version }}/show-backup.md %}#test-the-connection-to-cloud-storage) will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location.
 
 ## See Also
 

--- a/src/current/v24.1/show-backup.md
+++ b/src/current/v24.1/show-backup.md
@@ -48,8 +48,8 @@ Parameter | Description
 `SHOW BACKUP FROM subdirectory IN collectionURI` | Show the details of backups in the subdirectory at the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). Also, use `FROM LATEST in collectionURI` to show the most recent backup. [See the example](#show-the-most-recent-backup).
 `SHOW BACKUP SCHEMAS FROM subdirectory IN collectionURI` | Show the schema details of the backup in the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). [See the example](#show-a-backup-with-schemas).
 `kv_option_list` | Control the behavior of `SHOW BACKUP` with a comma-separated list of [these options](#options).
-`SHOW BACKUP CONNECTION collectionURI` | Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
-`connection_options_list` | Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
+`SHOW BACKUP CONNECTION collectionURI` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
+`connection_options_list` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
 
 ### Options
 
@@ -66,6 +66,10 @@ Option        | Value | Description
 `privileges`  | N/A   |  List which users and roles had which privileges on each table in the backup. Displays original ownership of the backup.
 
 #### Show backup connection options
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Option  | Value | Description
 --------+-------+------------
@@ -99,6 +103,10 @@ Field | Value | Description
 See [Show a backup with descriptor IDs](#show-a-backup-with-descriptor-ids) for the responses displayed when the `WITH debug_ids` option is specified.
 
 ### Show backup connection responses
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Field | Value | Description
 ------|-------|------------
@@ -329,6 +337,10 @@ SHOW BACKUP FROM '2020/09/24-190540.54' IN 's3://test/backups/test_explicit_kms?
 ~~~
 
 ### Test the connection to cloud storage
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Test the connection to a cloud storage location from each node in your cluster. `SHOW BACKUP CONNECTION` will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location:
 

--- a/src/current/v24.2/cockroachdb-feature-availability.md
+++ b/src/current/v24.2/cockroachdb-feature-availability.md
@@ -251,6 +251,9 @@ Command                                     | Description
 [`cockroach demo`]({% link {{ page.version.version }}/cockroach-demo.md %})     | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach sqlfmt`]({% link {{ page.version.version }}/cockroach-sqlfmt.md %}) | Reformat SQL queries for enhanced clarity.
 
+### Test the connection to cloud storage
+
+Test the connection to a cloud storage location from each node in your cluster. [`SHOW BACKUP CONNECTION`]({% link {{ page.version.version }}/show-backup.md %}#test-the-connection-to-cloud-storage) will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location.
 
 ## See Also
 

--- a/src/current/v24.2/show-backup.md
+++ b/src/current/v24.2/show-backup.md
@@ -48,8 +48,8 @@ Parameter | Description
 `SHOW BACKUP FROM subdirectory IN collectionURI` | Show the details of backups in the subdirectory at the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). Also, use `FROM LATEST in collectionURI` to show the most recent backup. [See the example](#show-the-most-recent-backup).
 `SHOW BACKUP SCHEMAS FROM subdirectory IN collectionURI` | Show the schema details of the backup in the given [collection URI]({% link {{ page.version.version }}/backup.md %}#backup-file-urls). [See the example](#show-a-backup-with-schemas).
 `kv_option_list` | Control the behavior of `SHOW BACKUP` with a comma-separated list of [these options](#options).
-`SHOW BACKUP CONNECTION collectionURI` | Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
-`connection_options_list` | Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
+`SHOW BACKUP CONNECTION collectionURI` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Test the connection of each node to your cloud storage location. Refer to [Test the connection to cloud storage](#test-the-connection-to-cloud-storage) for an example.
+`connection_options_list` | [(Preview)]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}) Control the parameters for testing the connection to your cloud storage location. Refer to [Show backup connection options](#show-backup-connection-options) for a list.
 
 ### Options
 
@@ -66,6 +66,10 @@ Option        | Value | Description
 `privileges`  | N/A   |  List which users and roles had which privileges on each table in the backup. Displays original ownership of the backup.
 
 #### Show backup connection options
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Option  | Value | Description
 --------+-------+------------
@@ -99,6 +103,10 @@ Field | Value | Description
 See [Show a backup with descriptor IDs](#show-a-backup-with-descriptor-ids) for the responses displayed when the `WITH debug_ids` option is specified.
 
 ### Show backup connection responses
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Field | Value | Description
 ------|-------|------------
@@ -329,6 +337,10 @@ SHOW BACKUP FROM '2020/09/24-190540.54' IN 's3://test/backups/test_explicit_kms?
 ~~~
 
 ### Test the connection to cloud storage
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
 
 Test the connection to a cloud storage location from each node in your cluster. `SHOW BACKUP CONNECTION` will measure the time it takes each node to write a file, read it, and delete it from the specified cloud storage location:
 


### PR DESCRIPTION
Fixes DOC-10392

This PR adds the `show backup connection` syntax to the `show backup` page.

- Parameters
- Options
- Responses
- Examples

**Note** the SQL diagramming here was tricky. Since the page was already using a local include for the railroad, this PR just updates that to add `connection`.