### PR TITLE
Convert more cockroachlabs.com URLs to use Liquid

### DIFF
--- a/src/current/v23.1/architecture/glossary.md
+++ b/src/current/v23.1/architecture/glossary.md
@@ -51,7 +51,7 @@ For more information on deployment options and guidelines on how to choose a dep
 
 {% include common/basic-terms.md %}
 
-For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture](https://www.cockroachlabs.com/docs/cockroachcloud/architecture#architecture).
+For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture]({% link cockroachcloud/architecture.md %}#architecture).
 
 ## Spatial and GIS terms
 

--- a/src/current/v23.1/architecture/sql-layer.md
+++ b/src/current/v23.1/architecture/sql-layer.md
@@ -21,7 +21,7 @@ If you haven't already, we recommend reading the [Architecture Overview]({% link
 
 ## Overview
 
-Once CockroachDB has been [deployed](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
+Once CockroachDB has been [deployed]({% link cockroachcloud/quickstart.md %}), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
 
 <a name="gateway-node"></a>
 

--- a/src/current/v23.1/architecture/storage-layer.md
+++ b/src/current/v23.1/architecture/storage-layer.md
@@ -175,4 +175,4 @@ The storage layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's next?
 
-Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).
+Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/quickstart.md %}) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).

--- a/src/current/v23.1/security-reference/authentication.md
+++ b/src/current/v23.1/security-reference/authentication.md
@@ -9,7 +9,7 @@ This page give an overview of CockroachDB's security features for authenticating
 
 Instead, you might be looking for:
 
-- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console](https://www.cockroachlabs.com/docs/cockroachcloud/authentication).
+- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console]({% link cockroachcloud/authentication.md %}).
 - [Accessing the DB console on CockroachDB {{ site.data.products.core }} clusters]({% link {{ page.version.version }}/ui-overview.md %}).
 
 ## Authentication configuration
@@ -106,7 +106,7 @@ This is convenient for quick usage and experimentation, but is not suitable for 
 
 CockroachDB {{ site.data.products.dedicated }} clusters enforce IP allow-listing, which must be configured through the CockroachDB Cloud Console.
 
-See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/network-authorization).
+See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/network-authorization.md %}).
 
 ### CockroachDB Self-Hosted
 

--- a/src/current/v23.1/security-reference/authorization.md
+++ b/src/current/v23.1/security-reference/authorization.md
@@ -9,7 +9,7 @@ Authorization, generally, is the control over **who** (users/roles) can perform 
 
 This page describes authorization of SQL users on particular [CockroachDB database clusters]({% link {{ page.version.version }}/architecture/glossary.md %}#cluster). This is distinct from authorization of CockroachDB {{ site.data.products.cloud }} users on CockroachDB {{ site.data.products.cloud }} organiations.
 
-Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model](https://www.cockroachlabs.com/docs/cockroachcloud/authorization#overview-of-the-cockroachdb-cloud-two-level-authorization-model)
+Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model)
 
 ## Authorization models
 

--- a/src/current/v23.1/security-reference/config-secure-hba.md
+++ b/src/current/v23.1/security-reference/config-secure-hba.md
@@ -20,7 +20,7 @@ Limiting allowed database connections to secure IP addresses reduces the risk th
 
 ## Step 1: Provision and access your cluster
 
-[Create your own free CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-a-serverless-cluster).
+[Create your own free CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/create-a-serverless-cluster.md %}).
 
 From the CockroachDB {{ site.data.products.serverless }} Cloud Console, select your new cluster and click the **Connect** button to obtain your connection credentials from the **Connection Info** pane in the CockroachDB Cloud Console.
 

--- a/src/current/v23.1/security-reference/encryption.md
+++ b/src/current/v23.1/security-reference/encryption.md
@@ -21,7 +21,7 @@ In addition to this infrastructure-level encryption, CockroachDB {{ site.data.pr
 
 Customer-Managed Encryption Keys (CMEK) allow you to protect data at rest in a CockroachDB {{ site.data.products.dedicated }} cluster using a cryptographic key that is entirely within your control, hosted in a supported key-management systems (KMS) platform. This key is called the _CMEK key_. The CMEK key is never present in the cluster. Using the KMS platform's identity access management (IAM) system, you manage CockroachDB's permission to use the key for encryption and decryption. If the key is unavailable, or if CockroachDB no longer has permission to decrypt using the key, the cluster cannot start. To temporarily make the cluster and its data unavailable, such as during a security investigation, you can revoke CockroachDB's access to use the CMEK key or temporarily disable the key within the KMS's infrastructure. To permanently make the cluster's data unavailable, you can delete the CMEK key from the KMS. CockroachDB never has access to the CMEK key materials, and the CMEK key never leaves the KMS.
 
-To learn more, see [Customer-Managed Encryption Keys](https://www.cockroachlabs.com/docs/cockroachcloud/cmek) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/managing-cmek).
+To learn more, see [Customer-Managed Encryption Keys]({% link cockroachcloud/cmek.md %}) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/managing-cmek.md %}).
 
 {{site.data.alerts.callout_success}}
 When CMEK is enabled, the **Encryption** option appears to be disabled in the [DB Console]({% link {{ page.version.version }}/ui-overview.md %}), because this option refers to [Encryption At Rest (Enterprise)](#encryption-at-rest-enterprise), which is a feature of CockroachDB {{ site.data.products.core }} clusters.
@@ -146,7 +146,7 @@ Enabling Encryption at Rest might result in a higher CPU utilization. We estimat
 
 ## See also
 
-- [Customer-Managed Encryption Keys (CMEK)](https://www.cockroachlabs.com/docs/cockroachcloud/cmek)
+- [Customer-Managed Encryption Keys (CMEK)]({% link cockroachcloud/cmek.md %})
 - [Client Connection Parameters]({% link {{ page.version.version }}/connection-parameters.md %})
 - [Manual Deployment]({% link {{ page.version.version }}/manual-deployment.md %})
 - [Orchestrated Deployment]({% link {{ page.version.version }}/kubernetes-overview.md %})

--- a/src/current/v23.1/security-reference/transport-layer-security.md
+++ b/src/current/v23.1/security-reference/transport-layer-security.md
@@ -22,7 +22,7 @@ This page provides a conceptual overview of Transport Layer Security (TLS) and t
 **Learn more:**
 
 - [Manage PKI certificates for a CockroachDB deployment with HashiCorp Vault]({% link {{ page.version.version }}/manage-certs-vault.md %})
-- [Certificate Authentication for SQL Clients in Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated)
+- [Certificate Authentication for SQL Clients in Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %})
 
 ## What is Transport Layer Security (TLS)?
 
@@ -164,7 +164,7 @@ PKI for internode communication within CockroachDB {{ site.data.products.dedicat
 
 Certificate authentication for SQL clients is available for CockroachDB {{ site.data.products.dedicated }} clusters.
 
-Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated) for procedural information on administering and using client certificate authentication.
+Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %}) for procedural information on administering and using client certificate authentication.
 
 ## CockroachDB's TLS support and operating modes
 

--- a/src/current/v23.2/architecture/glossary.md
+++ b/src/current/v23.2/architecture/glossary.md
@@ -43,7 +43,7 @@ For more information on deployment options and guidelines on how to choose a dep
 
 {% include common/basic-terms.md %}
 
-For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture](https://www.cockroachlabs.com/docs/cockroachcloud/architecture#architecture).
+For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture]({% link cockroachcloud/architecture.md %}#architecture).
 
 ## Spatial and GIS terms
 

--- a/src/current/v23.2/architecture/sql-layer.md
+++ b/src/current/v23.2/architecture/sql-layer.md
@@ -21,7 +21,7 @@ If you haven't already, we recommend reading the [Architecture Overview]({% link
 
 ## Overview
 
-Once CockroachDB has been [deployed](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
+Once CockroachDB has been [deployed]({% link cockroachcloud/quickstart.md %}), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
 
 <a name="gateway-node"></a>
 

--- a/src/current/v23.2/architecture/storage-layer.md
+++ b/src/current/v23.2/architecture/storage-layer.md
@@ -183,4 +183,4 @@ The storage layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's next?
 
-Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).
+Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/quickstart.md %}) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).

--- a/src/current/v23.2/security-reference/authentication.md
+++ b/src/current/v23.2/security-reference/authentication.md
@@ -9,7 +9,7 @@ This page give an overview of CockroachDB's security features for authenticating
 
 Instead, you might be looking for:
 
-- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console](https://www.cockroachlabs.com/docs/cockroachcloud/authentication).
+- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console]({% link cockroachcloud/authentication.md %}).
 - [Accessing the DB console on CockroachDB {{ site.data.products.core }} clusters]({% link {{ page.version.version }}/ui-overview.md %}).
 
 ## Authentication configuration
@@ -106,7 +106,7 @@ This is convenient for quick usage and experimentation, but is not suitable for 
 
 CockroachDB {{ site.data.products.dedicated }} clusters enforce IP allow-listing, which must be configured through the CockroachDB Cloud Console.
 
-See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/network-authorization).
+See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/network-authorization.md %}).
 
 ### CockroachDB Self-Hosted
 

--- a/src/current/v23.2/security-reference/authorization.md
+++ b/src/current/v23.2/security-reference/authorization.md
@@ -9,7 +9,7 @@ Authorization, generally, is the control over **who** (users/roles) can perform 
 
 This page describes authorization of SQL users on particular [CockroachDB database clusters]({% link {{ page.version.version }}/architecture/glossary.md %}#cluster). This is distinct from authorization of CockroachDB {{ site.data.products.cloud }} users on CockroachDB {{ site.data.products.cloud }} organiations.
 
-Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model](https://www.cockroachlabs.com/docs/cockroachcloud/authorization#overview-of-the-cockroachdb-cloud-two-level-authorization-model)
+Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model)
 
 ## Authorization models
 

--- a/src/current/v23.2/security-reference/config-secure-hba.md
+++ b/src/current/v23.2/security-reference/config-secure-hba.md
@@ -20,7 +20,7 @@ Limiting allowed database connections to secure IP addresses reduces the risk th
 
 ## Step 1: Provision and access your cluster
 
-[Create your own free CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-a-serverless-cluster).
+[Create your own free CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/create-a-serverless-cluster.md %}).
 
 From the CockroachDB {{ site.data.products.serverless }} Cloud Console, select your new cluster and click the **Connect** button to obtain your connection credentials from the **Connection Info** pane in the CockroachDB Cloud Console.
 

--- a/src/current/v23.2/security-reference/encryption.md
+++ b/src/current/v23.2/security-reference/encryption.md
@@ -21,7 +21,7 @@ In addition to this infrastructure-level encryption, CockroachDB {{ site.data.pr
 
 Customer-Managed Encryption Keys (CMEK) allow you to protect data at rest in a CockroachDB {{ site.data.products.dedicated }} cluster using a cryptographic key that is entirely within your control, hosted in a supported key-management systems (KMS) platform. This key is called the _CMEK key_. The CMEK key is never present in the cluster. Using the KMS platform's identity access management (IAM) system, you manage CockroachDB's permission to use the key for encryption and decryption. If the key is unavailable, or if CockroachDB no longer has permission to decrypt using the key, the cluster cannot start. To temporarily make the cluster and its data unavailable, such as during a security investigation, you can revoke CockroachDB's access to use the CMEK key or temporarily disable the key within the KMS's infrastructure. To permanently make the cluster's data unavailable, you can delete the CMEK key from the KMS. CockroachDB never has access to the CMEK key materials, and the CMEK key never leaves the KMS.
 
-To learn more, see [Customer-Managed Encryption Keys](https://www.cockroachlabs.com/docs/cockroachcloud/cmek) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/managing-cmek).
+To learn more, see [Customer-Managed Encryption Keys]({% link cockroachcloud/cmek.md %}) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/managing-cmek.md %}).
 
 {{site.data.alerts.callout_success}}
 When CMEK is enabled, the **Encryption** option appears to be disabled in the [DB Console]({% link {{ page.version.version }}/ui-overview.md %}), because this option refers to [Encryption At Rest (Enterprise)](#encryption-at-rest-enterprise), which is a feature of CockroachDB {{ site.data.products.core }} clusters.
@@ -146,7 +146,7 @@ Enabling Encryption at Rest might result in a higher CPU utilization. We estimat
 
 ## See also
 
-- [Customer-Managed Encryption Keys (CMEK)](https://www.cockroachlabs.com/docs/cockroachcloud/cmek)
+- [Customer-Managed Encryption Keys (CMEK)]({% link cockroachcloud/cmek.md %})
 - [Client Connection Parameters]({% link {{ page.version.version }}/connection-parameters.md %})
 - [Manual Deployment]({% link {{ page.version.version }}/manual-deployment.md %})
 - [Orchestrated Deployment]({% link {{ page.version.version }}/kubernetes-overview.md %})

--- a/src/current/v23.2/security-reference/transport-layer-security.md
+++ b/src/current/v23.2/security-reference/transport-layer-security.md
@@ -22,7 +22,7 @@ This page provides a conceptual overview of Transport Layer Security (TLS) and t
 **Learn more:**
 
 - [Manage PKI certificates for a CockroachDB deployment with HashiCorp Vault]({% link {{ page.version.version }}/manage-certs-vault.md %})
-- [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated)
+- [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %})
 
 ## What is Transport Layer Security (TLS)?
 
@@ -164,7 +164,7 @@ PKI for internode communication within CockroachDB {{ site.data.products.dedicat
 
 Certificate authentication for SQL clients is available for CockroachDB {{ site.data.products.dedicated }} clusters.
 
-Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated) for procedural information on administering and using client certificate authentication.
+Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %}) for procedural information on administering and using client certificate authentication.
 
 ## CockroachDB's TLS support and operating modes
 

--- a/src/current/v24.1/architecture/glossary.md
+++ b/src/current/v24.1/architecture/glossary.md
@@ -43,7 +43,7 @@ For more information on deployment options and guidelines on how to choose a dep
 
 {% include common/basic-terms.md %}
 
-For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture](https://www.cockroachlabs.com/docs/cockroachcloud/architecture#architecture).
+For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture]({% link cockroachcloud/architecture.md %}#architecture).
 
 ## Spatial and GIS terms
 

--- a/src/current/v24.1/architecture/sql-layer.md
+++ b/src/current/v24.1/architecture/sql-layer.md
@@ -21,7 +21,7 @@ If you haven't already, we recommend reading the [Architecture Overview]({% link
 
 ## Overview
 
-Once CockroachDB has been [deployed](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
+Once CockroachDB has been [deployed]({% link cockroachcloud/quickstart.md %}), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
 
 <a name="gateway-node"></a>
 

--- a/src/current/v24.1/architecture/storage-layer.md
+++ b/src/current/v24.1/architecture/storage-layer.md
@@ -183,4 +183,4 @@ The storage layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's next?
 
-Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).
+Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/quickstart.md %}) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).

--- a/src/current/v24.1/security-reference/authentication.md
+++ b/src/current/v24.1/security-reference/authentication.md
@@ -9,7 +9,7 @@ This page give an overview of CockroachDB's security features for authenticating
 
 Instead, you might be looking for:
 
-- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console](https://www.cockroachlabs.com/docs/cockroachcloud/authentication).
+- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console]({% link cockroachcloud/authentication.md %}).
 - [Accessing the DB console on CockroachDB {{ site.data.products.core }} clusters]({% link {{ page.version.version }}/ui-overview.md %}).
 
 ## Authentication configuration
@@ -106,7 +106,7 @@ This is convenient for quick usage and experimentation, but is not suitable for 
 
 CockroachDB {{ site.data.products.dedicated }} clusters enforce IP allow-listing, which must be configured through the CockroachDB Cloud Console.
 
-See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/network-authorization).
+See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/network-authorization.md %}).
 
 ### CockroachDB Self-Hosted
 

--- a/src/current/v24.1/security-reference/authorization.md
+++ b/src/current/v24.1/security-reference/authorization.md
@@ -9,7 +9,7 @@ Authorization, generally, is the control over **who** (users/roles) can perform 
 
 This page describes authorization of SQL users on particular [CockroachDB database clusters]({% link {{ page.version.version }}/architecture/glossary.md %}#cluster). This is distinct from authorization of CockroachDB {{ site.data.products.cloud }} users on CockroachDB {{ site.data.products.cloud }} organiations.
 
-Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model](https://www.cockroachlabs.com/docs/cockroachcloud/authorization#overview-of-the-cockroachdb-cloud-two-level-authorization-model)
+Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model)
 
 ## Authorization models
 

--- a/src/current/v24.1/security-reference/config-secure-hba.md
+++ b/src/current/v24.1/security-reference/config-secure-hba.md
@@ -20,7 +20,7 @@ Limiting allowed database connections to secure IP addresses reduces the risk th
 
 ## Step 1: Provision and access your cluster
 
-[Create your own free CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-a-serverless-cluster).
+[Create your own free CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/create-a-serverless-cluster.md %}).
 
 From the CockroachDB {{ site.data.products.serverless }} Cloud Console, select your new cluster and click the **Connect** button to obtain your connection credentials from the **Connection Info** pane in the CockroachDB Cloud Console.
 

--- a/src/current/v24.1/security-reference/encryption.md
+++ b/src/current/v24.1/security-reference/encryption.md
@@ -21,7 +21,7 @@ In addition to this infrastructure-level encryption, CockroachDB {{ site.data.pr
 
 Customer-Managed Encryption Keys (CMEK) allow you to protect data at rest in a CockroachDB {{ site.data.products.dedicated }} cluster using a cryptographic key that is entirely within your control, hosted in a supported key-management systems (KMS) platform. This key is called the _CMEK key_. The CMEK key is never present in the cluster. Using the KMS platform's identity access management (IAM) system, you manage CockroachDB's permission to use the key for encryption and decryption. If the key is unavailable, or if CockroachDB no longer has permission to decrypt using the key, the cluster cannot start. To temporarily make the cluster and its data unavailable, such as during a security investigation, you can revoke CockroachDB's access to use the CMEK key or temporarily disable the key within the KMS's infrastructure. To permanently make the cluster's data unavailable, you can delete the CMEK key from the KMS. CockroachDB never has access to the CMEK key materials, and the CMEK key never leaves the KMS.
 
-To learn more, see [Customer-Managed Encryption Keys](https://www.cockroachlabs.com/docs/cockroachcloud/cmek) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/managing-cmek).
+To learn more, see [Customer-Managed Encryption Keys]({% link cockroachcloud/cmek.md %}) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/managing-cmek.md %}).
 
 {{site.data.alerts.callout_success}}
 When CMEK is enabled, the **Encryption** option appears to be disabled in the [DB Console]({% link {{ page.version.version }}/ui-overview.md %}), because this option refers to [Encryption At Rest (Enterprise)](#encryption-at-rest-enterprise), which is a feature of CockroachDB {{ site.data.products.core }} clusters.
@@ -146,7 +146,7 @@ Enabling Encryption at Rest might result in a higher CPU utilization. We estimat
 
 ## See also
 
-- [Customer-Managed Encryption Keys (CMEK)](https://www.cockroachlabs.com/docs/cockroachcloud/cmek)
+- [Customer-Managed Encryption Keys (CMEK)]({% link cockroachcloud/cmek.md %})
 - [Client Connection Parameters]({% link {{ page.version.version }}/connection-parameters.md %})
 - [Manual Deployment]({% link {{ page.version.version }}/manual-deployment.md %})
 - [Orchestrated Deployment]({% link {{ page.version.version }}/kubernetes-overview.md %})

--- a/src/current/v24.1/security-reference/transport-layer-security.md
+++ b/src/current/v24.1/security-reference/transport-layer-security.md
@@ -22,7 +22,7 @@ This page provides a conceptual overview of Transport Layer Security (TLS) and t
 **Learn more:**
 
 - [Manage PKI certificates for a CockroachDB deployment with HashiCorp Vault]({% link {{ page.version.version }}/manage-certs-vault.md %})
-- [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated)
+- [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %})
 
 ## What is Transport Layer Security (TLS)?
 
@@ -164,7 +164,7 @@ PKI for internode communication within CockroachDB {{ site.data.products.dedicat
 
 Certificate authentication for SQL clients is available for CockroachDB {{ site.data.products.dedicated }} clusters.
 
-Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated) for procedural information on administering and using client certificate authentication.
+Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %}) for procedural information on administering and using client certificate authentication.
 
 ## CockroachDB's TLS support and operating modes
 

--- a/src/current/v24.2/architecture/glossary.md
+++ b/src/current/v24.2/architecture/glossary.md
@@ -43,7 +43,7 @@ For more information on deployment options and guidelines on how to choose a dep
 
 {% include common/basic-terms.md %}
 
-For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture](https://www.cockroachlabs.com/docs/cockroachcloud/architecture#architecture).
+For more information on CockroachDB Cloud, see [CockroachDB Cloud Architecture]({% link cockroachcloud/architecture.md %}#architecture).
 
 ## Spatial and GIS terms
 

--- a/src/current/v24.2/architecture/sql-layer.md
+++ b/src/current/v24.2/architecture/sql-layer.md
@@ -21,7 +21,7 @@ If you haven't already, we recommend reading the [Architecture Overview]({% link
 
 ## Overview
 
-Once CockroachDB has been [deployed](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
+Once CockroachDB has been [deployed]({% link cockroachcloud/quickstart.md %}), developers need only a [connection string]({% link {{ page.version.version }}/connection-parameters.md %}) to the cluster, and they can start working with SQL statements.
 
 <a name="gateway-node"></a>
 

--- a/src/current/v24.2/architecture/storage-layer.md
+++ b/src/current/v24.2/architecture/storage-layer.md
@@ -183,4 +183,4 @@ The storage layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's next?
 
-Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).
+Now that you've learned about our architecture, [start up a CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/quickstart.md %}) or [local cluster]({% link {{ page.version.version }}/install-cockroachdb.md %}) and start [building an app with CockroachDB]({% link {{ page.version.version}}/example-apps.md %}).

--- a/src/current/v24.2/security-reference/authentication.md
+++ b/src/current/v24.2/security-reference/authentication.md
@@ -9,7 +9,7 @@ This page give an overview of CockroachDB's security features for authenticating
 
 Instead, you might be looking for:
 
-- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console](https://www.cockroachlabs.com/docs/cockroachcloud/authentication).
+- [Logging in to the CockroachDB {{ site.data.products.cloud }} web console]({% link cockroachcloud/authentication.md %}).
 - [Accessing the DB console on CockroachDB {{ site.data.products.core }} clusters]({% link {{ page.version.version }}/ui-overview.md %}).
 
 ## Authentication configuration
@@ -106,7 +106,7 @@ This is convenient for quick usage and experimentation, but is not suitable for 
 
 CockroachDB {{ site.data.products.dedicated }} clusters enforce IP allow-listing, which must be configured through the CockroachDB Cloud Console.
 
-See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/network-authorization).
+See [Managing Network Authorization for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/network-authorization.md %}).
 
 ### CockroachDB Self-Hosted
 

--- a/src/current/v24.2/security-reference/authorization.md
+++ b/src/current/v24.2/security-reference/authorization.md
@@ -9,7 +9,7 @@ Authorization, generally, is the control over **who** (users/roles) can perform 
 
 This page describes authorization of SQL users on particular [CockroachDB database clusters]({% link {{ page.version.version }}/architecture/glossary.md %}#cluster). This is distinct from authorization of CockroachDB {{ site.data.products.cloud }} users on CockroachDB {{ site.data.products.cloud }} organiations.
 
-Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model](https://www.cockroachlabs.com/docs/cockroachcloud/authorization#overview-of-the-cockroachdb-cloud-two-level-authorization-model)
+Learn more: [Overview of the CockroachDB {{ site.data.products.cloud }} authorization model]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model)
 
 ## Authorization models
 

--- a/src/current/v24.2/security-reference/config-secure-hba.md
+++ b/src/current/v24.2/security-reference/config-secure-hba.md
@@ -20,7 +20,7 @@ Limiting allowed database connections to secure IP addresses reduces the risk th
 
 ## Step 1: Provision and access your cluster
 
-[Create your own free CockroachDB {{ site.data.products.serverless }} cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-a-serverless-cluster).
+[Create your own free CockroachDB {{ site.data.products.serverless }} cluster]({% link cockroachcloud/create-a-serverless-cluster.md %}).
 
 From the CockroachDB {{ site.data.products.serverless }} Cloud Console, select your new cluster and click the **Connect** button to obtain your connection credentials from the **Connection Info** pane in the CockroachDB Cloud Console.
 

--- a/src/current/v24.2/security-reference/encryption.md
+++ b/src/current/v24.2/security-reference/encryption.md
@@ -21,7 +21,7 @@ In addition to this infrastructure-level encryption, CockroachDB {{ site.data.pr
 
 Customer-Managed Encryption Keys (CMEK) allow you to protect data at rest in a CockroachDB {{ site.data.products.dedicated }} cluster using a cryptographic key that is entirely within your control, hosted in a supported key-management systems (KMS) platform. This key is called the _CMEK key_. The CMEK key is never present in the cluster. Using the KMS platform's identity access management (IAM) system, you manage CockroachDB's permission to use the key for encryption and decryption. If the key is unavailable, or if CockroachDB no longer has permission to decrypt using the key, the cluster cannot start. To temporarily make the cluster and its data unavailable, such as during a security investigation, you can revoke CockroachDB's access to use the CMEK key or temporarily disable the key within the KMS's infrastructure. To permanently make the cluster's data unavailable, you can delete the CMEK key from the KMS. CockroachDB never has access to the CMEK key materials, and the CMEK key never leaves the KMS.
 
-To learn more, see [Customer-Managed Encryption Keys](https://www.cockroachlabs.com/docs/cockroachcloud/cmek) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}](https://www.cockroachlabs.com/docs/cockroachcloud/managing-cmek).
+To learn more, see [Customer-Managed Encryption Keys]({% link cockroachcloud/cmek.md %}) and [Managing Customer-Managed Encryption Keys (CMEK) for CockroachDB {{ site.data.products.dedicated }}]({% link cockroachcloud/managing-cmek.md %}).
 
 {{site.data.alerts.callout_success}}
 When CMEK is enabled, the **Encryption** option appears to be disabled in the [DB Console]({% link {{ page.version.version }}/ui-overview.md %}), because this option refers to [Encryption At Rest (Enterprise)](#encryption-at-rest-enterprise), which is a feature of CockroachDB {{ site.data.products.core }} clusters.
@@ -146,7 +146,7 @@ Enabling Encryption at Rest might result in a higher CPU utilization. We estimat
 
 ## See also
 
-- [Customer-Managed Encryption Keys (CMEK)](https://www.cockroachlabs.com/docs/cockroachcloud/cmek)
+- [Customer-Managed Encryption Keys (CMEK)]({% link cockroachcloud/cmek.md %})
 - [Client Connection Parameters]({% link {{ page.version.version }}/connection-parameters.md %})
 - [Manual Deployment]({% link {{ page.version.version }}/manual-deployment.md %})
 - [Orchestrated Deployment]({% link {{ page.version.version }}/kubernetes-overview.md %})

--- a/src/current/v24.2/security-reference/transport-layer-security.md
+++ b/src/current/v24.2/security-reference/transport-layer-security.md
@@ -22,7 +22,7 @@ This page provides a conceptual overview of Transport Layer Security (TLS) and t
 **Learn more:**
 
 - [Manage PKI certificates for a CockroachDB deployment with HashiCorp Vault]({% link {{ page.version.version }}/manage-certs-vault.md %})
-- [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated)
+- [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %})
 
 ## What is Transport Layer Security (TLS)?
 
@@ -164,7 +164,7 @@ PKI for internode communication within CockroachDB {{ site.data.products.dedicat
 
 Certificate authentication for SQL clients is available for CockroachDB {{ site.data.products.dedicated }} clusters.
 
-Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters](https://www.cockroachlabs.com/docs/cockroachcloud/client-certs-dedicated) for procedural information on administering and using client certificate authentication.
+Refer to [Certificate Authentication for SQL Clients in CockroachDB Dedicated Clusters]({% link cockroachcloud/client-certs-dedicated.md %}) for procedural information on administering and using client certificate authentication.
 
 ## CockroachDB's TLS support and operating modes
 


### PR DESCRIPTION
Addresses DOC-10953

Summary of changes:

- In this change, we clean up all of the explicit URLs being used in the architecture/ and security-reference/ subfolders which were missed in previous changes