### PR TITLE
Add an example to filter columns on show changefeed jobs

### DIFF
--- a/src/current/_includes/v23.2/cdc/filter-show-changefeed-jobs-columns.md
+++ b/src/current/_includes/v23.2/cdc/filter-show-changefeed-jobs-columns.md
@@ -1,0 +1,11 @@
+You can filter the columns that `SHOW CHANGEFEED JOBS` displays using a `SELECT` statement:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT job_id, sink_uri, status, format FROM [SHOW CHANGEFEED JOBS] WHERE job_id = 997306743028908033;
+~~~
+~~~
+        job_id       |    sink_uri      | status   | format
+---------------------+------------------+----------+---------
+  997306743028908033 | external://kafka | running  | json
+~~~

--- a/src/current/_includes/v24.1/cdc/filter-show-changefeed-jobs-columns.md
+++ b/src/current/_includes/v24.1/cdc/filter-show-changefeed-jobs-columns.md
@@ -1,0 +1,11 @@
+You can filter the columns that `SHOW CHANGEFEED JOBS` displays using a `SELECT` statement:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT job_id, sink_uri, status, format FROM [SHOW CHANGEFEED JOBS] WHERE job_id = 997306743028908033;
+~~~
+~~~
+        job_id       |    sink_uri      | status   | format
+---------------------+------------------+----------+---------
+  997306743028908033 | external://kafka | running  | json
+~~~

--- a/src/current/_includes/v24.2/cdc/filter-show-changefeed-jobs-columns.md
+++ b/src/current/_includes/v24.2/cdc/filter-show-changefeed-jobs-columns.md
@@ -1,0 +1,11 @@
+You can filter the columns that `SHOW CHANGEFEED JOBS` displays using a `SELECT` statement:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SELECT job_id, sink_uri, status, format FROM [SHOW CHANGEFEED JOBS] WHERE job_id = 997306743028908033;
+~~~
+~~~
+        job_id       |    sink_uri      | status   | format
+---------------------+------------------+----------+---------
+  997306743028908033 | external://kafka | running  | json
+~~~

--- a/src/current/v23.2/create-and-configure-changefeeds.md
+++ b/src/current/v23.2/create-and-configure-changefeeds.md
@@ -115,6 +115,8 @@ To show a list of {{ site.data.products.enterprise }} changefeed jobs:
 
 {% include {{ page.version.version }}/cdc/show-changefeed-job-retention.md %}
 
+{% include {{ page.version.version }}/cdc/filter-show-changefeed-jobs-columns.md %}
+
 For more information, refer to [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs).
 
 ### Pause

--- a/src/current/v23.2/show-jobs.md
+++ b/src/current/v23.2/show-jobs.md
@@ -209,6 +209,8 @@ WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('paused');
 (1 row)
 ~~~
 
+{% include {{ page.version.version }}/cdc/filter-show-changefeed-jobs-columns.md %}
+
 ### Show schema changes
 
 You can show just schema change jobs by using `SHOW JOBS` as the data source for a [`SELECT`]({% link {{ page.version.version }}/select-clause.md %}) statement, and then filtering the `job_type` value with the `WHERE` clause:

--- a/src/current/v24.1/create-and-configure-changefeeds.md
+++ b/src/current/v24.1/create-and-configure-changefeeds.md
@@ -115,6 +115,8 @@ To show a list of {{ site.data.products.enterprise }} changefeed jobs:
 
 {% include {{ page.version.version }}/cdc/show-changefeed-job-retention.md %}
 
+{% include {{ page.version.version }}/cdc/filter-show-changefeed-jobs-columns.md %}
+
 For more information, refer to [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs).
 
 ### Pause

--- a/src/current/v24.1/show-jobs.md
+++ b/src/current/v24.1/show-jobs.md
@@ -203,6 +203,8 @@ WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('paused');
 (1 row)
 ~~~
 
+{% include {{ page.version.version }}/cdc/filter-show-changefeed-jobs-columns.md %}
+
 ### Show schema changes
 
 You can show just schema change jobs by using `SHOW JOBS` as the data source for a [`SELECT`]({% link {{ page.version.version }}/select-clause.md %}) statement, and then filtering the `job_type` value with the `WHERE` clause:

--- a/src/current/v24.2/create-and-configure-changefeeds.md
+++ b/src/current/v24.2/create-and-configure-changefeeds.md
@@ -119,6 +119,8 @@ To show a list of {{ site.data.products.enterprise }} changefeed jobs:
 
 {% include {{ page.version.version }}/cdc/show-changefeed-job-retention.md %}
 
+{% include {{ page.version.version }}/cdc/filter-show-changefeed-jobs-columns.md %}
+
 For more information, refer to [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs).
 
 ### Pause

--- a/src/current/v24.2/show-jobs.md
+++ b/src/current/v24.2/show-jobs.md
@@ -203,6 +203,8 @@ WITH x AS (SHOW CHANGEFEED JOBS) SELECT * FROM x WHERE status = ('paused');
 (1 row)
 ~~~
 
+{% include {{ page.version.version }}/cdc/filter-show-changefeed-jobs-columns.md %}
+
 ### Show schema changes
 
 You can show just schema change jobs by using `SHOW JOBS` as the data source for a [`SELECT`]({% link {{ page.version.version }}/select-clause.md %}) statement, and then filtering the `job_type` value with the `WHERE` clause:


### PR DESCRIPTION
Fixes DOC-10960

Adds a short filter column example for `SHOW CHANGEFEED JOBS` to the `SHOW JOB` page and the Create and Configure Changefeeds page.