### PR TITLE
DOC-11475 Remove duplicate entry for 24.3.0-alpha.2

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -6888,41 +6888,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.1.27
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-    This version is currently available only for select
-    CockroachDB Cloud clusters. To request to upgrade
-    a CockroachDB self-hosted cluster to this version,
-    [contact support](https://support.cockroachlabs.com/hc/requests/new).
-
-- release_name: v24.3.0-alpha.2
-  major_version: v24.3
-  release_date: '2024-10-14'
-  release_type: Testing
-  go_version: go1.22.5
-  sha: 58c475d67e32b75284b4fe293bff82807c3d129d
-  has_sql_only: true
-  has_sha256sum: true
-  mac:
-    mac_arm: true
-    mac_arm_experimental: true
-    mac_arm_limited_access: false
-  windows: true
-  linux:
-    linux_arm: true
-    linux_arm_experimental: false
-    linux_arm_limited_access: false
-    linux_intel_fips: true
-    linux_arm_fips: false
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-    docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: false
-  source: true
-  previous_release: v24.3.0-alpha.1
-
 
 - release_name: v24.3.0-alpha.2
   major_version: v24.3
@@ -6949,4 +6914,4 @@
     docker_arm_experimental: false
     docker_arm_limited_access: false
   source: true
-  previous_release: v24.3.0-alpha.1-218-g58c475d67e3
+  previous_release: v24.3.0-alpha.1


### PR DESCRIPTION
Fixes DOC-11475

In release.yml, fixed entries for v24.3.0-alpha.1 and v23.1.28.

rendered previews

- [Releases](https://deploy-preview-19013--cockroachdb-docs.netlify.app/docs/releases/#v24-3)
- [24.3](https://deploy-preview-19013--cockroachdb-docs.netlify.app/docs/releases/v24.3)
- [23.1.28](https://deploy-preview-19013--cockroachdb-docs.netlify.app/docs/releases/v23.1#v23-1-28)