### PR TITLE
Add missing backup schedule bug fix release note

### DIFF
--- a/src/current/_includes/releases/v23.1/v23.1.29.md
+++ b/src/current/_includes/releases/v23.1/v23.1.29.md
@@ -43,6 +43,7 @@ Release Date: November 18, 2024
 - Fixed a bug in the query optimizer which could cause CockroachDB nodes to crash in rare cases. The bug could occur when a query contained a filter of the form `col IN (elem0, elem1, ..., elemN)` such that `N` is very large, e.g. 1.6+ million, and when `col` exists in a hash-sharded index or exists in a table with an indexed, computed column dependent on `col`. [#133068][#133068]
 - Users with the admin role can now run `ALTER DEFAULT PRIVILEGES FOR target_role ...` on any `target_role`. Previously, this could result in a privilege error, which is incorrect as admins are allowed to perform any operation. [#133067][#133067]
 - `REASSIGN OWNED BY` will now transfer ownership of the public schema. Previously, it would always skip over the public schema even if it was owned by the target role. [#133067][#133067]
+- Fixed a bug where backup schedules could advance a protected timestamp too early, which caused incremental backups to fail. [#131388][#131388]
 
 [#126414]: https://github.com/cockroachdb/cockroach/pull/126414
 [#130987]: https://github.com/cockroachdb/cockroach/pull/130987

--- a/src/current/_includes/releases/v23.2/v23.2.16.md
+++ b/src/current/_includes/releases/v23.2/v23.2.16.md
@@ -41,6 +41,7 @@ Release Date: November 18, 2024
 - `REASSIGN OWNED BY` will now transfer ownership of the `public` schema. Previously, it would always skip over the `public` schema even if it was owned by the target role. [#133069][#133069]
 - Added a timer for inner changefeed sink client flushes. Fixed a bug where timers were not correctly registered with the metric system. [#133255][#133255]
 - Fixed an error that could be caused by using an `AS OF SYSTEM TIME` expression that references a user-defined (or unknown) type name. These kinds of expressions are invalid, but previously the error was not handled properly. This will now return the correct error message. [#132453][#132453]
+- Fixed a bug where backup schedules could advance a protected timestamp too early, which caused incremental backups to fail. [#131389][#131389]
 
 <h3 id="v23-2-15-performance-improvements">Performance improvements</h3>
 

--- a/src/current/_includes/releases/v24.1/v24.1.6.md
+++ b/src/current/_includes/releases/v24.1/v24.1.6.md
@@ -43,6 +43,7 @@ Release Date: October 17, 2024
 - The AWS endpoint and cloud custom HTTP client configuration are now considered when [implicit authentication]({% link v24.1/cloud-storage-authentication.md %}) is used for cloud storage. Previously, these were only considered when using explicit credentials. [#131202][#131202]
 - Fixed a bug where jobs created in sessions with non-zero session timezone offsets could hang before starting or report incorrect creation times when viewed in [`SHOW JOBS`]({% link v24.1/show-jobs.md %}) and the DB Console. [#131406][#131406]
 - Fixed a bug that could prevent a [changefeed]({% link v24.1/change-data-capture-overview.md %}) from being able to resume after being paused for a prolonged period of time. [#130920][#130920]
+- Fixed a bug where backup schedules could advance a protected timestamp too early, which caused incremental backups to fail. [#131390][#131390]
 
 <h3 id="v24-1-6-performance-improvements">Performance improvements</h3>
 

--- a/src/current/_includes/releases/v24.2/v24.2.4.md
+++ b/src/current/_includes/releases/v24.2/v24.2.4.md
@@ -52,6 +52,7 @@ Release Date: October 17, 2024
     [#130990][#130990]
 - Fixed a bug where jobs created in a session with a timezone offset configured could fail to start or could report an incorrect creation time in the output of [`SHOW JOBS`]({% link v24.2/show-jobs.md %}) and in the [DB Console]({% link v24.2/ui-overview.md %}). [#131407][#131407]
 - Fixed a bug that could prevent a [changefeed]({% link v24.2/change-data-capture-overview.md %}) from resuming after a prolonged [paused state]({% link v24.2/create-and-configure-changefeeds.md %}#pause). [#130921][#130921]
+- Fixed a bug where backup schedules could advance a protected timestamp too early, which caused incremental backups to fail. [#131391][#131391]
 
 <h3 id="v24-2-4-performance-improvements">Performance improvements</h3>
 

--- a/src/current/_includes/releases/v24.3/v24.3.0-alpha.1.md
+++ b/src/current/_includes/releases/v24.3/v24.3.0-alpha.1.md
@@ -210,6 +210,7 @@ Release Date: October 9, 2024
 - Fixed a bug which could result in [changefeeds using CDC queries]({% link v24.3/create-schedule-for-changefeed.md %}#create-a-scheduled-changefeed-with-cdc-queries) failing due to a system table being [garbage collected]({% link v24.3/architecture/storage-layer.md %}#garbage-collection). [#131027][#131027]
 - [`ALTER COLUMN TYPE`]({% link v24.3/alter-table.md %}#convert-to-a-different-data-type) now errors out when there is a [partial index]({% link v24.3/partial-indexes.md %}) that is dependent on the column being altered. [#131590][#131590]
 - Fixed a bug that prevented buffered file sinks from being included when iterating over all file sinks. This led to problems such as the `debug zip` command not being able to fetch logs for a cluster where buffering was enabled. [#130158][#130158]
+- Fixed a bug where backup schedules could advance a protected timestamp too early, which caused incremental backups to fail. [#131358][#131358]
 
 <h3 id="v24-3-0-alpha-1-performance-improvements">Performance improvements</h3>
 
@@ -321,6 +322,7 @@ Release Date: October 9, 2024
 [#131250]: https://github.com/cockroachdb/cockroach/pull/131250
 [#131309]: https://github.com/cockroachdb/cockroach/pull/131309
 [#131326]: https://github.com/cockroachdb/cockroach/pull/131326
+[#131358]: https://github.com/cockroachdb/cockroach/pull/131358
 [#131378]: https://github.com/cockroachdb/cockroach/pull/131378
 [#131383]: https://github.com/cockroachdb/cockroach/pull/131383
 [#131396]: https://github.com/cockroachdb/cockroach/pull/131396


### PR DESCRIPTION
Fixes DOC-12109

This PR adds a release note to versions 23.1 – 24.3 that was omitted from the original eng PR.