### PR TITLE
[DOC-10949] Update Docker instructions for Cloud-first

### DIFF
--- a/src/current/_includes/v24.1/install-docker-steps.md
+++ b/src/current/_includes/v24.1/install-docker-steps.md
@@ -1,0 +1,57 @@
+{% comment %}This include is used in install-cockroachdb-*.md{% endcomment %}
+{% capture deployment_link %}
+{% if page.name contains "mac" %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-mac.md %})
+{% elsif page.name contains "windows" %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-windows.md %})
+{% else %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-linux.md %})
+{% endif %}
+{% endcapture %}
+
+{{site.data.alerts.callout_danger}}
+Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.
+{{site.data.alerts.end}}
+
+CockroachDB's Docker images are [multi-platform images](https://docs.docker.com/build/building/multi-platform/) that contain binaries for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.
+
+Experimental images are not qualified for production use and not eligible for support or uptime SLA commitments.
+
+1. Install a container runtime, such as [Docker Desktop](https://docs.docker.com/desktop/).
+1. Verify that the runtime service is installed correctly and running in the background. Refer to the runtime's documentation. For Docker, start a terminal and run `docker version`. If you get an error, verify your installation and try again.
+1. Visit [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach) and decide which image tag to pull. Releases are rolled out gradually. Docker images for a new release are published when other binary artifacts are published. The following tag formats are commonly used, although other tags are available.
+
+    <table markdown="1">
+    <thead>
+      <tr>
+        <td>Tag</td>
+        <td>Example</td>
+        <td>Description</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>An exact patch</td>
+        <td>`{{ page.version.name }}`</td>
+        <td>Pins a cluster to an exact patch. The cluster is upgraded to a newer patch or major version only when you pull a newer tag.</td>
+      </tr>
+      <tr>
+        <td>Latest patch within a major version</td>
+        <td>`latest-{{ page.version.version }}`</td>
+        <td>Automatically updates a cluster to the latest patch of the version you specify. This tag is recommended in production, because it keeps your cluster updated within a major version but does not automatically upgrade your cluster to a new major version.</td>
+      </tr>
+      <tr>
+        <td>`latest`</td>
+        <td>The latest patch within the latest major version.
+        <td>This is the default if you do not specify a tag. It updates your cluster automatically to each new patch and major version, and is not recommended in production.</td>
+      </tr>
+    </tbody>
+    </table>
+
+    Copy the tag you want to pull.
+
+1. Pull the image. Replace `{TAG}` with the tag from the previous step.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker pull cockroachdb/cockroach:{TAG}
+    ~~~
+
+1. Start a cluster by starting the container on each node using `docker start`. The default command is `cockroach start`. Pass your desired flags as the final argument. For details, refer to {{ deployment_link | strip }}.

--- a/src/current/_includes/v24.2/install-docker-steps.md
+++ b/src/current/_includes/v24.2/install-docker-steps.md
@@ -1,0 +1,57 @@
+{% comment %}This include is used in install-cockroachdb-*.md{% endcomment %}
+{% capture deployment_link %}
+{% if page.name contains "mac" %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-mac.md %})
+{% elsif page.name contains "windows" %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-windows.md %})
+{% else %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-linux.md %})
+{% endif %}
+{% endcapture %}
+
+{{site.data.alerts.callout_danger}}
+Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.
+{{site.data.alerts.end}}
+
+CockroachDB's Docker images are [multi-platform images](https://docs.docker.com/build/building/multi-platform/) that contain binaries for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.
+
+Experimental images are not qualified for production use and not eligible for support or uptime SLA commitments.
+
+1. Install a container runtime, such as [Docker Desktop](https://docs.docker.com/desktop/install/).
+1. Verify that the runtime service is installed correctly and running in the background. Refer to the runtime's documentation. For Docker, start a terminal and run `docker version`. If you get an error, verify your installation and try again.
+1. Visit [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach) and decide which image tag to pull. CockroachDB images are published on [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach). Releases are rolled out gradually. Docker images for a new release are published when other binary artifacts are published. The following tag formats are commonly used, although other tags are available.
+
+    <table markdown="1">
+    <thead>
+      <tr>
+        <td>Tag</td>
+        <td>Example></td>
+        <td>Description</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>An exact patch</td>
+        <td>`{{ page.version.name }}`</td>
+        <td>Pins a cluster to an exact patch. The cluster is upgraded to a newer patch or major version only when you pull a newer tag.</td>
+      </tr>
+      <tr>
+        <td>Latest patch within a major version</td>
+        <td>`latest-{{ page.version.version }}`</td>
+        <td>Automatically updates a cluster to the latest patch of the version you specify. This tag is recommended in production, because it keeps your cluster updated within a major version but does not automatically upgrade your cluster to a new major version.</td>
+      </tr>
+      <tr>
+        <td>`latest`</td>
+        <td>The latest patch within the latest major version.
+        <td>This is the default default if you do not specify a tag. It updates your cluster automatically to each new patch and major version, and is not recommended in production.</td>
+      </tr>
+    </tbody>
+    </table>
+
+    Copy the tag you want to pull.
+
+1. Pull the image. Replace `{TAG}` with the tag from the previous step.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker pull cockroachdb/cockroach:{TAG}
+    ~~~
+
+1. Start a cluster by starting the container on each node using `docker start`. The default command is `cockroach start`. Pass your desired flags as the final argument. For details, refer to {{ deployment_link | strip }}.

--- a/src/current/_includes/v24.2/install-docker-steps.md
+++ b/src/current/_includes/v24.2/install-docker-steps.md
@@ -14,15 +14,15 @@ CockroachDB's Docker images are [multi-platform images](https://docs.docker.com/
 
 Experimental images are not qualified for production use and not eligible for support or uptime SLA commitments.
 
-1. Install a container runtime, such as [Docker Desktop](https://docs.docker.com/desktop/install/).
+1. Install a container runtime, such as [Docker Desktop](https://docs.docker.com/desktop/).
 1. Verify that the runtime service is installed correctly and running in the background. Refer to the runtime's documentation. For Docker, start a terminal and run `docker version`. If you get an error, verify your installation and try again.
-1. Visit [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach) and decide which image tag to pull. CockroachDB images are published on [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach). Releases are rolled out gradually. Docker images for a new release are published when other binary artifacts are published. The following tag formats are commonly used, although other tags are available.
+1. Visit [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach) and decide which image tag to pull. Releases are rolled out gradually. Docker images for a new release are published when other binary artifacts are published. The following tag formats are commonly used, although other tags are available.
 
     <table markdown="1">
     <thead>
       <tr>
         <td>Tag</td>
-        <td>Example></td>
+        <td>Example</td>
         <td>Description</td>
       </tr>
     </thead>
@@ -40,7 +40,7 @@ Experimental images are not qualified for production use and not eligible for su
       <tr>
         <td>`latest`</td>
         <td>The latest patch within the latest major version.
-        <td>This is the default default if you do not specify a tag. It updates your cluster automatically to each new patch and major version, and is not recommended in production.</td>
+        <td>This is the default if you do not specify a tag. It updates your cluster automatically to each new patch and major version, and is not recommended in production.</td>
       </tr>
     </tbody>
     </table>

--- a/src/current/_includes/v24.3/install-docker-steps.md
+++ b/src/current/_includes/v24.3/install-docker-steps.md
@@ -1,0 +1,57 @@
+{% comment %}This include is used in install-cockroachdb-*.md{% endcomment %}
+{% capture deployment_link %}
+{% if page.name contains "mac" %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-mac.md %})
+{% elsif page.name contains "windows" %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-windows.md %})
+{% else %}[Deploy a local container in Docker]({% link {{ page.version.version }}/start-a-local-cluster-in-docker-linux.md %})
+{% endif %}
+{% endcapture %}
+
+{{site.data.alerts.callout_danger}}
+Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.
+{{site.data.alerts.end}}
+
+CockroachDB's Docker images are [multi-platform images](https://docs.docker.com/build/building/multi-platform/) that contain binaries for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.
+
+Experimental images are not qualified for production use and not eligible for support or uptime SLA commitments.
+
+1. Install a container runtime, such as [Docker Desktop](https://docs.docker.com/desktop/).
+1. Verify that the runtime service is installed correctly and running in the background. Refer to the runtime's documentation. For Docker, start a terminal and run `docker version`. If you get an error, verify your installation and try again.
+1. Visit [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach) and decide which image tag to pull. Releases are rolled out gradually. Docker images for a new release are published when other binary artifacts are published. The following tag formats are commonly used, although other tags are available.
+
+    <table markdown="1">
+    <thead>
+      <tr>
+        <td>Tag</td>
+        <td>Example</td>
+        <td>Description</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>An exact patch</td>
+        <td>`{{ page.version.name }}`</td>
+        <td>Pins a cluster to an exact patch. The cluster is upgraded to a newer patch or major version only when you pull a newer tag.</td>
+      </tr>
+      <tr>
+        <td>Latest patch within a major version</td>
+        <td>`latest-{{ page.version.version }}`</td>
+        <td>Automatically updates a cluster to the latest patch of the version you specify. This tag is recommended in production, because it keeps your cluster updated within a major version but does not automatically upgrade your cluster to a new major version.</td>
+      </tr>
+      <tr>
+        <td>`latest`</td>
+        <td>The latest patch within the latest major version.
+        <td>This is the default if you do not specify a tag. It updates your cluster automatically to each new patch and major version, and is not recommended in production.</td>
+      </tr>
+    </tbody>
+    </table>
+
+    Copy the tag you want to pull.
+
+1. Pull the image. Replace `{TAG}` with the tag from the previous step.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    docker pull cockroachdb/cockroach:{TAG}
+    ~~~
+
+1. Start a cluster by starting the container on each node using `docker start`. The default command is `cockroach start`. Pass your desired flags as the final argument. For details, refer to {{ deployment_link | strip }}.

--- a/src/current/v24.1/install-cockroachdb-linux.md
+++ b/src/current/v24.1/install-cockroachdb-linux.md
@@ -15,9 +15,9 @@ docs_area: deploy
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
-See [Release Notes]({% link releases/{{page.version.version}}.md %}) for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see [Cluster Upgrade]({% link {{page.version.version}}/upgrade-cockroach-version.md %}).
+{% include latest-release-details.md %}
 
-Use one of the options below to install CockroachDB.
+Use one of the options below to install CockroachDB. To upgrade an existing cluster, refer to [Upgrade to {{ page.version.version }}]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 To install a FIPS-compliant CockroachDB binary, refer to [Install a FIPS-compliant build of CockroachDB]({% link {{ page.version.version }}/fips.md %}).
 
@@ -114,10 +114,10 @@ true
   </ul>
 </div>
 
-<div id="use-docker-linux" class="install-option">
-  <h2 id="install-docker">Use Docker</h2>
+<div id="use-docker-linux" markdown="1" class="install-option">
+<h2 id="install-docker">Use Docker</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+{% include {{ page.version.version }}/install-docker-steps.md %}
 
   <p>For CockroachDB v22.2.beta-5 and above, Docker images are <a href="https://docs.docker.com/build/building/multi-platform/">multi-platform images</a> that contain binaries for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.</p>
   <p>Docker images for previous releases contain Intel binaries only. Intel binaries can run on ARM systems, but with a significant reduction in performance.</p>

--- a/src/current/v24.1/install-cockroachdb-mac.md
+++ b/src/current/v24.1/install-cockroachdb-mac.md
@@ -15,20 +15,17 @@ docs_area: deploy
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
-See [Release Notes]({% link releases/{{page.version.version}}.md %}) for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see [Cluster Upgrade]({% link {{page.version.version}}/upgrade-cockroach-version.md %}).
-
-{% comment %}v22.2.0+{% endcomment %}
-{{site.data.alerts.callout_danger}}
-<p>On macOS ARM systems, <a href="{% link {{ page.version.version }}/spatial-data-overview.md %}">spatial features</a> are disabled due to an issue with macOS code signing for the <a href="https://libgeos.org/">GEOS</a> libraries. Users needing spatial features on an ARM Mac may instead <a href="https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta">use Rosetta</a> to <a href="#install-binary">run the Intel binary</a> or use the <a href="#use-docker">Docker image</a> distribution. Refer to <a href="https://github.com/cockroachdb/cockroach/issues/93161">GitHub tracking issue</a> for more information.</p>
-{{site.data.alerts.end}}
+{% include latest-release-details.md %}
 
 {% capture arch_note_homebrew %}<p>For CockroachDB v22.2.x and above, Homebrew installs binaries for your system architecture, either Intel or ARM (<a href="https://support.apple.com/HT211814">Apple Silicon</a>).</p><p>For previous releases, Homebrew installs Intel binaries. Intel binaries can run on ARM systems, but with a significant reduction in performance. CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
 
 {% capture arch_note_binaries %}<p>For CockroachDB v22.2.x and above, download the binaries for your system architecture, either Intel or ARM (<a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a>).</p><p>For previous releases, download Intel binaries. Intel binaries can run on ARM systems, but with a significant reduction in performance. CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
 
-{% capture arch_note_docker %}<p>For CockroachDB v22.2.beta-5 and above, Docker images are <a href="https://docs.docker.com/build/building/multi-platform/">multi-platform images</a> that contain binaries for both Intel and ARM (<a href="https://support.apple.com/HT211814">Apple Silicon</a>). Multi-platform images do not take up additional space on your Docker host.</p><p>Docker images for previous releases contain Intel binaries only. Intel binaries can run on ARM systems, but with a significant reduction in performance.</p><p>CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
+{{site.data.alerts.callout_info}}
+CockroachDB on macOS is experimental and not suitable for production deployments.
+{{site.data.alerts.end}}
 
-Use one of the options below to install CockroachDB.
+Use one of the options below to install CockroachDB. To upgrade an existing cluster, refer to [Upgrade to {{ page.version.version }}]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}). For limitations specific to geospatial features, refer to [Limitations](#limitations).
 
 <div id="use-homebrew" markdown="1" class="install-option">
 
@@ -87,7 +84,7 @@ true
 {% endcapture %}
 
 <div id="download-the-binary" class="install-option">
-  <h2 id="install-binary">Download the binary</h2>
+  <a id="install-the-binary"></a><h2 id="install-binary">Download the binary</h2>
   {{ arch_note_binaries }}
   <ol>
     <li>
@@ -173,42 +170,11 @@ true
   <p>To orchestrate CockroachDB locally using <a href="https://kubernetes.io/">Kubernetes</a>, either with configuration files or the <a href="https://helm.sh/">Helm</a> package manager, see <a href="orchestrate-a-local-cluster-with-kubernetes.html">Orchestrate CockroachDB Locally with Minikube</a>.</p>
 </div>
 
-<div id="use-docker" class="install-option">
-  <h2 id="install-docker">Use Docker</h2>
+<div id="use-docker" markdown="1" class="install-option">
+<h2 id="install-docker">Use Docker</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+{% include {{ page.version.version }}/install-docker-steps.md %}
 
-  {{ arch_note_docker }}
-
-  <ol>
-    <li>
-      <p>Install <a href="https://docs.docker.com/docker-for-mac/install/">Docker for Mac</a>. Please carefully check that you meet all prerequisites.</p>
-    </li>
-    <li>
-      <p>Confirm that the Docker daemon is running in the background:</p>
-
-      <div class="copy-clipboard">
-        <svg data-eventcategory="mac-docker-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
-        <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
-      </div>
-      <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step2"><span class="nv language-shell mac-docker-step2" id="mac-docker-step2-{{ page.version.version }}" data-eventcategory="mac-docker-step2">$ </span>docker version</code></pre></div>
-      <p>If you do not see the server listed, start the <strong>Docker</strong> daemon.</p>
-    </li>
-    <li>
-      <p>Pull the image for the {{page.release_info.version}} release of CockroachDB from <a href="https://hub.docker.com/r/{{page.release_info.docker_image}}/" class="mac-docker-step3" id="mac-docker-step3-{{page.version.version}}" data-eventcategory="mac-docker-step3">Docker Hub</a>:</p>
-
-      <div class="copy-clipboard">
-        <svg data-eventcategory="mac-docker-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
-        <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
-      </div>
-      <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step3"><span class="nv language-shell mac-docker-step3" id="mac-docker-step3-{{ page.version.version }}" data-eventcategory="mac-docker-step3">$ </span>docker pull {{page.release_info.docker_image}}:{{page.release_info.version}}</code></pre>
-      </div>
-    </li>
-    <li>
-      <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="3" %}
-    </li>
-  </ol>
 </div>
 
 <div id="build-from-source" class="install-option">
@@ -230,3 +196,9 @@ CockroachDB runtimes built for the ARM architecture have the following limitatio
 {% include {{ page.version.version }}/misc/install-next-steps.html %}
 
 {% include {{ page.version.version }}/misc/diagnostics-callout.html %}
+
+## Limitations
+
+{% comment %}v22.2.0+{% endcomment %}
+
+On macOS ARM systems, [spatial features]{% link {{ page.version.version }}/spatial-data-overview.md %}) are disabled due to an issue with macOS code signing for the <a href="https://libgeos.org/">GEOS</a> libraries. Users needing spatial features on an ARM Mac may instead [run the Intel binary](#install-the-binary) or use the[Docker container image](#use-docker). Refer to [GitHub issue #93161](https://github.com/cockroachdb/cockroach/issues/93161)</a> for more information.

--- a/src/current/v24.1/install-cockroachdb-windows.md
+++ b/src/current/v24.1/install-cockroachdb-windows.md
@@ -15,6 +15,8 @@ docs_area: deploy
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
+{% include latest-release-details.md %}
+
 {% include windows_warning.md %}
 
 Use one of the options below to install CockroachDB. To upgrade an existing cluster, refer to [Upgrade to {{ page.version.version }}]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
@@ -61,7 +63,7 @@ To orchestrate CockroachDB locally using [Kubernetes](https://kubernetes.io/), e
 
 </section>
 
-<section id="use-docker-windows" markdown="1" class="install-option">
+<div id="use-docker-windows" markdown="1" class="install-option">
 <h2 id="install-docker">Use Docker</h2>
 
 This section shows how to install CockroachDB on a Windows host using Docker. On a Linux or Windows Docker host, the image creates a Linux container.

--- a/src/current/v24.2/install-cockroachdb-linux.md
+++ b/src/current/v24.2/install-cockroachdb-linux.md
@@ -114,10 +114,10 @@ true
   </ul>
 </div>
 
-<div id="use-docker-linux" class="install-option">
-  <h2 id="install-docker">Use Docker</h2>
+<div id="use-docker-linux" markdown="1" class="install-option">
+<h2 id="install-docker">Use Docker</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+{% include {{ page.version.version }}/install-docker-steps.md %}
 
   <p>For CockroachDB v22.2.beta-5 and above, Docker images are <a href="https://docs.docker.com/build/building/multi-platform/">multi-platform images</a> that contain binaries for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.</p>
   <p>Docker images for previous releases contain Intel binaries only. Intel binaries can run on ARM systems, but with a significant reduction in performance.</p>

--- a/src/current/v24.2/install-cockroachdb-mac.md
+++ b/src/current/v24.2/install-cockroachdb-mac.md
@@ -21,8 +21,6 @@ docs_area: deploy
 
 {% capture arch_note_binaries %}<p>For CockroachDB v22.2.x and above, download the binaries for your system architecture, either Intel or ARM (<a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a>).</p><p>For previous releases, download Intel binaries. Intel binaries can run on ARM systems, but with a significant reduction in performance. CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
 
-{% capture arch_note_docker %}<p>For CockroachDB v22.2.beta-5 and above, Docker images are <a href="https://docs.docker.com/build/building/multi-platform/">multi-platform images</a> that contain binaries for both Intel and ARM (<a href="https://support.apple.com/HT211814">Apple Silicon</a>). Multi-platform images do not take up additional space on your Docker host.</p><p>Docker images for previous releases contain Intel binaries only. Intel binaries can run on ARM systems, but with a significant reduction in performance.</p><p>CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
-
 {{site.data.alerts.callout_info}}
 CockroachDB on macOS is experimental and not suitable for production deployments.
 {{site.data.alerts.end}}
@@ -172,42 +170,11 @@ true
   <p>To orchestrate CockroachDB locally using <a href="https://kubernetes.io/">Kubernetes</a>, either with configuration files or the <a href="https://helm.sh/">Helm</a> package manager, see <a href="orchestrate-a-local-cluster-with-kubernetes.html">Orchestrate CockroachDB Locally with Minikube</a>.</p>
 </div>
 
-<div id="use-docker" class="install-option">
-  <h2 id="install-docker">Use Docker</h2>
+<div id="use-docker" markdown="1" class="install-option">
+<h2 id="install-docker">Use Docker</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+{% include {{ page.version.version }}/install-docker-steps.md %}
 
-  {{ arch_note_docker }}
-
-  <ol>
-    <li>
-      <p>Install <a href="https://docs.docker.com/docker-for-mac/install/">Docker for Mac</a>. Please carefully check that you meet all prerequisites.</p>
-    </li>
-    <li>
-      <p>Confirm that the Docker daemon is running in the background:</p>
-
-      <div class="copy-clipboard">
-        <svg data-eventcategory="mac-docker-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
-        <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
-      </div>
-      <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step2"><span class="nv language-shell mac-docker-step2" id="mac-docker-step2-{{ page.version.version }}" data-eventcategory="mac-docker-step2">$ </span>docker version</code></pre></div>
-      <p>If you do not see the server listed, start the <strong>Docker</strong> daemon.</p>
-    </li>
-    <li>
-      <p>Pull the image for the {{page.release_info.version}} release of CockroachDB from <a href="https://hub.docker.com/r/{{page.release_info.docker_image}}/" class="mac-docker-step3" id="mac-docker-step3-{{page.version.version}}" data-eventcategory="mac-docker-step3">Docker Hub</a>:</p>
-
-      <div class="copy-clipboard">
-        <svg data-eventcategory="mac-docker-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
-        <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
-      </div>
-      <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step3"><span class="nv language-shell mac-docker-step3" id="mac-docker-step3-{{ page.version.version }}" data-eventcategory="mac-docker-step3">$ </span>docker pull {{page.release_info.docker_image}}:{{page.release_info.version}}</code></pre>
-      </div>
-    </li>
-    <li>
-      <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="3" %}
-    </li>
-  </ol>
 </div>
 
 <div id="build-from-source" class="install-option">

--- a/src/current/v24.2/install-cockroachdb-windows.md
+++ b/src/current/v24.2/install-cockroachdb-windows.md
@@ -63,7 +63,7 @@ To orchestrate CockroachDB locally using [Kubernetes](https://kubernetes.io/), e
 
 </section>
 
-<section id="use-docker-windows" markdown="1" class="install-option">
+<div id="use-docker-windows" markdown="1" class="install-option">
 <h2 id="install-docker">Use Docker</h2>
 
 This section shows how to install CockroachDB on a Windows host using Docker. On a Linux or Windows Docker host, the image creates a Linux container.

--- a/src/current/v24.3/install-cockroachdb-linux.md
+++ b/src/current/v24.3/install-cockroachdb-linux.md
@@ -114,10 +114,10 @@ true
   </ul>
 </div>
 
-<div id="use-docker-linux" class="install-option">
-  <h2 id="install-docker">Use Docker</h2>
+<div id="use-docker-linux" markdown="1" class="install-option">
+<h2 id="install-docker">Use Docker</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+{% include {{ page.version.version }}/install-docker-steps.md %}
 
   <p>For CockroachDB v22.2.beta-5 and above, Docker images are <a href="https://docs.docker.com/build/building/multi-platform/">multi-platform images</a> that contain binaries for both Intel and ARM. Multi-platform images do not take up additional space on your Docker host.</p>
   <p>Docker images for previous releases contain Intel binaries only. Intel binaries can run on ARM systems, but with a significant reduction in performance.</p>

--- a/src/current/v24.3/install-cockroachdb-mac.md
+++ b/src/current/v24.3/install-cockroachdb-mac.md
@@ -21,8 +21,6 @@ docs_area: deploy
 
 {% capture arch_note_binaries %}<p>For CockroachDB v22.2.x and above, download the binaries for your system architecture, either Intel or ARM (<a href="https://support.apple.com/en-us/HT211814">Apple Silicon</a>).</p><p>For previous releases, download Intel binaries. Intel binaries can run on ARM systems, but with a significant reduction in performance. CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
 
-{% capture arch_note_docker %}<p>For CockroachDB v22.2.beta-5 and above, Docker images are <a href="https://docs.docker.com/build/building/multi-platform/">multi-platform images</a> that contain binaries for both Intel and ARM (<a href="https://support.apple.com/HT211814">Apple Silicon</a>). Multi-platform images do not take up additional space on your Docker host.</p><p>Docker images for previous releases contain Intel binaries only. Intel binaries can run on ARM systems, but with a significant reduction in performance.</p><p>CockroachDB on ARM for macOS is <b>experimental</b> and is not yet qualified for production use and not eligible for support or uptime SLA commitments.</p>{% endcapture %}
-
 {{site.data.alerts.callout_info}}
 CockroachDB on macOS is experimental and not suitable for production deployments.
 {{site.data.alerts.end}}
@@ -172,42 +170,11 @@ true
   <p>To orchestrate CockroachDB locally using <a href="https://kubernetes.io/">Kubernetes</a>, either with configuration files or the <a href="https://helm.sh/">Helm</a> package manager, see <a href="orchestrate-a-local-cluster-with-kubernetes.html">Orchestrate CockroachDB Locally with Minikube</a>.</p>
 </div>
 
-<div id="use-docker" class="install-option">
-  <h2 id="install-docker">Use Docker</h2>
+<div id="use-docker" markdown="1" class="install-option">
+<h2 id="install-docker">Use Docker</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+{% include {{ page.version.version }}/install-docker-steps.md %}
 
-  {{ arch_note_docker }}
-
-  <ol>
-    <li>
-      <p>Install <a href="https://docs.docker.com/docker-for-mac/install/">Docker for Mac</a>. Please carefully check that you meet all prerequisites.</p>
-    </li>
-    <li>
-      <p>Confirm that the Docker daemon is running in the background:</p>
-
-      <div class="copy-clipboard">
-        <svg data-eventcategory="mac-docker-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
-        <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
-      </div>
-      <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step2"><span class="nv language-shell mac-docker-step2" id="mac-docker-step2-{{ page.version.version }}" data-eventcategory="mac-docker-step2">$ </span>docker version</code></pre></div>
-      <p>If you do not see the server listed, start the <strong>Docker</strong> daemon.</p>
-    </li>
-    <li>
-      <p>Pull the image for the {{page.release_info.version}} release of CockroachDB from <a href="https://hub.docker.com/r/{{page.release_info.docker_image}}/" class="mac-docker-step3" id="mac-docker-step3-{{page.version.version}}" data-eventcategory="mac-docker-step3">Docker Hub</a>:</p>
-
-      <div class="copy-clipboard">
-        <svg data-eventcategory="mac-docker-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>
-        <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
-      </div>
-      <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step3"><span class="nv language-shell mac-docker-step3" id="mac-docker-step3-{{ page.version.version }}" data-eventcategory="mac-docker-step3">$ </span>docker pull {{page.release_info.docker_image}}:{{page.release_info.version}}</code></pre>
-      </div>
-    </li>
-    <li>
-      <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="3" %}
-    </li>
-  </ol>
 </div>
 
 <div id="build-from-source" class="install-option">

--- a/src/current/v24.3/install-cockroachdb-windows.md
+++ b/src/current/v24.3/install-cockroachdb-windows.md
@@ -63,7 +63,7 @@ To orchestrate CockroachDB locally using [Kubernetes](https://kubernetes.io/), e
 
 </section>
 
-<section id="use-docker-windows" markdown="1" class="install-option">
+<div id="use-docker-windows" markdown="1" class="install-option">
 <h2 id="install-docker">Use Docker</h2>
 
 This section shows how to install CockroachDB on a Windows host using Docker. On a Linux or Windows Docker host, the image creates a Linux container.


### PR DESCRIPTION
[DOC-10949] Update Docker instructions for Cloud-first

- Also externalize Docker instructions into a version-specific include
- Also convert HTML to Markdown

This is related to #18826 but I separated it out on purpose so that I can rebase this one on that one's work.

Sending for initial review before backporting to more versions

### Previews
[src/current/v24.2/install-cockroachdb-mac.md](https://deploy-preview-18839--cockroachdb-docs.netlify.app/docs/v24.2/install-cockroachdb-mac.html)
[src/current/v24.2/install-cockroachdb-windows.md](https://deploy-preview-18839--cockroachdb-docs.netlify.app/docs/v24.2/install-cockroachdb-windows.html)
[src/current/v24.2/install-cockroachdb-linux.md](https://deploy-preview-18839--cockroachdb-docs.netlify.app/docs/v24.2/install-cockroachdb-linux.html)