### PR TITLE
Add paragraph on checksum verification in restore jobs for compliance

### DIFF
--- a/src/current/v23.1/restore.md
+++ b/src/current/v23.1/restore.md
@@ -150,7 +150,7 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
-CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+CockroachDB uses checksums to ensure data integrity during both the [write and read]({% link {{ page.version.version }}/architecture/reads-and-writes-overview.md %}) processes. When data is [written to disk]({% link {{ page.version.version }}/architecture/storage-layer.md %}), CockroachDB calculates and stores checksums with the data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads the data from the external backup storage and verifies the checksums to ensure that the data has not been corrupted during the storage or transfer of the backup.
 
 You can restore:
 

--- a/src/current/v23.1/restore.md
+++ b/src/current/v23.1/restore.md
@@ -150,6 +150,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
+CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+
 You can restore:
 
 - [A full cluster](#full-cluster)

--- a/src/current/v23.2/restore.md
+++ b/src/current/v23.2/restore.md
@@ -150,7 +150,7 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
-CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+CockroachDB uses checksums to ensure data integrity during both the [write and read]({% link {{ page.version.version }}/architecture/reads-and-writes-overview.md %}) processes. When data is [written to disk]({% link {{ page.version.version }}/architecture/storage-layer.md %}), CockroachDB calculates and stores checksums with the data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads the data from the external backup storage and verifies the checksums to ensure that the data has not been corrupted during the storage or transfer of the backup.
 
 You can restore:
 

--- a/src/current/v23.2/restore.md
+++ b/src/current/v23.2/restore.md
@@ -150,6 +150,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
+CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+
 You can restore:
 
 - [A full cluster](#full-cluster)

--- a/src/current/v24.1/restore.md
+++ b/src/current/v24.1/restore.md
@@ -150,7 +150,7 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
-CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+CockroachDB uses checksums to ensure data integrity during both the [write and read]({% link {{ page.version.version }}/architecture/reads-and-writes-overview.md %}) processes. When data is [written to disk]({% link {{ page.version.version }}/architecture/storage-layer.md %}), CockroachDB calculates and stores checksums with the data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads the data from the external backup storage and verifies the checksums to ensure that the data has not been corrupted during the storage or transfer of the backup.
 
 You can restore:
 

--- a/src/current/v24.1/restore.md
+++ b/src/current/v24.1/restore.md
@@ -150,6 +150,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
+CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+
 You can restore:
 
 - [A full cluster](#full-cluster)

--- a/src/current/v24.2/restore.md
+++ b/src/current/v24.2/restore.md
@@ -150,7 +150,7 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
-CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+CockroachDB uses checksums to ensure data integrity during both the [write and read]({% link {{ page.version.version }}/architecture/reads-and-writes-overview.md %}) processes. When data is [written to disk]({% link {{ page.version.version }}/architecture/storage-layer.md %}), CockroachDB calculates and stores checksums with the data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads the data from the external backup storage and verifies the checksums to ensure that the data has not been corrupted during the storage or transfer of the backup.
 
 You can restore:
 

--- a/src/current/v24.2/restore.md
+++ b/src/current/v24.2/restore.md
@@ -150,6 +150,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
+CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+
 You can restore:
 
 - [A full cluster](#full-cluster)

--- a/src/current/v24.3/restore.md
+++ b/src/current/v24.3/restore.md
@@ -150,7 +150,7 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
-CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+CockroachDB uses checksums to ensure data integrity during both the [write and read]({% link {{ page.version.version }}/architecture/reads-and-writes-overview.md %}) processes. When data is [written to disk]({% link {{ page.version.version }}/architecture/storage-layer.md %}), CockroachDB calculates and stores checksums with the data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads the data from the external backup storage and verifies the checksums to ensure that the data has not been corrupted during the storage or transfer of the backup.
 
 You can restore:
 

--- a/src/current/v24.3/restore.md
+++ b/src/current/v24.3/restore.md
@@ -150,6 +150,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 ## Functional details
 
+CockroachDB uses checksums to ensure data integrity during both the write and read processes. When data is written to disk, CockroachDB calculates and stores checksums for each block of data. The checksums are then used to verify the integrity of the data when it is read back from disk. A restore job reads each block of data from the external backup storage and verifies the checksum to ensure that the data has not been corrupted during the storage or transfer of the backup data.
+
 You can restore:
 
 - [A full cluster](#full-cluster)


### PR DESCRIPTION
Fixes DOC-11003

Currently, we only mention that restore verifies a checksum when using one of the backup validation options. A regular restore also verifies the checksums of the backup data before restoring to the cluster. This PR adds a short paragraph re this to the `RESTORE` functional detail section on the SQL page.

Versions 23.1 – 24.3