### PR TITLE
Add docs for PCR on Cloud in Preview

### DIFF
--- a/src/current/_includes/v25.1/known-limitations/physical-cluster-replication.md
+++ b/src/current/_includes/v25.1/known-limitations/physical-cluster-replication.md
@@ -1,5 +1,7 @@
-- Physical cluster replication is supported only on CockroachDB {{ site.data.products.core }} in new clusters on v23.2 or above. Physical Cluster Replication cannot be enabled on clusters that have been upgraded from a previous version of CockroachDB.
-- The primary and standby clusters must have the same [zone configurations]({% link {{ page.version.version }}/configure-replication-zones.md %}).
+- Physical cluster replication is supported on:
+    - CockroachDB self-hosted in new clusters on v23.2 or above. Physical Cluster Replication cannot be enabled on clusters that have been upgraded from a previous version of CockroachDB.
+    - CockroachDB {{ site.data.products.advanced }} in new clusters on v25.1 with the `"support_physical_cluster_replication"` field enabled.
+- The primary and standby clusters must have the same [zone configurations]({% link {{ page.version.version }}/configure-replication-zones.md %}) in CockroachDB self-hosted.
 - Failing back to the primary cluster after a failover is a manual process. Refer to [Fail back to the primary cluster]({% link {{ page.version.version }}/failover-replication.md %}#fail-back-to-the-primary-cluster). In addition, after failover, to continue using physical cluster replication, you must configure it again.
 - Before failover to the standby, the standby cluster does not support running [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) or [changefeeds]({% link {{ page.version.version }}/change-data-capture-overview.md %}).
 - Large data imports, such as those produced by [`RESTORE`]({% link {{ page.version.version }}/restore.md %}) or [`IMPORT INTO`]({% link {{ page.version.version }}/import-into.md %}), may dramatically increase [replication lag]({% link {{ page.version.version }}/physical-cluster-replication-technical-overview.md %}#failover-and-promotion-process).

--- a/src/current/_includes/v25.1/sidebar-data/cloud-deployments.json
+++ b/src/current/_includes/v25.1/sidebar-data/cloud-deployments.json
@@ -552,6 +552,12 @@
                 ]
               },
               {
+                "title": "Physical Cluster Replication",
+                "urls": [
+                    "/cockroachcloud/physical-cluster-replication.html"
+                ]
+              },
+              {
                 "title": "Billing Management",
                 "urls": [
                    "/cockroachcloud/billing-management.html"

--- a/src/current/_includes/v25.1/sidebar-data/cross-cluster-replication.json
+++ b/src/current/_includes/v25.1/sidebar-data/cross-cluster-replication.json
@@ -41,58 +41,70 @@
             ]
           },
           {
-            "title": "Set Up Physical Cluster Replication",
+            "title": "Physical Cluster Replication on Advanced",
             "urls": [
-              "/${VERSION}/set-up-physical-cluster-replication.html"
+              "/cockroachcloud/physical-cluster-replication.html"
             ]
           },
           {
-            "title": "Fail Over from a Primary to a Standby Cluster",
-            "urls": [
-              "/${VERSION}/failover-replication.html"
-            ]
-          },
-          {
-            "title": "Monitor a Replication Stream",
-            "urls": [
-              "/${VERSION}/physical-cluster-replication-monitoring.html"
-            ]
-          },
-          {
-            "title": "Technical Overview",
-            "urls": [
-              "/${VERSION}/physical-cluster-replication-technical-overview.html"
-            ]
-          },
-          {
-            "title": "Cluster Virtualization",
+            "title": "Physical Cluster Replication on Self-hosted",
             "items": [
-              {
-                "title": "Overview",
-                "urls": [
-                  "/${VERSION}/cluster-virtualization-overview.html"
-                ]
-              },
-              {
-                "title": "Work with Virtual Clusters",
-                "urls": [
-                  "/${VERSION}/work-with-virtual-clusters.html"
-                ]
-              },
-              {
-                "title": "Setting Scopes",
-                "urls": [
-                  "/${VERSION}/cluster-virtualization-setting-scopes.html"
-                ]
-              },
-              {
-                "title": "Metric Scopes",
-                "urls": [
-                  "/${VERSION}/cluster-virtualization-metric-scopes.html"
-                ]
-              }
+                {
+                    "title": "Set Up Physical Cluster Replication",
+                    "urls": [
+                      "/${VERSION}/set-up-physical-cluster-replication.html"
+                    ]
+                  },
+                  {
+                    "title": "Fail Over from a Primary to a Standby Cluster",
+                    "urls": [
+                      "/${VERSION}/failover-replication.html"
+                    ]
+                  },
+                  {
+                    "title": "Monitor a Replication Stream",
+                    "urls": [
+                      "/${VERSION}/physical-cluster-replication-monitoring.html"
+                    ]
+                  },
+                  {
+                    "title": "Technical Overview",
+                    "urls": [
+                      "/${VERSION}/physical-cluster-replication-technical-overview.html"
+                    ]
+                  },
+                  {
+                    "title": "Cluster Virtualization",
+                    "items": [
+                      {
+                        "title": "Overview",
+                        "urls": [
+                          "/${VERSION}/cluster-virtualization-overview.html"
+                        ]
+                      },
+                      {
+                        "title": "Work with Virtual Clusters",
+                        "urls": [
+                          "/${VERSION}/work-with-virtual-clusters.html"
+                        ]
+                      },
+                      {
+                        "title": "Setting Scopes",
+                        "urls": [
+                          "/${VERSION}/cluster-virtualization-setting-scopes.html"
+                        ]
+                      },
+                      {
+                        "title": "Metric Scopes",
+                        "urls": [
+                          "/${VERSION}/cluster-virtualization-metric-scopes.html"
+                        ]
+                      }
+                    ]
+                  }
             ]
           }
+          
         ]
       }
     ]

--- a/src/current/cockroachcloud/physical-cluster-replication.md
+++ b/src/current/cockroachcloud/physical-cluster-replication.md
@@ -1,0 +1,256 @@
+---
+title: Physical Cluster Replication
+summary: Set up physical cluster replication (PCR) in a Cloud deployment.
+toc: true
+---
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
+
+CockroachDB **physical cluster replication (PCR)** continuously sends all data at the byte level from a _primary_ cluster to an independent _standby_ cluster. Existing data and ongoing changes on the active primary cluster, which is serving application data, replicate asynchronously to the passive standby cluster.
+
+In a disaster recovery scenario, you can [fail over](#step-4-fail-over-to-the-standby-cluster) from the unavailable primary cluster to the standby cluster. This will stop the PCR stream, reset the standby cluster to a point in time where all ingested data is consistent, and mark the standby as ready to accept application traffic.
+
+## Set up PCR on CockroachDB {{ site.data.products.advanced }}
+
+In this guide, you'll use the [{{ site.data.products.cloud }} API]({% link cockroachcloud/cloud-api.md %}) to set up PCR from a primary cluster to a standby cluster, monitor the PCR stream, and fail over from the primary to the standby cluster.
+
+{{site.data.alerts.callout_info}}
+PCR is supported on CockroachDB {{ site.data.products.advanced }} and CockroachDB self-hosted clusters. For a guide to setting up PCR on CockroachDB self-hosted, refer to the [Set Up Physical Cluster Replication]({% link {{ site.current_cloud_version }}/set-up-physical-cluster-replication.md %}) tutorial.
+{{site.data.alerts.end}}
+
+### Before you begin
+
+You'll need the following:
+
+- [Cloud API Access]({% link cockroachcloud/managing-access.md %}#api-access).
+
+    To set up and manage PCR on CockroachDB {{ site.data.products.advanced }} clusters, you'll use the `'https://cockroachlabs.cloud/api/v1/replication-streams'` endpoint. Access to the `replication-streams` endpoint requires a valid CockroachDB {{ site.data.products.cloud }} [service account]({% link cockroachcloud/managing-access.md %}#manage-service-accounts) with the correct permissions.
+
+    The following describes the required roles for the `replication-streams` endpoint methods:
+
+    Method | Required roles | Description
+    -------+----------------+------------
+    `POST` | [Cluster Administrator]({% link cockroachcloud/authorization.md %}#cluster-administrator) | Create a PCR stream.
+    `GET` | [Cluster Administrator]({% link cockroachcloud/authorization.md %}#cluster-administrator), [Cluster Operator]({% link cockroachcloud/authorization.md %}#cluster-operator), [Cluster Developer]({% link cockroachcloud/authorization.md %}#cluster-developer) | Retrieve information for the PCR stream.
+    `PATCH` | [Cluster Administrator]({% link cockroachcloud/authorization.md %}#cluster-administrator) | Update the PCR stream to fail over.
+
+    {{site.data.alerts.callout_success}}
+    We recommend creating service accounts with the [principle of least privilege](https://wikipedia.org/wiki/Principle_of_least_privilege), and giving each application that accesses the API its own service account and API key. This allows fine-grained access to the cluster and PCR streams.
+    {{site.data.alerts.end}}
+
+- Read the [Configuration](#configuration) section for detail on cloud provider and region setup.
+
+### Configuration
+
+To set up PCR successfully:
+
+- Clusters must be in the same cloud (AWS, GCP, or Azure).
+- Clusters must be single [region]({% link cockroachcloud/regions.md %}) (multiple availability zones per clusteris supported).
+- The primary and standby cluster in AWS and Azure must be in different regions.
+- The primary and standby cluster in GCP can be in the same region, but must not have overlapping CIDR ranges.
+- Clusters can have different [node topology]({% link cockroachcloud/plan-your-cluster-advanced.md %}#cluster-topology) and [hardware configurations]({% link cockroachcloud/plan-your-cluster-advanced.md %}#cluster-sizing-and-scaling). For disaster recovery purposes (failover and redirecting application traffic to a standby), we recommend configuring the primary and standby clusters with similar hardware.
+
+### Step 1. Create the clusters
+
+To use PCR, it is necessary to set the **standby** cluster with the `support_physical_cluster_replication` field to `true`, which indicates that a cluster should start using an architecture that supports PCR. For details on supported cluster cloud provider and region setup, refer to [Configuration](#configuration).
+
+1. Send a `POST` request to create the primary cluster:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    curl --location --request POST 'https://cockroachlabs.cloud/api/v1/clusters' --header "Authorization: Bearer api_secret_key" --header 'Content-Type: application/json' --data '{"name": "primary_cluster_name", "provider": "AWS", "spec": {"dedicated": {"cockroachVersion": "v24.3", "hardware": {"disk_iops": 0, "machine_spec": {"num_virtual_cpus": 4}, "storage_gib": 16}, "region_nodes": {"us-east-1": 3}, "support_physical_cluster_replication": true}}}'
+    ~~~
+
+    Ensure that you replace each of the values for the cluster specification as per your requirements. For details on the cluster specifications, refer to [Create a cluster]({% link cockroachcloud/cloud-api.md %}#create-a-cluster). Also, replace `api_secret_key` with your API secret key. You can include `support_physical_cluster_replication` set to `true`, but it is not a requirement for the primary cluster.
+
+1. Send a `POST` request to create the standby cluster that includes your necessary cluster specification. Ensure that you include `support_physical_cluster_replication` set to `true`:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    curl --location --request POST 'https://cockroachlabs.cloud/api/v1/clusters' --header "Authorization: Bearer api_secret_key" --header 'Content-Type: application/json' --data '{"name": "standby_cluster_name", "provider": "AWS", "spec": {"dedicated": {"cockroachVersion": "v24.3", "hardware": {"disk_iops": 0, "machine_spec": {"num_virtual_cpus": 4}, "storage_gib": 16}, "region_nodes": {"us-east-2": 3}, "support_physical_cluster_replication": true}}}'
+    ~~~
+
+    If you're creating clusters in AWS or Azure, you must start the primary and standby clusters in different regions.
+
+{{site.data.alerts.callout_success}}
+We recommend [enabling Prometheus metrics export]({% link cockroachcloud/export-metrics.md %}) on your cluster before starting a PCR stream. For details on metrics to track, refer to [Monitor the PCR stream](#step-3-monitor-the-pcr-stream).
+{{site.data.alerts.end}}
+
+### Step 2. Start the PCR stream
+
+{{site.data.alerts.callout_info}}
+The standby cluster must be empty upon starting PCR. It is possible to write to both clusters before initiating the PCR stream, however, we recommend keeping the standby empty. That is, not writing to the standby prior to starting PCR. When you initiate the PCR stream, CockroachDB {{ site.data.products.cloud }} will take a full cluster backup of the standby cluster, delete all data from the standby, and then start the PCR stream.
+{{site.data.alerts.end}}
+
+With the primary and standby clusters created, you can now start the PCR stream.
+
+Send a `POST` request to the `/v1/replication-streams` endpoint to start the PCR stream:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --location --request POST 'https://cockroachlabs.cloud/api/v1/replication-streams' --header "Authorization: Bearer api_secret_key" --header 'Content-Type: application/json' --data '{"sourceClusterId": "primary_cluster_id","targetClusterId": "standby_cluster_id"}'
+~~~
+
+Replace:
+
+- `api_secret_key` with your API secret key.
+- `primary_cluster_id` with the cluster ID returned after creating the primary cluster.
+- `standby_cluster_id` with the cluster ID returned after creating the standby cluster.
+
+You can find the cluster IDs in the cluster creation output, or in the URL of the single cluster overview page: `https://cockroachlabs.cloud/cluster/{your_cluster_id}/overview`. The ID will resemble `ad1e8630-729a-40f3-87e4-9f72eb3347a0`.
+
+Once you have started PCR, the standby cluster cannot accept writes and reads, therefore the [Cloud Console]({% link cockroachcloud/cluster-overview-page.md %}) and SQL shell will be unavailable prior to failover.
+
+~~~ json
+{
+    "id": "7487d7a6-868b-4c6f-aa60-cc306cc525fe",
+    "status": "STARTING",
+    "source_cluster_id": "ad1e8630-729a-40f3-87e4-9f72eb3347a0",
+    "target_cluster_id": "e64b56c3-09f2-42ee-9f5a-d9b13985a897",
+    "created_at": "2025-01-13T16:41:20.467781Z",
+    "retained_time": null,
+    "replicated_time": null,
+    "failover_at": null,
+    "activation_at": null
+}
+~~~
+
+To start PCR between clusters, CockroachDB {{ site.data.products.cloud }} sets up VPC peering between clusters and validates the connectivity. As a result, it may take around 5 minutes to initialize the PCR job during which the status will be `STARTING`.
+
+### Step 3. Monitor the PCR stream
+
+For monitoring the current status of the PCR stream, send a `GET` request to the `/v1/replication-streams` endpoint along with the primary cluster, standby cluster, or the ID of the PCR stream:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --location --request GET "https://cockroachlabs.cloud/api/v1/replication-streams?cluster_id=primary/standby_cluster_id" --header "Authorization: Bearer api_secret_key" --header 'Content-Type: application/json' 
+~~~
+
+Replace:
+
+- `api_secret_key` with your API secret key.
+- `primary/standby_cluster_id` with the primary or standby cluster's ID.
+
+This will return:
+
+~~~json
+{
+  "replication_streams": [
+    {
+      "id": "7487d7a6-868b-4c6f-aa60-cc306cc525fe",
+      "status": "REPLICATING",
+      "source_cluster_id": "ad1e8630-729a-40f3-87e4-9f72eb3347a0",
+      "target_cluster_id": "e64b56c3-09f2-42ee-9f5a-d9b13985a897",
+      "created_at": "2025-01-13T16:41:20.467781Z",
+      "retained_time": "2025-01-13T19:35:14.472670Z",
+      "replicated_time": "2025-01-13T19:46:15Z",
+      "failover_at": null,
+      "activation_at": null
+    }
+  ],
+}
+~~~
+
+- `id`: The ID of the PCR stream.
+- `status`: The status of the PCR stream. For descriptions, refer to [Status](#status).
+- `source_cluster_id`: The cluster ID of the primary cluster.
+- `target_cluster_id`: The cluster ID of the standby cluster.
+- `created_at`: The timestamp when the PCR stream was started.
+- `retained_time`: The timestamp indicating the lower bound that the PCR stream can failover to. The tracked replicated time and the advancing [protected timestamp]({% link {{ site.current_cloud_version }}/architecture/storage-layer.md %}#protected-timestamps) allows PCR to also track [_retained time_](#technical-reference).
+- `replicated_time`: The latest time at which the standby cluster has consistent data.
+- `failover_at`: The requested timestamp for failover. This will return `NULL` until you have requested failover. If you used `"status":"FAILING_OVER"` to initiate the failover and omitted `failover_at`, the failover time will default to the latest consistent replicated time. For more details, refer to [Fail over to the standby cluster](#step-4-fail-over-to-the-standby-cluster).
+- `activation_at`: The CockroachDB system time at which failover is finalized, which could be different from the time that failover was requested. This field will return a response when the PCR stream is in [`COMPLETED` status](#status).
+
+For details on the returned statuses, refer to the [CockroachDB {{ site.data.products.cloud }} API reference](https://www.cockroachlabs.com/docs/api/cloud/v1).
+
+#### Status
+
+Status | Description
+-------+------------
+`STARTING` | Setting up VPC peering between clusters and validating the connectivity.
+`REPLICATING` | Completing an initial scan and then continuing ongoing replication between the primary and standby clusters.
+`FAILING_OVER` | Initiating the failover from the primary to the standby cluster.
+`COMPLETED` | The failover is complete and the standby cluster is now independent from the primary cluster.
+
+#### Metrics
+
+For continual monitoring of PCR, track the following metrics with [Prometheus]({% link cockroachcloud/export-metrics.md %}): 
+
+- `physical_replication.logical_bytes`: The logical bytes (the sum of all keys and values) ingested by all PCR streams.
+- `physical_replication.sst_bytes`: The SST bytes (compressed) sent to the KV layer by all PCR streams.
+- `physical_replication.replicated_time_seconds`: The replicated time of the PCR stream in seconds since the Unix epoch.
+
+### Step 4. Fail over to the standby cluster
+
+Failing over from the primary cluster to the standby cluster will stop the PCR stream, reset the standby cluster to a point in time where all ingested data is consistent, and mark the standby as ready to accept application traffic. You can schedule the failover to:
+
+- The latest consistent time.
+- A time in the past within the [`retained_time`](#technical-reference).
+- A time up to 1 hour in the future.
+
+To specify a timestamp, send a `PATCH` request to the `/v1/replication-streams` endpoint along with the primary cluster, standby cluster, or the ID of the PCR stream. Include the `failover_at` timestamp and the `"status": "FAILING_OVER"` field:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --location --request PATCH "https://cockroachlabs.cloud/api/v1/replication-streams/7487d7a6-868b-4c6f-aa60-cc306cc525fe" --header "Authorization: Bearer api_secret_key" --header 'Content-Type:application/json' --data '{"status": "FAILING_OVER", "failover_at": "2025-01-13T19:35:14.472670Z"}'
+~~~
+
+To fail over to the latest consistent time, you only need to include `"status": "FAILING_OVER"` in your request with one of the cluster IDs or PCR stream ID:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --location --request PATCH "https://cockroachlabs.cloud/api/v1/replication-streams/7487d7a6-868b-4c6f-aa60-cc306cc525fe" --header "Authorization: Bearer api_secret_key" --header 'Content-Type:application/json' --data '{"status": "FAILING_OVER"}'
+~~~
+~~~json
+{
+  "id": "f1ea3b5a-5b9b-4101-9db4-780734554b14",
+  "status": "FAILING_OVER",
+  "source_cluster_id": "560cc798-7881-4a5b-baf0-321354a42c19",
+  "target_cluster_id": "24a9d47c-418c-4abc-940b-d2f665d95715",
+  "created_at": "2025-01-23T16:54:15.926325Z",
+  "retained_time": null,
+  "replicated_time": null,
+  "failover_at": null,
+  "activation_at": null
+}
+~~~
+
+After the failover is complete, both clusters can receive traffic and operate as separate clusters. It is necessary to redirect application traffic manually.
+
+{{site.data.alerts.callout_info}}
+PCR is on the cluster level, which means that the job also replicates all system tables. Users that need to access the standby cluster after failover should use the user roles for the primary cluster, because the standby cluster is a copy of the primary cluster. PCR overwrites all previous system tables on the standby cluster.
+{{site.data.alerts.end}}
+
+### Fail back to the primary cluster
+
+To fail back from the standby to the primary cluster, start another PCR stream with the standby cluster as the `sourceClusterId` and the original primary cluster as the `targetClusterId`. 
+
+## Technical reference
+
+The replication happens at the byte level, which means that the job is unaware of databases, tables, row boundaries, and so on. However, when a [failover](#step-4-fail-over-to-the-standby-cluster) to the standby cluster is initiated, the PCR job ensures that the cluster is in a transactionally consistent state as of a certain point in time. Beyond the application data, the job will also replicate users, privileges, and schema changes.
+
+At startup, the PCR job will set up VPC peering between the primary and standby {{ site.data.products.advanced }} clusters and validate the connectivity.
+
+During the job, [rangefeeds]({% link {{ site.current_cloud_version }}/create-and-configure-changefeeds.md %}#enable-rangefeeds) are periodically emitting _resolved timestamps_, which is the time where the ingested data is known to be consistent. Resolved timestamps provide a guarantee that there are no new writes from before that timestamp. This allows the [protected timestamp]({% link {{ site.current_cloud_version }}/architecture/storage-layer.md %}#protected-timestamps) to move forward as the replicated timestamp advances, which permits the [garbage collection]({% link {{ site.current_cloud_version }}/architecture/storage-layer.md %}#garbage-collection) to continue as the PCR stream on the standby cluster advances.
+
+{{site.data.alerts.callout_info}}
+If the primary cluster does not receive replicated time information from the standby after 24 hours, it cancels the replication job. This ensures that an inactive replication job will not prevent garbage collection.
+{{site.data.alerts.end}}
+
+The tracked replicated time and the advancing protected timestamp provide the PCR job with enough information to track _retained time_, which is a timestamp in the past indicating the lower bound that the PCR stream could fail over to. Therefore, the _failover window_ for a PCR stream falls between the retained time and the replicated time.
+
+<img src="{{ 'images/v25.1/failover.svg' | relative_url }}" alt="Timeline showing how the failover window is between the retained time and replicated time." style="border:0px solid #eee;width:100%" />
+
+_Replication lag_ is the time between the most up-to-date replicated time and the actual time. While the PCR stream keeps as current as possible to the actual time, this replication lag window is where there is potential for data loss.
+
+For the [failover process](#step-4-fail-over-to-the-standby-cluster), the standby cluster waits until it has reached the specified failover time, which can be in the past (up to the retained time), the latest consistent timestamp, or in the future (up to 1 hour). Once that timestamp has been reached, the PCR stream stops and any data in the standby cluster that is **above** the failover time is removed. Depending on how much data the standby needs to revert, this can affect the duration of [RTO (recovery time objective)]({% link {{ site.current_cloud_version }}/disaster-recovery-overview.md %}).
+
+After reverting any necessary data, the standby cluster is promoted as available to serve traffic.
+
+## See also
+
+- [Physical Cluster Replication Overview]({% link {{ site.current_cloud_version }}/physical-cluster-replication-overview.md %})
+- [CockroachDB {{ site.data.products.cloud }} API reference](https://www.cockroachlabs.com/docs/api/cloud/v1)
+- [Disaster Recovery Overview]({% link {{ site.current_cloud_version }}/disaster-recovery-overview.md %})

--- a/src/current/css/customstyles.scss
+++ b/src/current/css/customstyles.scss
@@ -1,6 +1,5 @@
 ---
 ---
-
 @import "global/variables";
 
 @import "bs/functions";
@@ -113,7 +112,7 @@ table {
           line-height: 22px;
         }
         ul {
-          font-size: 14px;
+          font-size: 17px;
         }
       }
     }

--- a/src/current/v25.1/cockroachdb-feature-availability.md
+++ b/src/current/v25.1/cockroachdb-feature-availability.md
@@ -47,6 +47,10 @@ Any feature made available in a phase prior to GA is provided without any warran
 **The following features are in preview** and are subject to change. To share feedback and/or issues, contact [Support](https://support.cockroachlabs.com/hc).
 {{site.data.alerts.end}}
 
+### Physical cluster replication (PCR) on CockorachDB Advanced
+
+[PCR on CockroachDB {{ site.data.products.advanced }}]({% link cockroachcloud/physical-cluster-replication.md %}) is in preview. PCR continuously sends all data at the byte level from a primary cluster to an independent standby cluster. Existing data and ongoing changes on the active primary cluster, which is serving application data, replicate asynchronously to the passive standby cluster.
+
 ### Triggers
 
 [Triggers]({% link {{ page.version.version }}/triggers.md %}) are in Preview. A trigger executes a function when one or more specified SQL operations is performed on a table. Triggers respond to data changes by adding logic within the database, rather than in an application. They can be used to modify data before it is inserted, maintain data consistency across rows or tables, or record an update to a row.

--- a/src/current/v25.1/failover-replication.md
+++ b/src/current/v25.1/failover-replication.md
@@ -18,6 +18,10 @@ Initiating a failover is a manual process that makes the standby cluster ready t
 
 After a failover, you may want to _fail back_ to the original primary cluster (or a different cluster) to set up the original primary cluster to once again accept application traffic. For more details, refer to [Fail back to the primary cluster](#fail-back-to-the-primary-cluster).
 
+{{site.data.alerts.callout_info}}
+**This page is a guide to PCR failover in CockroachDB self-hosted clusters**. For {{ site.data.products.advanced }} clusters, refer to the [Physical Cluster Replication]({% link cockroachcloud/physical-cluster-replication.md %}#step-4-fail-over-to-the-standby-cluster) page in CockroachDB {{ site.data.products.cloud }}.
+{{site.data.alerts.end}}
+
 ## Before you begin
 
 During a replication stream, jobs running on the primary cluster will replicate to the standby cluster. Before you fail over to the standby cluster, or fail back to the original primary cluster, consider how you will manage running (replicated) jobs between the clusters. Refer to [Job management](#job-management) for instructions.

--- a/src/current/v25.1/physical-cluster-replication-monitoring.md
+++ b/src/current/v25.1/physical-cluster-replication-monitoring.md
@@ -5,10 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-{{site.data.alerts.callout_info}}
-Physical cluster replication is only supported in CockroachDB {{ site.data.products.core }} clusters.
-{{site.data.alerts.end}}
-
 You can monitor a [**physical cluster replication (PCR)**]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}) stream using:
 
 - [`SHOW VIRTUAL CLUSTER ... WITH REPLICATION STATUS`](#sql-shell) in the SQL shell.
@@ -18,6 +14,10 @@ You can monitor a [**physical cluster replication (PCR)**]({% link {{ page.versi
 When you complete a [failover]({% link {{ page.version.version }}/failover-replication.md %}), there will be a gap in the primary cluster's metrics whether you are monitoring via the [DB Console](#db-console) or [Prometheus](#prometheus).
 
 The standby cluster will also require separate monitoring to ensure observability during the failover period. You can use the DB console to track the relevant metrics, or you can use a tool like [Grafana]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %}#step-5-visualize-metrics-in-grafana) to create two separate dashboards, one for each cluster, or a single dashboard with data from both clusters.
+
+{{site.data.alerts.callout_info}}
+**This page is a guide to monitoring PCR in CockroachDB self-hosted clusters**. For {{ site.data.products.advanced }} clusters, refer to the [Physical Cluster Replication]({% link cockroachcloud/physical-cluster-replication.md %}#step-3-monitor-the-pcr-stream) page in CockroachDB {{ site.data.products.cloud }}.
+{{site.data.alerts.end}}
 
 ## SQL Shell
 

--- a/src/current/v25.1/set-up-physical-cluster-replication.md
+++ b/src/current/v25.1/set-up-physical-cluster-replication.md
@@ -5,10 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-{{site.data.alerts.callout_info}}
-Physical cluster replication is only supported in CockroachDB {{ site.data.products.core }} clusters.
-{{site.data.alerts.end}}
-
 In this tutorial, you will set up [**physical cluster replication (PCR)**]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}) between a primary cluster and standby cluster. The primary cluster is _active_, serving application traffic. The standby cluster is _passive_, accepting updates from the primary cluster. The replication stream will send changes from the primary to the standby.
 
 The unit of replication is a [virtual cluster]({% link {{ page.version.version }}/cluster-virtualization-overview.md %}), which is part of the underlying infrastructure in the primary and standby clusters.
@@ -17,6 +13,10 @@ In this tutorial, you will connect to:
 
 - The _system virtual cluster_ for administration tasks in both clusters, and starting the replication stream from the standby cluster.
 - The application _virtual cluster_ on the primary cluster to work with databases, tables, workloads, and so on.
+
+{{site.data.alerts.callout_info}}
+**This tutorial is to set up PCR on CockroachDB self-hosted clusters**. For {{ site.data.products.advanced }} clusters, refer to the [Physical Cluster Replication]({% link cockroachcloud/physical-cluster-replication.md %}) page in CockroachDB {{ site.data.products.cloud }}.
+{{site.data.alerts.end}}
 
 ## Overview
 


### PR DESCRIPTION
Fixes DOC-10050

PR adds docs for PCR on Advanced clusters in Preview phase.

- Adds a setup tutorial page with short technical reference to cover "replication lag" and "retained time" (without the VC mentions in the self-hosted docs).
- Updates the self-hosted PCR docs to callout Advanced availability and to navigate Cloud users to the correct docs.
- Updates the general PCR overview page to adapt the Features section to a comp table for the supported features in Advanced vs. self-hosted.
- Adds PCR on Advanced in the Preview section of the feature availability page.
- Includes the new PCR on Advanced page in under the `Cross-cluster Replication` nav item, and also under `Cloud Deployments`.

## Rendered Preview

[Cloud PCR page](https://deploy-preview-19320--cockroachdb-docs.netlify.app/docs/cockroachcloud/physical-cluster-replication)
[General PCR Overview page updates](https://deploy-preview-19320--cockroachdb-docs.netlify.app/docs/dev/physical-cluster-replication-overview#features)