### PR TITLE
Enable header for Cloud API Docs preview with new OpenAPI spec document

### DIFF
--- a/src/api/cloud/v1.md
+++ b/src/api/cloud/v1.md
@@ -102,7 +102,7 @@ docs_area: reference.api
             text-color = "#242A35"
             primary-color = "#6933FF"
             nav-bg-color = "#fff"
-            show-header = "false"
+            show-header = "true"
             regular-font = "'SourceSansPro-Regular', sans-serif"
             mono-font = "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
             show-method-in-nav-bar = "as-colored-text"


### PR DESCRIPTION
https://github.com/cockroachdb/docs/pull/17710/ would no longer build