### PR TITLE
Change deprecation warning for old backup syntax to removal note in v24.3+

### DIFF
--- a/src/current/_includes/v24.3/backups/backup-to-deprec.md
+++ b/src/current/_includes/v24.3/backups/backup-to-deprec.md
@@ -1,7 +1,0 @@
-{{site.data.alerts.callout_danger}}
-The `BACKUP ... TO` and `RESTORE ... FROM` syntax is **deprecated** as of v22.1 and will be removed in a future release.
-
-We recommend using the `BACKUP ... INTO {collectionURI}` syntax, which creates or adds to a [backup collection]({% link {{ page.version.version }}/take-full-and-incremental-backups.md %}#backup-collections) in your storage location. For restoring backups, we recommend using `RESTORE FROM {backup} IN {collectionURI}` with `{backup}` being [`LATEST`]({% link {{ page.version.version }}/restore.md %}#restore-the-most-recent-full-or-incremental-backup) or a specific [subdirectory]({% link {{ page.version.version }}/restore.md %}#subdir-param).
-
-For guidance on the syntax for backups and restores, see the [`BACKUP`]({% link {{ page.version.version }}/backup.md %}#examples) and [`RESTORE`]({% link {{ page.version.version }}/restore.md %}#examples) examples.
-{{site.data.alerts.end}}

--- a/src/current/_includes/v24.3/backups/old-syntax-removed.md
+++ b/src/current/_includes/v24.3/backups/old-syntax-removed.md
@@ -1,0 +1,5 @@
+{{site.data.alerts.callout_danger}}
+The `BACKUP ... TO` and `RESTORE ... FROM` syntax has been removed from CockroachDB v24.3 and later.
+
+For details on the syntax to run `BACKUP` and `RESTORE`, refer to the {% if page.name == "backup.md" %} [backup](#examples) {% else %} [backup]({% link {{ page.version.version }}/backup.md %}#examples) {% endif %} and {% if page.name == "restore.md" %} [restore](#examples) {% else %} [restore]({% link {{ page.version.version }}/restore.md %}#examples) {% endif %} examples.
+{{site.data.alerts.end}}

--- a/src/current/_includes/v24.3/backups/old-syntax-removed.md
+++ b/src/current/_includes/v24.3/backups/old-syntax-removed.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_danger}}
-The `BACKUP ... TO` and `RESTORE ... FROM` syntax has been removed from CockroachDB v24.3 and later.
+The `BACKUP ... TO` and `RESTORE ... FROM {storage_uri}` syntax has been removed from CockroachDB v24.3 and later.
 
 For details on the syntax to run `BACKUP` and `RESTORE`, refer to the {% if page.name == "backup.md" %} [backup](#examples) {% else %} [backup]({% link {{ page.version.version }}/backup.md %}#examples) {% endif %} and {% if page.name == "restore.md" %} [restore](#examples) {% else %} [restore]({% link {{ page.version.version }}/restore.md %}#examples) {% endif %} examples.
 {{site.data.alerts.end}}

--- a/src/current/v24.3/backup.md
+++ b/src/current/v24.3/backup.md
@@ -28,7 +28,7 @@ To view the contents of an backup created with the `BACKUP` statement, use [`SHO
 
 {% include {{ page.version.version }}/backups/scheduled-backups-tip.md %}
 
-{% include {{ page.version.version }}/backups/backup-to-deprec.md %}
+{% include {{ page.version.version }}/backups/old-syntax-removed.md %}
 
 ## Considerations
 
@@ -236,11 +236,7 @@ Per our guidance in the [Performance](#performance) section, we recommend starti
 
 If you need to limit the control specific users have over your storage buckets, see [Assume role authentication]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) for setup instructions.
 
-{{site.data.alerts.callout_info}}
-The `BACKUP ... TO` syntax is **deprecated** as of v22.1 and will be removed in a future release.
-
-Cockroach Labs recommends using the `BACKUP ... INTO {collectionURI}` syntax shown in the following examples.
-{{site.data.alerts.end}}
+{% include {{ page.version.version }}/backups/old-syntax-removed.md %}
 
 ### Back up a cluster
 

--- a/src/current/v24.3/restore.md
+++ b/src/current/v24.3/restore.md
@@ -17,7 +17,7 @@ You can restore:
 
 For details on restoring across versions of CockroachDB, see [Restoring Backups Across Versions]({% link {{ page.version.version }}/restoring-backups-across-versions.md %}).
 
-{% include {{ page.version.version }}/backups/backup-to-deprec.md %}
+{% include {{ page.version.version }}/backups/old-syntax-removed.md %}
 
 ## Considerations
 

--- a/src/current/v24.3/show-backup.md
+++ b/src/current/v24.3/show-backup.md
@@ -8,11 +8,9 @@ docs_area: reference.sql
 The `SHOW BACKUP` [statement]({% link {{ page.version.version }}/sql-statements.md %}) lists the contents of a backup created with the [`BACKUP`]({% link {{ page.version.version }}/backup.md %}) statement.
 
 {{site.data.alerts.callout_danger}}
-The `SHOW BACKUP` syntax **without** the `IN` keyword is **deprecated** as of v22.1 and will be removed in a future release.
+The `SHOW BACKUP` syntax **without** the `IN` keyword has been removed from CockroachDB v24.3 and later.
 
-We recommend using `SHOW BACKUP FROM {subdirectory} IN {collectionURI}` to view backups in a subdirectory at a collection's URI.
-
-For guidance on the syntax for `SHOW BACKUP FROM`, see the [examples](#examples).
+For guidance on the syntax for `SHOW BACKUP FROM`, refer to the [Synopsis](#synopsis) and [examples](#examples) on this page.
 {{site.data.alerts.end}}
 
 ## Required privileges

--- a/src/current/v24.3/take-full-and-incremental-backups.md
+++ b/src/current/v24.3/take-full-and-incremental-backups.md
@@ -14,7 +14,7 @@ There are two main types of backups:
 
 You can use the [`BACKUP`]({% link {{ page.version.version }}/backup.md %}) statement to efficiently back up your cluster's schemas and data to popular cloud services such as AWS S3, Google Cloud Storage, or NFS, and the [`RESTORE`]({% link {{ page.version.version }}/restore.md %}) statement to efficiently restore schema and data as necessary. For more information, see [Use Cloud Storage]({% link {{ page.version.version }}/use-cloud-storage.md %}).
 
-{% include {{ page.version.version }}/backups/backup-to-deprec.md %}
+{% include {{ page.version.version }}/backups/old-syntax-removed.md %}
 
 {% include {{ page.version.version }}/backups/scheduled-backups-tip.md %}
 


### PR DESCRIPTION
Fixes DOC-11663

Changes the deprecation notice for `BACKUP`, `RESTORE`, `SHOW BACKUP` old syntax to confirm the syntax has been removed in v24.3+.

## Rendered preview

https://deploy-preview-19192--cockroachdb-docs.netlify.app/docs/v24.3/backup.html
https://deploy-preview-19192--cockroachdb-docs.netlify.app/docs/v24.3/show-backup.html