### PR TITLE
DOC-11185 Cloud-2.0 fix cockroachcloud links on performance-recipes.md for v23.2, v24.1, v24.2

### DIFF
--- a/src/current/v23.2/performance-recipes.md
+++ b/src/current/v23.2/performance-recipes.md
@@ -12,7 +12,7 @@ This page provides recipes for fixing performance issues in your applications.
 
 This section describes how to use CockroachDB commands and dashboards to identify performance problems in your applications.
 
-<table>
+<table markdown="1">
   <tr>
     <th>Observation</th>
     <th>Diagnosis</th>

--- a/src/current/v24.1/performance-recipes.md
+++ b/src/current/v24.1/performance-recipes.md
@@ -12,7 +12,7 @@ This page provides recipes for fixing performance issues in your applications.
 
 This section describes how to use CockroachDB commands and dashboards to identify performance problems in your applications.
 
-<table>
+<table markdown="1">
   <tr>
     <th>Observation</th>
     <th>Diagnosis</th>

--- a/src/current/v24.2/performance-recipes.md
+++ b/src/current/v24.2/performance-recipes.md
@@ -12,7 +12,7 @@ This page provides recipes for fixing performance issues in your applications.
 
 This section describes how to use CockroachDB commands and dashboards to identify performance problems in your applications.
 
-<table>
+<table markdown="1">
   <tr>
     <th>Observation</th>
     <th>Diagnosis</th>


### PR DESCRIPTION
Fixes DOC-11185

In performance-recipes.md, added back markdown="1" so that liquid links are rendered properly in html table.