### PR TITLE
REL-1334 v24.2.1: [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6644,10 +6644,3 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v24.2.0
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).


### PR DESCRIPTION
Fixes REL-1334

In releases.yml, deleted cloud lines for v24.2.1 to enable download of self-hosted binaries.