### PR TITLE
REL-1855 v23.2.19 (was v23.2.18): [Docs] Generate release notes for Cloud

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -7733,3 +7733,31 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.17
+
+
+- release_name: v23.2.19
+  major_version: v23.2
+  release_date: '2025-01-09'
+  release_type: Production
+  go_version: go1.22.8
+  sha: 9577e2fa2e0a2dd6bae286ec1a3e89714e0cdeef
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+    mac_arm_experimental: true
+    mac_arm_limited_access: false
+  windows: true
+  linux:
+    linux_arm: true
+    linux_arm_experimental: false
+    linux_arm_limited_access: false
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+    docker_arm_experimental: false
+    docker_arm_limited_access: false
+  source: true
+  previous_release: v23.2.18

--- a/src/current/_includes/releases/v23.2/v23.2.19.md
+++ b/src/current/_includes/releases/v23.2/v23.2.19.md
@@ -1,0 +1,80 @@
+## v23.2.19
+
+Release Date: January 9, 2025
+
+{% include releases/new-release-downloads-docker-image.md release=include.release %}
+
+<h3 id="v23-2-19-security-updates">Security updates</h3>
+
+- The cluster setting server.jwt_authentication.issuers now takes the issuers configuration value apart from the URI. This can be set to one of the following values: 1. Simple string that Go can parse as a valid issuer URL. 2. String that can be parsed as valid JSON array of issuer URLs list. 3. String that can be parsed as valid JSON and deserialized into a map of issuer URLs to corresponding JWKS URIs. In the third case we will be overriding the JWKS URI present in the issuer's well-known endpoint. Example valid values: - 'https://accounts.google.com' - ['example.com/adfs','https://accounts.google.com'] - '{    "issuer_jwks_map": {        "https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs",        "example.com/adfs": "https://example.com/adfs/discovery/keys"     }    }' When `issuer_jwks_map` is set, we directly use the JWKS URI to get the key set. In all other cases where JWKSAutoFetchEnabled is set we obtain the JWKS URI first from issuer's well-known endpoint and then use this endpoint. [#138188][#138188]
+
+<h3 id="v23-2-19-general-changes">General changes</h3>
+
+- In order to improve the granularity of changefeed pipeline metrics, the changefeed metrics changefeed.admit_latency and changefeed.commit_latency have histogram buckets from 5ms to 60m (previously  500ms to 5m). The changefeed metrics changefeed.parallel_io_queue_nanos, changefeed.parallel_io_result_queue_nanos, changefeed.sink_batch_hist_nanos, changefeed.flush_hist_nanos, and changefeed.kafka_throttling_hist_nanos have histogram buckets from 5ms to 10m (previously 500ms to 5m). [#136618][#136618]
+- Add support for multiple seed brokers in the new kafka sink. [#136745][#136745]
+- Add a new metric (`distsender.rangefeed.catchup_ranges_waiting_client_side`) that counts how many rangefeeds are waiting on the client-side limiter to start performing catchup scans. [#136837][#136837]
+
+<h3 id="v23-2-19-{{-site.data.products.enterprise-}}-edition-changes">{{ site.data.products.enterprise }} edition changes</h3>
+
+- Adds changefeed support for the mvcc_timestamp option with the avro format. If both options are specified, the avro schema includes an mvcc_timestamp metadata field and emits the row's mvcc timestamp with the row data. [#136018][#136018]
+
+<h3 id="v23-2-19-sql-language-changes">SQL language changes</h3>
+
+- The `legacy_varchar_typing` session setting has been added, which reverts the changes of #133037 that cause the change in typing behavior described in #137837. Specifically, it makes type-checking and overload resolution ignore the newly added "unpreferred" overloads. This setting defaults to `on`. [#137922][#137922]
+
+<h3 id="v23-2-19-operational-changes">Operational changes</h3>
+
+- Telemetry delivery is now considered successful even in cases where we experience a network timeout. This will prevent throttling in cases outside an operator's control. [#136477][#136477]
+- When a schema change job is completed, rolls back, or encounteres a failure, the time taken since the job began is now logged in a structured log in the SQL_SCHEMA log channel. [#136952][#136952]
+
+<h3 id="v23-2-19-bug-fixes">Bug fixes</h3>
+
+- CREATE SCHEMA now returns the correct error if a the schema name is missing. [#135925][#135925]
+- Fixed an issue where corrupted table statistics could cause the cockroach process to crash. [#136043][#136043]
+- The `idle_in_session_timeout` setting now excludes the time spent waiting for schema changer jobs to complete, preventing unintended session termination during schema change operations. [#136508][#136508]
+- Fix a bug which causes the optimizer to use stale table statistics after altering an enum type used in the table. [#136832][#136832]
+- CockroachDB now better respects `statement_timeout` limit on queries involving the top K sort and merge join operations. [#136650][#136650]
+- Fixed an issue where license enforcement was not consistently disabled for single-node clusters started with start-single-node, ensuring proper behavior on cluster restarts. [#137009][#137009]
+- Fix a bug that caused queries against tables with user-defined types to sometimes fail with errors after restoring those tables. [#137356][#137356]
+- Fixed a bug that could cause an internal error if a table with an implicit (rowid) primary key was locked from within a subquery, like this: ``` SELECT * FROM (SELECT * FROM foo WHERE x = 2) FOR UPDATE; ``` The error could occur either under read-committed isolation, or with `optimizer_use_lock_op_for_serializable` enabled. [#137130][#137130]
+- Fixed an issue where adding an existing column with the IF NOT EXISTS option could exit too early, skipping necessary handling of the AST. This could lead to statement failure of the ALTER. [#137678][#137678]
+- CLOSE CURSOR statements are now allowed in read-only transactions, similat to Postgres. The bug has been present since at least 23.1 version. [#137788][#137788]
+- An issue where a schema change could incorrectly cause a changefeed to fail with an assertion error like `received boundary timestamp ... of type ... before reaching existing boundary of type ...` has now been fixed. [#137703][#137703]
+- Internal scans are now exempt from the sql.defaults.disallow_full_table_scans.enabled setting, allowing index creation even when the cluster setting is active. [#137720][#137720]
+- A new column of type JSON or JSONB and that has a UNIQUE constraint will now be blocked from being added to a table if the cluster has not yet finalized the upgrade to v23.2. [#137864][#137864]
+
+<h3 id="v23-2-19-miscellaneous">Miscellaneous</h3>
+
+<h4 id="v23-2-19-changes-without-release-note-annotation">Changes without release note annotation</h4>
+
+- [#137111][#137111] [03fcd9fdf][03fcd9fdf] release-23.2: docgen: update BEGIN and SET TRANSACTION diagrams (#137111)
+
+<h3 id="v23-2-19-doc-updates">Doc updates</h3>
+
+{% comment %}Docs team: Please add these manually.{% endcomment %}
+
+
+
+[#135925]: https://github.com/cockroachdb/cockroach/pull/135925
+[#136018]: https://github.com/cockroachdb/cockroach/pull/136018
+[#136043]: https://github.com/cockroachdb/cockroach/pull/136043
+[#136477]: https://github.com/cockroachdb/cockroach/pull/136477
+[#136508]: https://github.com/cockroachdb/cockroach/pull/136508
+[#136618]: https://github.com/cockroachdb/cockroach/pull/136618
+[#136650]: https://github.com/cockroachdb/cockroach/pull/136650
+[#136745]: https://github.com/cockroachdb/cockroach/pull/136745
+[#136832]: https://github.com/cockroachdb/cockroach/pull/136832
+[#136837]: https://github.com/cockroachdb/cockroach/pull/136837
+[#136952]: https://github.com/cockroachdb/cockroach/pull/136952
+[#137009]: https://github.com/cockroachdb/cockroach/pull/137009
+[#137111]: https://github.com/cockroachdb/cockroach/pull/137111
+[#137130]: https://github.com/cockroachdb/cockroach/pull/137130
+[#137356]: https://github.com/cockroachdb/cockroach/pull/137356
+[#137678]: https://github.com/cockroachdb/cockroach/pull/137678
+[#137703]: https://github.com/cockroachdb/cockroach/pull/137703
+[#137720]: https://github.com/cockroachdb/cockroach/pull/137720
+[#137788]: https://github.com/cockroachdb/cockroach/pull/137788
+[#137864]: https://github.com/cockroachdb/cockroach/pull/137864
+[#137922]: https://github.com/cockroachdb/cockroach/pull/137922
+[#138188]: https://github.com/cockroachdb/cockroach/pull/138188
+[03fcd9fdf]: https://github.com/cockroachdb/cockroach/commit/03fcd9fdf


### PR DESCRIPTION
Fixes REL-1855

unedited release notes.