### PR TITLE
Change remaining refs to 'connection retry'

### DIFF
--- a/src/current/cockroachcloud/troubleshooting-page.md
+++ b/src/current/cockroachcloud/troubleshooting-page.md
@@ -127,7 +127,7 @@ Error: dial tcp 35.240.101.1:26257: connect: connection refused
 
 <h4>Solution</h4>
 
-CockroachDB {{ site.data.products.cloud }} connections can occasionally become invalid due to upgrades, restarts, or other disruptions. Your application should use a [pool of persistent connections]({% link {{site.current_cloud_version}}/connection-pooling.md %}) and connection retry logic to ensure that connections remain current. See the [Production Checklist]({% link cockroachcloud/production-checklist.md %}) for more information.
+CockroachDB {{ site.data.products.cloud }} connections can occasionally become invalid due to upgrades, restarts, or other disruptions. Your application should use a [pool of persistent connections]({% link {{site.current_cloud_version}}/connection-pooling.md %}) and [mitigate connection disruptions]({% link {{ page.version.version }}/production-checklist.md %}#sql-connection-handling) to ensure that connections remain current. See the [Production Checklist]({% link cockroachcloud/production-checklist.md %}) for more information.
 
 ## Security errors
 

--- a/src/current/cockroachcloud/troubleshooting-page.md
+++ b/src/current/cockroachcloud/troubleshooting-page.md
@@ -127,7 +127,7 @@ Error: dial tcp 35.240.101.1:26257: connect: connection refused
 
 <h4>Solution</h4>
 
-CockroachDB {{ site.data.products.cloud }} connections can occasionally become invalid due to upgrades, restarts, or other disruptions. Your application should use a [pool of persistent connections]({% link {{site.current_cloud_version}}/connection-pooling.md %}) and [mitigate connection disruptions]({% link {{ page.version.version }}/production-checklist.md %}#sql-connection-handling) to ensure that connections remain current. See the [Production Checklist]({% link cockroachcloud/production-checklist.md %}) for more information.
+CockroachDB {{ site.data.products.cloud }} connections can occasionally become invalid due to upgrades, restarts, or other disruptions. Your application should use a [pool of persistent connections]({% link {{site.current_cloud_version}}/connection-pooling.md %}) and [mitigate connection disruptions]({% link cockroachcloud/production-checklist.md %}#sql-connection-handling) to ensure that connections remain current. See the [Production Checklist]({% link cockroachcloud/production-checklist.md %}) for more information.
 
 ## Security errors
 

--- a/src/current/v23.1/cluster-setup-troubleshooting.md
+++ b/src/current/v23.1/cluster-setup-troubleshooting.md
@@ -300,7 +300,7 @@ The reason this happens is as follows:
 
 For more information about how lease transfers work when a node dies, see [How leases are transferred from a dead node]({% link {{ page.version.version }}/architecture/replication-layer.md %}#how-leases-are-transferred-from-a-dead-node).
 
-The solution is to add connection retry logic to your application.
+The solution is to [use connection pooling]({% link {{ page.version.version }}/connection-pooling.md %}).
 
 ## Clock sync issues
 

--- a/src/current/v23.2/cluster-setup-troubleshooting.md
+++ b/src/current/v23.2/cluster-setup-troubleshooting.md
@@ -301,7 +301,7 @@ The reason this happens is as follows:
 
 For more information about how lease transfers work when a node dies, see [How leases are transferred from a dead node]({% link {{ page.version.version }}/architecture/replication-layer.md %}#how-leases-are-transferred-from-a-dead-node).
 
-The solution is to add connection retry logic to your application.
+The solution is to [use connection pooling]({% link {{ page.version.version }}/connection-pooling.md %}).
 
 ## Clock sync issues
 

--- a/src/current/v24.1/cluster-setup-troubleshooting.md
+++ b/src/current/v24.1/cluster-setup-troubleshooting.md
@@ -301,7 +301,7 @@ The reason this happens is as follows:
 
 For more information about how lease transfers work when a node dies, see [How leases are transferred from a dead node]({% link {{ page.version.version }}/architecture/replication-layer.md %}#how-leases-are-transferred-from-a-dead-node).
 
-The solution is to add connection retry logic to your application.
+The solution is to [use connection pooling]({% link {{ page.version.version }}/connection-pooling.md %}).
 
 ## Clock sync issues
 

--- a/src/current/v24.2/cluster-setup-troubleshooting.md
+++ b/src/current/v24.2/cluster-setup-troubleshooting.md
@@ -301,7 +301,7 @@ The reason this happens is as follows:
 
 For more information about how lease transfers work when a node dies, see [How leases are transferred from a dead node]({% link {{ page.version.version }}/architecture/replication-layer.md %}#how-leases-are-transferred-from-a-dead-node).
 
-The solution is to add connection retry logic to your application.
+The solution is to [use connection pooling]({% link {{ page.version.version }}/connection-pooling.md %}).
 
 ## Clock sync issues
 

--- a/src/current/v24.3/cluster-setup-troubleshooting.md
+++ b/src/current/v24.3/cluster-setup-troubleshooting.md
@@ -301,7 +301,7 @@ The reason this happens is as follows:
 
 For more information about how lease transfers work when a node dies, see [How leases are transferred from a dead node]({% link {{ page.version.version }}/architecture/replication-layer.md %}#how-leases-are-transferred-from-a-dead-node).
 
-The solution is to add connection retry logic to your application.
+The solution is to [use connection pooling]({% link {{ page.version.version }}/connection-pooling.md %}).
 
 ## Clock sync issues
 


### PR DESCRIPTION
Touches DOC-7401 again, a little

This came up again in today's SQL Foundations weekly (2024-10-21)

Summary: remove last lingering mentions of "connection retry" and instead point users to 'Connection Pooling' (on-prem) and 'Production Checklist' (cloud) pages instead.