### PR TITLE
adjust MOLT redirect logic

### DIFF
--- a/src/current/_data/redirects.yml
+++ b/src/current/_data/redirects.yml
@@ -247,10 +247,7 @@
   versions: ['cockroachcloud']
 
 - destination: molt/live-migration-service.md
-  sources:
-    - v23.1/live-migration-service.md
-    - v23.2/live-migration-service.md
-    - v24.1/live-migration-service.md
+  sources: [':version/live-migration-service.md']
 
 - destination: logging-overview.md
   sources: ['debug-and-error-logs.md']
@@ -275,15 +272,10 @@
   versions: ['v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
     
 - destination: molt/molt-fetch.md
-  sources:
-    - v23.2/molt-fetch.md
-    - v24.1/molt-fetch.md
+  sources: [':version/molt-fetch.md']
 
 - destination: molt/molt-verify.md
-  sources:
-    - v23.1/molt-verify.md
-    - v23.2/molt-verify.md
-    - v24.1/molt-verify.md
+  sources: [':version/molt-verify.md']
 
 - destination: node-shutdown.md
   sources: ['cockroach-quit.md']


### PR DESCRIPTION
Using a new way to redirect all version-specific MOLT docs to the `molt` repo.

The `:version` syntax causes the following paths to redirect to `molt`:

- `vXX.X`
- `stable`
- `dev`