### PR TITLE
Add docs for show external connection

### DIFF
--- a/src/current/_includes/v24.2/sidebar-data/sql.json
+++ b/src/current/_includes/v24.2/sidebar-data/sql.json
@@ -611,6 +611,12 @@
               ]
             },
             {
+              "title": "<code>SHOW EXTERNAL CONNECTION</code>",
+              "urls": [
+                "/${VERSION}/show-external-connection.html"
+              ]
+            },
+            {
               "title": "<code>SHOW FULL TABLE SCANS</code>",
               "urls": [
                 "/${VERSION}/show-full-table-scans.html"

--- a/src/current/v24.2/create-external-connection.md
+++ b/src/current/v24.2/create-external-connection.md
@@ -13,6 +13,7 @@ The [privilege model](#required-privileges) for external connections means that 
 
 You can also use the following SQL statements to work with external connections:
 
+- [`SHOW EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-external-connection.md %})
 - [`SHOW CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-create-external-connection.md %})
 - [`DROP EXTERNAL CONNECTION`]({% link {{ page.version.version }}/drop-external-connection.md %})
 
@@ -53,6 +54,7 @@ Parameter | Description
 
 Storage or sink      | Operation support
 ---------------------+---------------------------------
+[Amazon MSK]({% link {{ page.version.version }}/changefeed-sinks.md %}#amazon-msk) | Changefeeds
 [Amazon S3]({% link {{ page.version.version }}/use-cloud-storage.md %}) | Backups, restores, imports, exports, changefeeds
 [Amazon S3 KMS]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}#aws-kms-uri-format) | Encrypted backups
 [Azure Storage]({% link {{ page.version.version }}/use-cloud-storage.md %}) | Backups, restores, imports, exports, changefeeds
@@ -67,7 +69,7 @@ Storage or sink      | Operation support
 [Userfile]({% link {{ page.version.version }}/use-userfile-storage.md %}) | Backups, restores, imports, exports, changefeeds
 [Webhook]({% link {{ page.version.version }}/changefeed-sinks.md %}#webhook-sink) | Changefeeds
 
-For more information on authentication and forming the URI that an external connection will represent, see each of the links to the storage or sink pages in the table.
+For more information on authentication and forming the URI that an external connection will represent, refer to the storage or sink pages linked in the table.
 
 ### Changefeed sinks as external connections
 

--- a/src/current/v24.2/create-external-connection.md
+++ b/src/current/v24.2/create-external-connection.md
@@ -66,6 +66,7 @@ Storage or sink      | Operation support
 [HTTP(S)]({% link {{ page.version.version }}/changefeed-sinks.md %}) | Changefeeds
 [Kafka]({% link {{ page.version.version }}/changefeed-sinks.md %}#kafka) | Changefeeds
 [Nodelocal]({% link {{ page.version.version }}/use-cloud-storage.md %}) | Backups, restores, imports, exports, changefeeds
+[PostgreSQL]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#connection-reference) connections | Physical cluster replication
 [Userfile]({% link {{ page.version.version }}/use-userfile-storage.md %}) | Backups, restores, imports, exports, changefeeds
 [Webhook]({% link {{ page.version.version }}/changefeed-sinks.md %}#webhook-sink) | Changefeeds
 

--- a/src/current/v24.2/drop-external-connection.md
+++ b/src/current/v24.2/drop-external-connection.md
@@ -11,6 +11,7 @@ You can also use the following SQL statements to work with external connections:
 
 - [`CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/create-external-connection.md %})
 - [`SHOW CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-create-external-connection.md %})
+- [`SHOW EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-external-connection.md %})
 
 ## Required privileges
 

--- a/src/current/v24.2/set-up-physical-cluster-replication.md
+++ b/src/current/v24.2/set-up-physical-cluster-replication.md
@@ -464,6 +464,10 @@ This table outlines the connection strings you will need for this setup tutorial
 
 For additional detail on the standard CockroachDB connection parameters, refer to [Client Connection Parameters]({% link {{ page.version.version }}/connection-parameters.md %}#connect-using-a-url).
 
+{{site.data.alerts.callout_success}}
+You can use an [external connection]({% link {{ page.version.version }}/create-external-connection.md %}) to define a name for connections using the `postgresql://` scheme.
+{{site.data.alerts.end}}
+
 Cluster | Virtual Cluster | Usage | URL and Parameters
 --------+-----------------+-------+-------------------
 Primary | System | Set up a replication user and view running virtual clusters. Connect with [`cockroach sql`]({% link {{ page.version.version }}/cockroach-sql.md %}). | `"postgresql://root@{node IP or hostname}:{26257}?options=-ccluster=system&sslmode=verify-full"`<br><br><ul><li>`options=-ccluster=system`</li><li>`sslmode=verify-full`</li></ul>Use the `--certs-dir` flag to specify the path to your certificate.

--- a/src/current/v24.2/show-create-external-connection.md
+++ b/src/current/v24.2/show-create-external-connection.md
@@ -10,6 +10,7 @@ You can use external connections to specify and interact with resources that are
 You can also use the following SQL statements to work with external connections:
 
 - [`CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/create-external-connection.md %})
+- [`SHOW EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-external-connection.md %})
 - [`DROP EXTERNAL CONNECTION`]({% link {{ page.version.version }}/drop-external-connection.md %})
 
 ## Required privileges

--- a/src/current/v24.2/show-external-connection.md
+++ b/src/current/v24.2/show-external-connection.md
@@ -38,7 +38,7 @@ Response | Description
 
 ## Examples
 
-### Show all external connections
+### Show all external connections in the cluster
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/v24.2/show-external-connection.md
+++ b/src/current/v24.2/show-external-connection.md
@@ -1,0 +1,70 @@
+---
+title: SHOW EXTERNAL CONNECTION
+summary: The SHOW EXTERNAL CONNECTION statement lists external connections.
+toc: true
+---
+
+{% include_cached new-in.html version="v24.2" %} You can use external connections to specify and interact with resources that are external from CockroachDB. When creating an external connection, you define a name for an external connection while passing the provider URI and query parameters. `SHOW EXTERNAL CONNECTION` displays the connection name, URI, and the type of connection.
+
+You can also use the following SQL statements to work with external connections:
+
+- [`CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/create-external-connection.md %})
+- [`SHOW CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-create-external-connection.md %})
+- [`DROP EXTERNAL CONNECTION`]({% link {{ page.version.version }}/drop-external-connection.md %})
+
+## Required privileges
+
+Users with the [`admin` role]({% link {{ page.version.version }}/security-reference/authorization.md %}#admin-role) can view all external connections with `SHOW EXTERNAL CONNECTION`.
+
+Without the `admin` role, users can view the external connections that they own. Users own external connections that they have created with `CREATE EXTERNAL CONNECTION`.
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_external_connections.html %}
+</div>
+
+### Parameters
+
+`string_or_placeholder` is the name of the created external connection.
+
+## Responses
+
+Response | Description
+---------+------------
+`connection_name` | The user-specified name of the external connection.
+`connection_uri` | The [storage/sink]({% link {{ page.version.version }}/create-external-connection.md %}#supported-external-storage-and-sinks) URI that the external connection references.
+`connection_type` | `STORAGE` applies to [storage for backups and imports]({% link {{ page.version.version }}/use-cloud-storage.md %}) and [changefeed sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}).
+
+## Examples
+
+### Show all external connections
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW EXTERNAL CONNECTIONS;
+~~~
+~~~
+  connection_name |                                                                                                                                    connection_uri                                                                                                                                     | connection_type
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+  msk             | kafka://boot-vzq1qitx.c1.kafka-serverless.us-east-1.amazonaws.com:9098/?sasl_aws_iam_role_arn={ARN}&sasl_aws_iam_session_name={session name}t&sasl_aws_region=us-east-1&sasl_enabled=true&sasl_mechanism=AWS_MSK_IAM&tls_enabled=true                                                 | STORAGE
+  s3_bucket       | s3://bucket name?AWS_ACCESS_KEY_ID={access key}&AWS_SECRET_ACCESS_KEY=redacted                                                                                                                                                                                                        | STORAGE
+~~~
+
+### Show an external connection
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW EXTERNAL CONNECTION s3_bucket;
+~~~
+~~~
+  connection_name |                                       connection_uri                                       | connection_type
+------------------+--------------------------------------------------------------------------------------------+------------------
+  s3_bucket       | s3://bucket name?AWS_ACCESS_KEY_ID={access key}&AWS_SECRET_ACCESS_KEY=redacted             | STORAGE
+(1 row)
+~~~
+
+## See also
+
+- [Changefeed Sinks]({% link {{ page.version.version }}/changefeed-sinks.md %})
+- [Use Cloud Storage]({% link {{ page.version.version }}/use-cloud-storage.md %})

--- a/src/current/v24.2/show-external-connection.md
+++ b/src/current/v24.2/show-external-connection.md
@@ -34,7 +34,7 @@ Response | Description
 ---------+------------
 `connection_name` | The user-specified name of the external connection.
 `connection_uri` | The [storage/sink]({% link {{ page.version.version }}/create-external-connection.md %}#supported-external-storage-and-sinks) URI that the external connection references.
-`connection_type` | `STORAGE` applies to [storage for backups and imports]({% link {{ page.version.version }}/use-cloud-storage.md %}) and [changefeed sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}).
+`connection_type` | Possible values are: <br><ul><li>`STORAGE` applies to [storage for backups and imports]({% link {{ page.version.version }}/use-cloud-storage.md %}) and [changefeed sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}).</li><li>`KMS` applies to [storage for encrypted backups]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}).</li><li>`FOREIGNDATA`</li></ul>.
 
 ## Examples
 

--- a/src/current/v24.2/show-external-connection.md
+++ b/src/current/v24.2/show-external-connection.md
@@ -34,7 +34,7 @@ Response | Description
 ---------+------------
 `connection_name` | The user-specified name of the external connection.
 `connection_uri` | The [storage/sink]({% link {{ page.version.version }}/create-external-connection.md %}#supported-external-storage-and-sinks) URI that the external connection references.
-`connection_type` | Possible values are: <br><ul><li>`STORAGE` applies to [storage for backups and imports]({% link {{ page.version.version }}/use-cloud-storage.md %}) and [changefeed sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}).</li><li>`KMS` applies to [storage for encrypted backups]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}).</li><li>`FOREIGNDATA`</li></ul>.
+`connection_type` | Possible values are: <br><ul><li>`STORAGE` applies to [storage for backups and imports]({% link {{ page.version.version }}/use-cloud-storage.md %}) and [changefeed sinks]({% link {{ page.version.version }}/changefeed-sinks.md %}).</li><li>`KMS` applies to [storage for encrypted backups]({% link {{ page.version.version }}/take-and-restore-encrypted-backups.md %}).</li><li>`FOREIGNDATA` applies to [`postgres://` connections for physical cluster replication]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#connection-reference).</li></ul>.
 
 ## Examples
 


### PR DESCRIPTION
Fixes DOC-10317

This PR adds the `SHOW EXTERNAL CONNECTION` statement to the docs.

Also added the `postgresql` external connection support for physical cluster replication.