### PR TITLE
DOC-11204 Cloud 2.0 remove mention of Azure monitor on export logs for Standard

### DIFF
--- a/src/current/cockroachcloud/export-logs-advanced.md
+++ b/src/current/cockroachcloud/export-logs-advanced.md
@@ -49,6 +49,8 @@ Where:
 - `{log-channel}` is the CockroachDB [log channel]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels), such as `HEALTH` or `OPS`.
 - `{N}` is the node number of the CockroachDB {{ site.data.products.advanced }} node emitting the log messages. Log messages received before a node is fully started may appear in a log named without an explicit node number, ending in just `.n`.
 
+For Azure Monitor, the logs have a different name format, refer to [Enable log export - Verify]({% link cockroachcloud/export-logs-advanced.md %}?filters=azure-monitor-log-export#verify) instructions.
+
 ## Enable log export
 
 <div class="filters clearfix">

--- a/src/current/cockroachcloud/export-logs.md
+++ b/src/current/cockroachcloud/export-logs.md
@@ -49,8 +49,6 @@ Where:
 - `{log-channel}` is the CockroachDB [log channel]({% link {{site.current_cloud_version}}/logging-overview.md %}#logging-channels), such as `HEALTH` or `OPS`.
 - `{N}` is the node number of the CockroachDB {{ site.data.products.advanced }} node emitting the log messages. Log messages received before a node is fully started may appear in a log named without an explicit node number, e.g., ending in just `.n`.
 
-For Azure Monitor, the logs have a different name format, refer to [Enable log export](#enable-log-export) instructions.
-
 ## Enable log export
 
 <div class="filters clearfix">


### PR DESCRIPTION
Fixes DOC-11204

In export-logs.md, removed incorrect mention of Azure monitor.
In export-logs-advanced.md, added sentence about Azure monitor log naming format.