### PR TITLE
Update release date in releases.yml to support Liquid logic

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -7417,7 +7417,7 @@
 
 - release_name: v23.2.16
   major_version: v23.2
-  release_date: '2024-11-15'
+  release_date: '2024-11-16'
   release_type: Production
   go_version: go1.22.8
   sha: 720d706874e2424b32c7c9347f6d52140f83beee


### PR DESCRIPTION
Modified the date in `releases.yml` to ensure proper functionality of Liquid logic for identifying the latest release.