### PR TITLE
Fix latest-release-details include to actually show the latest release, use for v24.1

### DIFF
--- a/src/current/_includes/latest-release-details.md
+++ b/src/current/_includes/latest-release-details.md
@@ -4,15 +4,20 @@
 
 {% assign DEBUG = false %}
 
+{% assign latest_release = site.data.versions | where_exp: "rd", "rd.release_date != 'N/A'" | sort: "release_date" | last %}
+
 {% assign rd = site.data.versions | where_exp: "rd", "rd.major_version == page.version.version" | first %}
 {% assign latest = site.data.releases | where_exp: "latest", "latest.major_version == page.version.version" | sort: "release_date" | last %}
 
 {% assign released = false %}
 {% assign skippable = false %}
+{% assign lts = false %}
 {% if rd.release_date != "N/A" and rd.maint_supp_exp_date != "N/A" %}
     {% assign released = true %}
     {% if rd.asst_supp_exp_date == "N/A" %}
         {% assign skippable = true %}
+    {% elsif rd.initial_lts_patch != "N/A" %}
+      {% assign lts = true %}
     {% endif %}
 {% endif %}
 
@@ -24,8 +29,6 @@ released: {{ released }}<br />
 skippable: {{ skippable }}<br />
 {% endif %}
 
-CockroachDB {{ latest.major_version }} is the latest supported supported production release.{% if skippable == true %} It is an [Innovation release]({% link releases/release-support-policy.md %}#support-types) that is optional for CockroachDB {{ site.data.products.dedicated }} and CockroachDB {{ site.data.products.core }} but required for CockroachDB {{ site.data.products.serverless }}.{% else %} It is a required [Regular release]({% link releases/release-support-policy.md %}#support-types).{% endif %} To learn more, refer to [CockroachDB {{ latest.major_version }} Release Notes](https://cockroachlabs.com/docs/releases/{{ latest.major_version }}.html).
+This page shows how to {% if page.name contains 'upgrade' %}upgrade to {% else %}install {% endif %}CockroachDB {{ page.version.version }}{% if its == true %}([LTS]({% link releases/release-support-policy.md %}#support-types)){% endif %}. {% if skippable == true %} It is an [Innovation release]({% link releases/release-support-policy.md %}#support-types) that is optional for CockroachDB {{ site.data.products.dedicated }} and CockroachDB {{ site.data.products.core }} but required for CockroachDB {{ site.data.products.serverless }}.{% else %} It is a required [Regular release]({% link releases/release-support-policy.md %}#support-types). To learn more, refer to [CockroachDB {{ page.version.version }} Release Notes]({% link releases/{{ page.version.version }}.md %}).{% endif %}
 
-{% if page.version.version != blank and page.version.version != latest.major_version %}
-**This page refers to CockroachDB {{ page.version.version }}, not {{ latest.major_version }}.**
-{% endif %}
+{% if page.version.version != blank and page.version.version != latest_release.major_version %}Note that CockroachDB [{{ latest_release.major_version }}]({% link releases/{{ latest_release.major_version }}.md %}) is the latest supported production release, not {{ page.version.version }}.{% endif %}

--- a/src/current/v24.1/install-cockroachdb-linux.md
+++ b/src/current/v24.1/install-cockroachdb-linux.md
@@ -15,6 +15,8 @@ docs_area: deploy
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
+{% include latest-release-details.md %}
+
 See [Release Notes](https://www.cockroachlabs.com/docs/releases/{{page.version.version}}) for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see [Cluster Upgrade](https://www.cockroachlabs.com/docs/releases/{{page.version.version}}/upgrade-cockroach-version).
 
 Use one of the options below to install CockroachDB.

--- a/src/current/v24.1/install-cockroachdb-mac.md
+++ b/src/current/v24.1/install-cockroachdb-mac.md
@@ -15,6 +15,8 @@ docs_area: deploy
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
+{% include latest-release-details.md %}
+
 See [Release Notes](https://www.cockroachlabs.com/docs/releases/{{page.version.version}}) for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see [Cluster Upgrade](https://www.cockroachlabs.com/docs/releases/{{page.version.version}}/upgrade-cockroach-version).
 
 {% comment %}v22.2.0+{% endcomment %}

--- a/src/current/v24.1/install-cockroachdb-windows.md
+++ b/src/current/v24.1/install-cockroachdb-windows.md
@@ -15,6 +15,8 @@ docs_area: deploy
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
+{% include latest-release-details.md %}
+
 See [Release Notes](https://www.cockroachlabs.com/docs/releases/{{page.version.version}}) for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see [Cluster Upgrade](https://www.cockroachlabs.com/docs/releases/{{page.version.version}}/upgrade-cockroach-version).
 
 Use one of the options below to install CockroachDB.

--- a/src/current/v24.1/upgrade-cockroach-version.md
+++ b/src/current/v24.1/upgrade-cockroach-version.md
@@ -17,7 +17,7 @@ docs_area: manage
 
 Because of CockroachDB's [multi-active availability]({% link {{ page.version.version }}/multi-active-availability.md %}) design, you can perform a "rolling upgrade" of your CockroachDB cluster. This means that you can upgrade nodes one at a time without interrupting the cluster's overall health and operations.
 
-This page describes how to upgrade to the latest **{{ page.version.version }}** release, **{{ latest.release_name }}**{% if latest.lts == true %}&nbsp;([LTS]({% link releases/release-support-policy.md %}#support-types)){% endif %}. To upgrade CockroachDB on Kubernetes, refer to [single-cluster]({% link {{ page.version.version }}/upgrade-cockroachdb-kubernetes.md %}) or [multi-cluster]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}#upgrade-the-cluster) instead.
+{% include latest-release-details.md %}
 
 ## Terminology
 

--- a/src/current/v24.2/upgrade-cockroach-version.md
+++ b/src/current/v24.2/upgrade-cockroach-version.md
@@ -28,8 +28,6 @@ docs_area: manage
 
 Because of CockroachDB's [multi-active availability]({% link {{ page.version.version }}/multi-active-availability.md %}) design, you can perform a "rolling upgrade" of your CockroachDB cluster. This means that you can upgrade nodes one at a time without interrupting the cluster's overall health and operations.
 
-This page describes how to upgrade to the latest **{{ page.version.version }}** release, **{{ latest.release_name }}**{% if latest.lts == true %}&nbsp;([LTS]({% link releases/release-support-policy.md %}#support-types)){% endif %}.
-
 {% include latest-release-details.md %}
 
 To upgrade CockroachDB on Kubernetes, refer to [single-cluster]({% link {{ page.version.version }}/upgrade-cockroachdb-kubernetes.md %}) or [multi-cluster]({% link {{ page.version.version }}/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md %}#upgrade-the-cluster) instead.


### PR DESCRIPTION
When developing the tooling for innovation releases, I created an include to use on install and upgrade pages to always show what the latest version is, no matter what version of the page you are viewing. This was to help the reader get to the latest version of CockroachDB and of the page, if possible. However, I used the include only in the v24.2 version of the files and this did not cause the logic to fire, so I didn't notice that it was not actually working as intended.

This PR fixes that and updates the v24.1 install and upgrade pages to use the include, so that the v24.1 pages now show that v24.2 is currently the latest.