### PR TITLE
REL-1668 v24.1.8: [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -7522,13 +7522,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v24.1.7
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
       
 - release_name: v23.1.30
   major_version: v23.1


### PR DESCRIPTION
Fixes REL-1668

In releases.yml, removed cloud fields for v24.1.8 to show binary download links.