### PR TITLE
[DOC-11556] CV setting and metric scopes for v24.3

### DIFF
--- a/src/current/v24.3/cluster-virtualization-metric-scopes.md
+++ b/src/current/v24.3/cluster-virtualization-metric-scopes.md
@@ -92,58 +92,58 @@ SERVER: n/a
 - `changefeed.forwarded_resolved_messages`
 - `changefeed.frontier_updates`
 - `changefeed.internal_retry_message_count`
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+- `changefeed.kafka_throttling_hist_nanos`
+- `changefeed.lagging_ranges`
+- `changefeed.max_behind_nanos`
+- `changefeed.message_size_hist`
+- `changefeed.messages.messages_pushback_nanos`
+- `changefeed.network.bytes_in`
+- `changefeed.network.bytes_out`
+- `changefeed.nprocs_consume_event_nanos`
+- `changefeed.nprocs_flush_nanos`
+- `changefeed.nprocs_in_flight_count`
+- `changefeed.parallel_io_in_flight_keys`
+- `changefeed.parallel_io_pending_rows`
+- `changefeed.parallel_io_queue_nanos`
+- `changefeed.parallel_io_result_queue_nanos`
+- `changefeed.queue_time_nanos`
+- `changefeed.running`
+- `changefeed.schema_registry.registrations`
+- `changefeed.schema_registry.retry_count`
+- `changefeed.schemafeed.table_history_scans`
+- `changefeed.schemafeed.table_metadata_nanos`
+- `changefeed.sink_batch_hist_nanos`
+- `changefeed.sink_errors`
+- `changefeed.sink_io_inflight`
+- `changefeed.size_based_flushes`
+- `changefeed.total_ranges`
+- `changefeed.usage.error_count`
+- `changefeed.usage.query_duration`
+- `changefeed.usage.table_bytes`
+- `clock-offset.meannanos`
+- `clock-offset.stddevnanos`
+- `cloud.conns_opened`
+- `cloud.conns_reused`
+- `cloud.listing_results`
+- `cloud.listings`
+- `cloud.open_readers`
+- `cloud.open_writers`
+- `cloud.read_bytes`
+- `cloud.readers_opened`
+- `cloud.tls_handshakes`
+- `cloud.write_bytes`
+- `cloud.writers_opened`
+- `cluster.preserve-downgrade-option.last-updated`
+- `distsender.batch_requests.cross_region.bytes`
+- `distsender.batch_requests.cross_zone.bytes`
+- `distsender.batch_requests.replica_addressed.bytes`
+- `distsender.batch_responses.cross_region.bytes`
+- `distsender.batch_responses.cross_zone.bytes`
+- `distsender.batch_responses.replica_addressed.bytes`
+- `distsender.batches`
+- `distsender.batches.async.sent`
+- `distsender.batches.async.throttled`
+- `distsender.batches.partial`
 - `distsender.circuit_breaker.replicas.count`
 - `distsender.circuit_breaker.replicas.probes.failure`
 - `distsender.circuit_breaker.replicas.probes.running`

--- a/src/current/v24.3/cluster-virtualization-metric-scopes.md
+++ b/src/current/v24.3/cluster-virtualization-metric-scopes.md
@@ -17,7 +17,7 @@ When [cluster virtualization]({% link {{ page.version.version }}/cluster-virtual
 - When a metric is scoped to the system virtual cluster, it is included only in the metrics for the system virtual cluster. These metrics provide information about the underlying CockroachDB cluster's performance. Refer to [Metrics scoped to the system virtual cluster](#metrics-scoped-to-the-system-virtual-cluster).
 
 {% comment %}
-Src: cockroach gen metrics-list --format=csv against cockroach-v24.2.0-rc.1.darwin-10.9-amd64
+Src: cockroach gen metrics-list --format=csv against cockroach-v24.3.0-beta.1.darwin-10.9-amd64
 
 
 Also saved in https://docs.google.com/spreadsheets/d/1HIalzAhwU0CEYzSuG2m1aXSJRpiIyQPJdt8SusHpJ_U/edit?usp=sharing
@@ -32,23 +32,48 @@ SERVER: n/a
 
 {% comment %}LAYER=APPLICATION{% endcomment %}
 
+- `auth.cert.conn.latency`
+- `auth.gss.conn.latency`
+- `auth.jwt.conn.latency`
+- `auth.ldap.conn.latency`
+- `auth.password.conn.latency`
+- `auth.scram.conn.latency`
 - `backup.last-failed-time.kms-inaccessible`
-- `build.timestamp`
 - `changefeed.admit_latency`
 - `changefeed.aggregator_progress`
 - `changefeed.backfill_count`
 - `changefeed.backfill_pending_ranges`
 - `changefeed.batch_reduction_count`
 - `changefeed.buffer_entries_mem.acquired`
+- `changefeed.buffer_entries_mem.acquired.aggregator`
+- `changefeed.buffer_entries_mem.acquired.rangefeed`
 - `changefeed.buffer_entries_mem.released`
+- `changefeed.buffer_entries_mem.released.aggregator`
+- `changefeed.buffer_entries_mem.released.rangefeed`
 - `changefeed.buffer_entries.allocated_mem`
+- `changefeed.buffer_entries.allocated_mem.aggregator`
+- `changefeed.buffer_entries.allocated_mem.rangefeed`
 - `changefeed.buffer_entries.flush`
+- `changefeed.buffer_entries.flush.aggregator`
+- `changefeed.buffer_entries.flush.rangefeed`
 - `changefeed.buffer_entries.in`
+- `changefeed.buffer_entries.in.aggregator`
+- `changefeed.buffer_entries.in.rangefeed`
 - `changefeed.buffer_entries.kv`
+- `changefeed.buffer_entries.kv.aggregator`
+- `changefeed.buffer_entries.kv.rangefeed`
 - `changefeed.buffer_entries.out`
+- `changefeed.buffer_entries.out.aggregator`
+- `changefeed.buffer_entries.out.rangefeed`
 - `changefeed.buffer_entries.released`
+- `changefeed.buffer_entries.released.aggregator`
+- `changefeed.buffer_entries.released.rangefeed`
 - `changefeed.buffer_entries.resolved`
+- `changefeed.buffer_entries.resolved.aggregator`
+- `changefeed.buffer_entries.resolved.rangefeed`
 - `changefeed.buffer_pushback_nanos`
+- `changefeed.buffer_pushback_nanos.aggregator`
+- `changefeed.buffer_pushback_nanos.rangefeed`
 - `changefeed.bytes.messages_pushback_nanos`
 - `changefeed.checkpoint_hist_nanos`
 - `changefeed.checkpoint_progress`
@@ -67,54 +92,58 @@ SERVER: n/a
 - `changefeed.forwarded_resolved_messages`
 - `changefeed.frontier_updates`
 - `changefeed.internal_retry_message_count`
-- `changefeed.kafka_throttling_hist_nanos`
-- `changefeed.lagging_ranges`
-- `changefeed.max_behind_nanos`
-- `changefeed.message_size_hist`
-- `changefeed.messages.messages_pushback_nanos`
-- `changefeed.nprocs_consume_event_nanos`
-- `changefeed.nprocs_flush_nanos`
-- `changefeed.nprocs_in_flight_count`
-- `changefeed.parallel_io_in_flight_keys`
-- `changefeed.parallel_io_pending_rows`
-- `changefeed.parallel_io_queue_nanos`
-- `changefeed.parallel_io_result_queue_nanos`
-- `changefeed.queue_time_nanos`
-- `changefeed.running`
-- `changefeed.schema_registry.registrations`
-- `changefeed.schema_registry.retry_count`
-- `changefeed.schemafeed.table_history_scans`
-- `changefeed.schemafeed.table_metadata_nanos`
-- `changefeed.sink_batch_hist_nanos`
-- `changefeed.sink_io_inflight`
-- `changefeed.size_based_flushes`
-- `changefeed.usage.error_count`
-- `changefeed.usage.query_duration`
-- `changefeed.usage.table_bytes`
-- `clock-offset.meannanos`
-- `clock-offset.stddevnanos`
-- `cloud.conns_opened`
-- `cloud.conns_reused`
-- `cloud.listing_results`
-- `cloud.listings`
-- `cloud.open_readers`
-- `cloud.open_writers`
-- `cloud.read_bytes`
-- `cloud.readers_opened`
-- `cloud.tls_handshakes`
-- `cloud.write_bytes`
-- `cloud.writers_opened`
-- `cluster.preserve-downgrade-option.last-updated`
-- `distsender.batch_requests.cross_region.bytes`
-- `distsender.batch_requests.cross_zone.bytes`
-- `distsender.batch_requests.replica_addressed.bytes`
-- `distsender.batch_responses.cross_region.bytes`
-- `distsender.batch_responses.cross_zone.bytes`
-- `distsender.batch_responses.replica_addressed.bytes`
-- `distsender.batches`
-- `distsender.batches.async.sent`
-- `distsender.batches.async.throttled`
-- `distsender.batches.partial`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 - `distsender.circuit_breaker.replicas.count`
 - `distsender.circuit_breaker.replicas.probes.failure`
 - `distsender.circuit_breaker.replicas.probes.running`
@@ -288,6 +317,18 @@ SERVER: n/a
 - `jobs.auto_config_task.resume_completed`
 - `jobs.auto_config_task.resume_failed`
 - `jobs.auto_config_task.resume_retry_error`
+- `jobs.auto_create_partial_stats.currently_idle`
+- `jobs.auto_create_partial_stats.currently_paused`
+- `jobs.auto_create_partial_stats.currently_running`
+- `jobs.auto_create_partial_stats.expired_pts_records`
+- `jobs.auto_create_partial_stats.fail_or_cancel_completed`
+- `jobs.auto_create_partial_stats.fail_or_cancel_failed`
+- `jobs.auto_create_partial_stats.fail_or_cancel_retry_error`
+- `jobs.auto_create_partial_stats.protected_age_sec`
+- `jobs.auto_create_partial_stats.protected_record_count`
+- `jobs.auto_create_partial_stats.resume_completed`
+- `jobs.auto_create_partial_stats.resume_failed`
+- `jobs.auto_create_partial_stats.resume_retry_error`
 - `jobs.auto_create_stats.currently_idle`
 - `jobs.auto_create_stats.currently_paused`
 - `jobs.auto_create_stats.currently_running`
@@ -576,6 +617,18 @@ SERVER: n/a
 - `jobs.schema_change.resume_completed`
 - `jobs.schema_change.resume_failed`
 - `jobs.schema_change.resume_retry_error`
+- `jobs.standby_read_ts_poller.currently_idle`
+- `jobs.standby_read_ts_poller.currently_paused`
+- `jobs.standby_read_ts_poller.currently_running`
+- `jobs.standby_read_ts_poller.expired_pts_records`
+- `jobs.standby_read_ts_poller.fail_or_cancel_completed`
+- `jobs.standby_read_ts_poller.fail_or_cancel_failed`
+- `jobs.standby_read_ts_poller.fail_or_cancel_retry_error`
+- `jobs.standby_read_ts_poller.protected_age_sec`
+- `jobs.standby_read_ts_poller.protected_record_count`
+- `jobs.standby_read_ts_poller.resume_completed`
+- `jobs.standby_read_ts_poller.resume_failed`
+- `jobs.standby_read_ts_poller.resume_retry_error`
 - `jobs.typedesc_schema_change.currently_idle`
 - `jobs.typedesc_schema_change.currently_paused`
 - `jobs.typedesc_schema_change.currently_running`
@@ -588,6 +641,18 @@ SERVER: n/a
 - `jobs.typedesc_schema_change.resume_completed`
 - `jobs.typedesc_schema_change.resume_failed`
 - `jobs.typedesc_schema_change.resume_retry_error`
+- `jobs.update_table_metadata_cache.currently_idle`
+- `jobs.update_table_metadata_cache.currently_paused`
+- `jobs.update_table_metadata_cache.currently_running`
+- `jobs.update_table_metadata_cache.expired_pts_records`
+- `jobs.update_table_metadata_cache.fail_or_cancel_completed`
+- `jobs.update_table_metadata_cache.fail_or_cancel_failed`
+- `jobs.update_table_metadata_cache.fail_or_cancel_retry_error`
+- `jobs.update_table_metadata_cache.protected_age_sec`
+- `jobs.update_table_metadata_cache.protected_record_count`
+- `jobs.update_table_metadata_cache.resume_completed`
+- `jobs.update_table_metadata_cache.resume_failed`
+- `jobs.update_table_metadata_cache.resume_retry_error`
 - `kv.protectedts.reconciliation.errors`
 - `kv.protectedts.reconciliation.num_runs`
 - `kv.protectedts.reconciliation.records_processed`
@@ -597,40 +662,42 @@ SERVER: n/a
 - `logical_replication.commit_latency`
 - `logical_replication.events_dlqed`
 - `logical_replication.events_dlqed_age`
+- `logical_replication.events_dlqed_by_label`
 - `logical_replication.events_dlqed_errtype`
 - `logical_replication.events_dlqed_space`
 - `logical_replication.events_ingested`
+- `logical_replication.events_ingested_by_label`
 - `logical_replication.events_initial_failure`
 - `logical_replication.events_initial_success`
 - `logical_replication.events_retry_failure`
 - `logical_replication.events_retry_success`
-- `logical_replication.flush_bytes`
-- `logical_replication.flush_hist_nanos`
-- `logical_replication.flush_row_count`
 - `logical_replication.logical_bytes`
-- `logical_replication.optimistic_insert_conflict_count`
 - `logical_replication.replan_count`
+- `logical_replication.replicated_time_by_label`
 - `logical_replication.replicated_time_seconds`
 - `logical_replication.retry_queue_bytes`
 - `logical_replication.retry_queue_events`
+- `obs.tablemetadata.update_job.duration`
+- `obs.tablemetadata.update_job.errors`
+- `obs.tablemetadata.update_job.runs`
+- `obs.tablemetadata.update_job.table_updates`
 - `physical_replication.admit_latency`
 - `physical_replication.commit_latency`
 - `physical_replication.cutover_progress`
 - `physical_replication.distsql_replan_count`
-- `physical_replication.earliest_data_checkpoint_span`
 - `physical_replication.events_ingested`
 - `physical_replication.flush_hist_nanos`
 - `physical_replication.flushes`
-- `physical_replication.job_progress_updates`
-- `physical_replication.latest_data_checkpoint_span`
 - `physical_replication.logical_bytes`
 - `physical_replication.replicated_time_seconds`
 - `physical_replication.resolved_events_ingested`
 - `physical_replication.running`
-- `physical_replication.sst_bytes`
 - `requests.slow.distsender`
 - `round-trip-latency`
+- `rpc.client.bytes.egress`
+- `rpc.client.bytes.ingress`
 - `rpc.connection.avg_round_trip_latency`
+- `rpc.connection.connected`
 - `rpc.connection.failures`
 - `rpc.connection.healthy`
 - `rpc.connection.healthy_nanos`
@@ -896,6 +963,7 @@ SERVER: n/a
 - `tenant.sql_usage.external_io_ingress_bytes`
 - `tenant.sql_usage.kv_request_units`
 - `tenant.sql_usage.pgwire_egress_bytes`
+- `tenant.sql_usage.provisioned_vcpus`
 - `tenant.sql_usage.read_batches`
 - `tenant.sql_usage.read_bytes`
 - `tenant.sql_usage.read_requests`
@@ -931,7 +999,6 @@ SERVER: n/a
 - `txn.restarts.txnpush`
 - `txn.restarts.unknown`
 - `txn.restarts.writetooold`
-- `txn.restarts.writetoooldmulti`
 - `txn.rollbacks.async.failed`
 - `txn.rollbacks.failed`
 
@@ -950,8 +1017,8 @@ SERVER: n/a
 - `admission.admitted.elastic-cpu.bulk-normal-pri`
 - `admission.admitted.elastic-cpu.normal-pri`
 - `admission.admitted.elastic-stores`
+- `admission.admitted.elastic-stores.bulk-low-pri`
 - `admission.admitted.elastic-stores.bulk-normal-pri`
-- `admission.admitted.elastic-stores.ttl-low-pri`
 - `admission.admitted.kv`
 - `admission.admitted.kv-stores`
 - `admission.admitted.kv-stores.high-pri`
@@ -985,8 +1052,8 @@ SERVER: n/a
 - `admission.errored.elastic-cpu.bulk-normal-pri`
 - `admission.errored.elastic-cpu.normal-pri`
 - `admission.errored.elastic-stores`
+- `admission.errored.elastic-stores.bulk-low-pri`
 - `admission.errored.elastic-stores.bulk-normal-pri`
-- `admission.errored.elastic-stores.ttl-low-pri`
 - `admission.errored.kv`
 - `admission.errored.kv-stores`
 - `admission.errored.kv-stores.high-pri`
@@ -1032,8 +1099,8 @@ SERVER: n/a
 - `admission.requested.elastic-cpu.bulk-normal-pri`
 - `admission.requested.elastic-cpu.normal-pri`
 - `admission.requested.elastic-stores`
+- `admission.requested.elastic-stores.bulk-low-pri`
 - `admission.requested.elastic-stores.bulk-normal-pri`
-- `admission.requested.elastic-stores.ttl-low-pri`
 - `admission.requested.kv`
 - `admission.requested.kv-stores`
 - `admission.requested.kv-stores.high-pri`
@@ -1059,8 +1126,8 @@ SERVER: n/a
 - `admission.wait_durations.elastic-cpu.bulk-normal-pri`
 - `admission.wait_durations.elastic-cpu.normal-pri`
 - `admission.wait_durations.elastic-stores`
+- `admission.wait_durations.elastic-stores.bulk-low-pri`
 - `admission.wait_durations.elastic-stores.bulk-normal-pri`
-- `admission.wait_durations.elastic-stores.ttl-low-pri`
 - `admission.wait_durations.kv`
 - `admission.wait_durations.kv-stores`
 - `admission.wait_durations.kv-stores.high-pri`
@@ -1069,6 +1136,7 @@ SERVER: n/a
 - `admission.wait_durations.kv.high-pri`
 - `admission.wait_durations.kv.locking-normal-pri`
 - `admission.wait_durations.kv.normal-pri`
+- `admission.wait_durations.snapshot_ingest`
 - `admission.wait_durations.sql-kv-response`
 - `admission.wait_durations.sql-kv-response.locking-normal-pri`
 - `admission.wait_durations.sql-kv-response.normal-pri`
@@ -1085,8 +1153,8 @@ SERVER: n/a
 - `admission.wait_queue_length.elastic-cpu.bulk-normal-pri`
 - `admission.wait_queue_length.elastic-cpu.normal-pri`
 - `admission.wait_queue_length.elastic-stores`
+- `admission.wait_queue_length.elastic-stores.bulk-low-pri`
 - `admission.wait_queue_length.elastic-stores.bulk-normal-pri`
-- `admission.wait_queue_length.elastic-stores.ttl-low-pri`
 - `admission.wait_queue_length.kv`
 - `admission.wait_queue_length.kv-stores`
 - `admission.wait_queue_length.kv-stores.high-pri`
@@ -1180,6 +1248,8 @@ SERVER: n/a
 - `kv.rangefeed.budget_allocation_blocked`
 - `kv.rangefeed.budget_allocation_failed`
 - `kv.rangefeed.catchup_scan_nanos`
+- `kv.rangefeed.closed_timestamp_max_behind_nanos`
+- `kv.rangefeed.closed_timestamp.slow_ranges`
 - `kv.rangefeed.mem_shared`
 - `kv.rangefeed.mem_system`
 - `kv.rangefeed.processors_goroutine`
@@ -1246,9 +1316,57 @@ SERVER: n/a
 - `kvadmission.flow_token_dispatch.pending_regular`
 - `kvadmission.flow_token_dispatch.remote_elastic`
 - `kvadmission.flow_token_dispatch.remote_regular`
+- `kvflowcontrol.eval_wait.elastic.duration`
+- `kvflowcontrol.eval_wait.elastic.requests.admitted`
+- `kvflowcontrol.eval_wait.elastic.requests.bypassed`
+- `kvflowcontrol.eval_wait.elastic.requests.errored`
+- `kvflowcontrol.eval_wait.elastic.requests.waiting`
+- `kvflowcontrol.eval_wait.regular.duration`
+- `kvflowcontrol.eval_wait.regular.requests.admitted`
+- `kvflowcontrol.eval_wait.regular.requests.bypassed`
+- `kvflowcontrol.eval_wait.regular.requests.errored`
+- `kvflowcontrol.eval_wait.regular.requests.waiting`
+- `kvflowcontrol.range_controller.count`
+- `kvflowcontrol.send_queue.bytes`
+- `kvflowcontrol.send_queue.count`
+- `kvflowcontrol.send_queue.prevent.count`
+- `kvflowcontrol.send_queue.scheduled.deducted_bytes`
+- `kvflowcontrol.send_queue.scheduled.force_flush`
+- `kvflowcontrol.streams.eval.elastic.blocked_count`
+- `kvflowcontrol.streams.eval.elastic.total_count`
+- `kvflowcontrol.streams.eval.regular.blocked_count`
+- `kvflowcontrol.streams.eval.regular.total_count`
+- `kvflowcontrol.streams.send.elastic.blocked_count`
+- `kvflowcontrol.streams.send.elastic.total_count`
+- `kvflowcontrol.streams.send.regular.blocked_count`
+- `kvflowcontrol.streams.send.regular.total_count`
+- `kvflowcontrol.tokens.eval.elastic.available`
+- `kvflowcontrol.tokens.eval.elastic.deducted`
+- `kvflowcontrol.tokens.eval.elastic.returned`
+- `kvflowcontrol.tokens.eval.elastic.returned.disconnect`
+- `kvflowcontrol.tokens.eval.elastic.unaccounted`
+- `kvflowcontrol.tokens.eval.regular.available`
+- `kvflowcontrol.tokens.eval.regular.deducted`
+- `kvflowcontrol.tokens.eval.regular.returned`
+- `kvflowcontrol.tokens.eval.regular.returned.disconnect`
+- `kvflowcontrol.tokens.eval.regular.unaccounted`
+- `kvflowcontrol.tokens.send.elastic.available`
+- `kvflowcontrol.tokens.send.elastic.deducted`
+- `kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue`
+- `kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue`
+- `kvflowcontrol.tokens.send.elastic.returned`
+- `kvflowcontrol.tokens.send.elastic.returned.disconnect`
+- `kvflowcontrol.tokens.send.elastic.unaccounted`
+- `kvflowcontrol.tokens.send.regular.available`
+- `kvflowcontrol.tokens.send.regular.deducted`
+- `kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue`
+- `kvflowcontrol.tokens.send.regular.returned`
+- `kvflowcontrol.tokens.send.regular.returned.disconnect`
+- `kvflowcontrol.tokens.send.regular.unaccounted`
 - `leases.epoch`
 - `leases.error`
 - `leases.expiration`
+- `leases.leader`
 - `leases.liveness`
 - `leases.preferences.less-preferred`
 - `leases.preferences.violating`
@@ -1393,8 +1511,11 @@ SERVER: n/a
 - `raft.rcvd.bytes`
 - `raft.rcvd.cross_region.bytes`
 - `raft.rcvd.cross_zone.bytes`
+- `raft.rcvd.defortifyleader`
 - `raft.rcvd.dropped`
 - `raft.rcvd.dropped_bytes`
+- `raft.rcvd.fortifyleader`
+- `raft.rcvd.fortifyleaderresp`
 - `raft.rcvd.heartbeat`
 - `raft.rcvd.heartbeatresp`
 - `raft.rcvd.prevote`
@@ -1468,6 +1589,7 @@ SERVER: n/a
 - `rangekeybytes`
 - `rangekeycount`
 - `ranges`
+- `ranges.decommissioning`
 - `ranges.overreplicated`
 - `ranges.unavailable`
 - `ranges.underreplicated`
@@ -1580,9 +1702,6 @@ SERVER: n/a
 - `storage.batch-commit.wal-rotation.duration`
 - `storage.block-load.active`
 - `storage.block-load.queued`
-- `storage.category-pebble-manifest.bytes-written`
-- `storage.category-pebble-wal.bytes-written`
-- `storage.category-unspecified.bytes-written`
 - `storage.checkpoints`
 - `storage.compactions.duration`
 - `storage.compactions.keys.pinned.bytes`
@@ -1666,8 +1785,26 @@ SERVER: n/a
 - `storage.wal.failover.switch.count`
 - `storage.wal.failover.write_and_sync.latency`
 - `storage.wal.fsync.latency`
+- `storage.write-amplification`
 - `storage.write-stall-nanos`
 - `storage.write-stalls`
+- `storeliveness.heartbeat.failures`
+- `storeliveness.heartbeat.successes`
+- `storeliveness.message_handle.failures`
+- `storeliveness.message_handle.successes`
+- `storeliveness.support_for.stores`
+- `storeliveness.support_from.stores`
+- `storeliveness.support_withdraw.failures`
+- `storeliveness.support_withdraw.successes`
+- `storeliveness.transport.receive_dropped`
+- `storeliveness.transport.receive-queue-bytes`
+- `storeliveness.transport.receive-queue-size`
+- `storeliveness.transport.received`
+- `storeliveness.transport.send_dropped`
+- `storeliveness.transport.send-queue-bytes`
+- `storeliveness.transport.send-queue-idle`
+- `storeliveness.transport.send-queue-size`
+- `storeliveness.transport.sent`
 - `sysbytes`
 - `syscount`
 - `tenant.consumption.cross_region_network_ru`

--- a/src/current/v24.3/cluster-virtualization-setting-scopes.md
+++ b/src/current/v24.3/cluster-virtualization-setting-scopes.md
@@ -18,7 +18,7 @@ When [cluster virtualization]({% link {{ page.version.version }}/cluster-virtual
 - When a cluster setting is system-visible, it can be set only from the system virtual cluster but can be queried from any virtual cluster. For example, a virtual cluster can query a system-visible cluster setting's value, such as `storage.max_sync_duration`, to help adapt to the CockroachDB cluster's configuration.
 
 {% comment %}
-Src: cockroach gen metrics-list --format=csv against cockroach-v24.2.0-rc.1.darwin-10.9-amd64
+Src: cockroach gen metrics-list --format=csv against cockroach-v24.3.0-beta.1.darwin-10.9-amd64
 
 Also saved in https://docs.google.com/spreadsheets/d/1HIalzAhwU0CEYzSuG2m1aXSJRpiIyQPJdt8SusHpJ_U/edit?usp=sharing
 (shared CRL-internal). Sort by the Class column, then Settings column, and paste into the correct section below.
@@ -54,13 +54,41 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `changefeed.memory.per_changefeed_limit`
 - `changefeed.min_highwater_advance`
 - `changefeed.node_throttle_config`
-- `changefeed.protect_timestamp_interval`
 - `changefeed.protect_timestamp.max_age`
+- `changefeed.protect_timestamp_interval`
 - `changefeed.schema_feed.read_with_priority_after`
 - `changefeed.sink_io_workers`
 - `cloudstorage.azure.concurrent_upload_buffers`
+- `cloudstorage.azure.read.node_burst_limit`
+- `cloudstorage.azure.read.node_rate_limit`
+- `cloudstorage.azure.write.node_burst_limit`
+- `cloudstorage.azure.write.node_rate_limit`
+- `cloudstorage.gs.read.node_burst_limit`
+- `cloudstorage.gs.read.node_rate_limit`
+- `cloudstorage.gs.write.node_burst_limit`
+- `cloudstorage.gs.write.node_rate_limit`
 - `cloudstorage.http.custom_ca`
+- `cloudstorage.http.read.node_burst_limit`
+- `cloudstorage.http.read.node_rate_limit`
+- `cloudstorage.http.write.node_burst_limit`
+- `cloudstorage.http.write.node_rate_limit`
+- `cloudstorage.nodelocal.read.node_burst_limit`
+- `cloudstorage.nodelocal.read.node_rate_limit`
+- `cloudstorage.nodelocal.write.node_burst_limit`
+- `cloudstorage.nodelocal.write.node_rate_limit`
+- `cloudstorage.nullsink.read.node_burst_limit`
+- `cloudstorage.nullsink.read.node_rate_limit`
+- `cloudstorage.nullsink.write.node_burst_limit`
+- `cloudstorage.nullsink.write.node_rate_limit`
+- `cloudstorage.s3.read.node_burst_limit`
+- `cloudstorage.s3.read.node_rate_limit`
+- `cloudstorage.s3.write.node_burst_limit`
+- `cloudstorage.s3.write.node_rate_limit`
 - `cloudstorage.timeout`
+- `cloudstorage.userfile.read.node_burst_limit`
+- `cloudstorage.userfile.read.node_rate_limit`
+- `cloudstorage.userfile.write.node_burst_limit`
+- `cloudstorage.userfile.write.node_rate_limit`
 - `cluster.auto_upgrade.enabled`
 - `cluster.preserve_downgrade_option`
 - `debug.zip.redact_addresses.enabled`
@@ -88,10 +116,12 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `kv.transaction.max_refresh_spans_bytes`
 - `kv.transaction.randomized_anchor_key.enabled`
 - `kv.transaction.reject_over_max_intents_budget.enabled`
-- `kv.transaction.write_pipelining.enabled (alias: kv.transaction.write_pipelining_enabled)`
 - `kv.transaction.write_pipelining.locking_reads.enabled`
-- `kv.transaction.write_pipelining.max_batch_size (alias: kv.transaction.write_pipelining_max_batch_size)`
 - `kv.transaction.write_pipelining.ranged_writes.enabled`
+- `kv.transaction.write_pipelining.enabled (alias: kv.transaction.write_pipelining_enabled)`
+- `kv.transaction.write_pipelining.max_batch_size (alias: kv.transaction.write_pipelining_max_batch_size)`
+- `obs.tablemetadata.automatic_updates.enabled`
+- `obs.tablemetadata.data_valid_duration`
 - `schedules.backup.gc_protection.enabled`
 - `security.ocsp.mode`
 - `security.ocsp.timeout`
@@ -109,6 +139,17 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `server.hsts.enabled`
 - `server.http.base_path`
 - `server.identity_map.configuration`
+- `server.jwt_authentication.audience`
+- `server.jwt_authentication.claim`
+- `server.jwt_authentication.client.timeout`
+- `server.jwt_authentication.enabled`
+- `server.jwt_authentication.issuers.configuration (alias: server.jwt_authentication.issuers)`
+- `server.jwt_authentication.issuers.custom_ca`
+- `server.jwt_authentication.jwks`
+- `server.jwt_authentication.jwks_auto_fetch.enabled`
+- `server.ldap_authentication.client.tls_certificate`
+- `server.ldap_authentication.client.tls_key`
+- `server.ldap_authentication.domain.custom_ca`
 - `server.log_gc.max_deletions_per_cycle`
 - `server.log_gc.period`
 - `server.max_connections_per_gateway`
@@ -116,9 +157,9 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `server.oidc_authentication.autologin.enabled (alias: server.oidc_authentication.autologin)`
 - `server.oidc_authentication.button_text`
 - `server.oidc_authentication.claim_json_key`
+- `server.oidc_authentication.client.timeout`
 - `server.oidc_authentication.client_id`
 - `server.oidc_authentication.client_secret`
-- `server.oidc_authentication.client.timeout`
 - `server.oidc_authentication.enabled`
 - `server.oidc_authentication.principal_regex`
 - `server.oidc_authentication.provider_url`
@@ -127,7 +168,6 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `server.redact_sensitive_settings.enabled`
 - `server.shutdown.connections.timeout (alias: server.shutdown.connection_wait)`
 - `server.shutdown.initial_wait (alias: server.shutdown.drain_wait)`
-- `server.shutdown.jobs.timeout (alias: server.shutdown.jobs_wait)`
 - `server.shutdown.transactions.timeout (alias: server.shutdown.query_wait)`
 - `server.sql_tcp_keep_alive.count`
 - `server.sql_tcp_keep_alive.interval`
@@ -210,7 +250,6 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `sql.insights.execution_insights_capacity`
 - `sql.insights.high_retry_count.threshold`
 - `sql.insights.latency_threshold`
-- `sql.log.all_statements.enabled (alias: sql.trace.log_statement_execute)`
 - `sql.log.slow_query.experimental_full_table_scans.enabled`
 - `sql.log.slow_query.internal_queries.enabled`
 - `sql.log.slow_query.latency_threshold`
@@ -239,6 +278,9 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `sql.stats.automatic_collection.enabled`
 - `sql.stats.automatic_collection.fraction_stale_rows`
 - `sql.stats.automatic_collection.min_stale_rows`
+- `sql.stats.automatic_partial_collection.enabled`
+- `sql.stats.automatic_partial_collection.fraction_stale_rows`
+- `sql.stats.automatic_partial_collection.min_stale_rows`
 - `sql.stats.cleanup.recurrence`
 - `sql.stats.flush.enabled`
 - `sql.stats.flush.interval`
@@ -247,6 +289,8 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `sql.stats.forecasts.min_goodness_of_fit`
 - `sql.stats.forecasts.min_observations`
 - `sql.stats.histogram_buckets.count`
+- `sql.stats.histogram_buckets.include_most_common_values.enabled`
+- `sql.stats.histogram_buckets.max_fraction_most_common_values`
 - `sql.stats.histogram_collection.enabled`
 - `sql.stats.histogram_samples.count`
 - `sql.stats.multi_column_collection.enabled`
@@ -255,8 +299,8 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `sql.stats.post_events.enabled`
 - `sql.stats.response.max`
 - `sql.stats.response.show_internal.enabled`
-- `sql.stats.system_tables_autostats.enabled`
 - `sql.stats.system_tables.enabled`
+- `sql.stats.system_tables_autostats.enabled`
 - `sql.stats.virtual_computed_columns.enabled`
 - `sql.telemetry.query_sampling.enabled`
 - `sql.telemetry.query_sampling.internal.enabled`
@@ -266,6 +310,7 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `sql.telemetry.transaction_sampling.statement_events_per_transaction.max`
 - `sql.temp_object_cleaner.cleanup_interval`
 - `sql.temp_object_cleaner.wait_interval`
+- `sql.log.all_statements.enabled (alias: sql.trace.log_statement_execute)`
 - `sql.trace.stmt.enable_threshold`
 - `sql.trace.txn.enable_threshold`
 - `sql.ttl.changefeed_replication.disabled`
@@ -274,8 +319,10 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `sql.ttl.default_select_batch_size`
 - `sql.ttl.default_select_rate_limit`
 - `sql.ttl.job.enabled`
-- `sql.txn_fingerprint_id_cache.capacity`
 - `sql.txn.read_committed_isolation.enabled`
+- `sql.txn.repeatable_read_isolation.enabled (alias: sql.txn.snapshot_isolation.enabled)`
+- `sql.txn_fingerprint_id_cache.capacity`
+- `storage.ingestion.value_blocks.enabled`
 - `storage.max_sync_duration.fatal.enabled`
 - `trace.debug_http_endpoint.enabled (alias: trace.debug.enable)`
 - `trace.opentelemetry.collector`
@@ -291,11 +338,12 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 
 - `admission.disk_bandwidth_tokens.elastic.enabled`
 - `admission.kv.enabled`
+- `physical_replication.consumer.minimum_flush_interval (alias: bulkio.stream_ingestion.minimum_flush_interval)`
 - `kv.allocator.lease_rebalance_threshold`
 - `kv.allocator.load_based_lease_rebalancing.enabled`
 - `kv.allocator.load_based_rebalancing`
-- `kv.allocator.load_based_rebalancing_interval`
 - `kv.allocator.load_based_rebalancing.objective`
+- `kv.allocator.load_based_rebalancing_interval`
 - `kv.allocator.qps_rebalance_threshold`
 - `kv.allocator.range_rebalance_threshold`
 - `kv.allocator.store_cpu_rebalance_threshold`
@@ -304,6 +352,8 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `kv.lease_transfer_read_summary.global_budget`
 - `kv.lease_transfer_read_summary.local_budget`
 - `kv.log_range_and_node_events.enabled`
+- `kv.raft.leader_fortification.fraction_enabled`
+- `kv.range.range_size_hard_cap`
 - `kv.range_split.by_load.enabled (alias: kv.range_split.by_load_enabled)`
 - `kv.range_split.load_cpu_threshold`
 - `kv.range_split.load_qps_threshold`
@@ -313,13 +363,13 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `kv.snapshot_rebalance.max_rate`
 - `kv.snapshot_receiver.excise.enabled`
 - `kvadmission.store.provisioned_bandwidth`
-- `physical_replication.consumer.minimum_flush_interval (alias: bulkio.stream_ingestion.minimum_flush_interval)`
+- `kvadmission.store.snapshot_ingest_bandwidth_control.enabled`
 - `server.consistency_check.max_rate`
 - `server.rangelog.ttl`
 - `server.shutdown.lease_transfer_iteration.timeout (alias: server.shutdown.lease_transfer_wait)`
 - `spanconfig.bounds.enabled`
-- `spanconfig.range_coalescing.application.enabled (alias: spanconfig.tenant_coalesce_adjacent.enabled)`
 - `spanconfig.range_coalescing.system.enabled (alias: spanconfig.storage_coalesce_adjacent.enabled)`
+- `spanconfig.range_coalescing.application.enabled (alias: spanconfig.tenant_coalesce_adjacent.enabled)`
 - `storage.experimental.eventually_file_only_snapshots.enabled`
 - `storage.ingest_split.enabled`
 - `storage.wal_failover.unhealthy_op_threshold`
@@ -343,6 +393,8 @@ system-visible: Can be set / modified only from the system virtual cluster, but 
 - `kv.rangefeed.enabled`
 - `security.client_cert.subject_required.enabled`
 - `sql.schema.telemetry.recurrence`
+- `storage.columnar_blocks.enabled`
+- `storage.delete_compaction_excise.enabled`
 - `storage.max_sync_duration`
 - `storage.sstable.compression_algorithm`
 - `storage.sstable.compression_algorithm_backup_storage`


### PR DESCRIPTION
[DOC-11556] CV setting and metric scopes for v24.3

Previews:
[src/current/v24.3/cluster-virtualization-metric-scopes.md](https://deploy-preview-19051--cockroachdb-docs.netlify.app/docs/v24.3/cluster-virtualization-metric-scopes.html)
[src/current/v24.3/cluster-virtualization-setting-scopes.md](https://deploy-preview-19051--cockroachdb-docs.netlify.app/docs/v24.3/cluster-virtualization-setting-scopes.html)

[Instructions for generating these](https://docs.google.com/spreadsheets/d/1HIalzAhwU0CEYzSuG2m1aXSJRpiIyQPJdt8SusHpJ_U/edit?gid=1642767093#gid=1642767093)