### PR TITLE
REL-1381 v23.1.28 (was 23.1.27): [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6888,10 +6888,3 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.27
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-    This version is currently available only for select
-    CockroachDB Cloud clusters. To request to upgrade
-    a CockroachDB self-hosted cluster to this version,
-    [contact support](https://support.cockroachlabs.com/hc/requests/new).

--- a/src/current/_includes/releases/new-release-downloads-docker-image.md
+++ b/src/current/_includes/releases/new-release-downloads-docker-image.md
@@ -28,7 +28,7 @@ Experimental downloads are not qualified for production use and not eligible for
   {% capture onclick_string %}onclick="{{ experimental_download_js }}"{% endcapture %}
   {% capture linux_arm_button_text_addendum %}{% if r.linux.linux_arm_experimental == true %}<br />(Experimental){% endif %}{% if r.linux.linux_arm_limited_access == true %}<br />(Limited Access){% endif %}{% endcapture %}
 
-<div><div class="clearfix">
+<div><div class="clearfix" markdown="1">
 
 <table style="max-width: 90%;">
   <thead>


### PR DESCRIPTION
Fixes REL-1381

In releases.yml, removed cloud attributes to show download links.

Rendered preview:
- [Downloads](https://deploy-preview-19011--cockroachdb-docs.netlify.app/docs/releases/v23.1#v23-1-28-downloads)
- [Docker image](https://deploy-preview-19011--cockroachdb-docs.netlify.app/docs/releases/v23.1#v23-1-28-docker-image)