### PR TITLE
Update v23.1.28 release notes

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.28.md
+++ b/src/current/_includes/releases/v23.1/v23.1.28.md
@@ -3,6 +3,11 @@
 Release Date: October 10, 2024
 
 {% include releases/new-release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-1-28-security-changes">Security changes</h3>
+
+ [`SHOW CHANGEFEED JOB`]({% link v23.1/show-changefeed-job.md %}), [`SHOW CHANGEFEED JOBS`]({% link v23.1/show-changefeed-jobs.md %}#show-changefeed-jobs), and [`SHOW JOBS`]({% link v23.1/show-jobs.md %}) commands no longer expose user sensitive information like `client_key`. [#129910][#129910]
+
 <h3 id="v23-1-28-general-changes">General changes</h3>
 
 - Upgraded [gRPC]({% link v23.1/architecture/distribution-layer.md %}#grpc) to v1.56.3. [#130044][#130044]
@@ -21,15 +26,8 @@ Release Date: October 10, 2024
 - Fixed a bug where the [`schema_locked` table parameter]({% link v23.1/with-storage-parameter.md %}#table-parameters) did not prevent a table from being referenced by a [foreign key]({% link v23.1/foreign-key.md %}). [#129752][#129752]
 - Fixed a bug where the [`require_explicit_primary_keys`]({% link v23.1/session-variables.md %}#require-explicit-primary-keys) session variable would overly aggressively prevent all [`CREATE TABLE`]({% link v23.1/create-table.md %}) statements from working. [#129905][#129905]
 - Fixed a rare bug where a [lease transfer]({% link v23.1/architecture/replication-layer.md %}#epoch-based-leases-table-data) could lead to a `side-transport update saw closed timestamp regression` panic. The bug could occur when a node was [overloaded]({% link v23.1/ui-overload-dashboard.md %}) and failing to heartbeat its [node liveness]({% link v23.1/cluster-setup-troubleshooting.md %}#node-liveness-issues) record. [#130124][#130124]
-- Fixed a slow-building memory leak when using [Kerberos authentication]({% link v23.1/gssapi_authentication.md %}). [#130316][#130316] [#130820][#130820]
 - Resolve a log message that read: `expiration of liveness record ... is not greater than expiration of the previous lease ... after liveness heartbeat`. This message is no longer possible. [#130623][#130623]
 - Fixed a potential memory leak in [changefeeds]({% link v23.1/change-data-capture-overview.md %}) using a [cloud storage sink]({% link v23.1/changefeed-sinks.md %}#cloud-storage-sink). The memory leak could occur if both `changefeed.fast_gzip.enabled` and `changefeed.cloudstorage.async_flush.enabled` are `true` and the changefeed received an error while attempting to write to the cloud storage sink. [#130613][#130613]
-
-<h3 id="v23-1-28-miscellaneous">Miscellaneous</h3>
-
-<h4 id="v23-1-28-security-fix">Security fix</h4>
-
-- SHOW CHANGEFEED JOB, [SHOW CHANGEFEED JOBS]({% link v23.1/show-jobs.md %}#show-changefeed-jobs), and [SHOW JOBS]({% link v23.1/show-jobs.md %}) no longer expose user sensitive information like `client_key`. [#129910][#129910]
 
 
 [#128068]: https://github.com/cockroachdb/cockroach/pull/128068

--- a/src/current/_includes/releases/v23.1/v23.1.28.md
+++ b/src/current/_includes/releases/v23.1/v23.1.28.md
@@ -6,7 +6,7 @@ Release Date: October 10, 2024
 
 <h3 id="v23-1-28-security-changes">Security changes</h3>
 
- [`SHOW CHANGEFEED JOB`]({% link v23.1/show-changefeed-job.md %}), [`SHOW CHANGEFEED JOBS`]({% link v23.1/show-changefeed-jobs.md %}#show-changefeed-jobs), and [`SHOW JOBS`]({% link v23.1/show-jobs.md %}) commands no longer expose user sensitive information like `client_key`. [#129910][#129910]
+- [`SHOW JOBS`]({% link v23.1/show-jobs.md %}) and its variants [`SHOW CHANGEFEED JOB`]({% link v23.1/show-jobs.md %}#show-changefeed-jobs) and [`SHOW CHANGEFEED JOBS`]({% link v23.1/show-jobs.md %}#show-changefeed-jobs) no longer expose user sensitive information like `client_key`. [#129910][#129910]
 
 <h3 id="v23-1-28-general-changes">General changes</h3>
 


### PR DESCRIPTION
- Remove duplicate note
- Move security note to the correct part of the file
- In security note, add a link to a command a fix a link pointing to the wrong reference