### PR TITLE
Add docs for read on standby in PCR

### DIFF
--- a/src/current/_includes/v24.3/physical-replication/failover-read-virtual-cluster.md
+++ b/src/current/_includes/v24.3/physical-replication/failover-read-virtual-cluster.md
@@ -1,0 +1,1 @@
+If you started the PCR stream with the `READ VIRTUAL CLUSTER` option, failing over with `SYSTEM TIME` will destroy the `readonly` virtual cluster. If you fail over with `LATEST`, the `readonly` virtual cluster will remain on the original standby cluster, but will **not** update with new writes.

--- a/src/current/_includes/v24.3/physical-replication/fast-failback-syntax.md
+++ b/src/current/_includes/v24.3/physical-replication/fast-failback-syntax.md
@@ -1,4 +1,4 @@
-To fail back to a cluster that was previously the primary cluster, use the [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) syntax:
+To {% if page.name == "alter-virtual-cluster.md" %} [fail back]({% link {{ page.version.version }}/failover-replication.md %}#fail-back-to-the-primary-cluster) {% else %} fail back {% endif %} to a cluster that was previously the primary cluster, use the {% if page.name == "alter-virtual-cluster.md" %} `ALTER VIRTUAL CLUSTER` {% else %} [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) {% endif %} syntax:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/_includes/v24.3/physical-replication/show-virtual-cluster-data-state.md
+++ b/src/current/_includes/v24.3/physical-replication/show-virtual-cluster-data-state.md
@@ -1,7 +1,8 @@
 State      | Description
 -----------+----------------
+`add` | The [`readonly` virtual cluster]({% link {{ page.version.version }}/create-virtual-cluster.md %}#start-a-pcr-stream-with-read-from-standby) is waiting for the PCR job's initial scan to complete then `readonly` will be available for read queries.
 `initializing replication` | The replication job is completing the initial scan of data from the primary cluster before it starts replicating data in real time.
-`ready` | A virtual cluster's data is ready for use.
+`ready` | A virtual cluster's data is ready for use. The `readonly` virtual cluster is ready to serve read queries.
 `replicating` | The replication job has started and is replicating data.
 `replication paused` | The replication job is paused due to an error or a manual request with [`ALTER VIRTUAL CLUSTER ... PAUSE REPLICATION`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}).
 `replication pending failover` | The replication job is running and the failover time has been set. Once the the replication reaches the failover time, the failover will begin automatically.

--- a/src/current/v24.3/alter-virtual-cluster.md
+++ b/src/current/v24.3/alter-virtual-cluster.md
@@ -81,7 +81,7 @@ You can use either:
 - `LATEST` to specify the most recent replicated timestamp.
 
 {{site.data.alerts.callout_info}}
-If you started the PCR stream with the `READ VIRTUAL CLUSTER` option, failing over with `SYSTEM TIME` will destroy the `readonly` virtual cluster. If you fail over with `LATEST`, the `readonly` virtual cluster will remain on the original standby cluster.
+If you started the PCR stream with the `READ VIRTUAL CLUSTER` option, failing over with `SYSTEM TIME` will destroy the `readonly` virtual cluster. If you fail over with `LATEST`, the `readonly` virtual cluster will remain on the original standby cluster, but will **not** update with new writes.
 {{site.data.alerts.end}}
 
 ### Start the failback process

--- a/src/current/v24.3/alter-virtual-cluster.md
+++ b/src/current/v24.3/alter-virtual-cluster.md
@@ -81,7 +81,7 @@ You can use either:
 - `LATEST` to specify the most recent replicated timestamp.
 
 {{site.data.alerts.callout_info}}
-If you started the PCR stream with the `READ VIRTUAL CLUSTER` option, failing over with `SYSTEM TIME` will destroy the `readonly` virtual cluster. If you fail over with `LATEST`, the `readonly` virtual cluster will remain on the original standby cluster, but will **not** update with new writes.
+{% include {{ page.version.version }}/physical-replication/failover-read-virtual-cluster.md %}
 {{site.data.alerts.end}}
 
 ### Start the failback process

--- a/src/current/v24.3/alter-virtual-cluster.md
+++ b/src/current/v24.3/alter-virtual-cluster.md
@@ -44,8 +44,8 @@ Parameter | Description
 `RESUME REPLICATION` | Resume the replication stream.
 `COMPLETE REPLICATION TO` | Set the time to complete the replication. Use: <br><ul><li>`SYSTEM TIME` to specify a [timestamp]({% link {{ page.version.version }}/as-of-system-time.md %}). Refer to [Fail over to a point in time]({% link {{ page.version.version }}/failover-replication.md %}#fail-over-to-a-point-in-time) for an example.</li><li>`LATEST` to specify the most recent replicated timestamp. Refer to [Fail over to a point in time]({% link {{ page.version.version }}/failover-replication.md %}#fail-over-to-the-most-recent-replicated-time) for an example.</li></ul>
 `SET REPLICATION RETENTION = duration` | Change the [duration]({% link {{ page.version.version }}/interval.md %}) of the retention window that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
-`SET REPLICATION EXPIRATION WINDOW = duration` | Override the default producer job's expiration window of 24 hours. The producer job expiration window determines how long the producer job will continue to run without a heartbeat from the consumer job. Refer to the [Technical Overview]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}) for more details.
-`START REPLICATION OF virtual_cluster_spec ON physical_cluster` | Reset a virtual cluster to the time when the virtual cluster on the promoted standby diverged from it. To reuse as much of the existing data on the original primary cluster as possible, you can run this statement as part of the [failback]({% link {{ page.version.version }}/failover-replication.md %}#fail-back-to-the-primary-cluster) process. This command fails if the virtual cluster was not originally replicated from the original primary cluster.
+`SET REPLICATION EXPIRATION WINDOW = duration` | Override the default producer job's expiration window of 24 hours. The producer job expiration window determines how long the producer job will continue to run without a heartbeat from the consumer job. For more details, refer to the [Technical Overview]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}).
+`START REPLICATION OF virtual_cluster_spec ON physical_cluster` | Reset a virtual cluster to the time when the virtual cluster on the promoted standby diverged from it. To reuse as much of the existing data on the original primary cluster as possible, you can run this statement as part of the [failback]({% link {{ page.version.version }}/failover-replication.md %}#fail-back-to-the-primary-cluster) process. This command fails if the virtual cluster was not originally replicated from the original primary cluster. Refer to [Options](#options) for details on how you can configure a PCR stream initiated as a failback.
 `START SERVICE SHARED` | Start a virtual cluster so it is ready to accept SQL connections after failover.
 `RENAME TO virtual_cluster_spec` | Rename a virtual cluster.
 `STOP SERVICE` | Stop the `shared` service for a virtual cluster. The virtual cluster's `data_state` will still be `ready` so that the service can be restarted.
@@ -53,6 +53,16 @@ Parameter | Description
 `REVOKE ALL CAPABILITIES` | Revoke all [capabilities]({% link {{ page.version.version }}/create-virtual-cluster.md %}#capabilities) from a virtual cluster.
 `GRANT CAPABILITY virtual_cluster_capability_list` | Specify a [capability]({% link {{ page.version.version }}/create-virtual-cluster.md %}#capabilities) to grant to a virtual cluster.
 `REVOKE CAPABILITY virtual_cluster_capability_list` | Revoke a [capability]({% link {{ page.version.version }}/create-virtual-cluster.md %}#capabilities) from a virtual cluster.
+
+## Options
+
+You can use the following options with `ALTER VIRTUAL CLUSTER {vc} START REPLICATION OF virtual_cluster_spec ON physical_cluster` to initiate the [failback process]({% link {{ page.version.version }}/failover-replication.md %}#fail-back-to-the-primary-cluster).
+
+Option | Value | Description
+-------+-------+------------
+`EXPIRATION WINDOW` | Duration | Override the default producer job's expiration window of 24 hours. The producer job expiration window determines how long the producer job will continue to run without a heartbeat from the consumer job. For more details, refer to the [Technical Overview]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}).
+<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | N/A | Configure the PCR stream to allow reads from the standby cluster. **Note:** This only allows for reads on the standby's virtual cluster. You cannot perform writes or schema changes to user tables while connected to the standby virtual cluster. For more details, refer to [Start the failback process](#start-the-failback-process).
+`RETENTION` | Duration | Change the [duration]({% link {{ page.version.version }}/interval.md %}) of the retention window that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ## Examples
 
@@ -70,9 +80,15 @@ You can use either:
 - `SYSTEM TIME` to specify a [timestamp]({% link {{ page.version.version }}/as-of-system-time.md %}).
 - `LATEST` to specify the most recent replicated timestamp.
 
+{{site.data.alerts.callout_info}}
+If you started the PCR stream with the `READ VIRTUAL CLUSTER` option, failing over with `SYSTEM TIME` will destroy the `readonly` virtual cluster. If you fail over with `LATEST`, the `readonly` virtual cluster will remain on the original standby cluster.
+{{site.data.alerts.end}}
+
 ### Start the failback process
 
 {% include {{ page.version.version }}/physical-replication/fast-failback-syntax.md %}
+
+{% include_cached new-in.html version="v24.3" %} Use the `READ VIRTUAL CLUSTER` option with the `ALTER VIRTUAL CLUSTER` failback syntax to start a PCR stream that also creates a read-only virtual cluster on the standby cluster.
 
 ### Set a retention window
 

--- a/src/current/v24.3/create-virtual-cluster.md
+++ b/src/current/v24.3/create-virtual-cluster.md
@@ -49,7 +49,7 @@ Parameter | Description
 
 Option | Description
 -------+-------------
-<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | Create a [read-only virtual cluster]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#start-up-sequence-with-read-on-stnadby) on the standby cluster, which allows reads of the standby's replicating virtual cluster. For an example, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
+<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | Create a [read-only virtual cluster]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#start-up-sequence-with-read-on-standby) on the standby cluster, which allows reads of the standby's replicating virtual cluster. For an example, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
 `RETENTION` | Configure a [retention window]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#failover-and-promotion-process) that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ## Connection string

--- a/src/current/v24.3/create-virtual-cluster.md
+++ b/src/current/v24.3/create-virtual-cluster.md
@@ -43,18 +43,18 @@ Parameter | Description
 `LIKE virtual_cluster_spec` | Creates a virtual cluster with the same [capabilities](#capabilities) and settings as another virtual cluster.
 `primary_virtual_cluster` | The name of the primary's virtual cluster to replicate.
 `primary_connection_string` | The PostgreSQL connection string to the primary cluster. Refer to [Connection string](#connection-string) for more detail.
-`replication_options_list`| Options to modify the replication streams. Refer to [Options](#options).
+`replication_options_list`| Options to modify the PCR streams. Refer to [Options](#options).
 
 ## Options
 
 Option | Description
 -------+-------------
-<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | Configure the PCR stream to allow reads from the standby cluster. For more details, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
+<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | Create a [read-only virtual cluster]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#start-up-sequence-with-read-on-stnadby) on the standby cluster, which allows reads of the standby's replicating virtual cluster. For an example, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
 `RETENTION` | Configure a [retention window]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#failover-and-promotion-process) that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ## Connection string
 
-When you [initiate a replication stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#step-4-start-replication) from the standby cluster, it is necessary to pass a connection string to the system virtual cluster on the primary cluster:
+When you [initiate a PCR stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#step-4-start-replication) from the standby cluster, it is necessary to pass a connection string to the system virtual cluster on the primary cluster:
 
 {% include_cached copy-clipboard.html %}
 ~~~
@@ -78,31 +78,31 @@ Value | Description
 Cockroach Labs does not recommend changing the default capabilities of created virtual clusters.
 {{site.data.alerts.end}}
 
-_Capabilities_ control what a virtual cluster can do. When you start a replication stream, you can specify a virtual cluster with `LIKE` to ensure other virtual clusters on the standby cluster will work in the same way. `LIKE` will refer to a virtual cluster on the CockroachDB cluster you're running the statement from.
+_Capabilities_ control what a virtual cluster can do. When you start a PCR stream, you can specify a virtual cluster with `LIKE` to ensure other virtual clusters on the standby cluster will work in the same way. `LIKE` will refer to a virtual cluster on the CockroachDB cluster you're running the statement from.
 
 ## Examples
 
 ### Start a PCR stream
 
-To start a replication stream to the standby of the primary's virtual cluster:
+To start a PCR stream to the standby of the primary's virtual cluster:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'postgresql://{connection string to primary}';
 ~~~
 
-This will create a `main` virtual cluster in the standby cluster. The standby's system virtual cluster will connect to the primary cluster to initiate the replication stream job. For detail on the replication stream, refer to the [Responses]({% link {{ page.version.version }}/show-virtual-cluster.md %}#responses) for `SHOW VIRTUAL CLUSTER`.
+This will create a `main` virtual cluster in the standby cluster. The standby's system virtual cluster will connect to the primary cluster to initiate the PCR job. For details on the PCR stream, refer to the [Responses]({% link {{ page.version.version }}/show-virtual-cluster.md %}#responses) for `SHOW VIRTUAL CLUSTER`.
 
 ### Specify a retention window for a PCR stream
 
-When you initiate a replication stream, you can specify a retention window to protect data from [garbage collection]({% link {{ page.version.version }}/architecture/storage-layer.md %}#garbage-collection). The retention window controls how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to:
+When you initiate a PCR stream, you can specify a retention window to protect data from [garbage collection]({% link {{ page.version.version }}/architecture/storage-layer.md %}#garbage-collection). The retention window controls how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'postgresql://{connection string to primary}' WITH RETENTION '36h';
 ~~~
 
-This will initiate a replication stream from the primary cluster into the standby cluster's new `main` virtual cluster. The `RETENTION` option allows you to specify a timestamp in the past for failover to the standby cluster. After failover, the standby `main` virtual cluster will be transactionally consistent to any timestamp within that retention window.
+This will initiate a PCR stream from the primary cluster into the standby cluster's new `main` virtual cluster. The `RETENTION` option allows you to specify a timestamp in the past for failover to the standby cluster. After failover, the standby `main` virtual cluster will be transactionally consistent to any timestamp within that retention window.
 
 {% include {{ page.version.version }}/physical-replication/retention.md %}
 

--- a/src/current/v24.3/create-virtual-cluster.md
+++ b/src/current/v24.3/create-virtual-cluster.md
@@ -147,7 +147,7 @@ cockroach sql --url `"postgresql://root@{node IP or hostname}:{26257}?options=-c
 You can only read data on the created `readonly` virtual cluster, other operations like `SHOW VIRTUAL CLUSTERS` must be run from the `system` virtual cluster. To connect to the `readonly` virtual cluster, refer to the [Connection Reference]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#connection-reference).
 {{site.data.alerts.end}}
 
-After a [failover]({% link {{ page.version.version }}/failover-replication.md %}) to the standby cluster, the `readonly` virtual cluster will remain on the promoted standby. Use [`DROP VIRTUAL CLUSTER`]({% link {{ page.version.version }}/drop-virtual-cluster.md %}) to remove the `readonly` virtual cluster.
+{% include {{ page.version.version }}/physical-replication/failover-read-virtual-cluster.md %} Use [`DROP VIRTUAL CLUSTER`]({% link {{ page.version.version }}/drop-virtual-cluster.md %}) to remove the `readonly` virtual cluster.
 
 For details on adding a read-only virtual cluster after a failback, refer to the [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) page.
 

--- a/src/current/v24.3/create-virtual-cluster.md
+++ b/src/current/v24.3/create-virtual-cluster.md
@@ -49,7 +49,7 @@ Parameter | Description
 
 Option | Description
 -------+-------------
-`READ VIRTUAL CLUSTER` | 
+<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | Configure the PCR stream to allow reads from the standby cluster. For more details, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
 `RETENTION` | Configure a [retention window]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#failover-and-promotion-process) that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ## Connection string
@@ -82,7 +82,7 @@ _Capabilities_ control what a virtual cluster can do. When you start a replicati
 
 ## Examples
 
-### Start a replication stream
+### Start a PCR stream
 
 To start a replication stream to the standby of the primary's virtual cluster:
 
@@ -93,7 +93,7 @@ CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'postgresql://{connectio
 
 This will create a `main` virtual cluster in the standby cluster. The standby's system virtual cluster will connect to the primary cluster to initiate the replication stream job. For detail on the replication stream, refer to the [Responses]({% link {{ page.version.version }}/show-virtual-cluster.md %}#responses) for `SHOW VIRTUAL CLUSTER`.
 
-### Specify a retention window for a replication stream
+### Specify a retention window for a PCR stream
 
 When you initiate a replication stream, you can specify a retention window to protect data from [garbage collection]({% link {{ page.version.version }}/architecture/storage-layer.md %}#garbage-collection). The retention window controls how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to:
 
@@ -105,6 +105,51 @@ CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'postgresql://{connectio
 This will initiate a replication stream from the primary cluster into the standby cluster's new `main` virtual cluster. The `RETENTION` option allows you to specify a timestamp in the past for failover to the standby cluster. After failover, the standby `main` virtual cluster will be transactionally consistent to any timestamp within that retention window.
 
 {% include {{ page.version.version }}/physical-replication/retention.md %}
+
+### Start a PCR stream with read from standby
+
+{% include_cached new-in.html version="v24.3" %} Use the `READ VIRTUAL CLUSTER` option to set up a PCR stream that also creates a read-only virtual cluster on the standby cluster. You can create a PCR job as per the [Set Up Physical Cluster Replication]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}) guide and then add the option to the `CREATE VIRTUAL CLUSTER` statement:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'postgresql://{connection string to primary}' WITH READ VIRTUAL CLUSTER;
+~~~
+
+View the newly created virtual clusters:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW VIRTUAL CLUSTERS;
+~~~
+
+You'll find: 
+
+- The `main` virtual cluster, which is accepting writes from the primary cluster. 
+- The `main-readonly` virtual cluster, which is a read-only version of the `main` virtual cluster.
+
+~~~
+  id |     name      | data_state  | service_mode
+-----+---------------+-------------+---------------
+   1 | system        | ready       | shared
+   3 | main          | replicating | none
+   4 | main-readonly | ready       | shared
+(3 rows)
+~~~
+
+To read table data from the standby cluster, connect to the `readonly` virtual cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+cockroach sql --url `"postgresql://root@{node IP or hostname}:{26257}?options=-ccluster=main-readonly&sslmode=verify-full"` --certs-dir=certs
+~~~
+
+{{site.data.alerts.callout_info}}
+You can only read data on the created `readonly` virtual cluster, other operations like `SHOW VIRTUAL CLUSTERS` must be run from the `system` virtual cluster. To connect to the `readonly` virtual cluster, refer to the [Connection Reference]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#connection-reference).
+{{site.data.alerts.end}}
+
+After a [failover]({% link {{ page.version.version }}/failover-replication.md %}) to the standby cluster, the `readonly` virtual cluster will remain on the promoted standby. Use [`DROP VIRTUAL CLUSTER`]({% link {{ page.version.version }}/drop-virtual-cluster.md %}) to remove the `readonly` virtual cluster.
+
+For details on adding a read-only virtual cluster after a failback, refer to the [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) page.
 
 ## See also
 

--- a/src/current/v24.3/failover-replication.md
+++ b/src/current/v24.3/failover-replication.md
@@ -259,6 +259,10 @@ This section illustrates the steps to fail back to the original primary cluster 
 
     This will reset the virtual cluster on **Cluster A** back to the time at which the same virtual cluster on **Cluster B** diverged from it. **Cluster A** will check with **Cluster B** to confirm that its virtual cluster was replicated from **Cluster A** as part of the original [PCR stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}).
 
+    {{site.data.alerts.callout_info}}
+    If you want to start the PCR stream with a read-only virtual cluster on the standby after failing back to the original primary cluster, run the [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) statement in this step with the `READ VIRTUAL CLUSTER` option.
+    {{site.data.alerts.end}}
+
 1. Check the status of the virtual cluster on **A**:
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/v24.3/set-up-physical-cluster-replication.md
+++ b/src/current/v24.3/set-up-physical-cluster-replication.md
@@ -323,6 +323,10 @@ The system virtual cluster in the standby cluster initiates and controls the rep
 
     Once the standby cluster has made a connection to the primary cluster, the standby will pull the topology of the primary cluster and will distribute the replication work across all nodes in the primary and standby.
 
+    {{site.data.alerts.callout_success}}
+    You can also start a PCR stream that includes a read-only standby virtual cluster that allows you to read data on the standby cluster. For more details, refer to the [`CREATE VIRTUAL CLUSTER`]({% link {{ page.version.version }}/create-virtual-cluster.md %}#start-a-pcr-stream-with-read-from-standby) page.
+    {{site.data.alerts.end}}
+
 1. To view all virtual clusters on the standby, run:
 
     {% include_cached copy-clipboard.html %}
@@ -468,12 +472,15 @@ For additional detail on the standard CockroachDB connection parameters, refer t
 You can use an [external connection]({% link {{ page.version.version }}/create-external-connection.md %}) to define a name for connections using the `postgresql://` scheme.
 {{site.data.alerts.end}}
 
+The table uses `main` as an example name for the virtual cluster that contains user table data in the primary and standby clusters.
+
 Cluster | Virtual Cluster | Usage | URL and Parameters
 --------+-----------------+-------+-------------------
 Primary | System | Set up a replication user and view running virtual clusters. Connect with [`cockroach sql`]({% link {{ page.version.version }}/cockroach-sql.md %}). | `"postgresql://root@{node IP or hostname}:{26257}?options=-ccluster=system&sslmode=verify-full"`<br><br><ul><li>`options=-ccluster=system`</li><li>`sslmode=verify-full`</li></ul>Use the `--certs-dir` flag to specify the path to your certificate.
 Primary | Main | Add and run a workload with [`cockroach workload`]({% link {{ page.version.version }}/cockroach-workload.md %}). | `"postgresql://root@{node IP or hostname}:{26257}?options=-ccluster=main&sslmode=verify-full&sslrootcert=certs/ca.crt&sslcert=certs/client.root.crt&sslkey=certs/client.root.key"`<br><br>{% include {{ page.version.version }}/connect/cockroach-workload-parameters.md %} As a result, for the example in this tutorial, you will need:<br><br><ul><li>`options=-ccluster={virtual_cluster_name}`</li><li>`sslmode=verify-full`</li><li>`sslrootcert={path}/certs/ca.crt`</li><li>`sslcert={path}/certs/client.root.crt`</li><li>`sslkey={path}/certs/client.root.key`</li></ul>
 Standby | System | Manage the replication stream. Connect with [`cockroach sql`]({% link {{ page.version.version }}/cockroach-sql.md %}). | `"postgresql://root@{node IP or hostname}:{26257}?options=-ccluster=system&sslmode=verify-full"`<br><br><ul><li>`options=-ccluster=system`</li><li>`sslmode=verify-full`</li></ul>Use the `--certs-dir` flag to specify the path to your certificate.
 Standby/Primary | System | Connect to the other cluster. | `"postgresql://{replication user}:{password}@{node IP or hostname}:{26257}/defaultdb?options=-ccluster%3Dsystem&sslinline=true&sslmode=verify-full&sslrootcert=-----BEGIN+CERTIFICATE-----{encoded_cert}-----END+CERTIFICATE-----%0A"`<br><br>Generate the connection string with [`cockroach encode-uri`](#step-3-manage-the-cluster-certificates). Use the generated connection string in:<br><br><ul><li>`CREATE VIRTUAL CLUSTER` statements to [start the replication stream](#step-4-start-replication).</li><li>`ALTER VIRTUAL CLUSTER` statements to [fail back to the primary cluster]({% link {{ page.version.version }}/failover-replication.md %}#fail-back-to-the-primary-cluster).</li></ul>
+Standby | Read only | Run read queries on the standby's replicating virtual cluster | `"postgresql://root@{node IP or hostname}:{26257}?options=-ccluster=main-readonly&sslmode=verify-full"`<br><br><ul><li>`options=-ccluster=main-readonly`</li><li>`sslmode=verify-full`</li></ul>Use the `--certs-dir` flag to specify the path to your certificate.
 
 ## What's next
 


### PR DESCRIPTION
Fixes DOC-8047

This PR adds the `READ VIRTUAL CLUSTER` option to the `CREATE VIRTUAL CLUSTER` statement. This allows for reads on the standby virtual cluster during a PCR stream. Updates `ALTER VIRTUAL CLUSTER` too, with the same option for the failback process.