### PR TITLE
Backport changes from cockroachdb/docs#19008

### DIFF
--- a/src/current/v23.1/diagnostics-reporting.md
+++ b/src/current/v23.1/diagnostics-reporting.md
@@ -28,6 +28,10 @@ In all cases, names and other string values are scrubbed and replaced with under
 
 ## Opt out of diagnostics reporting
 
+{{site.data.alerts.callout_info}}
+Diagnostics reporting is required for [**Enterprise Trial** or **Enterprise Free** licenses]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses). Therefore, the cluster setting `diagnostics.reporting.enabled` is ignored on clusters with these licenses. The following opt-out methods apply only to clusters with an [**Enterprise** license]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses).
+{{site.data.alerts.end}}
+
 ### At cluster initialization
 
 To make sure that absolutely no diagnostic details are shared, you can set the environment variable `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true` before starting the first node of the cluster. Note that this works only when set before starting the first node of the cluster. Once the cluster is running, you need to use the `SET CLUSTER SETTING` method described below.

--- a/src/current/v23.2/diagnostics-reporting.md
+++ b/src/current/v23.2/diagnostics-reporting.md
@@ -28,6 +28,10 @@ In all cases, names and other string values are scrubbed and replaced with under
 
 ## Opt out of diagnostics reporting
 
+{{site.data.alerts.callout_info}}
+Diagnostics reporting is required for [**Enterprise Trial** or **Enterprise Free** licenses]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses). Therefore, the cluster setting `diagnostics.reporting.enabled` is ignored on clusters with these licenses. The following opt-out methods apply only to clusters with an [**Enterprise** license]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses).
+{{site.data.alerts.end}}
+
 ### At cluster initialization
 
 To make sure that absolutely no diagnostic details are shared, you can set the environment variable `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true` before starting the first node of the cluster. Note that this works only when set before starting the first node of the cluster. Once the cluster is running, you need to use the `SET CLUSTER SETTING` method described below.

--- a/src/current/v24.1/diagnostics-reporting.md
+++ b/src/current/v24.1/diagnostics-reporting.md
@@ -28,6 +28,10 @@ In all cases, names and other string values are scrubbed and replaced with under
 
 ## Opt out of diagnostics reporting
 
+{{site.data.alerts.callout_info}}
+Diagnostics reporting is required for [**Enterprise Trial** or **Enterprise Free** licenses]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses). Therefore, the cluster setting `diagnostics.reporting.enabled` is ignored on clusters with these licenses. The following opt-out methods apply only to clusters with an [**Enterprise** license]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses).
+{{site.data.alerts.end}}
+
 ### At cluster initialization
 
 To make sure that absolutely no diagnostic details are shared, you can set the environment variable `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true` before starting the first node of the cluster. Note that this works only when set before starting the first node of the cluster. Once the cluster is running, you need to use the `SET CLUSTER SETTING` method described below.

--- a/src/current/v24.2/diagnostics-reporting.md
+++ b/src/current/v24.2/diagnostics-reporting.md
@@ -28,6 +28,10 @@ In all cases, names and other string values are scrubbed and replaced with under
 
 ## Opt out of diagnostics reporting
 
+{{site.data.alerts.callout_info}}
+Diagnostics reporting is required for [**Enterprise Trial** or **Enterprise Free** licenses]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses). Therefore, the cluster setting `diagnostics.reporting.enabled` is ignored on clusters with these licenses. The following opt-out methods apply only to clusters with an [**Enterprise** license]({% link {{ page.version.version }}/licensing-faqs.md %}#types-of-licenses).
+{{site.data.alerts.end}}
+
 ### At cluster initialization
 
 To make sure that absolutely no diagnostic details are shared, you can set the environment variable `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true` before starting the first node of the cluster. Note that this works only when set before starting the first node of the cluster. Once the cluster is running, you need to use the `SET CLUSTER SETTING` method described below.


### PR DESCRIPTION
Addresses DOC-11674

Summary of changes:

- Backport changes from cockroachdb/docs#19008 to v23.1, v23.2, v24.1, and v24.2