### PR TITLE
Update the restore backups across major version docs for innovation releases

### DIFF
--- a/src/current/releases/release-support-policy.md
+++ b/src/current/releases/release-support-policy.md
@@ -30,7 +30,7 @@ There are two major release types: [Regular and Innovation releases]({% link rel
   - Cockroach Labs may direct customers to [upgrade](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version) to a later version of CockroachDB to resolve or further troubleshoot an issue.
 - **Unsupported**: The day that a major version’s final support period ends is its unsupported date. After a version reaches end of life, Cockroach Labs provides no further support for the release.
   - A Regular release reaches unsupported at the Assistance Support phase's end date.
-  - An Innovation releases reaches unsupported at the Maintenance Support phase's end date.
+  - An Innovation release reaches unsupported at the Maintenance Support phase's end date.
 
 ## Support Types
 

--- a/src/current/v24.1/restoring-backups-across-versions.md
+++ b/src/current/v24.1/restoring-backups-across-versions.md
@@ -11,23 +11,29 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v22.2.x" format. For example, both v22.2.8 and v22.2.14 are considered as v22.2 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 ## Support for restoring backups into a newer version
 
-Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**.
+Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. 
 
-For example, backups taken on v22.1.x can be restored into v22.2.x. Backups taken on v22.2.x can be restored into v23.1.x. The following table outlines this support:
+Additionally, you can skip an [innovation release]({% link releases/index.md %}#major-releases) version when restoring a backup. Innovation releases are intermediate releases that introduce new features, but are not long-term supported versions.
+
+Other than skipping innovation releases, restoring backups outside major version N or N+1 is **not supported**.
+
+For example, backups taken on v24.1.x can be restored into v24.3.x (skipping the v24.2 innovation release). Backups taken on v24.3.x can be restored into v25.1.x:
 
 Backup taken on version   | Restorable into version
 --------------------------+--------------------------
-21.1.x                    | 21.1.x, 21.2.x
-21.2.x                    | 21.2.x, 22.1.x
-22.1.x                    | 22.1.x, 22.2.x
-22.2.x                    | 22.2.x, 23.1.x
+23.2.x                    | 23.2.x, 24.1.x
+24.1.x                    | 24.1.x, 24.2.x, 24.3.x
+24.2.x (innovation)       | 24.2.x, 24.3.x
+24.3.x                    | 24.3.x, 25.1.x (innovation), 25.2.x
+
+Refer to [Recent releases]({% link releases/index.md %}#recent-releases) and [Upcoming releases]({% link releases/index.md %}#upcoming-releases).
 
 When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}) page.
 

--- a/src/current/v24.1/restoring-backups-across-versions.md
+++ b/src/current/v24.1/restoring-backups-across-versions.md
@@ -11,7 +11,7 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "{{ page.version.version }}.x" format. For example, both {{ page.version.version }}.1 and {{ page.version.version }}.2 are considered as {{ page.version.version }} clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).

--- a/src/current/v24.2/restoring-backups-across-versions.md
+++ b/src/current/v24.2/restoring-backups-across-versions.md
@@ -11,23 +11,29 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v22.2.x" format. For example, both v22.2.8 and v22.2.14 are considered as v22.2 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 ## Support for restoring backups into a newer version
 
-Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**.
+Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. 
 
-For example, backups taken on v22.1.x can be restored into v22.2.x. Backups taken on v22.2.x can be restored into v23.1.x. The following table outlines this support:
+Additionally, you can skip an [innovation release]({% link releases/index.md %}#major-releases) version when restoring a backup. Innovation releases are intermediate releases that introduce new features, but are not long-term supported versions.
+
+Other than skipping innovation releases, restoring backups outside major version N or N+1 is **not supported**.
+
+For example, backups taken on v24.1.x can be restored into v24.3.x (skipping the v24.2 innovation release). Backups taken on v24.3.x can be restored into v25.1.x:
 
 Backup taken on version   | Restorable into version
 --------------------------+--------------------------
-21.1.x                    | 21.1.x, 21.2.x
-21.2.x                    | 21.2.x, 22.1.x
-22.1.x                    | 22.1.x, 22.2.x
-22.2.x                    | 22.2.x, 23.1.x
+23.2.x                    | 23.2.x, 24.1.x
+24.1.x                    | 24.1.x, 24.2.x, 24.3.x
+24.2.x (innovation)       | 24.2.x, 24.3.x
+24.3.x                    | 24.3.x, 25.1.x (innovation), 25.2.x
+
+Refer to [Recent releases]({% link releases/index.md %}#recent-releases) and [Upcoming releases]({% link releases/index.md %}#upcoming-releases).
 
 When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}) page.
 

--- a/src/current/v24.2/restoring-backups-across-versions.md
+++ b/src/current/v24.2/restoring-backups-across-versions.md
@@ -11,7 +11,7 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "{{ page.version.version }}.x" format. For example, both {{ page.version.version }}.1 and {{ page.version.version }}.2 are considered as {{ page.version.version }} clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).

--- a/src/current/v24.3/restoring-backups-across-versions.md
+++ b/src/current/v24.3/restoring-backups-across-versions.md
@@ -11,23 +11,29 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v22.2.x" format. For example, both v22.2.8 and v22.2.14 are considered as v22.2 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 ## Support for restoring backups into a newer version
 
-Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**.
+Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. 
 
-For example, backups taken on v22.1.x can be restored into v22.2.x. Backups taken on v22.2.x can be restored into v23.1.x. The following table outlines this support:
+Additionally, you can skip an [innovation release]({% link releases/index.md %}#major-releases) version when restoring a backup. Innovation releases are intermediate releases that introduce new features, but are not long-term supported versions.
+
+Other than skipping innovation releases, restoring backups outside major version N or N+1 is **not supported**.
+
+For example, backups taken on v24.1.x can be restored into v24.3.x (skipping the v24.2 innovation release). Backups taken on v24.3.x can be restored into v25.1.x:
 
 Backup taken on version   | Restorable into version
 --------------------------+--------------------------
-21.1.x                    | 21.1.x, 21.2.x
-21.2.x                    | 21.2.x, 22.1.x
-22.1.x                    | 22.1.x, 22.2.x
-22.2.x                    | 22.2.x, 23.1.x
+23.2.x                    | 23.2.x, 24.1.x
+24.1.x                    | 24.1.x, 24.2.x, 24.3.x
+24.2.x (innovation)       | 24.2.x, 24.3.x
+24.3.x                    | 24.3.x, 25.1.x (innovation), 25.2.x
+
+Refer to [Recent releases]({% link releases/index.md %}#recent-releases) and [Upcoming releases]({% link releases/index.md %}#upcoming-releases).
 
 When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}) page.
 

--- a/src/current/v24.3/restoring-backups-across-versions.md
+++ b/src/current/v24.3/restoring-backups-across-versions.md
@@ -11,7 +11,7 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "{{ page.version.version }}.x" format. For example, both {{ page.version.version }}.1 and {{ page.version.version }}.2 are considered as {{ page.version.version }} clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).

--- a/src/current/v25.1/restoring-backups-across-versions.md
+++ b/src/current/v25.1/restoring-backups-across-versions.md
@@ -11,23 +11,29 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v22.2.x" format. For example, both v22.2.8 and v22.2.14 are considered as v22.2 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).
 
 ## Support for restoring backups into a newer version
 
-Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. Restoring backups outside major version N or N+1 is **not supported**.
+Cockroach Labs supports restoring a backup taken on a cluster on a specific major version into a cluster that is on the same version or the next major version. Therefore, when upgrading your cluster from version N to N+1, if you took a backup on major version N, you can restore it to your cluster on either major version N or N+1. 
 
-For example, backups taken on v22.1.x can be restored into v22.2.x. Backups taken on v22.2.x can be restored into v23.1.x. The following table outlines this support:
+Additionally, you can skip an [innovation release]({% link releases/index.md %}#major-releases) version when restoring a backup. Innovation releases are intermediate releases that introduce new features, but are not long-term supported versions.
+
+Other than skipping innovation releases, restoring backups outside major version N or N+1 is **not supported**.
+
+For example, backups taken on v24.1.x can be restored into v24.3.x (skipping the v24.2 innovation release). Backups taken on v24.3.x can be restored into v25.1.x:
 
 Backup taken on version   | Restorable into version
 --------------------------+--------------------------
-21.1.x                    | 21.1.x, 21.2.x
-21.2.x                    | 21.2.x, 22.1.x
-22.1.x                    | 22.1.x, 22.2.x
-22.2.x                    | 22.2.x, 23.1.x
+23.2.x                    | 23.2.x, 24.1.x
+24.1.x                    | 24.1.x, 24.2.x, 24.3.x
+24.2.x (innovation)       | 24.2.x, 24.3.x
+24.3.x                    | 24.3.x, 25.1.x (innovation), 25.2.x
+
+Refer to [Recent releases]({% link releases/index.md %}#recent-releases) and [Upcoming releases]({% link releases/index.md %}#upcoming-releases).
 
 When a cluster is in a mixed-version state during an upgrade, [full cluster restores]({% link {{ page.version.version }}/restore.md %}#restore-a-cluster) will fail. See the [Upgrade documentation]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}) for the necessary steps to finalize your upgrade. For CockroachDB {{ site.data.products.cloud }} clusters, see the [CockroachDB Cloud Upgrade Policy]({% link cockroachcloud/upgrade-policy.md %}) page.
 

--- a/src/current/v25.1/restoring-backups-across-versions.md
+++ b/src/current/v25.1/restoring-backups-across-versions.md
@@ -11,7 +11,7 @@ This page describes the support Cockroach Labs provides for restoring backups ac
 - [Support for long-term backup archival](#support-for-long-term-backup-archival)
 
 {{site.data.alerts.callout_info}}
-Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "v24.1.x" format. For example, both v24.1.8 and v24.1.12 are considered as v24.1 clusters for backup purposes.
+Since CockroachDB considers the cluster version when running a backup, this page refers to versions in a "{{ page.version.version }}.x" format. For example, both {{ page.version.version }}.1 and {{ page.version.version }}.2 are considered as {{ page.version.version }} clusters for backup purposes.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/backups/recommend-backups-for-upgrade.md%} See [how to upgrade to the latest version of CockroachDB]({% link {{ page.version.version }}/upgrade-cockroach-version.md %}).


### PR DESCRIPTION
Fixes DOC-11980

This PR updates the Restoring Backups Across Versions page to account for innovation releases.

Innovation releases were introduced in v24.2, so the changes have been added to v24.1+ since the policy is that users can restore to the same major version, or one above — v24.1 clusters can upgrade to v24.3 (skipping the first v24.2 innovation release).