### PR TITLE
Add preview label to PCR read on standby docs

### DIFF
--- a/src/current/_includes/v24.3/physical-replication/show-virtual-cluster-data-state.md
+++ b/src/current/_includes/v24.3/physical-replication/show-virtual-cluster-data-state.md
@@ -1,6 +1,6 @@
 State      | Description
 -----------+----------------
-`add` | The [`readonly` virtual cluster]({% link {{ page.version.version }}/create-virtual-cluster.md %}#start-a-pcr-stream-with-read-from-standby) is waiting for the PCR job's initial scan to complete then `readonly` will be available for read queries.
+`add` | ([**Preview**]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}#features-in-preview)) The [`readonly` virtual cluster]({% link {{ page.version.version }}/create-virtual-cluster.md %}#start-a-pcr-stream-with-read-from-standby) is waiting for the PCR job's initial scan to complete, then `readonly` will be available for read queries.
 `initializing replication` | The replication job is completing the initial scan of data from the primary cluster before it starts replicating data in real time.
 `ready` | A virtual cluster's data is ready for use. The `readonly` virtual cluster is ready to serve read queries.
 `replicating` | The replication job has started and is replicating data.

--- a/src/current/v24.3/alter-virtual-cluster.md
+++ b/src/current/v24.3/alter-virtual-cluster.md
@@ -9,8 +9,6 @@ docs_area: reference.sql
 {% include feature-phases/preview.md %}
 {{site.data.alerts.end}}
 
-
-
 The `ALTER VIRTUAL CLUSTER` statement initiates a failover in a [**physical cluster replication (PCR)** job]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}) and manages a virtual cluster.
 
 {% include {{ page.version.version }}/physical-replication/phys-rep-sql-pages.md %}
@@ -61,7 +59,7 @@ You can use the following options with `ALTER VIRTUAL CLUSTER {vc} START REPLICA
 Option | Value | Description
 -------+-------+------------
 `EXPIRATION WINDOW` | Duration | Override the default producer job's expiration window of 24 hours. The producer job expiration window determines how long the producer job will continue to run without a heartbeat from the consumer job. For more details, refer to the [Technical Overview]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}).
-<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | N/A | Configure the PCR stream to allow reads from the standby cluster. **Note:** This only allows for reads on the standby's virtual cluster. You cannot perform writes or schema changes to user tables while connected to the standby virtual cluster. For more details, refer to [Start the failback process](#start-the-failback-process).
+<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | N/A | ([**Preview**]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}#features-in-preview)) Configure the PCR stream to allow reads from the standby cluster. <br>**Note:** This only allows for reads on the standby's virtual cluster. You cannot perform writes or schema changes to user tables while connected to the standby virtual cluster. For more details, refer to [Start the failback process](#start-the-failback-process).
 `RETENTION` | Duration | Change the [duration]({% link {{ page.version.version }}/interval.md %}) of the retention window that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ## Examples
@@ -88,7 +86,7 @@ You can use either:
 
 {% include {{ page.version.version }}/physical-replication/fast-failback-syntax.md %}
 
-{% include_cached new-in.html version="v24.3" %} Use the `READ VIRTUAL CLUSTER` option with the `ALTER VIRTUAL CLUSTER` failback syntax to start a PCR stream that also creates a read-only virtual cluster on the standby cluster.
+{% include_cached new-in.html version="v24.3" %} ([**Preview**]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}#features-in-preview)) Use the `READ VIRTUAL CLUSTER` option with the `ALTER VIRTUAL CLUSTER` failback syntax to start a PCR stream that also creates a read-only virtual cluster on the standby cluster.
 
 ### Set a retention window
 

--- a/src/current/v24.3/cockroachdb-feature-availability.md
+++ b/src/current/v24.3/cockroachdb-feature-availability.md
@@ -91,6 +91,10 @@ The [`VECTOR`]({% link {{ page.version.version }}/vector.md %}) data type stores
 
 **Logical data replication (LDR)** continuously replicates tables between active CockroachDB clusters. Both source and destination cluster can receive application reads and writes, with LDR enabling bidirectional replication for eventual consistency in the replicating tables. The active-active setup between clusters can provide protection against cluster, datacenter, or region failure while still achieving single-region low latency reads and writes in the individual CockroachDB clusters. Setting up LDR between a source and destination CockroachDB {{ site.data.products.core }} cluster is in preview.
 
+### Read on standby cluster in physical cluster replication (PCR) for CockroachDB {{ site.data.products.core }}
+ 
+The [`READ VIRTUAL CLUSTER`]({% link {{ page.version.version }}/create-virtual-cluster.md %}#options) option allows you to set up a PCR stream that also creates a read-only virtual cluster on the standby cluster. You can create a PCR job as per the [Set Up Physical Cluster Replication]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}) guide and then add the option to the [`CREATE VIRTUAL CLUSTER`]({% link {{ page.version.version }}/create-virtual-cluster.md %}) statement.
+
 ### Custom Metrics Chart page for CockroachDB {{ site.data.products.cloud }} clusters
 
 The [**Custom Metrics Chart** page]({% link cockroachcloud/custom-metrics-chart-page.md %}) for CockroachDB {{ site.data.products.cloud }} clusters allows you to create custom charts showing the time series data for an available metric or combination of metrics.

--- a/src/current/v24.3/create-virtual-cluster.md
+++ b/src/current/v24.3/create-virtual-cluster.md
@@ -7,13 +7,15 @@ docs_area: reference.sql
 
 {{site.data.alerts.callout_info}}
 {% include feature-phases/preview.md %}
-
-Physical cluster replication is only supported in CockroachDB {{ site.data.products.core }} clusters.
 {{site.data.alerts.end}}
 
 The `CREATE VIRTUAL CLUSTER` statement creates a new virtual cluster. It is supported only starting a [**physical cluster replication (PCR)** job]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}).
 
 {% include {{ page.version.version }}/physical-replication/phys-rep-sql-pages.md %}
+
+{{site.data.alerts.callout_info}}
+Physical cluster replication is only supported in CockroachDB {{ site.data.products.core }} clusters.
+{{site.data.alerts.end}}
 
 ## Required privileges
 
@@ -49,7 +51,7 @@ Parameter | Description
 
 Option | Description
 -------+-------------
-<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | Create a [read-only virtual cluster]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#start-up-sequence-with-read-on-standby) on the standby cluster, which allows reads of the standby's replicating virtual cluster. For an example, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
+<span class="version-tag">New in v24.3:</span> `READ VIRTUAL CLUSTER` | ([**Preview**]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}#features-in-preview)) Create a [read-only virtual cluster]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#start-up-sequence-with-read-on-standby) on the standby cluster, which allows reads of the standby's replicating virtual cluster. For an example, refer to [Start a PCR stream with read from standby](#start-a-pcr-stream-with-read-from-standby).
 `RETENTION` | Configure a [retention window]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#failover-and-promotion-process) that will control how far in the past you can [fail over]({% link {{ page.version.version }}/failover-replication.md %}) to.<br><br>{% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ## Connection string
@@ -107,6 +109,10 @@ This will initiate a PCR stream from the primary cluster into the standby cluste
 {% include {{ page.version.version }}/physical-replication/retention.md %}
 
 ### Start a PCR stream with read from standby
+
+{{site.data.alerts.callout_info}}
+While **physical cluster replication (PCR)** is generally available, using the `READ VIRTUAL CLUSTER` option to read from a standby cluster is in [preview]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}#features-in-preview).
+{{site.data.alerts.end}}
 
 {% include_cached new-in.html version="v24.3" %} Use the `READ VIRTUAL CLUSTER` option to set up a PCR stream that also creates a read-only virtual cluster on the standby cluster. You can create a PCR job as per the [Set Up Physical Cluster Replication]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}) guide and then add the option to the `CREATE VIRTUAL CLUSTER` statement:
 

--- a/src/current/v24.3/failover-replication.md
+++ b/src/current/v24.3/failover-replication.md
@@ -260,7 +260,7 @@ This section illustrates the steps to fail back to the original primary cluster 
     This will reset the virtual cluster on **Cluster A** back to the time at which the same virtual cluster on **Cluster B** diverged from it. **Cluster A** will check with **Cluster B** to confirm that its virtual cluster was replicated from **Cluster A** as part of the original [PCR stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}).
 
     {{site.data.alerts.callout_info}}
-    If you want to start the PCR stream with a read-only virtual cluster on the standby after failing back to the original primary cluster, run the [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) statement in this step with the `READ VIRTUAL CLUSTER` option.
+    ([**Preview**]({% link {{ page.version.version }}/cockroachdb-feature-availability.md %}#features-in-preview)) If you want to start the PCR stream with a read-only virtual cluster on the standby after failing back to the original primary cluster, run the [`ALTER VIRTUAL CLUSTER`]({% link {{ page.version.version }}/alter-virtual-cluster.md %}) statement in this step with the `READ VIRTUAL CLUSTER` option.
     {{site.data.alerts.end}}
 
 1. Check the status of the virtual cluster on **A**:

--- a/src/current/v24.3/physical-cluster-replication-technical-overview.md
+++ b/src/current/v24.3/physical-cluster-replication-technical-overview.md
@@ -35,6 +35,10 @@ The stream initialization proceeds as follows:
 
 #### Start-up sequence with read on standby
 
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
+
 {% include_cached new-in.html version="v24.3" %} You can start a PCR stream with the `READ VIRTUAL CLUSTER` option, which allows you to perform reads on the standby's replicating virtual cluster. When this option is specified, the following additional steps occur during the PCR stream start-up sequence:
 
 1. The system virtual cluster on the standby also creates a `readonly` virtual cluster alongside the replicating virtual cluster. The `readonly` virtual cluster will be offline initially.


### PR DESCRIPTION
Fixes DOC-11751

We've decided to move PCR read on standby to the public preview phase.

Note on the main example on the `CREATE VIRTUAL CLUSTER` page, I've added a custom "preview" note since cluster virtualization is in preview but PCR generally is GA. See files for details.