### PR TITLE
[DOC-9723] Update Terraform page for new plans

### DIFF
--- a/src/current/_includes/v24.2/sidebar-data/cloud-deployments.json
+++ b/src/current/_includes/v24.2/sidebar-data/cloud-deployments.json
@@ -48,7 +48,7 @@
                     ]
             },
             {
-                "title": "Provision a Serverless Cluster with Terraform",
+                "title": "Use the Terraform provider",
                 "urls": [
                     "/cockroachcloud/provision-a-cluster-with-terraform.html"
                 ]

--- a/src/current/cockroachcloud/provision-a-cluster-with-terraform.md
+++ b/src/current/cockroachcloud/provision-a-cluster-with-terraform.md
@@ -7,7 +7,7 @@ docs_area: manage
 
 [Terraform](https://terraform.io) is an infrastructure-as-code provisioning tool that uses configuration files to define application and network resources. You can provision CockroachDB Cloud clusters and cluster resources by using the [CockroachDB Cloud Terraform provider](https://registry.terraform.io/providers/cockroachdb/cockroach) in your Terraform configuration files.
 
-This page shows how to use the CockroachDB Cloud Terraform provider to create and manage clusters in CockroachDB Cloud. This page is not exhaustive; you can browse an extensive set of [example recipes](https://github.com/cockroachdb/terraform-provider-cockroach/tree/main/examples) in the Terraform provider's GitHub registry.
+This page shows how to use the CockroachDB Cloud Terraform provider to create and manage clusters in CockroachDB Cloud. This page is not exhaustive; you can browse an extensive set of [example recipes](https://github.com/cockroachdb/terraform-provider-cockroach/tree/main/examples) in the Terraform provider's GitHub repository.
 
 {{site.data.alerts.callout_info}}
 If you used the Terraform provider to manage CockroachDB {{ site.data.products.serverless }} clusters that have been migrated to CockroachDB {{ site.data.products.basic }}, your recipes must be updated to work with CockroachDB {{ site.data.products.basic }}.

--- a/src/current/cockroachcloud/provision-a-cluster-with-terraform.md
+++ b/src/current/cockroachcloud/provision-a-cluster-with-terraform.md
@@ -73,8 +73,6 @@ Before you start this tutorial, you must
 Terraform reports the actions it will take. Verify the details, then type `yes` to apply the changes.
 {% endcapture %}
 
-Terraform uses a infrastructure-as-code approach to managing resources. Terraform configuration files allow you to define resources declaratively and let Terraform manage their lifecycle.
-
 <section class="filter-content" markdown="1" data-scope="basic">
 
 In this tutorial, you will create a CockroachDB {{ site.data.products.basic }} cluster.
@@ -118,7 +116,7 @@ In this tutorial, you will create a CockroachDB {{ site.data.products.standard }
       plan           = "STANDARD"
       serverless = {
         usage_limits = {
-          provisioned_vcpus = 2
+          provisioned_virtual_cpus = 2
         }
       }
       regions = [
@@ -131,7 +129,7 @@ In this tutorial, you will create a CockroachDB {{ site.data.products.standard }
     ~~~
       - Replace `cockroach-standard` with a name for the cluster.
       - Set `cloud_provider` to `AWS` `AZURE`, or `GCP`.
-      - Under `usage_limits`, set `provisioned_vcpus` to the number of vCPUs required per node.
+      - Under `usage_limits`, set `provisioned_virtual_cpus` to the required maximum vCPUs for the cluster.
       - Under `regions`, add the names of one or more regions for the cluster.
       - To optionally enable [deletion protection]({% link cockroachcloud/basic-cluster-management.md %}#enable-deletion-protection), set `delete_protection` to `true`.
 {{ remaining_steps }}
@@ -152,7 +150,7 @@ In this tutorial, you will create a CockroachDB {{ site.data.products.advanced }
       plan           = "ADVANCED"
       dedicated = {
         storage_gib = 15
-        num_vcpus = 4
+        num_virtual_cpus = 4
       }
       regions = [
         {
@@ -165,7 +163,7 @@ In this tutorial, you will create a CockroachDB {{ site.data.products.advanced }
     ~~~
       - Replace `cockroach-advanced` with a name for the cluster.
       - Set `cloud_provider` to `AWS` `AZURE`, or `GCP`.
-      - Under `dedicated`, set `storage_gib` to a value large enough to contain the cluster's expected data. Set `num_vcpus` to the number of vCPUs per node.
+      - Under `dedicated`, set `storage_gib` to a value large enough to contain the cluster's expected data. Set `num_virtual_cpus` to the number of vCPUs per node.
       - Under `regions`, add the names of one or more regions for the cluster and specify the `node_count`, or the number of nodes, per region.
       - To optionally enable [deletion protection]({% link cockroachcloud/basic-cluster-management.md %}#enable-deletion-protection), set `delete_protection` to `true`.
 {{ remaining_steps }}


### PR DESCRIPTION
[DOC-9723] Update Terraform page for new plans

- Update page title (but not filename) with an eye toward covering more than cluster creation on the page in future
- Update page variables and filter tabs
- Split Serverless into Basic and Standard
- Removed the `tfvars` construct in favor of directly copying the examples from https://github.com/cockroachdb/terraform-provider-cockroach/blob/398102111d6e696a4e2c034077f812cd1917f675/examples/resources/cockroach_cluster/resource.tf with the following changes:
  - Replace `machine_type` field in Advanced example with `provisioned_vcpus`, per [thread](https://cockroachlabs.slack.com/archives/C01CD39JX8E/p1726523199408789).
  - Subsequently replaced `provisioned_vcpus` with `provisioned_virtual_cpus` and `num_vcpus` with `num_virtual_cpus`, per @andy-kimball 
  - Removed output that will necessarily be different from the reader's actual experience and presents maintenance challenges over time, with little benefit to the reader.
- Restructured Markdown source a bit for ease of maintenance

**Out of scope for this PR**: Changing from Basic to Standard using Terraform. Coming subsequent to this PR.
