### PR TITLE
Fix redirect to Compare page

### DIFF
--- a/src/current/_data/redirects.yml
+++ b/src/current/_data/redirects.yml
@@ -794,9 +794,6 @@
 - destination: stable/cockroach-sql.md
   sources: ['use-the-built-in-sql-client.md']
 
-- destination: stable/cockroachdb-in-comparison.md
-  sources: ['cockroachdb-in-comparison.md']
-
 - destination: stable/column-families.md
   sources: ['column-families.md']
 
@@ -1018,6 +1015,7 @@
 
 - destination: https://www.cockroachlabs.com/compare/
   sources:
+    - stable/cockroachdb-in-comparison.md
     - v23.1/cockroachdb-in-comparison.md
     - v23.2/cockroachdb-in-comparison.md
     - v24.1/cockroachdb-in-comparison.md


### PR DESCRIPTION
A fix to the redirects implemented in https://github.com/cockroachdb/docs/pull/19303, which did not account for the path with /stable, only with certain /<major_version> paths. 