### PR TITLE
Fix version selection logic: Prioritize lexicographically larger release name for same release date

### DIFF
--- a/src/current/_includes/version-switcher.html
+++ b/src/current/_includes/version-switcher.html
@@ -1,7 +1,7 @@
 {% assign DEBUG=false %}
 
 {% comment %}Get the version of the page we are currently viewing{% endcomment %}
-{% assign version = site.data.versions | where_exp: "v", "v.major_version == page.version.version" | sort: "release_date" | first %}
+{% assign version = site.data.versions | where_exp: "v", "v.major_version == page.version.version" | sort: "release_date, release_name" | reverse | first %}
 {% unless version %}Error: Could not get version details for version {{ page.version.version }}. Giving up.{% break %}{% endunless %}
 
 {% comment %}Check whether the current page's version is released and if so, is LTS{% endcomment %}
@@ -35,7 +35,7 @@
         {% for v in page.versions %}
           {% assign v_is_lts = false %}
           {% comment %}Get major-version details for this version{% endcomment %}
-          {% assign major_version_details = site.data.versions | where_exp: "pv", "pv.major_version == v.version.version" | sort: "release_date" | first %}
+          {% assign major_version_details = site.data.versions | where_exp: "pv", "pv.major_version == v.version.version" | sort: "release_date, release_name" | reverse | first %}
           {% unless major_version_details %}Error: Could not get version details for version {{ v.version }}. Giving up.{% break %}{% endunless %}
 
           {% comment %}Check whether this version is released and if so, and is LTS{% endcomment %}


### PR DESCRIPTION
### Summary:
This PR updates the version selection logic to handle cases where multiple versions have the same release date. In such cases, the version with the lexicographically larger release name is now prioritized.

### Details:
- The current version selection process was sorting by release date, but did not account for cases where multiple versions have identical release dates.
- Added a secondary sort by `release_name` in reverse lexicographical order to ensure the version with the largest release name is selected when release dates are tied.
  
### Example:
Given two versions with the same release date:
- `23.2.15` and `23.2.1.6`
- The system will now pick `23.2.16` if both have the same `release_date`, ensuring the lexicographically larger release is chosen.

