### PR TITLE
Fix master ref in sql diagram remote include uri

### DIFF
--- a/src/current/v22.1/alter-backup.md
+++ b/src/current/v22.1/alter-backup.md
@@ -16,7 +16,7 @@ CockroachDB supports AWS and Google Cloud KMS keys. For more detail on encrypted
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup.html %}
 </div>
 
 ## Parameters
@@ -58,7 +58,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     ADD NEW_KMS = 'aws:///{new-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}'
     WITH OLD_KMS = 'aws:///{old-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -67,7 +67,7 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2022/03/23-213101.37' IN 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     ADD NEW_KMS = 'aws:///{new-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}'
     WITH OLD_KMS = 'aws:///{old-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`](show-backup.html).
 
@@ -80,7 +80,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 'gs://{BUCKET NAME}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
     ADD NEW_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{new key}?AUTH=specified&CREDENTIALS={encoded key}'
     WITH OLD_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{old key}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -89,7 +89,7 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2022/03/23-213101.37' IN 'gs://{BUCKET NAME}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
     ADD NEW_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{new key}?AUTH=specified&CREDENTIALS={encoded key}'
     WITH OLD_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{old key}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`](show-backup.html).
 

--- a/src/current/v22.1/alter-changefeed.md
+++ b/src/current/v22.1/alter-changefeed.md
@@ -21,7 +21,7 @@ It is necessary to [**pause**](pause-job.html) a changefeed before running the `
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_changefeed.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_changefeed.html %}
 </div>
 
 ## Parameters
@@ -134,7 +134,7 @@ For more information on enabling changefeeds, see [Create and Configure Changefe
 
     The output from `ALTER CHANGEFEED` will show the `CREATE CHANGEFEED` statement with the options you've defined. After modifying a changefeed with `ALTER CHANGEFEED`, the `CREATE` description will show the fully qualified table name.
 
-    For an explanation on each of these options, see the `CREATE CHANGEFEED` [options](create-changefeed.html#options).  
+    For an explanation on each of these options, see the `CREATE CHANGEFEED` [options](create-changefeed.html#options).
 
 1. Resume the changefeed job with `RESUME JOB`:
 

--- a/src/current/v22.1/show-create-schedule.md
+++ b/src/current/v22.1/show-create-schedule.md
@@ -14,7 +14,7 @@ Only members of the [`admin` role](security-reference/authorization.html#admin-r
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}
 </div>
 
 ## Parameters

--- a/src/current/v22.2/alter-backup-schedule.md
+++ b/src/current/v22.2/alter-backup-schedule.md
@@ -25,7 +25,7 @@ To alter a backup schedule, you must be the owner of the backup schedule, i.e., 
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup_schedule.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup_schedule.html %}
 </div>
 
 ## Parameters

--- a/src/current/v22.2/alter-backup.md
+++ b/src/current/v22.2/alter-backup.md
@@ -16,7 +16,7 @@ CockroachDB supports AWS and Google Cloud KMS keys. For more detail on encrypted
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup.html %}
 </div>
 
 ## Parameters
@@ -58,7 +58,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     ADD NEW_KMS = 'aws:///{new-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}'
     WITH OLD_KMS = 'aws:///{old-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -67,7 +67,7 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2022/03/23-213101.37' IN 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     ADD NEW_KMS = 'aws:///{new-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}'
     WITH OLD_KMS = 'aws:///{old-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`](show-backup.html).
 
@@ -80,7 +80,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 'gs://{BUCKET NAME}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
     ADD NEW_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{new key}?AUTH=specified&CREDENTIALS={encoded key}'
     WITH OLD_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{old key}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -89,7 +89,7 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2022/03/23-213101.37' IN 'gs://{BUCKET NAME}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
     ADD NEW_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{new key}?AUTH=specified&CREDENTIALS={encoded key}'
     WITH OLD_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{old key}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`](show-backup.html).
 

--- a/src/current/v22.2/alter-changefeed.md
+++ b/src/current/v22.2/alter-changefeed.md
@@ -21,7 +21,7 @@ It is necessary to [**pause**](pause-job.html) a changefeed before running the `
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_changefeed.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_changefeed.html %}
 </div>
 
 ## Parameters

--- a/src/current/v22.2/show-create-schedule.md
+++ b/src/current/v22.2/show-create-schedule.md
@@ -14,7 +14,7 @@ Only members of the [`admin` role](security-reference/authorization.html#admin-r
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.1/alter-backup-schedule.md
+++ b/src/current/v23.1/alter-backup-schedule.md
@@ -25,7 +25,7 @@ To alter a backup schedule, you must be the owner of the backup schedule, i.e., 
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup_schedule.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup_schedule.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.1/alter-backup.md
+++ b/src/current/v23.1/alter-backup.md
@@ -16,7 +16,7 @@ CockroachDB supports AWS, Azure, and Google Cloud KMS keys. For more detail on e
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup.html %}
 </div>
 
 ## Parameters
@@ -58,7 +58,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     ADD NEW_KMS = 'aws:///{new-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}'
     WITH OLD_KMS = 'aws:///{old-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -67,13 +67,13 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2022/03/23-213101.37' IN 's3://{BUCKET NAME}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     ADD NEW_KMS = 'aws:///{new-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}'
     WITH OLD_KMS = 'aws:///{old-key}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION={location}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`]({% link {{ page.version.version }}/show-backup.md %}).
 
 ### Add an Azure KMS key to an encrypted backup
 
-{% include_cached new-in.html version="v23.1" %} 
+{% include_cached new-in.html version="v23.1" %}
 
 To add a new KMS key to the most recent backup:
 
@@ -82,7 +82,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 'azure-blob://{container name}?AUTH=specified&AZURE_ACCOUNT_NAME={account name}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_TENANT_ID={tenant ID}'
     ADD NEW_KMS = 'azure-kms:///{new key}/{new key version}?AZURE_TENANT_ID={tenant ID}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_VAULT_NAME={key vault name}'
     WITH OLD_KMS = 'azure-kms:///{old key}/{old key version}?AZURE_TENANT_ID={tenant ID}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_VAULT_NAME={key vault name}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -91,7 +91,7 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2023/03/14-203808.29' IN 'azure-blob://{container name}?AUTH=specified&AZURE_ACCOUNT_NAME={account name}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_TENANT_ID={tenant ID}'
     ADD NEW_KMS = 'azure-kms:///{new key}/{new key version}?AZURE_TENANT_ID={tenant ID}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_VAULT_NAME={key vault name}'
     WITH OLD_KMS = 'azure-kms:///{old key}/{old key version}?AZURE_TENANT_ID={tenant ID}&AZURE_CLIENT_ID={client ID}&AZURE_CLIENT_SECRET={client secret}&AZURE_VAULT_NAME={key vault name}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`]({% link {{ page.version.version }}/show-backup.md %}).
 
@@ -104,7 +104,7 @@ To add a new KMS key to the most recent backup:
 ALTER BACKUP LATEST IN 'gs://{BUCKET NAME}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
     ADD NEW_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{new key}?AUTH=specified&CREDENTIALS={encoded key}'
     WITH OLD_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{old key}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~  
+~~~
 
 To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement that points to the full backup:
 
@@ -113,7 +113,7 @@ To add a new KMS key to a specific backup, issue an `ALTER BACKUP` statement tha
 ALTER BACKUP '2022/03/23-213101.37' IN 'gs://{BUCKET NAME}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
     ADD NEW_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{new key}?AUTH=specified&CREDENTIALS={encoded key}'
     WITH OLD_KMS = 'gs:///projects/{project name}/locations/{location}/keyRings/{key ring name}/cryptoKeys/{old key}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~  
+~~~
 
 To list backup directories at a collection's URI, see [`SHOW BACKUP`]({% link {{ page.version.version }}/show-backup.md %}).
 

--- a/src/current/v23.1/alter-changefeed.md
+++ b/src/current/v23.1/alter-changefeed.md
@@ -21,7 +21,7 @@ It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_changefeed.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_changefeed.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.1/show-create-schedule.md
+++ b/src/current/v23.1/show-create-schedule.md
@@ -14,7 +14,7 @@ Only members of the [`admin` role]({% link {{ page.version.version }}/security-r
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.2/alter-backup-schedule.md
+++ b/src/current/v23.2/alter-backup-schedule.md
@@ -25,7 +25,7 @@ To alter a backup schedule, you must be the owner of the backup schedule, i.e., 
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup_schedule.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup_schedule.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.2/alter-backup.md
+++ b/src/current/v23.2/alter-backup.md
@@ -16,7 +16,7 @@ CockroachDB supports AWS, Azure, and Google Cloud KMS keys. For more detail on e
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.2/alter-changefeed.md
+++ b/src/current/v23.2/alter-changefeed.md
@@ -21,7 +21,7 @@ It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_changefeed.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_changefeed.html %}
 </div>
 
 ## Parameters

--- a/src/current/v23.2/show-create-schedule.md
+++ b/src/current/v23.2/show-create-schedule.md
@@ -14,7 +14,7 @@ Only members of the [`admin` role]({% link {{ page.version.version }}/security-r
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.1/alter-backup-schedule.md
+++ b/src/current/v24.1/alter-backup-schedule.md
@@ -25,7 +25,7 @@ To alter a backup schedule, you must be the owner of the backup schedule, i.e., 
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup_schedule.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup_schedule.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.1/alter-backup.md
+++ b/src/current/v24.1/alter-backup.md
@@ -16,7 +16,7 @@ CockroachDB supports AWS, Azure, and Google Cloud KMS keys. For more detail on e
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.1/alter-changefeed.md
+++ b/src/current/v24.1/alter-changefeed.md
@@ -21,7 +21,7 @@ It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_changefeed.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_changefeed.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.1/show-create-schedule.md
+++ b/src/current/v24.1/show-create-schedule.md
@@ -14,7 +14,7 @@ Only members of the [`admin` role]({% link {{ page.version.version }}/security-r
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.2/alter-backup-schedule.md
+++ b/src/current/v24.2/alter-backup-schedule.md
@@ -25,7 +25,7 @@ To alter a backup schedule, you must be the owner of the backup schedule, i.e., 
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup_schedule.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup_schedule.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.2/alter-backup.md
+++ b/src/current/v24.2/alter-backup.md
@@ -16,7 +16,7 @@ CockroachDB supports AWS, Azure, and Google Cloud KMS keys. For more detail on e
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_backup.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_backup.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.2/alter-changefeed.md
+++ b/src/current/v24.2/alter-changefeed.md
@@ -21,7 +21,7 @@ It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/alter_changefeed.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_changefeed.html %}
 </div>
 
 ## Parameters

--- a/src/current/v24.2/show-create-schedule.md
+++ b/src/current/v24.2/show-create-schedule.md
@@ -14,7 +14,7 @@ Only members of the [`admin` role]({% link {{ page.version.version }}/security-r
 ## Synopsis
 
 <div>
-{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}
 </div>
 
 ## Parameters


### PR DESCRIPTION
Fixes DOC-11093

Updated the instances of 

{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/master/grammar_svg/show_create_schedules.html %}

To 

{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_create_schedules.html %}

in 4 different commands. 