### PR TITLE
Small update to PCR upgrade language

### DIFF
--- a/src/current/v23.2/physical-cluster-replication-overview.md
+++ b/src/current/v23.2/physical-cluster-replication-overview.md
@@ -122,7 +122,7 @@ Statement | Action
 
 ### Cluster versions and upgrades
 
-The standby cluster host will need to be at the same major version as, or one version ahead of, the primary's application virtual cluster at the time of cutover.
+The standby cluster must be at the same version as, or one version ahead of, the primary's application virtual cluster at the time of cutover.
 
 To [upgrade]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) a virtualized cluster, you must carefully and manually apply the upgrade. For details, refer to [Upgrades]({% link {{ page.version.version }}/work-with-virtual-clusters.md %}#upgrade-a-cluster) in the [Cluster Virtualization Overview]({% link {{ page.version.version }}/cluster-virtualization-overview.md %}).
 

--- a/src/current/v24.1/physical-cluster-replication-overview.md
+++ b/src/current/v24.1/physical-cluster-replication-overview.md
@@ -72,7 +72,7 @@ For more comprehensive guides, refer to:
 
 ### Cluster versions and upgrades
 
-The standby cluster host will need to be at the same major version as, or one version ahead of, the primary's virtual cluster at the time of [cutover]({% link {{ page.version.version }}/cutover-replication.md %}).
+The standby cluster must be at the same version as, or one version ahead of, the primary's virtual cluster at the time of [cutover]({% link {{ page.version.version }}/cutover-replication.md %}).
 
 To [upgrade]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) a virtualized cluster, you must carefully and manually apply the upgrade. For details, refer to [Upgrades]({% link {{ page.version.version }}/work-with-virtual-clusters.md %}#upgrade-a-cluster) in the [Cluster Virtualization Overview]({% link {{ page.version.version }}/cluster-virtualization-overview.md %}).
 

--- a/src/current/v24.2/physical-cluster-replication-overview.md
+++ b/src/current/v24.2/physical-cluster-replication-overview.md
@@ -72,7 +72,7 @@ For more comprehensive guides, refer to:
 
 ### Cluster versions and upgrades
 
-The standby cluster host will need to be at the same major version as, or one version ahead of, the primary's virtual cluster at the time of [cutover]({% link {{ page.version.version }}/cutover-replication.md %}).
+The standby cluster must be at the same version as, or one version ahead of, the primary's virtual cluster at the time of [cutover]({% link {{ page.version.version }}/cutover-replication.md %}).
 
 To [upgrade]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) a virtualized cluster, you must carefully and manually apply the upgrade. For details, refer to [Upgrades]({% link {{ page.version.version }}/work-with-virtual-clusters.md %}#upgrade-a-cluster) in the [Cluster Virtualization Overview]({% link {{ page.version.version }}/cluster-virtualization-overview.md %}).
 


### PR DESCRIPTION
This is a quick fix to remove the "host" language from the PCR docs. This is confusing because we use this terminology for tenanted serverless clusters,