### PR TITLE
DOC-10895 Cloud 2.0 update export logs and metrics for Azure Monitor

### DIFF
--- a/src/current/cockroachcloud/export-logs-advanced.md
+++ b/src/current/cockroachcloud/export-logs-advanced.md
@@ -8,7 +8,7 @@ cloud: true
 
 {% include cockroachcloud/filter-tabs/export-logs.md %}
 
-CockroachDB {{ site.data.products.advanced }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure log export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, send log entries to specific log group targets by log channel, and more.
+CockroachDB {{ site.data.products.advanced }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure log export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), [GCP Cloud Logging](https://cloud.google.com/logging), or [Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/logs/data-platform-logs). Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, send log entries to specific log group targets by log channel, and more.
 
 ## The `logexport` endpoint
 
@@ -31,11 +31,11 @@ Method | Description
 -------|------------
 `GET` | Returns the current status of the log export configuration.
 `POST` | Enables log export, or updates an existing log export configuration.
-`DELETE` | Disables log export, halting all log export to Amazon CloudWatch or GCP Cloud Logging.
+`DELETE` | Disables log export, halting all log export to Amazon CloudWatch, GCP Cloud Logging, or Azure Monitor.
 
 ## Log name format
 
-When written to your chosen cloud log sink, logs have the following name format:
+GCP Cloud Logging and AWS CloudWatch logs have the following name format:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -46,7 +46,7 @@ Where:
 
 - `{log-name}` is a string of your choosing as you configure log export. For Amazon CloudWatch, this is the [log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) you create as part of enabling log export. For GCP Cloud Logging, this is the `log_name` you choose during configuration. See the [Enable log export](#enable-log-export) instructions specific to your cloud provider for more information.
 - `{region}` is the cloud provider region where your CockroachDB {{ site.data.products.advanced }} cluster resides.
-- `{log-channel}` is the CockroachDB [log channel](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels), such as `HEALTH` or `OPS`.
+- `{log-channel}` is the CockroachDB [log channel]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels), such as `HEALTH` or `OPS`.
 - `{N}` is the node number of the CockroachDB {{ site.data.products.advanced }} node emitting the log messages. Log messages received before a node is fully started may appear in a log named without an explicit node number, ending in just `.n`.
 
 ## Enable log export
@@ -54,13 +54,14 @@ Where:
 <div class="filters clearfix">
   <button class="filter-button" data-scope="aws-log-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="gcp-log-export">GCP Cloud Logging</button>
+  <button class="filter-button" data-scope="azure-monitor-log-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-log-export">
 
 Perform the following steps to enable log export from your CockroachDB {{ site.data.products.advanced }} cluster to Amazon CloudWatch.
 
-1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, see the custom configuration option in step 8.
+1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, refer to the custom configuration option in step 9 below.
 
 1. Find your CockroachDB {{ site.data.products.advanced }} cluster ID:
 
@@ -187,10 +188,10 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             ~~~
 
             This configuration:
-            - Enables [redaction](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) globally for all log entries emitted to Amazon CloudWatch.
+            - Enables [redaction]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) globally for all log entries emitted to Amazon CloudWatch.
             - Does not send log entries in the `SESSIONS` and `SQL_PERF` logging channels.
-            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to a Amazon CloudWatch log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
-            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to an Amazon CloudWatch log group named `devops`, but only for those entries that are of log [severity level](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities) `WARNING` or higher.
+            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to a Amazon CloudWatch log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
+            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Amazon CloudWatch log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` Amazon CloudWatch log group.
 
         1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
@@ -293,7 +294,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
         ~~~
 
         Where:
-        - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as determined in step 2.
+        - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as determined in step 3.
         - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
         - `{log_name}` is a string of your choosing to represent logs written from your CockroachDB {{ site.data.products.advanced }} cluster. This name will appear in the name of each log written to GCP Cloud Logging.
         - `{gcp_project_id}` is your GCP project ID, as shown in your GCP Cloud Console [Settings page](https://console.cloud.google.com/iam-admin/settings).
@@ -329,10 +330,10 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             ~~~
 
             This configuration:
-            - Enables [redaction](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) globally for all log entries emitted to GCP Cloud Logging.
+            - Enables [redaction]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) globally for all log entries emitted to GCP Cloud Logging.
             - Does not send log entries in the `SESSIONS` and `SQL_PERF` logging channels.
-            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to a GCP Cloud Logging log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
-            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to a GCP Cloud Logging log group named `devops`, but only for those entries that are of log [severity level](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities) `WARNING` or higher.
+            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to a GCP Cloud Logging log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
+            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to a GCP Cloud Logging log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` GCP Cloud Logging log group.
 
         1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
@@ -354,7 +355,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
             Where:
             - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as determined in step 2.
-            - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+            - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
             - `{gcp_project_id}` is your GCP project ID, as shown in your GCP Cloud Console [Settings page](https://console.cloud.google.com/iam-admin/settings).
 
 1. Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
@@ -369,6 +370,135 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
     Run the command periodically until the command returns a status of `ENABLED`, at which point the configuration across all nodes is complete, and logs will begin appearing in GCP Cloud Logging. Since the configuration is applied to cluster nodes in a rolling fashion, you may see some logs appear even before the `GET` command returns an `ENABLED` status.
 
 1. Once log export has been enabled, you can access logs from your CockroachDB {{ site.data.products.advanced }} cluster directly in GCP Cloud Logging's [Log Explorer](https://console.cloud.google.com/logs/query).
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="azure-monitor-log-export">
+
+{{site.data.alerts.callout_info}}
+Exporting Logs to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access](https://www.cockroachlabs.com/docs/{{ site.current_cloud_version }}/cockroachdb-feature-availability)** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
+{{site.data.alerts.end}}
+
+Perform the following steps to enable log export from your CockroachDB {{ site.data.products.advanced }} cluster to Azure Monitor.
+
+1. Find your CockroachDB {{ site.data.products.advanced }} cluster ID:
+
+	1. Visit the CockroachDB {{ site.data.products.cloud }} console [cluster page](https://cockroachlabs.cloud/clusters).
+	1. Click on the name of your cluster.
+	1. Find your cluster ID in the URL of the single cluster overview page and note the value: `https://cockroachlabs.cloud/cluster/{your_cluster_id}/overview`.
+
+1. [Create a Log Analytics workspace in Azure Portal](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/quick-create-workspace?tabs=azure-portal).
+
+    1. Navigate to the Log Analytics workspace. Under **Settings**, click **Agents**.
+    1. Click **Log Analytics agent instructions** section header.
+    1. In that section, note the values for the **Workspace ID** and **Primary key** (or **Secondary key**)
+
+1. Use one of the following Cloud API commands to enable log export for your CockroachDB {{ site.data.products.advanced }} cluster.
+
+   - The first presents a basic configuration, where all logs are sent to Azure Monitor using the [default](#default) settings.
+   - The second allows for more detailed [customization](#custom) of the logging configuration, such as the ability to send certain log channels to specific target log tables, or the ability to redact sensitive log entries.
+
+### Default
+
+To enable log export for your CockroachDB {{ site.data.products.advanced }} cluster with default logging configuration, issue the following Cloud API command:
+
+{% include_cached copy-clipboard.html %}
+~~~shell
+curl --request POST \
+--url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/logexport \
+--header "Authorization: Bearer {secret_key}" \
+--data '{"type": "AZURE_LOG_ANALYTICS", "log_name": "{log_prefix}", "auth_principal": "{workspace_id}", "azure_shared_key": "{primary_or_secondary_key}"}'
+~~~
+
+Where:
+
+- `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as previously noted.
+- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. For instructions on generating this key, refer to [API Access]({% link cockroachcloud/managing-access.md %}#api-access) for instructions on generating this key.
+- `{log_prefix}` is a user-specified prefix for the table that will be created in the Log Analytics workspace.
+- `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID** as previously noted.
+- `{azure_shared_key}` is the **Primary key** or **Secondary key** as previously noted.
+
+### Custom
+
+To enable log export for your CockroachDB {{ site.data.products.advanced }} cluster with custom logging configuration:
+
+1. Consult the log export entry on the [CockroachDB {{ site.data.products.cloud }} API Reference](https://www.cockroachlabs.com/docs/api/cloud/v1.html#post-/api/v1/clusters/-cluster_id-/logexport) to determine the customized logging configuration you would like to use. Under the **REQUEST** section, select the **SCHEMA** tab to view the supported log configuration options.
+
+    For example, consider the following configuration:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~json
+    {
+        "type": "AZURE_LOG_ANALYTICS",
+        "log_name": "default",
+        "auth_principal": "{workspace_id}",
+        "azure_shared_key": "{primary_or_secondary_key}",
+        "redact": true,
+        "region": "",
+        "omitted_channels": [ "SESSIONS", "SQL_PERF"],
+        "groups": [
+                {
+                    "log_name": "sql",
+                    "channels": ["SQL_SCHEMA", "SQL_EXEC"],
+                    "redact": false
+                },
+                {
+                    "log_name": "devops",
+                    "channels": ["OPS", "HEALTH", "STORAGE"],
+                    "min_level": "WARNING"
+                }
+        ]
+    }
+    ~~~
+
+    This configuration:
+    - Enables [redaction]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) globally for all log entries emitted to Azure Monitor.
+    - Does not send log entries in the `SESSIONS` and `SQL_PERF` logging channels.
+    - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Azure Monitor log table prefixed with `sql`, and overrides (disables) the global redaction configuration for only these two log channels.
+    - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Azure Monitor log table prefixed with `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
+    - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the Azure Monitor log table prefixed with `default`.
+
+1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding example configuration becomes the following single line, suitable for the next step's `POST` command:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~json
+    {"type":"AZURE_LOG_ANALYTICS","log_name":"default","auth_principal":"{workspace_id}","azure_shared_key":"{primary_or_secondary_key}","redact":true,"region":"","omitted_channels":["SESSIONS","SQL_PERF"],"groups":[{"log_name":"sql","channels":["SQL_SCHEMA","SQL_EXEC"],"redact":false},{"log_name":"devops","channels":["OPS","HEALTH","STORAGE"],"min_level":"WARNING"}]}
+    ~~~
+
+1. To enable log export for your CockroachDB {{ site.data.products.advanced }} cluster with the example custom logging configuration, issue the following Cloud API command:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    curl --request POST \
+        --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/logexport \
+        --header "Authorization: Bearer {secret_key}" \
+        --data '{"type":"AZURE_LOG_ANALYTICS","log_name":"default","auth_principal":"{workspace_id}","azure_shared_key":"{primary_or_secondary_key}","redact":true,"region":"","omitted_channels":["SESSIONS","SQL_PERF"],"groups":[{"log_name":"sql","channels":["SQL_SCHEMA","SQL_EXEC"],"redact":false},{"log_name":"devops","channels":["OPS","HEALTH","STORAGE"],"min_level":"WARNING"}]}'
+    ~~~
+
+    Where:
+    - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as previously noted.
+    - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+    - `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID** as previously noted.
+    - `{azure_shared_key}` is the **Primary key** or **Secondary key** as previously noted.
+
+### Verify
+
+- Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~shell
+    curl --request GET \
+      --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/logexport \
+      --header "Authorization: Bearer {secret_key}"
+    ~~~
+
+    When the command returns a status of `ENABLED`, the configuration has been applied to all nodes, and logs will begin appearing in Azure Monitor. Since the configuration is applied to cluster nodes one at a time, logs may begin to appear even before the status is `ENABLED`.
+
+- Once log export has been enabled, you can access logs from your CockroachDB {{ site.data.products.advanced }} cluster directly in [Azure Portal](https://portal.azure.com/#home).
+
+  - Navigate to the Log Analytics workspace created previously.
+  - In the left menu, under **Settings**, click **Tables**. In the **Table names** column, there should be a table name with the following pattern: `{log_prefix}_{region}_CL`. For example, `crdb_eastus_CL` where `{log_prefix}` is the string passed to `log_name` in the Cloud API command (`crdb` in this case), `{region}` is the region of your cluster (`eastus` in this case), and `CL` is the suffix for a classic custom table.
+  - To view the logs in this table, in the left menu, click **Logs**. In a **New Query** window, enter the table name and click **Run**.
 
 </section>
 
@@ -414,7 +544,7 @@ Where:
 
 ## Limitations
 
-- CockroachDB {{ site.data.products.advanced }} clusters hosted on AWS can only export logs to Amazon CloudWatch. Similarly, CockroachDB {{ site.data.products.advanced }} clusters hosted on GCP can only export logs to GCP Cloud Logging.
+- CockroachDB {{ site.data.products.advanced }} clusters hosted on AWS can only export logs to Amazon CloudWatch. Similarly, CockroachDB {{ site.data.products.advanced }} clusters hosted on GCP can only export logs to GCP Cloud Logging, and CockroachDB {{ site.data.products.advanced }} clusters hosted on Azure can only export logs to Azure Monitor.
 
 ## CockroachDB {{ site.data.products.advanced }} log export Frequently Asked Questions (FAQ)
 
@@ -428,7 +558,7 @@ Yes, use the custom log configuration step for your cloud provider, and specify 
 
 ### Is it possible to send logs from one cloud provider to another?
 
-No, if your CockroachDB {{ site.data.products.advanced }} cluster resides on AWS, you can only export your logs to Amazon CloudWatch. Similarly, if your CockroachDB {{ site.data.products.advanced }} cluster resides on GCP, you can only export your logs to GCP Cloud Logging.
+No, if your CockroachDB {{ site.data.products.advanced }} cluster resides on AWS, you can only export your logs to Amazon CloudWatch. Similarly, if your CockroachDB {{ site.data.products.advanced }} cluster resides on GCP, you can only export your logs to GCP Cloud Logging, and if your CockroachDB {{ site.data.products.advanced }} cluster resides on Azure, you can only export your logs to Azure Monitor.
 
 ### For a multi-region cluster, are the logs from all regions exported to one cloud log sink region?
 
@@ -436,11 +566,11 @@ No, logs for each region in your cluster are exported to the corresponding cloud
 
 ### What log channels are supported?
 
-Currently, the following CockroachDB [log channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) are supported for export in this manner: `SESSIONS`, `OPS`, `HEALTH`, `STORAGE`, `SQL_SCHEMA`, `USER_ADMIN`, `PRIVILEGES`, `SENSITIVE_ACCESS`, `SQL_EXEC`, and `SQL_PERF`. Other log channels are not exportable from CockroachDB {{ site.data.products.advanced }}.
+Currently, the following CockroachDB [log channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) are supported for export in this manner: `SESSIONS`, `OPS`, `HEALTH`, `STORAGE`, `SQL_SCHEMA`, `USER_ADMIN`, `PRIVILEGES`, `SENSITIVE_ACCESS`, `SQL_EXEC`, and `SQL_PERF`. Other log channels are not exportable from CockroachDB {{ site.data.products.advanced }}.
 
 ### Is it possible to include SQL audit logs as part of the log export capability?
 
-Yes, the [SQL Audit Log](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/sql-audit-logging) is exported via the `SENSITIVE_ACCESS` log channel by default, as long as you have previously enabled audit logging on desired tables using the [`ALTER TABLE ...EXPERIMENTAL_AUDIT`](/docs/{{site.current_cloud_version}}/alter-table.html#experimental_audit) statement.
+Yes, the [SQL Audit Log]({% link {{site.current_cloud_version}}/sql-audit-logging.md %}) is exported via the `SENSITIVE_ACCESS` log channel by default, as long as you have previously enabled audit logging on desired tables using the [`ALTER TABLE ...EXPERIMENTAL_AUDIT`]({% link {{site.current_cloud_version}}/alter-table.md %}#experimental_audit) statement.
 
 ### Can I use an AWS External ID with the log export feature?
 
@@ -448,7 +578,7 @@ No, the CockroachDB {{ site.data.products.advanced }} log export feature does no
 
 ### Does log export configuration use the same syntax as CockroachDB log configuration?
 
-No, log export configuration uses the [CockroachDB {{ site.data.products.cloud }} API](https://www.cockroachlabs.com/docs/api/cloud/v1.html#post-/api/v1/clusters/-cluster_id-/logexport) syntax. For example, log export uses `min_level` to define log [severity levels](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities), while CockroachDB uses `filter`.
+No, log export configuration uses the [CockroachDB {{ site.data.products.cloud }} API](https://www.cockroachlabs.com/docs/api/cloud/v1.html#post-/api/v1/clusters/-cluster_id-/logexport) syntax. For example, log export uses `min_level` to define log [severity levels]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities), while CockroachDB uses `filter`.
 
 ### Why are some logs appearing without a node number in the name?
 

--- a/src/current/cockroachcloud/export-logs-advanced.md
+++ b/src/current/cockroachcloud/export-logs-advanced.md
@@ -44,7 +44,7 @@ GCP Cloud Logging and AWS CloudWatch logs have the following name format:
 
 Where:
 
-- `{log-name}` is a string of your choosing as you configure log export. For Amazon CloudWatch, this is the [log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) you create as part of enabling log export. For GCP Cloud Logging, this is the `log_name` you choose during configuration. See the [Enable log export](#enable-log-export) instructions specific to your cloud provider for more information.
+- `{log-name}` is a string of your choosing as you configure log export. For Amazon CloudWatch, this is the [log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) you create as part of enabling log export. For GCP Cloud Logging, this is the `log_name` you choose during configuration. Refer to the [Enable log export](#enable-log-export) instructions specific to your cloud provider for more information.
 - `{region}` is the cloud provider region where your CockroachDB {{ site.data.products.advanced }} cluster resides.
 - `{log-channel}` is the CockroachDB [log channel]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels), such as `HEALTH` or `OPS`.
 - `{N}` is the node number of the CockroachDB {{ site.data.products.advanced }} node emitting the log messages. Log messages received before a node is fully started may appear in a log named without an explicit node number, ending in just `.n`.
@@ -61,7 +61,7 @@ Where:
 
 Perform the following steps to enable log export from your CockroachDB {{ site.data.products.advanced }} cluster to Amazon CloudWatch.
 
-1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, refer to the custom configuration option in step 8 below.
+1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, refer to the custom configuration option in step 8.
 
 1. Find your CockroachDB {{ site.data.products.advanced }} cluster ID:
 
@@ -78,7 +78,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 	  --header 'Authorization: Bearer {secret_key}' | jq .account_id
 	~~~
 
-    See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating the `{secret_key}`.
+    Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating the `{secret_key}`.
 
 1.  Create a cross-account IAM role in your AWS account:
 
@@ -153,7 +153,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
         Where:
         - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as determined in step 2.
-        - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+        - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
         - `{log_group_name}` is the target Amazon CloudWatch log group you created in step 1.
         - `{role_arn}` is the ARN for the `CockroachCloudLogExportRole` role you copied in step 7.
 
@@ -194,7 +194,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Amazon CloudWatch log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` Amazon CloudWatch log group.
 
-        1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
+        1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third-party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
 
             {% include_cached copy-clipboard.html %}
             ~~~json
@@ -213,7 +213,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
             Where:
             - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as determined in step 2.
-            - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+            - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
             - `{role_arn}` is the ARN for the `CockroachCloudLogExportRole` role you copied in step 7.
 
 1. Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
@@ -254,7 +254,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
     Where:
     - `{your_cluster_id}` is the cluster ID of your CockroachDB {{ site.data.products.advanced }} cluster as determined in step 2.
-    - `{secret_key}` is your API access key. See [API Access]({% link cockroachcloud/managing-access.md %}) for more details.
+    - `{secret_key}` is your API access key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for more details.
 
     The resulting GCP principal should resemble the following example:
 
@@ -295,7 +295,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
         Where:
         - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as determined in step 3.
-        - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+        - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
         - `{log_name}` is a string of your choosing to represent logs written from your CockroachDB {{ site.data.products.advanced }} cluster. This name will appear in the name of each log written to GCP Cloud Logging.
         - `{gcp_project_id}` is your GCP project ID, as shown in your GCP Cloud Console [Settings page](https://console.cloud.google.com/iam-admin/settings).
 
@@ -336,7 +336,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to a GCP Cloud Logging log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` GCP Cloud Logging log group.
 
-        1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
+        1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third-party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
 
             {% include_cached copy-clipboard.html %}
             ~~~json
@@ -376,7 +376,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 <section class="filter-content" markdown="1" data-scope="azure-monitor-log-export">
 
 {{site.data.alerts.callout_info}}
-Exporting Logs to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access](https://www.cockroachlabs.com/docs/{{ site.current_cloud_version }}/cockroachdb-feature-availability)** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
+Exporting Logs to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access]({% link {{site.current_cloud_version}}/cockroachdb-feature-availability.md %})** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
 {{site.data.alerts.end}}
 
 Perform the following steps to enable log export from your CockroachDB {{ site.data.products.advanced }} cluster to Azure Monitor.
@@ -412,11 +412,11 @@ curl --request POST \
 
 Where:
 
-- `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as previously noted.
-- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. For instructions on generating this key, refer to [API Access]({% link cockroachcloud/managing-access.md %}#api-access) for instructions on generating this key.
+- `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID.
+- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}#api-access) for instructions on generating this key.
 - `{log_prefix}` is a user-specified prefix for the table that will be created in the Log Analytics workspace.
-- `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID** as previously noted.
-- `{azure_shared_key}` is the **Primary key** or **Secondary key** as previously noted.
+- `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID**.
+- `{azure_shared_key}` is the **Primary key** or **Secondary key**.
 
 ### Custom
 
@@ -458,7 +458,7 @@ To enable log export for your CockroachDB {{ site.data.products.advanced }} clus
     - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Azure Monitor log table prefixed with `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
     - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the Azure Monitor log table prefixed with `default`.
 
-1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding example configuration becomes the following single line, suitable for the next step's `POST` command:
+1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this, use a third-party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding example configuration becomes the following single line, suitable for the next step's `POST` command:
 
     {% include_cached copy-clipboard.html %}
     ~~~json
@@ -476,14 +476,14 @@ To enable log export for your CockroachDB {{ site.data.products.advanced }} clus
     ~~~
 
     Where:
-    - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID as previously noted.
-    - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
-    - `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID** as previously noted.
-    - `{azure_shared_key}` is the **Primary key** or **Secondary key** as previously noted.
+    - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster ID.
+    - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+    - `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID**.
+    - `{azure_shared_key}` is the **Primary key** or **Secondary key**.
 
 ### Verify
 
-- Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
+1. Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
 
     {% include_cached copy-clipboard.html %}
     ~~~shell
@@ -494,11 +494,11 @@ To enable log export for your CockroachDB {{ site.data.products.advanced }} clus
 
     When the command returns a status of `ENABLED`, the configuration has been applied to all nodes, and logs will begin appearing in Azure Monitor. Since the configuration is applied to cluster nodes one at a time, logs may begin to appear even before the status is `ENABLED`.
 
-- Once log export has been enabled, you can access logs from your CockroachDB {{ site.data.products.advanced }} cluster directly in [Azure Portal](https://portal.azure.com/#home).
+1. Once log export has been enabled, you can access logs from your CockroachDB {{ site.data.products.advanced }} cluster directly in [Azure Portal](https://portal.azure.com/#home).
 
-  - Navigate to the Log Analytics workspace created previously.
-  - In the left menu, under **Settings**, click **Tables**. In the **Table names** column, there should be a table name with the following pattern: `{log_prefix}_{region}_CL`. For example, `crdb_eastus_CL` where `{log_prefix}` is the string passed to `log_name` in the Cloud API command (`crdb` in this case), `{region}` is the region of your cluster (`eastus` in this case), and `CL` is the suffix for a classic custom table.
-  - To view the logs in this table, in the left menu, click **Logs**. In a **New Query** window, enter the table name and click **Run**.
+  1. Navigate to the Log Analytics workspace created previously.
+  1. In the left menu, under **Settings**, click **Tables**. In the **Table names** column, there should be a table name with the following pattern: `{log_prefix}_{region}_CL`. For example, `crdb_eastus_CL` where `{log_prefix}` is the string passed to `log_name` in the Cloud API command (`crdb` in this case), `{region}` is the region of your cluster (`eastus` in this case), and `CL` is the suffix for a classic custom table.
+  1. To view the logs in this table, in the left menu, click **Logs**. In a **New Query** window, enter the table name and click **Run**.
 
 </section>
 
@@ -520,7 +520,7 @@ curl --request GET \
 Where:
 
 - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
-- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
 
 ## Update an existing log export configuration
 
@@ -540,7 +540,7 @@ curl --request DELETE \
 Where:
 
 - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
-- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
 
 ## Limitations
 
@@ -550,7 +550,7 @@ Where:
 
 ### Is it possible to configure exported logs to be redacted at source?
 
-Yes, use the `redact: true` log configuration option. See [Redact logs](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) for more information.
+Yes, use the `redact: true` log configuration option. Refer to [Redact logs]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) for more information.
 
 ### Is it possible to send different log channels to different log groups in my cloud log sink?
 
@@ -582,7 +582,7 @@ No, log export configuration uses the [CockroachDB {{ site.data.products.cloud }
 
 ### Why are some logs appearing without a node number in the name?
 
-Log messages received from CockroachDB {{ site.data.products.advanced }} nodes that are not yet fully started may arrive without a node number appended to the log name, in the format `{logname}.n`. Node-specific log messages, as they are received, are written to node-specific logs in the format `{logname}.n1`, `{logname}.n2`, etc., where the number following the `n` characters is the node ID. See [Log Name Format](#log-name-format).
+Log messages received from CockroachDB {{ site.data.products.advanced }} nodes that are not yet fully started may arrive without a node number appended to the log name, in the format `{logname}.n`. Node-specific log messages, as they are received, are written to node-specific logs in the format `{logname}.n1`, `{logname}.n2`, etc., where the number following the `n` characters is the node ID. Refer to [Log Name Format](#log-name-format).
 
 ## Troubleshooting
 

--- a/src/current/cockroachcloud/export-logs-advanced.md
+++ b/src/current/cockroachcloud/export-logs-advanced.md
@@ -61,7 +61,7 @@ Where:
 
 Perform the following steps to enable log export from your CockroachDB {{ site.data.products.advanced }} cluster to Amazon CloudWatch.
 
-1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, refer to the custom configuration option in step 9 below.
+1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, refer to the custom configuration option in step 8 below.
 
 1. Find your CockroachDB {{ site.data.products.advanced }} cluster ID:
 
@@ -590,7 +590,7 @@ Log messages received from CockroachDB {{ site.data.products.advanced }} nodes t
 
 Most log export errors stem from incorrect AWS IAM configuration. Ensure you have followed steps 1 through 6 of the [Enable log export](#enable-log-export) instructions closely, and that you have a **cross-account** IAM role which trusts your CockroachDB {{ site.data.products.advanced }} AWS account ID (as determined in step 3) and has permission to write to your specified log group in CloudWatch (as created in step 1).
 
-When supplying the [Amazon Resource Name (ARN)](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) to step 9, be sure you are supplying the ARN for the `CockroachCloudLogExportRole` role, **not** the ARN for the `CockroachCloudLogExportPolicy` policy. Whether you are using the default logging configuration or the custom configuration: be sure to supply this ARN to the `auth_principal` parameter, in the `--data` payload.
+When supplying the [Amazon Resource Name (ARN)](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) to step 8, be sure you are supplying the ARN for the `CockroachCloudLogExportRole` role, **not** the ARN for the `CockroachCloudLogExportPolicy` policy. Whether you are using the default logging configuration or the custom configuration: be sure to supply this ARN to the `auth_principal` parameter, in the `--data` payload.
 
 ### GCP Cloud Logging
 

--- a/src/current/cockroachcloud/export-logs.md
+++ b/src/current/cockroachcloud/export-logs.md
@@ -44,7 +44,7 @@ GCP Cloud Logging and Amazon CloudWatch logs have the following name format:
 
 Where:
 
-- `{log-name}` is a string of your choosing as you configure log export. For Amazon CloudWatch, this is the [log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) you create as part of enabling log export. For GCP Cloud Logging, this is the `log_name` you choose during configuration. See the [Enable log export](#enable-log-export) instructions specific to your cloud provider for more information.
+- `{log-name}` is a string of your choosing as you configure log export. For Amazon CloudWatch, this is the [log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) you create as part of enabling log export. For GCP Cloud Logging, this is the `log_name` you choose during configuration. Refer to the [Enable log export](#enable-log-export) instructions specific to your cloud provider for more information.
 - `{region}` is the cloud provider region where your CockroachDB {{ site.data.products.standard }} cluster resides.
 - `{log-channel}` is the CockroachDB [log channel]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels), such as `HEALTH` or `OPS`.
 
@@ -59,7 +59,7 @@ Where:
 
 Perform the following steps to enable log export from your CockroachDB {{ site.data.products.standard }} cluster to Amazon CloudWatch.
 
-1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, see the custom configuration option in step 8.
+1. Create the desired target Amazon CloudWatch log group by following the [Create a log group in CloudWatch logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) instructions. If you already have a log group created, you can skip this step. To send logs to more than one target log group, refer to the custom configuration option in step 8.
 
 1. Find your CockroachDB {{ site.data.products.standard }} cluster ID:
 
@@ -78,7 +78,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
     Where:
     - `{your_cluster_id}` is the cluster ID of your CockroachDB {{ site.data.products.standard }} cluster as determined in step 2.
-    - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for more details.
+    - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for more details.
 
 1.  Create a cross-account IAM role in your AWS account:
 
@@ -154,7 +154,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
         Where:
         - `{cluster_id}` is your CockroachDB {{ site.data.products.standard }} cluster ID as determined in step 2.
-        - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+        - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
         - `{log_group_name}` is the target Amazon CloudWatch log group you created in step 1.
         - `{role_arn}` is the ARN for the `CockroachCloudLogExportRole` role you copied in step 7.
 
@@ -195,7 +195,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Amazon CloudWatch log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` Amazon CloudWatch log group.
 
-        1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
+        1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third-party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
 
             {% include_cached copy-clipboard.html %}
             ~~~json
@@ -214,7 +214,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
             Where:
             - `{cluster_id}` is your CockroachDB {{ site.data.products.standard }} cluster ID as determined in step 2.
-            - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+            - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
             - `{role_arn}` is the ARN for the `CockroachCloudLogExportRole` role you copied in step 7.
 
 1. Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
@@ -255,7 +255,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
     Where:
     - `{your_cluster_id}` is the cluster ID of your CockroachDB {{ site.data.products.standard }} cluster as determined in step 2.
-    - `{secret_key}` is your API access key. See [API Access]({% link cockroachcloud/managing-access.md %}) for more details.
+    - `{secret_key}` is your API access key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for more details.
 
     The resulting GCP principal should resemble the following example:
 
@@ -305,7 +305,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
         Where:
         - `{cluster_id}` is your CockroachDB {{ site.data.products.standard }} cluster ID as determined in step 2.
-        - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+        - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
         - `{log_name}` is a string of your choosing to represent logs written from your CockroachDB {{ site.data.products.standard }} cluster. This name will appear in the name of each log written to GCP Cloud Logging.
         - `{service_account_email}` is the email address of the service account that you copied in step 6.
 
@@ -365,7 +365,7 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
 
             Where:
             - `{cluster_id}` is your CockroachDB {{ site.data.products.standard }} cluster ID as determined in step 2.
-            - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+            - `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
             - `{service_account_email}` is the email address of the service account that you copied in step 6.
 
 1. Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
@@ -401,7 +401,7 @@ curl --request GET \
 Where:
 
 - `{cluster_id}` is your CockroachDB {{ site.data.products.standard }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
-- `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+- `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
 
 ## Update an existing log export configuration
 
@@ -421,7 +421,7 @@ curl --request DELETE \
 Where:
 
 - `{cluster_id}` is your CockroachDB {{ site.data.products.standard }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
-- `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+- `{secret_key}` is your CockroachDB {{ site.data.products.standard }} API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
 
 ## Limitations
 
@@ -431,7 +431,7 @@ Where:
 
 ### Is it possible to configure exported logs to be redacted at source?
 
-Yes, use the `redact: true` log configuration option. See [Redact logs]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) for more information.
+Yes, use the `redact: true` log configuration option. Refer to [Redact logs]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) for more information.
 
 ### Is it possible to send different log channels to different log groups in my cloud log sink?
 

--- a/src/current/cockroachcloud/export-logs.md
+++ b/src/current/cockroachcloud/export-logs.md
@@ -6,7 +6,9 @@ docs_area: manage
 cloud: true
 ---
 
-CockroachDB {{ site.data.products.standard }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure log export to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), [GCP Cloud Logging](https://cloud.google.com/logging), or [Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs). Once the export is configured, logs will flow from all nodes in all regions of your cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, send log entries to specific log group targets by log channel, among others.
+{% include cockroachcloud/filter-tabs/export-logs.md %}
+
+CockroachDB {{ site.data.products.standard }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure log export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) or [GCP Cloud Logging](https://cloud.google.com/logging). Once the export is configured, logs will flow from all [regions]({% link cockroachcloud/regions.md %}) of your CockroachDB {{ site.data.products.standard }} cluster to your chosen cloud log sink. You can configure log export to redact sensitive log entries, limit log output by severity, send log entries to specific log group targets by log channel, and more.
 
 ## The `logexport` endpoint
 
@@ -29,11 +31,11 @@ Method | Description
 -------|------------
 `GET` | Returns the current status of the log export configuration.
 `POST` | Enables log export, or updates an existing log export configuration.
-`DELETE` | Disables log export, halting all log export to AWS CloudWatch, GCP Cloud Logging, or Azure Monitor.
+`DELETE` | Disables log export, halting all log export to Amazon CloudWatch or GCP Cloud Logging.
 
 ## Log name format
 
-GCP Cloud Logging and AWS CloudWatch logs have the following name format:
+GCP Cloud Logging and Amazon CloudWatch logs have the following name format:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -44,16 +46,13 @@ Where:
 
 - `{log-name}` is a string of your choosing as you configure log export. For Amazon CloudWatch, this is the [log group](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#Create-Log-Group) you create as part of enabling log export. For GCP Cloud Logging, this is the `log_name` you choose during configuration. See the [Enable log export](#enable-log-export) instructions specific to your cloud provider for more information.
 - `{region}` is the cloud provider region where your CockroachDB {{ site.data.products.standard }} cluster resides.
-- `{log-channel}` is the CockroachDB [log channel](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels), such as `HEALTH` or `OPS`.
-
-For Azure Monitor, the logs have a different name format, refer to [Enable log export](#enable-log-export) instructions.
+- `{log-channel}` is the CockroachDB [log channel]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels), such as `HEALTH` or `OPS`.
 
 ## Enable log export
 
 <div class="filters clearfix">
   <button class="filter-button" data-scope="aws-log-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="gcp-log-export">GCP Cloud Logging</button>
-  <button class="filter-button" data-scope="azure-monitor-log-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-log-export">
@@ -190,10 +189,10 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             ~~~
 
             This configuration:
-            - Enables [redaction](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) globally for all log entries emitted to Amazon CloudWatch.
+            - Enables [redaction]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) globally for all log entries emitted to Amazon CloudWatch.
             - Does not send log entries in the `SESSIONS` and `SQL_PERF` logging channels.
-            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to a Amazon CloudWatch log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
-            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to an Amazon CloudWatch log group named `devops`, but only for those entries that are of log [severity level](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities) `WARNING` or higher.
+            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to a Amazon CloudWatch log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
+            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to an Amazon CloudWatch log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` Amazon CloudWatch log group.
 
         1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
@@ -341,10 +340,10 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
             ~~~
 
             This configuration:
-            - Enables [redaction](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) globally for all log entries emitted to GCP Cloud Logging.
+            - Enables [redaction]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) globally for all log entries emitted to GCP Cloud Logging.
             - Does not send log entries in the `SESSIONS` and `SQL_PERF` logging channels.
-            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to a GCP Cloud Logging log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
-            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to a GCP Cloud Logging log group named `devops`, but only for those entries that are of log [severity level](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities) `WARNING` or higher.
+            - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels)) to a GCP Cloud Logging log group named `sql`, and overrides (disables) the global redaction configuration for just these two log channels only.
+            - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) to a GCP Cloud Logging log group named `devops`, but only for those entries that are of log [severity level]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities) `WARNING` or higher.
             - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the `default` GCP Cloud Logging log group.
 
         1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this easily, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding configuration becomes the following single line:
@@ -381,135 +380,6 @@ Perform the following steps to enable log export from your CockroachDB {{ site.d
     Run the command periodically until the command returns a status of `ENABLED`, at which point the configuration is complete, and logs will begin appearing in GCP Cloud Logging. Since the configuration is applied to cluster [regions]({% link cockroachcloud/regions.md %}) in a rolling fashion, you may see some logs appear even before the `GET` command returns an `ENABLED` status.
 
 1. Once log export has been enabled, you can access logs from your CockroachDB {{ site.data.products.standard }} cluster directly in GCP Cloud Logging's [Log Explorer](https://console.cloud.google.com/logs/query).
-
-</section>
-
-<section class="filter-content" markdown="1" data-scope="azure-monitor-log-export">
-
-{{site.data.alerts.callout_info}}
-Exporting Logs to Azure Monitor from a CockroachDB {{ site.data.products.dedicated }} cluster is in **[limited access](https://www.cockroachlabs.com/docs/{{ site.current_cloud_version }}/cockroachdb-feature-availability)** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
-{{site.data.alerts.end}}
-
-Perform the following steps to enable log export from your CockroachDB {{ site.data.products.dedicated }} cluster to Azure Monitor.
-
-1. Find your CockroachDB {{ site.data.products.dedicated }} cluster ID:
-
-	1. Visit the CockroachDB {{ site.data.products.cloud }} console [cluster page](https://cockroachlabs.cloud/clusters).
-	1. Click on the name of your cluster.
-	1. Find your cluster ID in the URL of the single cluster overview page and note the value: `https://cockroachlabs.cloud/cluster/{your_cluster_id}/overview`.
-
-1. [Create a Log Analytics workspace in Azure Portal](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/quick-create-workspace?tabs=azure-portal).
-
-    1. Navigate to the Log Analytics workspace. Under **Settings**, click **Agents**.
-    1. Click **Log Analytics agent instructions** section header.
-    1. In that section, note the values for the **Workspace ID** and **Primary key** (or **Secondary key**)
-
-1. Use one of the following Cloud API commands to enable log export for your CockroachDB {{ site.data.products.dedicated }} cluster.
-
-   - The first presents a basic configuration, where all logs are sent to Azure Monitor using the [default](#default) settings.
-   - The second allows for more detailed [customization](#custom) of the logging configuration, such as the ability to send certain log channels to specific target log tables, or the ability to redact sensitive log entries.
-
-### Default
-
-To enable log export for your CockroachDB {{ site.data.products.dedicated }} cluster with default logging configuration, issue the following Cloud API command:
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-curl --request POST \
---url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/logexport \
---header "Authorization: Bearer {secret_key}" \
---data '{"type": "AZURE_LOG_ANALYTICS", "log_name": "{log_prefix}", "auth_principal": "{workspace_id}", "azure_shared_key": "{primary_or_secondary_key}"}'
-~~~
-
-Where:
-
-- `{cluster_id}` is your CockroachDB {{ site.data.products.dedicated }} cluster ID as previously noted.
-- `{secret_key}` is your CockroachDB {{ site.data.products.dedicated }} API key. For instructions on generating this key, refer to [API Access]({% link cockroachcloud/managing-access.md %}#api-access) for instructions on generating this key.
-- `{log_prefix}` is a user-specified prefix for the table that will be created in the Log Analytics workspace.
-- `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID** as previously noted.
-- `{azure_shared_key}` is the **Primary key** or **Secondary key** as previously noted.
-
-### Custom
-
-To enable log export for your CockroachDB {{ site.data.products.dedicated }} cluster with custom logging configuration:
-
-1. Consult the log export entry on the [CockroachDB {{ site.data.products.cloud }} API Reference](https://www.cockroachlabs.com/docs/api/cloud/v1.html#post-/api/v1/clusters/-cluster_id-/logexport) to determine the customized logging configuration you would like to use. Under the **REQUEST** section, select the **SCHEMA** tab to view the supported log configuration options.
-
-    For example, consider the following configuration:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~json
-    {
-        "type": "AZURE_LOG_ANALYTICS",
-        "log_name": "default",
-        "auth_principal": "{workspace_id}",
-        "azure_shared_key": "{primary_or_secondary_key}",
-        "redact": true,
-        "region": "",
-        "omitted_channels": [ "SESSIONS", "SQL_PERF"],
-        "groups": [
-                {
-                    "log_name": "sql",
-                    "channels": ["SQL_SCHEMA", "SQL_EXEC"],
-                    "redact": false
-                },
-                {
-                    "log_name": "devops",
-                    "channels": ["OPS", "HEALTH", "STORAGE"],
-                    "min_level": "WARNING"
-                }
-        ]
-    }
-    ~~~
-
-    This configuration:
-    - Enables [redaction](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) globally for all log entries emitted to Azure Monitor.
-    - Does not send log entries in the `SESSIONS` and `SQL_PERF` logging channels.
-    - Sends log entries in the `SQL_SCHEMA` and `SQL_EXEC` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to an Azure Monitor log table prefixed with `sql`, and overrides (disables) the global redaction configuration for only these two log channels.
-    - Sends log entries in the `OPS`, `HEALTH`, and `STORAGE` [logging channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) to an Azure Monitor log table prefixed with `devops`, but only for those entries that are of log [severity level](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities) `WARNING` or higher.
-    - Sends log entries in all other [logging channels](#what-log-channels-are-supported) to the Azure Monitor log table prefixed with `default`.
-
-1. Once you have determined the configuration you'd like to use, edit the configuration to be a single line, the required form for passing to the configuration command in the next step. To accomplish this, use a third party minifier, such as [json minifier](https://jsonformatter.org/json-minify). The preceding example configuration becomes the following single line, suitable for the next step's `POST` command:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~json
-    {"type":"AZURE_LOG_ANALYTICS","log_name":"default","auth_principal":"{workspace_id}","azure_shared_key":"{primary_or_secondary_key}","redact":true,"region":"","omitted_channels":["SESSIONS","SQL_PERF"],"groups":[{"log_name":"sql","channels":["SQL_SCHEMA","SQL_EXEC"],"redact":false},{"log_name":"devops","channels":["OPS","HEALTH","STORAGE"],"min_level":"WARNING"}]}
-    ~~~
-
-1. To enable log export for your CockroachDB {{ site.data.products.dedicated }} cluster with the example custom logging configuration, issue the following Cloud API command:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~shell
-    curl --request POST \
-        --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/logexport \
-        --header "Authorization: Bearer {secret_key}" \
-        --data '{"type":"AZURE_LOG_ANALYTICS","log_name":"default","auth_principal":"{workspace_id}","azure_shared_key":"{primary_or_secondary_key}","redact":true,"region":"","omitted_channels":["SESSIONS","SQL_PERF"],"groups":[{"log_name":"sql","channels":["SQL_SCHEMA","SQL_EXEC"],"redact":false},{"log_name":"devops","channels":["OPS","HEALTH","STORAGE"],"min_level":"WARNING"}]}'
-    ~~~
-
-    Where:
-    - `{cluster_id}` is your CockroachDB {{ site.data.products.dedicated }} cluster ID as previously noted.
-    - `{secret_key}` is your CockroachDB {{ site.data.products.dedicated }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
-    - `{auth_principal}` is the ID for the Log Analytics workspace, **Workspace ID** as previously noted.
-    - `{azure_shared_key}` is the **Primary key** or **Secondary key** as previously noted.
-
-### Verify
-
-- Depending on the size of your cluster and how many regions it spans, the configuration may take a moment. You can monitor the ongoing status of the configuration using the following Cloud API command:
-
-    {% include_cached copy-clipboard.html %}
-    ~~~shell
-    curl --request GET \
-      --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/logexport \
-      --header "Authorization: Bearer {secret_key}"
-    ~~~
-
-    When the command returns a status of `ENABLED`, the configuration has been applied to all nodes, and logs will begin appearing in Azure Monitor. Since the configuration is applied to cluster nodes one at a time, logs may begin to appear even before the status is `ENABLED`.
-
-- Once log export has been enabled, you can access logs from your CockroachDB {{ site.data.products.dedicated }} cluster directly in [Azure Portal](https://portal.azure.com/#home).
-
-  - Navigate to the Log Analytics workspace created previously.
-  - In the left menu, under **Settings**, click **Tables**. In the **Table names** column, there should be a table name with the following pattern: `{log_prefix}_{region}_CL`. For example, `crdb_eastus_CL` where `{log_prefix}` is the string passed to `log_name` in the Cloud API command (`crdb` in this case), `{region}` is the region of your cluster (`eastus` in this case), and `CL` is the suffix for a classic custom table.
-  - To view the logs in this table, in the left menu, click **Logs**. In a **New Query** window, enter the table name and click **Run**.
 
 </section>
 
@@ -555,17 +425,13 @@ Where:
 
 ## Limitations
 
-<<<<<<< HEAD
 - CockroachDB {{ site.data.products.standard }} clusters hosted on AWS can only export logs to Amazon CloudWatch. Similarly, CockroachDB {{ site.data.products.standard }} clusters hosted on GCP can only export logs to GCP Cloud Logging.
-=======
-- CockroachDB {{ site.data.products.dedicated }} clusters hosted on AWS can only export logs to AWS CloudWatch. Similarly, CockroachDB {{ site.data.products.dedicated }} clusters hosted on GCP can only export logs to GCP Cloud Logging, and CockroachDB {{ site.data.products.dedicated }} clusters hosted on Azure can only export logs to Azure Monitor.
->>>>>>> origin/main
 
 ## CockroachDB {{ site.data.products.standard }} log export Frequently Asked Questions (FAQ)
 
 ### Is it possible to configure exported logs to be redacted at source?
 
-Yes, use the `redact: true` log configuration option. See [Redact logs](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/configure-logs#redact-logs) for more information.
+Yes, use the `redact: true` log configuration option. See [Redact logs]({% link {{site.current_cloud_version}}/configure-logs.md %}#redact-logs) for more information.
 
 ### Is it possible to send different log channels to different log groups in my cloud log sink?
 
@@ -573,11 +439,7 @@ Yes, use the custom log configuration step for your cloud provider, and specify 
 
 ### Is it possible to send logs from one cloud provider to another?
 
-<<<<<<< HEAD
 No, if your CockroachDB {{ site.data.products.standard }} cluster resides on AWS, you can only export your logs to Amazon CloudWatch. Similarly, if your CockroachDB {{ site.data.products.standard }} cluster resides on GCP, you can only export your logs to GCP Cloud Logging.
-=======
-No, if your CockroachDB {{ site.data.products.dedicated }} cluster resides on AWS, you can only export your logs to AWS CloudWatch. Similarly, if your CockroachDB {{ site.data.products.dedicated }} cluster resides on GCP, you can only export your logs to GCP Cloud Logging, and if your CockroachDB {{ site.data.products.dedicated }} cluster resides on Azure, you can only export your logs to Azure Monitor.
->>>>>>> origin/main
 
 ### For a multi-region cluster, are the logs from all regions exported to one cloud log sink region?
 
@@ -585,11 +447,11 @@ No, logs for each region in your cluster are exported to the corresponding cloud
 
 ### What log channels are supported?
 
-Currently, the following CockroachDB [log channels](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/logging-overview#logging-channels) are supported for export in this manner: `SESSIONS`, `OPS`, `HEALTH`, `STORAGE`, `SQL_SCHEMA`, `USER_ADMIN`, `PRIVILEGES`, `SENSITIVE_ACCESS`, `SQL_EXEC`, and `SQL_PERF`. Other log channels are not exportable from CockroachDB {{ site.data.products.standard }}.
+Currently, the following CockroachDB [log channels]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels) are supported for export in this manner: `SESSIONS`, `OPS`, `HEALTH`, `STORAGE`, `SQL_SCHEMA`, `USER_ADMIN`, `PRIVILEGES`, `SENSITIVE_ACCESS`, `SQL_EXEC`, and `SQL_PERF`. Other log channels are not exportable from CockroachDB {{ site.data.products.standard }}.
 
 ### Is it possible to include SQL audit logs as part of the log export capability?
 
-Yes, the [SQL Audit Log](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/sql-audit-logging) is exported via the `SENSITIVE_ACCESS` log channel by default, as long as you have previously enabled audit logging on desired tables using the [`ALTER TABLE ...EXPERIMENTAL_AUDIT`](/docs/{{site.current_cloud_version}}/alter-table.html#experimental_audit) statement.
+Yes, the [SQL Audit Log]({% link {{site.current_cloud_version}}/sql-audit-logging.md %}) is exported via the `SENSITIVE_ACCESS` log channel by default, as long as you have previously enabled audit logging on desired tables using the [`ALTER TABLE ...EXPERIMENTAL_AUDIT`]({% link {{site.current_cloud_version}}/alter-table.md %}#experimental_audit) statement.
 
 ### Can I use an AWS External ID with the log export feature?
 
@@ -597,7 +459,7 @@ No, the CockroachDB {{ site.data.products.standard }} log export feature does no
 
 ### Does log export configuration use the same syntax as CockroachDB log configuration?
 
-No, log export configuration uses the [CockroachDB {{ site.data.products.cloud }} API](https://www.cockroachlabs.com/docs/api/cloud/v1.html#post-/api/v1/clusters/-cluster_id-/logexport) syntax. For example, log export uses `min_level` to define log [severity levels](/docs/{{site.current_cloud_version}}/logging.html#logging-levels-severities), while CockroachDB uses `filter`.
+No, log export configuration uses the [CockroachDB {{ site.data.products.cloud }} API](https://www.cockroachlabs.com/docs/api/cloud/v1.html#post-/api/v1/clusters/-cluster_id-/logexport) syntax. For example, log export uses `min_level` to define log [severity levels]({% link {{site.current_cloud_version}}/logging.md %}#logging-levels-severities), while CockroachDB uses `filter`.
 
 ## Troubleshooting
 

--- a/src/current/cockroachcloud/export-metrics-advanced.md
+++ b/src/current/cockroachcloud/export-metrics-advanced.md
@@ -221,6 +221,13 @@ A subset of CockroachDB metrics require that you explicitly [enable percentiles]
 
 <section class="filter-content" markdown="1" data-scope="prometheus-metrics-export">
 
+{{site.data.alerts.callout_info}}
+For CockroachDB {{ site.data.products.advanced }} clusters hosted on **Azure**:
+{% include_cached feature-phases/preview.md %}
+
+For CockroachDB {{ site.data.products.advanced }} clusters hosted on AWS and GCP: This feature is in [general availability]({% link {{site.current_cloud_version}}/cockroachdb-feature-availability.md %}).
+{{site.data.alerts.end}}
+
 1. Find your CockroachDB {{ site.data.products.advanced }} cluster ID:
 
 	1. Visit the CockroachDB {{ site.data.products.cloud }} console [cluster page](https://cockroachlabs.cloud/clusters).

--- a/src/current/cockroachcloud/export-metrics-advanced.md
+++ b/src/current/cockroachcloud/export-metrics-advanced.md
@@ -54,7 +54,7 @@ See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-servi
 {% include_cached feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on AWS. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on Azure, you can export metrics to [Azure Monitor](?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
+Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on AWS. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on Azure, you can export metrics to [Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics-advanced.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) instead.
 
 {{site.data.alerts.callout_info}}
 Enabling metrics export will send around 250 metrics per node to Amazon CloudWatch. Review the [Amazon CloudWatch documentation](https://aws.amazon.com/cloudwatch/pricing/) to gauge how this adds to your Amazon CloudWatch spend.
@@ -340,7 +340,7 @@ For CockroachDB {{ site.data.products.advanced }} clusters hosted on AWS and GCP
 Exporting Metrics to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access]({% link {{site.current_cloud_version}}/cockroachdb-feature-availability.md %})** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
 {{site.data.alerts.end}}
 
-Exporting metrics to Azure Monitor is available only on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. {{ site.data.products.advanced }} clusters hosted in AWS If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on AWS, you can export metrics to [Amazon CloudWatch](?filters=aws-metrics-export#enable-metrics-export). If it is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export#enable-metrics-export) or [Prometheus](?filters=prometheus-metrics-export#enable-metrics-export) instead.
+Exporting metrics to Azure Monitor is available only on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. {{ site.data.products.advanced }} clusters hosted in AWS If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on AWS, you can export metrics to [Amazon CloudWatch]({% link cockroachcloud/export-metrics-advanced.md %}?filters=aws-metrics-export#enable-metrics-export). If it is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics-advanced.md %}?filters=datadog-metrics-export#enable-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export#enable-metrics-export) instead.
 
 To enable metrics export to Azure Monitor:
 
@@ -574,7 +574,7 @@ Where:
 
 ## Limitations
 
-- Metrics export to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters which are hosted on AWS. Similarly, metrics export to Azure is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
+- Metrics export to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters which are hosted on AWS. Similarly, metrics export to Azure is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics-advanced.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) instead.
 - Amazon CloudWatch does not currently support histograms. Any histogram-type metrics emitted from your CockroachDB {{ site.data.products.advanced }} cluster are dropped by CloudWatch. See [Prometheus metric type conversion](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics-conversion.html) for more information, and [Logging dropped Prometheus metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-troubleshooting-EKS.html#ContainerInsights-Prometheus-troubleshooting-droppedmetrics) for instructions on tracking dropped histogram metrics in CloudWatch.
 
 ## Troubleshooting
@@ -585,7 +585,7 @@ Be sure you are providing **your own** AWS Account ID as shown on the AWS [IAM p
 
 If you are using an existing AWS role, or are otherwise using a role name different from the example name used in this tutorial, be sure to use your own role name in step 8 in place of `CockroachCloudMetricsExportRole`.
 
-Your CockroachDB {{ site.data.products.advanced }} cluster must be running on AWS (not GCP or Azure) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on Azure, you can export metrics to [Azure Monitor](?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
+Your CockroachDB {{ site.data.products.advanced }} cluster must be running on AWS (not GCP or Azure) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on Azure, you can export metrics to [Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics-advanced.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) instead.
 
 ## See Also
 

--- a/src/current/cockroachcloud/export-metrics-advanced.md
+++ b/src/current/cockroachcloud/export-metrics-advanced.md
@@ -340,7 +340,7 @@ For CockroachDB {{ site.data.products.advanced }} clusters hosted on AWS and GCP
 Exporting Metrics to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access]({% link {{site.current_cloud_version}}/cockroachdb-feature-availability.md %})** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
 {{site.data.alerts.end}}
 
-Exporting metrics to Azure Monitor is available only on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. {{ site.data.products.advanced }} clusters hosted in AWS If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on AWS, you can export metrics to [Amazon CloudWatch]({% link cockroachcloud/export-metrics-advanced.md %}?filters=aws-metrics-export#enable-metrics-export). If it is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics-advanced.md %}?filters=datadog-metrics-export#enable-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export#enable-metrics-export) instead.
+Exporting metrics to Azure Monitor is available only on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on AWS, you can export metrics to [Amazon CloudWatch]({% link cockroachcloud/export-metrics-advanced.md %}?filters=aws-metrics-export#enable-metrics-export). If it is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics-advanced.md %}?filters=datadog-metrics-export#enable-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export#enable-metrics-export) instead.
 
 To enable metrics export to Azure Monitor:
 
@@ -359,14 +359,14 @@ To enable metrics export to Azure Monitor:
     cat ca.crt ca.key | awk '{printf "%s\\n", $0}'  > concatenated.pem
     ~~~
 
-1. To give access to the CockroachDB cluster to your Azure tenant, [create a Microsoft Entra application](https://learn.microsoft.com/entra/identity-platform/howto-create-service-principal-portal). When registering the application, leave the optional **Redirect URI** empty since certificate-based authentication is being used, not browser-based authentication.
+1. To give the CockroachDB cluster access to your Azure tenant, [create a Microsoft Entra application](https://learn.microsoft.com/entra/identity-platform/howto-create-service-principal-portal). When registering the application, leave the optional **Redirect URI** empty since certificate-based authentication is being used, not browser-based authentication.
 
   1. Once the application is registered, upload the certificate file (`ca.crt`) created in step 2.
   1. From the **Overview** page for the Entra application, note the values for **Display Name**, **Application (client) ID**, and **Directory (tenant) ID**, which will be used in step 5.
 
 1. To allow Azure Monitor to receive metrics, [create an Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource).
 
-  1. In the newly-created Application Insights resource, add a role assignment that assigns the Entra application (search for the **Display Name** from step 3) to the role [Monitoring Metrics Publisher](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/monitor#monitoring-metrics-publisher).
+  1. In the newly created Application Insights resource, add a role assignment that assigns the Entra application (search for the **Display Name** from step 3) to the role [Monitoring Metrics Publisher](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/monitor#monitoring-metrics-publisher).
   1. On the **Overview** page for the Application Insights resource, view the **Connection String**. Note the values for **InstrumentationKey** and **IngestionEndpoint**, which will be used in step 5.
 
 1. To enable metrics export for your CockroachDB {{ site.data.products.advanced }} cluster, issue the following [Cloud API]({% link cockroachcloud/cloud-api.md %}) command:

--- a/src/current/cockroachcloud/export-metrics-advanced.md
+++ b/src/current/cockroachcloud/export-metrics-advanced.md
@@ -6,17 +6,13 @@ docs_area: manage
 cloud: true
 ---
 
-CockroachDB {{ site.data.products.advanced }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure metrics export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), [Datadog](https://www.datadoghq.com/), or [Prometheus](https://prometheus.io/). Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
+CockroachDB {{ site.data.products.advanced }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure metrics export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), [Datadog](https://www.datadoghq.com/), [Prometheus](https://prometheus.io/), or [Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/essentials/data-platform-metrics). Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 {{site.data.alerts.callout_success}}
-To export metrics from a CockroachDB {{ site.data.products.core }} cluster, refer to [Monitoring and Alerting](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/monitoring-and-alerting) instead of this page.
+To export metrics from a CockroachDB {{ site.data.products.core }} cluster, refer to [Monitoring and Alerting]({% link {{site.current_cloud_version}}/monitoring-and-alerting.md %}) instead of this page.
 {{site.data.alerts.end}}
 
-Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters which are hosted on AWS. Metrics export to Datadog and Prometheus is supported on all CockroachDB {{ site.data.products.advanced }} clusters.
-
-{{site.data.alerts.callout_info}}
-{% include_cached feature-phases/preview.md %}
-{{site.data.alerts.end}}
+Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on AWS. Exporting metrics to Azure Monitor is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. Metrics export to Datadog and Prometheus is supported on all CockroachDB {{ site.data.products.advanced }} clusters.
 
 <a id="the-metricexport-endpoint"></a>
 
@@ -26,9 +22,10 @@ To configure and manage metrics export for your CockroachDB {{ site.data.product
 
 Cloud metrics sink | Metrics export endpoint
 ------------------ | ----------------------------------------------------
-Amazon CloudWatch     | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/cloudwatch`
+Amazon CloudWatch  | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/cloudwatch`
 Datadog            | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/datadog`
 Prometheus         | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/prometheus`
+Azure Monitor      | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/azuremonitor`
 
 Access to the `metricexport` endpoints requires a valid CockroachDB {{ site.data.products.cloud }} [service account]({% link cockroachcloud/managing-access.md %}#manage-service-accounts) with the appropriate permissions (`admin` privilege, Cluster Administrator role, or Cluster Operator role).
 
@@ -38,7 +35,7 @@ Method | Required permissions | Description
 --- | --- | ---
 `GET` | `ADMIN`, `EDIT`, or `READ` | Returns the current status of the metrics export configuration.
 `POST` | `ADMIN` or `EDIT` | Enables metrics export, or updates an existing metrics export configuration.
-`DELETE` | `ADMIN` | Disables metrics export, halting all metrics export to Amazon CloudWatch, Datadog, or Prometheus.
+`DELETE` | `ADMIN` | Disables metrics export, halting all metrics export to Amazon CloudWatch, Datadog, Prometheus, or Azure Monitor.
 
 See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-service-accounts) for instructions on configuring a service account with these required permissions.
 
@@ -48,11 +45,16 @@ See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-servi
   <button class="filter-button" data-scope="aws-metrics-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="datadog-metrics-export">Datadog</button>
   <button class="filter-button" data-scope="prometheus-metrics-export">Prometheus</button>
+  <button class="filter-button" data-scope="azure-monitor-metrics-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
 
-Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP or Azure, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
+{{site.data.alerts.callout_info}}
+{% include_cached feature-phases/preview.md %}
+{{site.data.alerts.end}}
+
+Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on AWS. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on Azure, you can export metrics to [Azure Monitor](?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
 
 {{site.data.alerts.callout_info}}
 Enabling metrics export will send around 250 metrics per node to Amazon CloudWatch. Review the [Amazon CloudWatch documentation](https://aws.amazon.com/cloudwatch/pricing/) to gauge how this adds to your Amazon CloudWatch spend.
@@ -335,7 +337,7 @@ For CockroachDB {{ site.data.products.advanced }} clusters hosted on AWS and GCP
 <section class="filter-content" markdown="1" data-scope="azure-monitor-metrics-export">
 
 {{site.data.alerts.callout_info}}
-Exporting Metrics to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access](https://www.cockroachlabs.com/docs/{{ site.current_cloud_version }}/cockroachdb-feature-availability)** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
+Exporting Metrics to Azure Monitor from a CockroachDB {{ site.data.products.advanced }} cluster is in **[limited access]({% link {{site.current_cloud_version}}/cockroachdb-feature-availability.md %})** and is only available to enrolled organizations. To enroll your organization, contact your Cockroach Labs account team. This feature is subject to change.
 {{site.data.alerts.end}}
 
 Exporting metrics to Azure Monitor is available only on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. {{ site.data.products.advanced }} clusters hosted in AWS If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on AWS, you can export metrics to [Amazon CloudWatch](?filters=aws-metrics-export#enable-metrics-export). If it is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export#enable-metrics-export) or [Prometheus](?filters=prometheus-metrics-export#enable-metrics-export) instead.
@@ -357,14 +359,14 @@ To enable metrics export to Azure Monitor:
     cat ca.crt ca.key | awk '{printf "%s\\n", $0}'  > concatenated.pem
     ~~~
 
-1. To give access to the CockroachDB cluster to your Azure tenant, [create a Microsoft Entra application](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal). When registering the application, leave the optional **Redirect URI** empty since certificate-based authentication is being used, not browser-based authentication.
+1. To give access to the CockroachDB cluster to your Azure tenant, [create a Microsoft Entra application](https://learn.microsoft.com/entra/identity-platform/howto-create-service-principal-portal). When registering the application, leave the optional **Redirect URI** empty since certificate-based authentication is being used, not browser-based authentication.
 
   1. Once the application is registered, upload the certificate file (`ca.crt`) created in step 2.
   1. From the **Overview** page for the Entra application, note the values for **Display Name**, **Application (client) ID**, and **Directory (tenant) ID**, which will be used in step 5.
 
-1. To allow Azure Monitor to receive metrics, [create an Application Insights resource](https://learn.microsoft.com/en-us/azure/azure-monitor/app/create-workspace-resource).
+1. To allow Azure Monitor to receive metrics, [create an Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-workspace-resource).
 
-  1. In the newly-created Application Insights resource, add a role assignment that assigns the Entra application (search for the **Display Name** from step 3) to the role [Monitoring Metrics Publisher](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/monitor#monitoring-metrics-publisher).
+  1. In the newly-created Application Insights resource, add a role assignment that assigns the Entra application (search for the **Display Name** from step 3) to the role [Monitoring Metrics Publisher](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/monitor#monitoring-metrics-publisher).
   1. On the **Overview** page for the Application Insights resource, view the **Connection String**. Note the values for **InstrumentationKey** and **IngestionEndpoint**, which will be used in step 5.
 
 1. To enable metrics export for your CockroachDB {{ site.data.products.advanced }} cluster, issue the following [Cloud API]({% link cockroachcloud/cloud-api.md %}) command:
@@ -411,6 +413,7 @@ To enable metrics export to Azure Monitor:
   <button class="filter-button" data-scope="aws-metrics-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="datadog-metrics-export">Datadog</button>
   <button class="filter-button" data-scope="prometheus-metrics-export">Prometheus</button>
+  <button class="filter-button" data-scope="azure-monitor-metrics-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
@@ -467,6 +470,24 @@ Where:
 
 </section>
 
+<section class="filter-content" markdown="1" data-scope="azure-monitor-metrics-export">
+
+To check the status of an existing Azure Monitor metrics export configuration, use the following Cloud API command:
+
+{% include_cached copy-clipboard.html %}
+~~~shell
+curl --request GET \
+  --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/metricexport/azuremonitor \
+  --header "Authorization: Bearer {secret_key}"
+~~~
+
+Where:
+
+- `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
+- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+
+</section>
+
 ## Update an existing metrics export configuration
 
 To update an existing CockroachDB {{ site.data.products.advanced }} metrics export configuration, make any necessary changes to your cloud provider configuration (e.g., Amazon CloudWatch, Datadog, or Prometheus), then issue the same `POST` Cloud API command as shown in the [Enable metrics export](#enable-metrics-export) instructions for your cloud provider with the desired updated configuration. Follow the [Monitor the status of a metrics export configuration](#monitor-the-status-of-a-metrics-export-configuration) instructions to ensure the update completes successfully.
@@ -477,11 +498,12 @@ To update an existing CockroachDB {{ site.data.products.advanced }} metrics expo
   <button class="filter-button" data-scope="aws-metrics-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="datadog-metrics-export">Datadog</button>
   <button class="filter-button" data-scope="prometheus-metrics-export">Prometheus</button>
+  <button class="filter-button" data-scope="azure-monitor-metrics-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
 
-To disable an existing Amazon CloudWatch metrics export configuration, and stop sending metrics to Cloudwatch, use the following Cloud API command:
+To disable an existing Amazon CloudWatch metrics export configuration, and stop sending metrics to CloudWatch, use the following Cloud API command:
 
 {% include_cached copy-clipboard.html %}
 ~~~shell
@@ -530,12 +552,29 @@ Where:
 
 - `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
 - `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="azure-monitor-metrics-export">
+
+To disable an existing Azure Monitor metrics export configuration, and stop sending metrics to Azure Monitor, use the following Cloud API command:
+
+{% include_cached copy-clipboard.html %}
+~~~shell
+curl --request DELETE \
+  --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/metricexport/azuremonitor \
+  --header "Authorization: Bearer {secret_key}"
+~~~
+
+Where:
+
+- `{cluster_id}` is your CockroachDB {{ site.data.products.advanced }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
+- `{secret_key}` is your CockroachDB {{ site.data.products.advanced }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
 
 </section>
 
 ## Limitations
 
-- Metrics export to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP or Azure, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
+- Metrics export to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.advanced }} clusters which are hosted on AWS. Similarly, metrics export to Azure is only available on CockroachDB {{ site.data.products.advanced }} clusters that are hosted on Azure. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
 - Amazon CloudWatch does not currently support histograms. Any histogram-type metrics emitted from your CockroachDB {{ site.data.products.advanced }} cluster are dropped by CloudWatch. See [Prometheus metric type conversion](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics-conversion.html) for more information, and [Logging dropped Prometheus metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-troubleshooting-EKS.html#ContainerInsights-Prometheus-troubleshooting-droppedmetrics) for instructions on tracking dropped histogram metrics in CloudWatch.
 
 ## Troubleshooting
@@ -546,9 +585,9 @@ Be sure you are providing **your own** AWS Account ID as shown on the AWS [IAM p
 
 If you are using an existing AWS role, or are otherwise using a role name different from the example name used in this tutorial, be sure to use your own role name in step 8 in place of `CockroachCloudMetricsExportRole`.
 
-Your CockroachDB {{ site.data.products.advanced }} cluster must be running on AWS (not GCP or Azure) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP or Azure, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
+Your CockroachDB {{ site.data.products.advanced }} cluster must be running on AWS (not GCP or Azure) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on Azure, you can export metrics to [Azure Monitor](?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.advanced }} cluster is hosted on GCP, you can export metrics to [Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
 
 ## See Also
 
-- [Export Metrics From a CockroachDB Standard Cluster]({% link cockroachcloud/export-metrics.md %})
+- [Export Metrics From a CockroachDB {{ site.data.products.standard }} Cluster]({% link cockroachcloud/export-metrics.md %})
 - [Differences in Metrics between Third-Party Monitoring Integrations and DB Console]({% link {{site.current_cloud_version}}/differences-in-metrics-between-third-party-monitoring-integrations-and-db-console.md %})

--- a/src/current/cockroachcloud/export-metrics.md
+++ b/src/current/cockroachcloud/export-metrics.md
@@ -52,7 +52,7 @@ See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-servi
 {% include_cached feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
+Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
 
 {{site.data.alerts.callout_info}}
 Enabling metrics export will send around 90 metrics per [region]({% link cockroachcloud/regions.md %}) to Amazon CloudWatch. Review the [Amazon CloudWatch documentation](https://aws.amazon.com/cloudwatch/pricing/) to gauge how this adds to your Amazon CloudWatch spend.
@@ -459,7 +459,7 @@ Where:
 
 ## Limitations
 
-- Metrics export to Amazon CloudWatch is available only on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
+- Metrics export to Amazon CloudWatch is available only on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
 - Amazon CloudWatch does not currently support histograms. Any histogram-type metrics emitted from your CockroachDB {{ site.data.products.standard }} cluster are dropped by CloudWatch. See [Prometheus metric type conversion](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics-conversion.html) for more information, and [Logging dropped Prometheus metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-troubleshooting-EKS.html#ContainerInsights-Prometheus-troubleshooting-droppedmetrics) for instructions on tracking dropped histogram metrics in CloudWatch.
 
 ## Troubleshooting
@@ -470,7 +470,7 @@ Be sure you are providing **your own** AWS Account ID as shown on the AWS [IAM p
 
 If you are using an existing AWS role, or are otherwise using a role name different from the example name used in this tutorial, be sure to use your own role name in step 8 in place of `CockroachCloudMetricsExportRole`.
 
-Your CockroachDB {{ site.data.products.standard }} cluster must be running on AWS (not GCP) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
+Your CockroachDB {{ site.data.products.standard }} cluster must be running on AWS (not GCP) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
 
 ## See Also
 

--- a/src/current/cockroachcloud/export-metrics.md
+++ b/src/current/cockroachcloud/export-metrics.md
@@ -6,13 +6,13 @@ docs_area: manage
 cloud: true
 ---
 
-CockroachDB {{ site.data.products.standard }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure metrics export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), [Datadog](https://www.datadoghq.com/), [Prometheus](https://prometheus.io/), or [Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-platform-metrics). Once the export is configured, metrics will flow from all nodes in all regions of your cluster to your chosen cloud metrics sink.
+CockroachDB {{ site.data.products.standard }} users can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}) to configure metrics export to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), [Datadog](https://www.datadoghq.com/), or [Prometheus](https://prometheus.io/). Once the export is configured, metrics will flow from all [regions]({% link cockroachcloud/regions.md %}) of your CockroachDB {{ site.data.products.standard }} cluster to your chosen cloud metrics sink.
 
 {{site.data.alerts.callout_success}}
-CockroachDB {{ site.data.products.standard }} clusters use [Cloud Console]({% link cockroachcloud/cluster-management.md %}#view-clusters-page) instead of [DB Console]({% link {{site.current_cloud_version}}/ui-overview.md %}), and DB Console is disabled. To export metrics from a CockroachDB {{ site.data.products.core }} cluster, refer to [Monitoring and Alerting](https://www.cockroachlabs.com/docs/{{site.current_cloud_version}}/monitoring-and-alerting) instead of this page.
+CockroachDB {{ site.data.products.standard }} clusters use [Cloud Console]({% link cockroachcloud/cluster-management.md %}#view-clusters-page) instead of [DB Console]({% link {{site.current_cloud_version}}/ui-overview.md %}), and DB Console is disabled. To export metrics from a CockroachDB {{ site.data.products.core }} cluster, refer to [Monitoring and Alerting]({% link {{site.current_cloud_version}}/monitoring-and-alerting.md %}) instead of this page.
 {{site.data.alerts.end}}
 
-Exporting metrics to Amazon CloudWatch is available only on CockroachDB {{ site.data.products.standard }} clusters that are hosted on AWS. Exporting metrics to Azure Monitor is available only on CockroachDB {{ site.data.products.standard }} clusters that are hosted on Azure. Metrics export to Datadog and Prometheus is supported on all CockroachDB {{ site.data.products.standard }} clusters.
+Exporting metrics to Amazon CloudWatch is available only on CockroachDB {{ site.data.products.standard }} clusters that are hosted on AWS. Metrics export to Datadog and Prometheus is supported on all CockroachDB {{ site.data.products.standard }} clusters.
 
 <a id="the-metricexport-endpoint"></a>
 
@@ -22,10 +22,9 @@ To configure and manage metrics export for your CockroachDB {{ site.data.product
 
 Cloud metrics sink | Metrics export endpoint
 ------------------ | ----------------------------------------------------
-Amazon CloudWatch     | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/cloudwatch`
+Amazon CloudWatch  | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/cloudwatch`
 Datadog            | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/datadog`
 Prometheus         | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/prometheus`
-Azure Monitor      | `https://cockroachlabs.cloud/api/v1/clusters/{your_cluster_id}/metricexport/azuremonitor`
 
 Access to the `metricexport` endpoints requires a valid CockroachDB {{ site.data.products.cloud }} [service account]({% link cockroachcloud/managing-access.md %}#manage-service-accounts) with the appropriate permissions (`admin` privilege or Cluster Admin role).
 
@@ -35,7 +34,7 @@ Method | Required permissions | Description
 --- | --- | ---
 `GET` | `ADMIN`, `EDIT`, or `READ` | Returns the current status of the metrics export configuration.
 `POST` | `ADMIN` or `EDIT` | Enables metrics export, or updates an existing metrics export configuration.
-`DELETE` | `ADMIN` | Disables metrics export, halting all metrics export to Amazon CloudWatch, Datadog, Prometheus, or Azure Monitor.
+`DELETE` | `ADMIN` | Disables metrics export, halting all metrics export to Amazon CloudWatch, Datadog, or Prometheus.
 
 See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-service-accounts) for instructions on configuring a service account with these required permissions.
 
@@ -45,7 +44,6 @@ See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-servi
   <button class="filter-button" data-scope="aws-metrics-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="datadog-metrics-export">Datadog</button>
   <button class="filter-button" data-scope="prometheus-metrics-export">Prometheus</button>
-  <button class="filter-button" data-scope="azure-monitor-metrics-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
@@ -54,7 +52,7 @@ See [Service accounts]({% link cockroachcloud/managing-access.md %}#manage-servi
 {% include_cached feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.dedicated }} clusters that are hosted on AWS. If your CockroachDB {{ site.data.products.dedicated }} cluster is hosted on Azure, you can export metrics to [Azure Monitor]({% link cockroachcloud/export-metrics.md %}?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.dedicated }} cluster is hosted on GCP, you can export metrics to [Datadog]({% link cockroachcloud/export-metrics.md %}?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
+Exporting metrics to Amazon CloudWatch is only available on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
 
 {{site.data.alerts.callout_info}}
 Enabling metrics export will send around 90 metrics per [region]({% link cockroachcloud/regions.md %}) to Amazon CloudWatch. Review the [Amazon CloudWatch documentation](https://aws.amazon.com/cloudwatch/pricing/) to gauge how this adds to your Amazon CloudWatch spend.
@@ -173,7 +171,7 @@ Perform the following steps to enable metrics export from your CockroachDB {{ si
 {% include_cached feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-To enable metrics export for your CockroachDB {{ site.data.products.dedicated }} cluster to Datadog, you can either enable the Datadog integration in your CockroachDB {{ site.data.products.dedicated }} Cloud Console, or on the command line via the [Cloud API]({% link cockroachcloud/cloud-api.md %}):
+To enable metrics export for your CockroachDB {{ site.data.products.standard }} cluster to Datadog, you can either:
 
 - Use the Cloud Console, following the [Monitor CockroachDB {{ site.data.products.cloud }} with Datadog]({% link cockroachcloud/tools-page.md %}#monitor-cockroachdb-cloud-with-datadog) instructions.
 
@@ -337,7 +335,6 @@ A subset of CockroachDB metrics require that you explicitly [enable percentiles]
   <button class="filter-button" data-scope="aws-metrics-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="datadog-metrics-export">Datadog</button>
   <button class="filter-button" data-scope="prometheus-metrics-export">Prometheus</button>
-  <button class="filter-button" data-scope="azure-monitor-metrics-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
@@ -394,24 +391,6 @@ Where:
 
 </section>
 
-<section class="filter-content" markdown="1" data-scope="azure-monitor-metrics-export">
-
-To check the status of an existing Azure Monitor metrics export configuration, use the following Cloud API command:
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-curl --request GET \
-  --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/metricexport/azuremonitor \
-  --header "Authorization: Bearer {secret_key}"
-~~~
-
-Where:
-
-- `{cluster_id}` is your CockroachDB {{ site.data.products.dedicated }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
-- `{secret_key}` is your CockroachDB {{ site.data.products.dedicated }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
-
-</section>
-
 ## Update an existing metrics export configuration
 
 To update an existing CockroachDB {{ site.data.products.standard }} metrics export configuration, make any necessary changes to your cloud provider configuration (e.g., Amazon CloudWatch, Datadog, or Prometheus), then issue the same `POST` Cloud API command as shown in the [Enable metrics export](#enable-metrics-export) instructions for your cloud provider with the desired updated configuration. Follow the [Monitor the status of a metrics export configuration](#monitor-the-status-of-a-metrics-export-configuration) instructions to ensure the update completes successfully.
@@ -422,12 +401,11 @@ To update an existing CockroachDB {{ site.data.products.standard }} metrics expo
   <button class="filter-button" data-scope="aws-metrics-export">Amazon CloudWatch</button>
   <button class="filter-button" data-scope="datadog-metrics-export">Datadog</button>
   <button class="filter-button" data-scope="prometheus-metrics-export">Prometheus</button>
-  <button class="filter-button" data-scope="azure-monitor-metrics-export">Azure Monitor</button>
 </div>
 
 <section class="filter-content" markdown="1" data-scope="aws-metrics-export">
 
-To disable an existing Amazon CloudWatch metrics export configuration, and stop sending metrics to Cloudwatch, use the following Cloud API command:
+To disable an existing Amazon CloudWatch metrics export configuration, and stop sending metrics to CloudWatch, use the following Cloud API command:
 
 {% include_cached copy-clipboard.html %}
 ~~~shell
@@ -479,26 +457,9 @@ Where:
 
 </section>
 
-<section class="filter-content" markdown="1" data-scope="azure-monitor-metrics-export">
-
-To disable an existing Azure Monitor metrics export configuration, and stop sending metrics to Azure Monitor, use the following Cloud API command:
-
-{% include_cached copy-clipboard.html %}
-~~~shell
-curl --request DELETE \
-  --url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/metricexport/azuremonitor \
-  --header "Authorization: Bearer {secret_key}"
-~~~
-
-Where:
-
-- `{cluster_id}` is your CockroachDB {{ site.data.products.dedicated }} cluster's cluster ID, which can be found in the URL of your [Cloud Console](https://cockroachlabs.cloud/clusters/) for the specific cluster you wish to configure, resembling `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
-- `{secret_key}` is your CockroachDB {{ site.data.products.dedicated }} API key. See [API Access]({% link cockroachcloud/managing-access.md %}) for instructions on generating this key.
-</section>
-
 ## Limitations
 
-- Metrics export to Amazon CloudWatch is available only on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. Metrics export to Azure is available only on CockroachDB {{ site.data.products.dedicated }} clusters which are hosted on Azure. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](export-metrics.html?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
+- Metrics export to Amazon CloudWatch is available only on CockroachDB {{ site.data.products.standard }} clusters which are hosted on AWS. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
 - Amazon CloudWatch does not currently support histograms. Any histogram-type metrics emitted from your CockroachDB {{ site.data.products.standard }} cluster are dropped by CloudWatch. See [Prometheus metric type conversion](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics-conversion.html) for more information, and [Logging dropped Prometheus metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-troubleshooting-EKS.html#ContainerInsights-Prometheus-troubleshooting-droppedmetrics) for instructions on tracking dropped histogram metrics in CloudWatch.
 
 ## Troubleshooting
@@ -509,9 +470,9 @@ Be sure you are providing **your own** AWS Account ID as shown on the AWS [IAM p
 
 If you are using an existing AWS role, or are otherwise using a role name different from the example name used in this tutorial, be sure to use your own role name in step 8 in place of `CockroachCloudMetricsExportRole`.
 
-Your CockroachDB {{ site.data.products.standard }} cluster must be running on AWS (not GCP or Azure) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on Azure, you can export metrics to [Azure Monitor]({% link cockroachcloud/export-metrics.md %}?filters=azure-monitor-metrics-export). If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](export-metrics.html?filters=datadog-metrics-export) or [Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) instead.
+Your CockroachDB {{ site.data.products.standard }} cluster must be running on AWS (not GCP) to make use of metrics export to Amazon CloudWatch. If your CockroachDB {{ site.data.products.standard }} cluster is hosted on GCP, you can [export metrics to Datadog](?filters=datadog-metrics-export) or [Prometheus](?filters=prometheus-metrics-export) instead.
 
 ## See Also
 
-- [Export Metrics From a CockroachDB Advanced Cluster]({% link cockroachcloud/export-metrics-advanced.md %})
+- [Export Metrics From a CockroachDB {{ site.data.products.advanced }} Cluster]({% link cockroachcloud/export-metrics-advanced.md %})
 - [Differences in Metrics between Third-Party Monitoring Integrations and DB Console]({% link {{site.current_cloud_version}}/differences-in-metrics-between-third-party-monitoring-integrations-and-db-console.md %})

--- a/src/current/v23.1/cockroachdb-feature-availability.md
+++ b/src/current/v23.1/cockroachdb-feature-availability.md
@@ -51,7 +51,7 @@ General availability (GA)                     | Feature is production-ready and 
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
 ### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).

--- a/src/current/v23.1/cockroachdb-feature-availability.md
+++ b/src/current/v23.1/cockroachdb-feature-availability.md
@@ -28,10 +28,10 @@ General availability (GA)                     | Feature is production-ready and 
 {{site.data.alerts.end}}
 
 ### Export logs to Azure Monitor
-[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs-advanced.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### Export metrics to Azure Monitor
-[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### AWS PrivateLink for CockroachDB Serverless
 [Connecting privately to a multi-region CockroachDB {{ site.data.products.serverless }} cluster using AWS PrivateLink]({% link cockroachcloud/aws-privatelink.md %}?filters=serverless) is in limited access. This can help your organization meet its security requirements and reduce your cluster's exposure to public networks. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
@@ -50,8 +50,8 @@ General availability (GA)                     | Feature is production-ready and 
 
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
-### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/export-metrics.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
+### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).

--- a/src/current/v23.2/cockroachdb-feature-availability.md
+++ b/src/current/v23.2/cockroachdb-feature-availability.md
@@ -56,7 +56,7 @@ Any feature made available in a phase prior to GA is provided without any warran
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
 ### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).

--- a/src/current/v23.2/cockroachdb-feature-availability.md
+++ b/src/current/v23.2/cockroachdb-feature-availability.md
@@ -32,10 +32,10 @@ Any feature made available in a phase prior to GA is provided without any warran
 {{site.data.alerts.end}}
 
 ### Export logs to Azure Monitor
-[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs-advanced.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### Export metrics to Azure Monitor
-[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### AWS PrivateLink for CockroachDB Serverless
 
@@ -55,8 +55,8 @@ Any feature made available in a phase prior to GA is provided without any warran
 
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
-### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/export-metrics.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
+### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).
@@ -176,10 +176,6 @@ This example uses the `users` table from our open-source, fictional peer-to-peer
 ### Super regions
 
 [Super regions]({% link {{ page.version.version }}/multiregion-overview.md %}#super-regions) allow you to define a set of database regions such that schema objects will have all of their replicas stored _only_ in regions that are members of the super region. The primary use case for super regions is data domiciling.
-
-### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
-
-CockroachDB {{ site.data.products.dedicated }} users can use the [Cloud API](https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api) to configure [metrics export](https://www.cockroachlabs.com/docs/cockroachcloud/export-metrics) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/). Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
 
 ### Show range information for a specific row
 

--- a/src/current/v24.1/cockroachdb-feature-availability.md
+++ b/src/current/v24.1/cockroachdb-feature-availability.md
@@ -63,7 +63,7 @@ Any feature made available in a phase prior to GA is provided without any warran
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
 ### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 [Exporting metrics from CockroachDB {{ site.data.products.advanced }} to Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
 

--- a/src/current/v24.1/cockroachdb-feature-availability.md
+++ b/src/current/v24.1/cockroachdb-feature-availability.md
@@ -32,10 +32,10 @@ Any feature made available in a phase prior to GA is provided without any warran
 {{site.data.alerts.end}}
 
 ### Export logs to Azure Monitor
-[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs-advanced.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### Export metrics to Azure Monitor
-[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### AWS PrivateLink for CockroachDB Serverless
 [Connecting privately to a multi-region CockroachDB {{ site.data.products.serverless }} cluster using AWS PrivateLink]({% link cockroachcloud/aws-privatelink.md %}?filters=serverless) is in limited access. This can help your organization meet its security requirements and reduce your cluster's exposure to public networks. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
@@ -62,10 +62,10 @@ Any feature made available in a phase prior to GA is provided without any warran
 
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
-### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/export-metrics.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
+### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
-[Exporting metrics from CockroachDB {{ site.data.products.dedicated }} to Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }} to Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
 
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).

--- a/src/current/v24.2/cockroachdb-feature-availability.md
+++ b/src/current/v24.2/cockroachdb-feature-availability.md
@@ -71,7 +71,7 @@ The [`VECTOR`]({% link {{ page.version.version }}/vector.md %}) data type stores
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
 ### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
 [Exporting metrics from CockroachDB {{ site.data.products.advanced }} to Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
 

--- a/src/current/v24.2/cockroachdb-feature-availability.md
+++ b/src/current/v24.2/cockroachdb-feature-availability.md
@@ -32,10 +32,10 @@ Any feature made available in a phase prior to GA is provided without any warran
 {{site.data.alerts.end}}
 
 ### Export logs to Azure Monitor
-[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting logs to Azure Monitor]({% link cockroachcloud/export-logs-advanced.md %}?filters=azure-monitor-log-export) from your CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, logs will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to Azure Monitor. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### Export metrics to Azure Monitor
-[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.dedicated }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
+[Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
 ### AWS PrivateLink for CockroachDB Serverless
 [Connecting privately to a multi-region CockroachDB {{ site.data.products.serverless }} cluster using AWS PrivateLink]({% link cockroachcloud/aws-privatelink.md %}?filters=serverless) is in limited access. This can help your organization meet its security requirements and reduce your cluster's exposure to public networks. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
@@ -70,10 +70,10 @@ The [`VECTOR`]({% link {{ page.version.version }}/vector.md %}) data type stores
 
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.
 
-### Export metrics from CockroachDB {{ site.data.products.dedicated }} clusters
-[Exporting metrics from CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/export-metrics.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.dedicated }} cluster to your chosen cloud metrics sink.
+### Export metrics from CockroachDB {{ site.data.products.advanced }} clusters
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/export-metrics-advanced.md %}) to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) or [Datadog](https://www.datadoghq.com/) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink.
 
-[Exporting metrics from CockroachDB {{ site.data.products.dedicated }} to Prometheus]({% link cockroachcloud/export-metrics.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
+[Exporting metrics from CockroachDB {{ site.data.products.advanced }} to Prometheus]({% link cockroachcloud/export-metrics-advanced.md %}?filters=prometheus-metrics-export) using the [Cloud API]({% link cockroachcloud/cloud-api.md %}) is in preview for clusters hosted on Azure. It is in general availability for clusters hosted on AWS and GCP.
 
 {{site.data.alerts.callout_info}}
 Exporting metrics to Azure Monitor is in limited access. Refer to [Exporting metrics to Azure Monitor](#export-metrics-to-azure-monitor).


### PR DESCRIPTION
Fixes DOC-10895

- In cockroachdb-feature-availability.md, (1) replaced dedicated with advanced, (2) updated links to export-*-advanced, (3) replaced AWS CloudWatch with Amazon CloudWatch.
- In export-metrics.md, (1) removed mentions of Azure Monitor.
- In export-metrics-advanced.md, (1) added mentions of Azure Monitor, (2) replaced mentions of dedicated with advanced, (3) added Prometheus preview note for Azure.
- In export-logs.md, (1) removed mentions of Azure monitor, (2) added filter-tabs include for Standard/Advanced, (3) resolved merge conflict.
- In export-logs-advanced.md, (1) added mentions of Azure monitor, (2) replaced AWS CloudWatch with Amazon CloudWatch, (3) corrected references to config step.
- In export-*.md files, (1) replaced cockroachlabs.com links with liquid links, (2) replaced AWS CloudWatch with Amazon CloudWatch, (3) removed en-us from external links.
