### PR TITLE
REL-1489 Withdraw v24.2.1 from release notes page

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6644,3 +6644,4 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v24.2.0
+  withdrawn: true

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -293,6 +293,7 @@ To learn what’s new in this release, refer to [Feature Highlights]({% link rel
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
                 {% if r.withdrawn == true %} {% comment %} Suppress download links for withdrawn releases. {% endcomment %}
             <td colspan="2"><span class="badge badge-gray">Withdrawn</span></td>{% comment %}covers both Intel and ARM columns {% endcomment %}
+                  {% continue %}
                 {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
             <td colspan="2"><span>{{ r.cloud_only_message_short }}</span></td>
                   {% continue %}
@@ -350,6 +351,7 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
             {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
             <td colspan="2"><span class="badge badge-gray">Withdrawn</span></td>{% comment %}covers both Intel and ARM columns {% endcomment %}
+              {% continue %}
             {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
             <td colspan="2"><span>{{ r.cloud_only_message_short }}</span></td>
               {% continue %}
@@ -403,6 +405,7 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
             <td>{{ r.release_date }}</td> {% comment %} Release date of the release. {% endcomment %}
                 {% if r.withdrawn == true %} {% comment %} Suppress withdrawn releases. {% endcomment %}
             <td colspan="2"><span class="badge badge-gray">Withdrawn</span></td>{% comment %}covers both Intel and ARM columns {% endcomment %}
+                  {% continue %}
                 {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
             <td colspan="2"><span>{{ r.cloud_only_message_short }}</span></td>
                   {% continue %}
@@ -543,6 +546,7 @@ macOS downloads are **experimental**. Experimental downloads are not yet qualifi
               {% continue %}
             {% elsif r.cloud_only == true %} {% comment %} Suppress download links for Cloud-first releases {% endcomment %}
             <td><span>{{ r.cloud_only_message_short }}</span></td>
+                {% continue %}
             {% else %} {% comment %} Add download links for all non-withdrawn versions. {% endcomment %}
             <td>
                 {% if r.source == true %}


### PR DESCRIPTION
Fixes REL-1489

In releases.yml, added line for v24.2.1 to withdraw release.