### PR TITLE
Update docs for changefeed privileges in v25.1

### DIFF
--- a/src/current/_includes/v23.1/cdc/privilege-model.md
+++ b/src/current/_includes/v23.1/cdc/privilege-model.md
@@ -39,5 +39,5 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
 {{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
 {{site.data.alerts.end}}

--- a/src/current/_includes/v23.1/cdc/privilege-model.md
+++ b/src/current/_includes/v23.1/cdc/privilege-model.md
@@ -1,9 +1,3 @@
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
-
-There is continued support for the [legacy privilege model](#legacy-privilege-model) for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the new privilege model that follows in this section for all changefeeds.
-{{site.data.alerts.end}}
-
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
 {% include_cached copy-clipboard.html %}
@@ -14,22 +8,11 @@ GRANT CHANGEFEED ON TABLE example_table TO user;
 When you grant a user the `CHANGEFEED` privilege on a set of tables, they can:
 
 - Create changefeeds on the target tables even if the user does **not** have the [`CONTROLCHANGEFEED` role option]({% link {{ page.version.version }}/alter-role.md %}#role-options) or the `SELECT` privilege on the tables.
-- {% include_cached new-in.html version="v23.1" %} Manage the changefeed jobs running on the tables using the [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs), [`PAUSE JOB`]({% link {{ page.version.version }}/pause-job.md %}), [`RESUME JOB`]({% link {{ page.version.version }}/resume-job.md %}), and [`CANCEL JOB`](cancel-job.html) commands.
+- Manage the changefeed jobs running on the tables using the [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs), [`PAUSE JOB`]({% link {{ page.version.version }}/pause-job.md %}), [`RESUME JOB`]({% link {{ page.version.version }}/resume-job.md %}), and [`CANCEL JOB`](cancel-job.html) commands.
 
 These users will be able to create changefeeds, but they will not be able to run a `SELECT` query on that data directly. However, they could still read this data indirectly if they have read access to the [sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
 
 {% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
-
-### Privilege model
-
-The following summarizes the operations users can run when they have changefeed privileges on a table:
-
-Granted privileges | Usage
--------------------+-------
-`CHANGEFEED` | Create changefeeds on tables.<br>Manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
-`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
 
 You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#default-privileges) with [`ALTER DEFAULT PRIVILEGES`]({% link {{ page.version.version }}/alter-default-privileges.md %}#grant-default-privileges-to-a-specific-role):
 
@@ -38,6 +21,18 @@ You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ p
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
+### Privilege model
+
+{{site.data.alerts.callout_success}}
+For fine-grained access control, we recommend using the system-level privileges `CHANGEFEED` and `CONTROLJOB` / `VIEWJOB`.
 {{site.data.alerts.end}}
+
+The following summarizes the operations users can run when they have changefeed privileges on a table:
+
+Granted privileges | Usage
+-------------------+-------
+`CHANGEFEED` | Create changefeeds on tables.<br>View and manage changefeed jobs on tables.
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.<br><br>The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the [system-level privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) `CHANGEFEED` and `CONTROLJOB`/ `VIEWJOB` for fine-grained access control.
+`admin` | Create, view, and manage changefeed jobs. 

--- a/src/current/_includes/v23.2/cdc/privilege-model.md
+++ b/src/current/_includes/v23.2/cdc/privilege-model.md
@@ -39,5 +39,5 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
 {{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
 {{site.data.alerts.end}}

--- a/src/current/_includes/v23.2/cdc/privilege-model.md
+++ b/src/current/_includes/v23.2/cdc/privilege-model.md
@@ -1,9 +1,3 @@
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
-
-There is continued support for the [legacy privilege model](#legacy-privilege-model) for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the new privilege model that follows in this section for all changefeeds.
-{{site.data.alerts.end}}
-
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
 {% include_cached copy-clipboard.html %}
@@ -20,17 +14,6 @@ These users will be able to create changefeeds, but they will not be able to run
 
 {% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
 
-### Privilege model
-
-The following summarizes the operations users can run when they have changefeed privileges on a table:
-
-Granted privileges | Usage
--------------------+-------
-`CHANGEFEED` | Create changefeeds on tables.<br>Manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
-`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
-
 You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#default-privileges) with [`ALTER DEFAULT PRIVILEGES`]({% link {{ page.version.version }}/alter-default-privileges.md %}#grant-default-privileges-to-a-specific-role):
 
 {% include_cached copy-clipboard.html %}
@@ -38,6 +21,18 @@ You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ p
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
+### Privilege model
+
+{{site.data.alerts.callout_success}}
+For fine-grained access control, we recommend using the system-level privileges `CHANGEFEED` and `CONTROLJOB` / `VIEWJOB`.
 {{site.data.alerts.end}}
+
+The following summarizes the operations users can run when they have changefeed privileges on a table:
+
+Granted privileges | Usage
+-------------------+-------
+`CHANGEFEED` | Create changefeeds on tables.<br>View and manage changefeed jobs on tables.
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.<br><br>The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the [system-level privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) `CHANGEFEED` and `CONTROLJOB`/ `VIEWJOB` for fine-grained access control.
+`admin` | Create, view, and manage changefeed jobs. 

--- a/src/current/_includes/v24.1/cdc/privilege-model.md
+++ b/src/current/_includes/v24.1/cdc/privilege-model.md
@@ -1,9 +1,3 @@
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
-
-There is continued support for the [legacy privilege model](#legacy-privilege-model) for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the new privilege model that follows in this section for all changefeeds.
-{{site.data.alerts.end}}
-
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
 {% include_cached copy-clipboard.html %}
@@ -20,17 +14,6 @@ These users will be able to create changefeeds, but they will not be able to run
 
 {% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
 
-### Privilege model
-
-The following summarizes the operations users can run when they have changefeed privileges on a table:
-
-Granted privileges | Usage
--------------------+-------
-`CHANGEFEED` | Create changefeeds on tables.<br>Manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
-`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
-
 You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#default-privileges) with [`ALTER DEFAULT PRIVILEGES`]({% link {{ page.version.version }}/alter-default-privileges.md %}#grant-default-privileges-to-a-specific-role):
 
 {% include_cached copy-clipboard.html %}
@@ -38,6 +21,18 @@ You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ p
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
+### Privilege model
+
+{{site.data.alerts.callout_success}}
+For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
 {{site.data.alerts.end}}
+
+The following summarizes the operations users can run when they have changefeed privileges on a table:
+
+Granted privileges | Usage
+-------------------+-------
+`CHANGEFEED` | Create changefeeds on tables.<br>View and manage changefeed jobs on tables.
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.<br><br>The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the [system-level privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) `CHANGEFEED` and `CONTROLJOB`/ `VIEWJOB` for fine-grained access control.
+`admin` | Create, view, and manage changefeed jobs. 

--- a/src/current/_includes/v24.1/cdc/privilege-model.md
+++ b/src/current/_includes/v24.1/cdc/privilege-model.md
@@ -39,5 +39,5 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
 {{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
 {{site.data.alerts.end}}

--- a/src/current/_includes/v24.1/cdc/privilege-model.md
+++ b/src/current/_includes/v24.1/cdc/privilege-model.md
@@ -24,7 +24,7 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ### Privilege model
 
 {{site.data.alerts.callout_success}}
-For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
+For fine-grained access control, we recommend using the system-level privileges `CHANGEFEED` and `CONTROLJOB` / `VIEWJOB`.
 {{site.data.alerts.end}}
 
 The following summarizes the operations users can run when they have changefeed privileges on a table:

--- a/src/current/_includes/v24.2/cdc/privilege-model.md
+++ b/src/current/_includes/v24.2/cdc/privilege-model.md
@@ -1,9 +1,3 @@
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
-
-There is continued support for the [legacy privilege model](#legacy-privilege-model) for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the new privilege model that follows in this section for all changefeeds.
-{{site.data.alerts.end}}
-
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
 {% include_cached copy-clipboard.html %}
@@ -20,17 +14,6 @@ These users will be able to create changefeeds, but they will not be able to run
 
 {% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
 
-### Privilege model
-
-The following summarizes the operations users can run when they have changefeed privileges on a table:
-
-Granted privileges | Usage
--------------------+-------
-`CHANGEFEED` | Create changefeeds on tables.<br>Manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
-`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
-
 You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#default-privileges) with [`ALTER DEFAULT PRIVILEGES`]({% link {{ page.version.version }}/alter-default-privileges.md %}#grant-default-privileges-to-a-specific-role):
 
 {% include_cached copy-clipboard.html %}
@@ -38,6 +21,18 @@ You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ p
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
+### Privilege model
+
+{{site.data.alerts.callout_success}}
+For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
 {{site.data.alerts.end}}
+
+The following summarizes the operations users can run when they have changefeed privileges on a table:
+
+Granted privileges | Usage
+-------------------+-------
+`CHANGEFEED` | Create changefeeds on tables.<br>View and manage changefeed jobs on tables.
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.<br><br>The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the [system-level privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) `CHANGEFEED` and `CONTROLJOB`/ `VIEWJOB` for fine-grained access control.
+`admin` | Create, view, and manage changefeed jobs. 

--- a/src/current/_includes/v24.2/cdc/privilege-model.md
+++ b/src/current/_includes/v24.2/cdc/privilege-model.md
@@ -39,5 +39,5 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
 {{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
 {{site.data.alerts.end}}

--- a/src/current/_includes/v24.2/cdc/privilege-model.md
+++ b/src/current/_includes/v24.2/cdc/privilege-model.md
@@ -24,7 +24,7 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ### Privilege model
 
 {{site.data.alerts.callout_success}}
-For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
+For fine-grained access control, we recommend using the system-level privileges `CHANGEFEED` and `CONTROLJOB` / `VIEWJOB`.
 {{site.data.alerts.end}}
 
 The following summarizes the operations users can run when they have changefeed privileges on a table:

--- a/src/current/_includes/v24.3/cdc/privilege-model.md
+++ b/src/current/_includes/v24.3/cdc/privilege-model.md
@@ -1,9 +1,3 @@
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
-
-There is continued support for the [legacy privilege model](#legacy-privilege-model) for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the new privilege model that follows in this section for all changefeeds.
-{{site.data.alerts.end}}
-
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
 {% include_cached copy-clipboard.html %}
@@ -20,17 +14,6 @@ These users will be able to create changefeeds, but they will not be able to run
 
 {% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
 
-### Privilege model
-
-The following summarizes the operations users can run when they have changefeed privileges on a table:
-
-Granted privileges | Usage
--------------------+-------
-`CHANGEFEED` | Create changefeeds on tables.<br>Manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
-`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
-
 You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#default-privileges) with [`ALTER DEFAULT PRIVILEGES`]({% link {{ page.version.version }}/alter-default-privileges.md %}#grant-default-privileges-to-a-specific-role):
 
 {% include_cached copy-clipboard.html %}
@@ -38,6 +21,18 @@ You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ p
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
+### Privilege model
+
+{{site.data.alerts.callout_success}}
+For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
 {{site.data.alerts.end}}
+
+The following summarizes the operations users can run when they have changefeed privileges on a table:
+
+Granted privileges | Usage
+-------------------+-------
+`CHANGEFEED` | Create changefeeds on tables.<br>View and manage changefeed jobs on tables.
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.<br><br>The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the [system-level privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) `CHANGEFEED` and `CONTROLJOB`/ `VIEWJOB` for fine-grained access control.
+`admin` | Create, view, and manage changefeed jobs. 

--- a/src/current/_includes/v24.3/cdc/privilege-model.md
+++ b/src/current/_includes/v24.3/cdc/privilege-model.md
@@ -39,5 +39,5 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
 {{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
 {{site.data.alerts.end}}

--- a/src/current/_includes/v24.3/cdc/privilege-model.md
+++ b/src/current/_includes/v24.3/cdc/privilege-model.md
@@ -24,7 +24,7 @@ ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ### Privilege model
 
 {{site.data.alerts.callout_success}}
-For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
+For fine-grained access control, we recommend using the system-level privileges `CHANGEFEED` and `CONTROLJOB` / `VIEWJOB`.
 {{site.data.alerts.end}}
 
 The following summarizes the operations users can run when they have changefeed privileges on a table:

--- a/src/current/_includes/v25.1/cdc/privilege-model.md
+++ b/src/current/_includes/v25.1/cdc/privilege-model.md
@@ -1,8 +1,28 @@
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
+{{site.data.alerts.callout_danger}}
+As of v25.1, viewing and managing a changefeed job by users with the `CHANGEFEED` privilege is **deprecated**. This functionality of the `CHANGEFEED` privilege will be removed in a future release.
 
-There is continued support for the [legacy privilege model](#legacy-privilege-model) for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the new privilege model that follows in this section for all changefeeds.
+We recommend transitioning users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 {{site.data.alerts.end}}
+
+### Privilege model
+
+The following summarizes the operations users can run depending on whether the assigned privileges are at the job or table level:
+
+Granted privileges | Usage
+-------------------+-------
+`CHANGEFEED` | Create changefeeds on tables. For details, refer to [`CHANGEFEED` privilege](#changefeed-privilege).<br>**Deprecated**: View and manage changefeed jobs on tables.
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI. For details, refer to [`CHANGEFEED` privilege](#changefeed-privilege).<br>**Deprecated**: View and manage changefeed jobs on tables.<br><br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+Job ownership | [View]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs) and manage changefeed jobs ([pause]({% link {{ page.version.version }}/pause-job.md %}), [resume]({% link {{ page.version.version }}/resume-job.md %}), and [cancel]({% link {{ page.version.version }}/cancel-job.md %})). For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
+`CONTROLJOB` | Manage changefeed jobs ([pause]({% link {{ page.version.version }}/pause-job.md %}), [resume]({% link {{ page.version.version }}/resume-job.md %}), and [cancel]({% link {{ page.version.version }}/cancel-job.md %})). For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
+`VIEWJOB` | [View]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs) changefeed jobs. For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
+`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
+
+{{site.data.alerts.callout_info}}
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+{{site.data.alerts.end}}
+
+#### `CHANGEFEED` privilege
 
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
@@ -14,22 +34,9 @@ GRANT CHANGEFEED ON TABLE example_table TO user;
 When you grant a user the `CHANGEFEED` privilege on a set of tables, they can:
 
 - Create changefeeds on the target tables even if the user does **not** have the [`CONTROLCHANGEFEED` role option]({% link {{ page.version.version }}/alter-role.md %}#role-options) or the `SELECT` privilege on the tables.
-- Manage the changefeed jobs running on the tables using the [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs), [`PAUSE JOB`]({% link {{ page.version.version }}/pause-job.md %}), [`RESUME JOB`]({% link {{ page.version.version }}/resume-job.md %}), and [`CANCEL JOB`](cancel-job.html) commands.
+- **Deprecated as of v25.1**: Manage the changefeed jobs running on the tables using the [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs), [`PAUSE JOB`]({% link {{ page.version.version }}/pause-job.md %}), [`RESUME JOB`]({% link {{ page.version.version }}/resume-job.md %}), and [`CANCEL JOB`](cancel-job.html) commands.
 
 These users will be able to create changefeeds, but they will not be able to run a `SELECT` query on that data directly. However, they could still read this data indirectly if they have read access to the [sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
-
-{% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
-
-### Privilege model
-
-The following summarizes the operations users can run when they have changefeed privileges on a table:
-
-Granted privileges | Usage
--------------------+-------
-`CHANGEFEED` | Create changefeeds on tables.<br>Manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI.<br>Manage changefeed jobs on tables.<br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
-`SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
 
 You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#default-privileges) with [`ALTER DEFAULT PRIVILEGES`]({% link {{ page.version.version }}/alter-default-privileges.md %}#grant-default-privileges-to-a-specific-role):
 
@@ -38,6 +45,20 @@ You can add `CHANGEFEED` to the user or role's [default privileges]({% link {{ p
 ALTER DEFAULT PRIVILEGES GRANT CHANGEFEED ON TABLES TO user;
 ~~~
 
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
-{{site.data.alerts.end}}
+{% include {{ page.version.version }}/cdc/ext-conn-cluster-setting.md %}
+
+#### View and manage changefeed jobs
+
+Users can [view]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs) and manage changefeed jobs when one of the following are met:
+
+- **Job ownership**: They own the job, or are a member of a role that owns a job.  
+- **Global privileges**: They are assigned [`CONTROLJOB` or `VIEWJOB`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+To give a set of users access to a specific job, or set of jobs, you can assign them to a [role]({% link {{ page.version.version }}/security-reference/authorization.md %}#users-and-roles) that owns the job(s). 
+
+{% include_cached new-in.html version="v25.1" %} You can transfer ownership of a job to a role or user using the [`ALTER JOB`]({% link {{ page.version.version }}/alter-job.md %}) statement:
+
+{% include_cached copy-clipboard.html %}
+~~~sql
+ALTER JOB job_ID OWNER TO role_name;
+~~~

--- a/src/current/_includes/v25.1/cdc/privilege-model.md
+++ b/src/current/_includes/v25.1/cdc/privilege-model.md
@@ -1,10 +1,14 @@
 {{site.data.alerts.callout_danger}}
-As of v25.1, viewing and managing a changefeed job by users with the `CHANGEFEED` privilege is **deprecated**. This functionality of the `CHANGEFEED` privilege will be removed in a future release.
+As of v25.1, **viewing and managing** a changefeed job by users with the [`CHANGEFEED` privilege](#changefeed-privilege) is **deprecated**. This functionality of the `CHANGEFEED` privilege will be removed in a future release.
 
 We recommend transitioning users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 {{site.data.alerts.end}}
 
 ### Privilege model
+
+{{site.data.alerts.callout_success}}
+For fine-grained access control, we recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB` / `VIEWJOB`](#view-and-manage-changefeed-jobs).
+{{site.data.alerts.end}}
 
 The following summarizes the operations users can run depending on whether the assigned privileges are at the job or table level:
 
@@ -16,13 +20,14 @@ Job ownership | [View]({% link {{ page.version.version }}/show-jobs.md %}#show-c
 `CONTROLJOB` | Manage changefeed jobs ([pause]({% link {{ page.version.version }}/pause-job.md %}), [resume]({% link {{ page.version.version }}/resume-job.md %}), and [cancel]({% link {{ page.version.version }}/cancel-job.md %})). For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 `VIEWJOB` | [View]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs) changefeed jobs. For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 `SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. For an alternative, refer to the [`CHANGEFEED` privilege](#changefeed-privilege). 
-
-{{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
-{{site.data.alerts.end}}
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege.<br><br>The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privileges [`CHANGEFEED`](#changefeed-privilege) and [`CONTROLJOB`/ `VIEWJOB`](#view-and-manage-changefeed-jobs) for fine-grained access control.
+`admin` | Create, view, and manage changefeed jobs. 
 
 #### `CHANGEFEED` privilege
+
+{{site.data.alerts.callout_info}}
+Viewing and managing changefeed jobs with the `CHANGEFEED` privilege is **deprecated** as of v25.1. Instead, transition users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
+{{site.data.alerts.end}}
 
 You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-on-specific-tables-in-a-database) a user the `CHANGEFEED` privilege to allow them to create changefeeds on a specific table:
 
@@ -32,10 +37,6 @@ GRANT CHANGEFEED ON TABLE example_table TO user;
 ~~~
 
 When you grant a user the `CHANGEFEED` privilege on a set of tables, they can create changefeeds on the target tables even if the user does **not** have the [`CONTROLCHANGEFEED` role option]({% link {{ page.version.version }}/alter-role.md %}#role-options) or the `SELECT` privilege on the tables.
-
-{{site.data.alerts.callout_info}}
-Viewing and managing changefeed jobs with the `CHANGEFEED` privilege is **deprecated** as of v25.1. Instead, transition users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
-{{site.data.alerts.end}}
 
 These users will be able to create changefeeds, but they will not be able to run a `SELECT` query on that data directly. However, they could still read this data indirectly if they have read access to the [sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
 

--- a/src/current/_includes/v25.1/cdc/privilege-model.md
+++ b/src/current/_includes/v25.1/cdc/privilege-model.md
@@ -10,16 +10,16 @@ The following summarizes the operations users can run depending on whether the a
 
 Granted privileges | Usage
 -------------------+-------
-`CHANGEFEED` | Create changefeeds on tables. For details, refer to [`CHANGEFEED` privilege](#changefeed-privilege).<br>**Deprecated**: View and manage changefeed jobs on tables.
-`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI. For details, refer to [`CHANGEFEED` privilege](#changefeed-privilege).<br>**Deprecated**: View and manage changefeed jobs on tables.<br><br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
+`CHANGEFEED` | Create changefeeds on tables. For details, refer to [`CHANGEFEED` privilege](#changefeed-privilege).<br>**Deprecated**: View and manage changefeed jobs on tables. Instead, transition users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
+`CHANGEFEED` + [`USAGE`]({% link {{ page.version.version }}/create-external-connection.md %}#required-privileges) on external connection | Create changefeeds on tables to an external connection URI. For details, refer to [`CHANGEFEED` privilege](#changefeed-privilege).<br>**Deprecated**: View and manage changefeed jobs on tables. Instead, transition users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).<br><br>**Note:** If you need to manage access to changefeed sink URIs, set the `changefeed.permissions.require_external_connection_sink.enabled=true` cluster setting. This will mean that users with these privileges can **only** create changefeeds on external connections.
 Job ownership | [View]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs) and manage changefeed jobs ([pause]({% link {{ page.version.version }}/pause-job.md %}), [resume]({% link {{ page.version.version }}/resume-job.md %}), and [cancel]({% link {{ page.version.version }}/cancel-job.md %})). For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 `CONTROLJOB` | Manage changefeed jobs ([pause]({% link {{ page.version.version }}/pause-job.md %}), [resume]({% link {{ page.version.version }}/resume-job.md %}), and [cancel]({% link {{ page.version.version }}/cancel-job.md %})). For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 `VIEWJOB` | [View]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs) changefeed jobs. For details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
 `SELECT` | Create a sinkless changefeed that emits messages to a SQL client.
-**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables.
+**Deprecated** `CONTROLCHANGEFEED` role option + `SELECT` | Create changefeeds on tables. For an alternative, refer to the [`CHANGEFEED` privilege](#changefeed-privilege). 
 
 {{site.data.alerts.callout_info}}
-Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be deprecated in a future release.
+Users with the `CONTROLCHANGEFEED` role option must have `SELECT` on each table, even if they are also granted the `CHANGEFEED` privilege. The `CONTROLCHANGEFEED` role option will be removed in a future release.
 {{site.data.alerts.end}}
 
 #### `CHANGEFEED` privilege
@@ -31,10 +31,11 @@ You can [grant]({% link {{ page.version.version }}/grant.md %}#grant-privileges-
 GRANT CHANGEFEED ON TABLE example_table TO user;
 ~~~
 
-When you grant a user the `CHANGEFEED` privilege on a set of tables, they can:
+When you grant a user the `CHANGEFEED` privilege on a set of tables, they can create changefeeds on the target tables even if the user does **not** have the [`CONTROLCHANGEFEED` role option]({% link {{ page.version.version }}/alter-role.md %}#role-options) or the `SELECT` privilege on the tables.
 
-- Create changefeeds on the target tables even if the user does **not** have the [`CONTROLCHANGEFEED` role option]({% link {{ page.version.version }}/alter-role.md %}#role-options) or the `SELECT` privilege on the tables.
-- **Deprecated as of v25.1**: Manage the changefeed jobs running on the tables using the [`SHOW CHANGEFEED JOB`]({% link {{ page.version.version }}/show-jobs.md %}#show-changefeed-jobs), [`PAUSE JOB`]({% link {{ page.version.version }}/pause-job.md %}), [`RESUME JOB`]({% link {{ page.version.version }}/resume-job.md %}), and [`CANCEL JOB`](cancel-job.html) commands.
+{{site.data.alerts.callout_info}}
+Viewing and managing changefeed jobs with the `CHANGEFEED` privilege is **deprecated** as of v25.1. Instead, transition users that need to view and manage running changefeed jobs to [roles]({% link {{ page.version.version }}/create-role.md %}) that own the [jobs]({% link {{ page.version.version }}/show-jobs.md %}) or [granting]({% link {{ page.version.version }}/grant.md %}) them the `VIEWJOB` or `CONTROLJOB` privilege. For more details, refer to [View and manage changefeed jobs](#view-and-manage-changefeed-jobs).
+{{site.data.alerts.end}}
 
 These users will be able to create changefeeds, but they will not be able to run a `SELECT` query on that data directly. However, they could still read this data indirectly if they have read access to the [sink]({% link {{ page.version.version }}/changefeed-sinks.md %}).
 
@@ -54,7 +55,7 @@ Users can [view]({% link {{ page.version.version }}/show-jobs.md %}#show-changef
 - **Job ownership**: They own the job, or are a member of a role that owns a job.  
 - **Global privileges**: They are assigned [`CONTROLJOB` or `VIEWJOB`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
 
-To give a set of users access to a specific job, or set of jobs, you can assign them to a [role]({% link {{ page.version.version }}/security-reference/authorization.md %}#users-and-roles) that owns the job(s). 
+To give a set of users access to a specific job, or set of jobs, assign them to a [role]({% link {{ page.version.version }}/security-reference/authorization.md %}#users-and-roles) that owns the job(s). 
 
 {% include_cached new-in.html version="v25.1" %} You can transfer ownership of a job to a role or user using the [`ALTER JOB`]({% link {{ page.version.version }}/alter-job.md %}) statement:
 

--- a/src/current/_includes/v25.1/sidebar-data/sql.json
+++ b/src/current/_includes/v25.1/sidebar-data/sql.json
@@ -59,12 +59,6 @@
                 ]
             },
             {
-                "title": "<code>ALTER JOB</code>",
-                "urls": [
-                  "/${VERSION}/alter-job.html"
-                ]
-            },
-            {
               "title": "<code>ALTER PARTITION</code>",
               "urls": [
                 "/${VERSION}/alter-partition.html"

--- a/src/current/_includes/v25.1/sidebar-data/sql.json
+++ b/src/current/_includes/v25.1/sidebar-data/sql.json
@@ -53,6 +53,18 @@
               ]
             },
             {
+                "title": "<code>ALTER JOB</code>",
+                "urls": [
+                  "/${VERSION}/alter-job.html"
+                ]
+            },
+            {
+                "title": "<code>ALTER JOB</code>",
+                "urls": [
+                  "/${VERSION}/alter-job.html"
+                ]
+            },
+            {
               "title": "<code>ALTER PARTITION</code>",
               "urls": [
                 "/${VERSION}/alter-partition.html"

--- a/src/current/v23.1/alter-changefeed.md
+++ b/src/current/v23.1/alter-changefeed.md
@@ -18,6 +18,16 @@ The statement will return a job ID and the new job description.
 
 It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %}) a changefeed before running the `ALTER CHANGEFEED` statement against it. For an example of a changefeed modification using `ALTER CHANGEFEED`, see [Modify a changefeed](#modify-a-changefeed).
 
+## Required privileges
+
+To alter a changefeed, the user must have one of the following:
+
+- `CHANGEFEED` privilege on the table.
+- `admin` role.
+- `CONTROLCHANGEFEED` role option + `SELECT` on the table. (**Deprecated**) The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privilege [`CHANGEFEED`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+For more details on the required privileges for changefeeds generally, refer to the [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) page.
+
 ## Synopsis
 
 <div>
@@ -56,10 +66,6 @@ Consider the following when specifying options with `ALTER CHANGEFEED`:
     ~~~
 
     Setting `initial_scan = 'yes'` will trigger an initial scan on the newly added table. You may also explicitly define `initial_scan = 'no'`, though this is already the default behavior. The changefeed does not track the application of this option post scan. This means that you will not see the option listed in output or after a `SHOW CHANGEFEED JOB` statement.
-
-## Required privileges
-
-To alter a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Examples
 

--- a/src/current/v23.1/create-changefeed.md
+++ b/src/current/v23.1/create-changefeed.md
@@ -23,7 +23,7 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 ### Legacy privilege model
 
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
+To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Synopsis
 

--- a/src/current/v23.1/create-changefeed.md
+++ b/src/current/v23.1/create-changefeed.md
@@ -21,10 +21,6 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v23.1/create-schedule-for-changefeed.md
+++ b/src/current/v23.1/create-schedule-for-changefeed.md
@@ -15,7 +15,7 @@ For more detail on using changefeeds to create an export of your table data, see
 
 ### Legacy privilege model
 
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
+To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Synopsis
 

--- a/src/current/v23.1/create-schedule-for-changefeed.md
+++ b/src/current/v23.1/create-schedule-for-changefeed.md
@@ -13,10 +13,6 @@ For more detail on using changefeeds to create an export of your table data, see
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v23.2/alter-changefeed.md
+++ b/src/current/v23.2/alter-changefeed.md
@@ -18,6 +18,16 @@ The statement will return a job ID and the new job description.
 
 It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %}) a changefeed before running the `ALTER CHANGEFEED` statement against it. For an example of a changefeed modification using `ALTER CHANGEFEED`, see [Modify a changefeed](#modify-a-changefeed).
 
+## Required privileges
+
+To alter a changefeed, the user must have one of the following:
+
+- `CHANGEFEED` privilege on the table.
+- `admin` role.
+- `CONTROLCHANGEFEED` role option + `SELECT` on the table. (**Deprecated**) The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privilege [`CHANGEFEED`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+For more details on the required privileges for changefeeds generally, refer to the [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) page.
+
 ## Synopsis
 
 <div>
@@ -56,10 +66,6 @@ Consider the following when specifying options with `ALTER CHANGEFEED`:
     ~~~
 
     Setting `initial_scan = 'yes'` will trigger an initial scan on the newly added table. You may also explicitly define `initial_scan = 'no'`, though this is already the default behavior. The changefeed does not track the application of this option post scan. This means that you will not see the option listed in output or after a `SHOW CHANGEFEED JOB` statement.
-
-## Required privileges
-
-To alter a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Examples
 

--- a/src/current/v23.2/create-changefeed.md
+++ b/src/current/v23.2/create-changefeed.md
@@ -23,7 +23,7 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 ### Legacy privilege model
 
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
+To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Synopsis
 

--- a/src/current/v23.2/create-changefeed.md
+++ b/src/current/v23.2/create-changefeed.md
@@ -21,10 +21,6 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v23.2/create-schedule-for-changefeed.md
+++ b/src/current/v23.2/create-schedule-for-changefeed.md
@@ -15,7 +15,7 @@ For more detail on using changefeeds to create an export of your table data, see
 
 ### Legacy privilege model
 
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
+To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Synopsis
 

--- a/src/current/v23.2/create-schedule-for-changefeed.md
+++ b/src/current/v23.2/create-schedule-for-changefeed.md
@@ -13,10 +13,6 @@ For more detail on using changefeeds to create an export of your table data, see
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CONTROLCHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v24.1/alter-changefeed.md
+++ b/src/current/v24.1/alter-changefeed.md
@@ -18,6 +18,16 @@ The statement will return a job ID and the new job description.
 
 It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %}) a changefeed before running the `ALTER CHANGEFEED` statement against it. For an example of a changefeed modification using `ALTER CHANGEFEED`, see [Modify a changefeed](#modify-a-changefeed).
 
+## Required privileges
+
+To alter a changefeed, the user must have one of the following:
+
+- `CHANGEFEED` privilege on the table.
+- `admin` role.
+- `CONTROLCHANGEFEED` role option + `SELECT` on the table. (**Deprecated**) The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privilege [`CHANGEFEED`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+For more details on the required privileges for changefeeds generally, refer to the [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) page.
+
 ## Synopsis
 
 <div>
@@ -56,10 +66,6 @@ Consider the following when specifying options with `ALTER CHANGEFEED`:
     ~~~
 
     Setting `initial_scan = 'yes'` will trigger an initial scan on the newly added table. You may also explicitly define `initial_scan = 'no'`, though this is already the default behavior. The changefeed does not track the application of this option post scan. This means that you will not see the option listed in output or after a `SHOW CHANGEFEED JOB` statement.
-
-## Required privileges
-
-To alter a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Examples
 

--- a/src/current/v24.1/create-changefeed.md
+++ b/src/current/v24.1/create-changefeed.md
@@ -21,10 +21,6 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v24.1/create-schedule-for-changefeed.md
+++ b/src/current/v24.1/create-schedule-for-changefeed.md
@@ -13,10 +13,6 @@ For more detail on using changefeeds to create an export of your table data, see
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v24.2/alter-changefeed.md
+++ b/src/current/v24.2/alter-changefeed.md
@@ -18,6 +18,16 @@ The statement will return a job ID and the new job description.
 
 It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %}) a changefeed before running the `ALTER CHANGEFEED` statement against it. For an example of a changefeed modification using `ALTER CHANGEFEED`, see [Modify a changefeed](#modify-a-changefeed).
 
+## Required privileges
+
+To alter a changefeed, the user must have one of the following:
+
+- `CHANGEFEED` privilege on the table.
+- `admin` role.
+- `CONTROLCHANGEFEED` role option + `SELECT` on the table. (**Deprecated**) The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privilege [`CHANGEFEED`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+For more details on the required privileges for changefeeds generally, refer to the [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) page.
+
 ## Synopsis
 
 <div>
@@ -56,10 +66,6 @@ Consider the following when specifying options with `ALTER CHANGEFEED`:
     ~~~
 
     Setting `initial_scan = 'yes'` will trigger an initial scan on the newly added table. You may also explicitly define `initial_scan = 'no'`, though this is already the default behavior. The changefeed does not track the application of this option post scan. This means that you will not see the option listed in output or after a `SHOW CHANGEFEED JOB` statement.
-
-## Required privileges
-
-To alter a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Examples
 

--- a/src/current/v24.2/create-changefeed.md
+++ b/src/current/v24.2/create-changefeed.md
@@ -21,10 +21,6 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v24.2/create-schedule-for-changefeed.md
+++ b/src/current/v24.2/create-schedule-for-changefeed.md
@@ -13,10 +13,6 @@ For more detail on using changefeeds to create an export of your table data, see
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v24.3/alter-changefeed.md
+++ b/src/current/v24.3/alter-changefeed.md
@@ -18,6 +18,16 @@ The statement will return a job ID and the new job description.
 
 It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %}) a changefeed before running the `ALTER CHANGEFEED` statement against it. For an example of a changefeed modification using `ALTER CHANGEFEED`, see [Modify a changefeed](#modify-a-changefeed).
 
+## Required privileges
+
+To alter a changefeed, the user must have one of the following:
+
+- `CHANGEFEED` privilege on the table.
+- `admin` role.
+- `CONTROLCHANGEFEED` role option + `SELECT` on the table. (**Deprecated**) The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privilege [`CHANGEFEED`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+For more details on the required privileges for changefeeds generally, refer to the [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) page.
+
 ## Synopsis
 
 <div>
@@ -56,10 +66,6 @@ Consider the following when specifying options with `ALTER CHANGEFEED`:
     ~~~
 
     Setting `initial_scan = 'yes'` will trigger an initial scan on the newly added table. You may also explicitly define `initial_scan = 'no'`, though this is already the default behavior. The changefeed does not track the application of this option post scan. This means that you will not see the option listed in output or after a `SHOW CHANGEFEED JOB` statement.
-
-## Required privileges
-
-To alter a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Examples
 

--- a/src/current/v24.3/create-changefeed.md
+++ b/src/current/v24.3/create-changefeed.md
@@ -21,10 +21,6 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v24.3/create-schedule-for-changefeed.md
+++ b/src/current/v24.3/create-schedule-for-changefeed.md
@@ -13,10 +13,6 @@ For more detail on using changefeeds to create an export of your table data, see
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v25.1/alter-changefeed.md
+++ b/src/current/v25.1/alter-changefeed.md
@@ -18,6 +18,16 @@ The statement will return a job ID and the new job description.
 
 It is necessary to [**pause**]({% link {{ page.version.version }}/pause-job.md %}) a changefeed before running the `ALTER CHANGEFEED` statement against it. For an example of a changefeed modification using `ALTER CHANGEFEED`, see [Modify a changefeed](#modify-a-changefeed).
 
+## Required privileges
+
+To alter a changefeed, the user must have one of the following:
+
+- `CHANGEFEED` privilege on the table.
+- `admin` role.
+- `CONTROLCHANGEFEED` role option + `SELECT` on the table. (**Deprecated**) The `CONTROLCHANGEFEED` role option will be removed in a future release. We recommend using the system-level privilege [`CHANGEFEED`]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges).
+
+For more details on the required privileges for changefeeds generally, refer to the [`CREATE CHANGEFEED`]({% link {{ page.version.version }}/create-changefeed.md %}) page.
+
 ## Synopsis
 
 <div>
@@ -57,9 +67,6 @@ Consider the following when specifying options with `ALTER CHANGEFEED`:
 
     Setting `initial_scan = 'yes'` will trigger an initial scan on the newly added table. You may also explicitly define `initial_scan = 'no'`, though this is already the default behavior. The changefeed does not track the application of this option post scan. This means that you will not see the option listed in output or after a `SHOW CHANGEFEED JOB` statement.
 
-## Required privileges
-
-To alter a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Examples
 

--- a/src/current/v25.1/alter-job.md
+++ b/src/current/v25.1/alter-job.md
@@ -1,0 +1,48 @@
+---
+title: ALTER JOB
+summary: Use the ALTER JOB statement to transfer ownership of a job between users or roles.
+toc: true
+---
+
+{% include_cached new-in.html version="v25.1" %} The `ALTER JOB` statement transfers ownership of a [job]({% link {{ page.version.version }}/show-jobs.md %}) between [users]({% link {{ page.version.version }}/create-user.md %}) or [roles]({% link {{ page.version.version }}/create-role.md %}).
+
+## Required privileges
+
+To alter job ownership, the user must be one of the following: 
+
+- The current job owner.
+- A member of the role that is the current owner. 
+- An `admin`.
+
+Unless the user is an `admin`, they can only transfer ownership of a job to themselves or to a role of which they are a member.
+
+To add a user to a role, refer to the [`GRANT`]({% link {{ page.version.version }}/grant.md %}) statement.
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/alter_job.html %}
+</div>
+
+### Parameters
+
+Parameter | Description
+----------+------------
+`a_expr` | The job ID to modify.
+`role_spec` | The role or user.
+
+## Example
+
+To transfer job ownership from the user who created the job to a role they're a member of:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER JOB job_id OWNER TO role_name;
+~~~
+
+## See also
+
+- [`SHOW JOBS`]({% link {{ page.version.version }}/show-jobs.md %})
+- [`PAUSE JOB`]({% link {{ page.version.version }}/pause-job.md %})
+- [`RESUME JOB`]({% link {{ page.version.version }}/resume-job.md %})
+- [`CANCEL JOB`]({% link {{ page.version.version }}/cancel-job.md %})

--- a/src/current/v25.1/create-changefeed.md
+++ b/src/current/v25.1/create-changefeed.md
@@ -21,16 +21,6 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-{{site.data.alerts.callout_info}}
-Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
-
-There is continued support for the legacy privilege model for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the [new privilege model](#required-privileges) for all changefeeds.
-{{site.data.alerts.end}}
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v25.1/create-changefeed.md
+++ b/src/current/v25.1/create-changefeed.md
@@ -23,6 +23,12 @@ The [examples](#examples) on this page provide the foundational syntax of the `C
 
 ### Legacy privilege model
 
+{{site.data.alerts.callout_info}}
+Starting in v22.2, CockroachDB introduces a new [system-level privilege model]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) that provides finer control over a user's privilege to work with the database, including creating and managing changefeeds.
+
+There is continued support for the legacy privilege model for changefeeds in v23.1, however it **will be removed** in a future release of CockroachDB. We recommend implementing the [new privilege model](#required-privileges) for all changefeeds.
+{{site.data.alerts.end}}
+
 To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
 
 ## Synopsis

--- a/src/current/v25.1/create-schedule-for-changefeed.md
+++ b/src/current/v25.1/create-schedule-for-changefeed.md
@@ -13,10 +13,6 @@ For more detail on using changefeeds to create an export of your table data, see
 
 {% include {{ page.version.version }}/cdc/privilege-model.md %}
 
-### Legacy privilege model
-
-To create a changefeed, the user must be a member of the `admin` role or have the [`CREATECHANGEFEED`]({% link {{ page.version.version }}/create-user.md %}#create-a-user-that-can-control-changefeeds) parameter set.
-
 ## Synopsis
 
 <div>

--- a/src/current/v25.1/create-user.md
+++ b/src/current/v25.1/create-user.md
@@ -205,8 +205,6 @@ with_password         | VALID UNTIL=2021-10-10 00:00:00+00:00 | {}
 
 ### Create a user that can pause, resume, and cancel non-admin jobs
 
-The following example allows the user to cancel [queries]({% link {{ page.version.version }}/cancel-query.md %}) and [sessions]({% link {{ page.version.version }}/cancel-session.md %}) for other non-`admin` roles:
-
 The following example allows the user to [pause]({% link {{ page.version.version }}/pause-job.md %}), [resume]({% link {{ page.version.version }}/resume-job.md %}), and [cancel]({% link {{ page.version.version }}/cancel-job.md %}) jobs:
 
 ~~~ sql


### PR DESCRIPTION
Fixes DOC-12058

This PR updates the changefeed privilege docs to deprecate the use of the `CHANGEFEED` privilege for viewing and managing changefeed jobs on tables users have the privilege on (from v25.1). Instead, documenting that users should use job ownership or global privileges to view and manage jobs.

Also, made changes to an incorrect role option listed since v20.2 (was listed as `CREATECHANGEFEED` should have been `CONTROLCHANGEFEED`). This make sense and has meant that the content for this deprecated role option is now consolidated into the Privilege model table.

Also, made adjustments to the `ALTER CHANGEFEED` privilege section as per the above changes + testing.

## Preview

https://deploy-preview-19290--cockroachdb-docs.netlify.app/docs/v25.1/alter-job.html
https://deploy-preview-19290--cockroachdb-docs.netlify.app/docs/v25.1/create-changefeed.html#required-privileges