### PR TITLE
DOC-9631 update v24.2 feature availability of Metric scrape (prometheus-compatible metric endpoint) supported for Dedicated Azure cluster

### DIFF
--- a/src/current/v24.2/cockroachdb-feature-availability.md
+++ b/src/current/v24.2/cockroachdb-feature-availability.md
@@ -65,6 +65,8 @@ The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-
 ### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
 [Exporting metrics from CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/export-metrics.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
 
+[Exporting metrics from CockroachDB {{ site.data.products.dedicated }} to Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
+
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).
 {{site.data.alerts.end}}


### PR DESCRIPTION
Fixes DOC-9631

Copied cockroachdb-feature-availability.md from v24.1 to v24.2.