### PR TITLE
Update Standard connect-to-your-cluster.md

### DIFF
--- a/src/current/cockroachcloud/connect-to-your-cluster.md
+++ b/src/current/cockroachcloud/connect-to-your-cluster.md
@@ -78,7 +78,7 @@ Self-service VPC peering setup is not supported for CockroachDB {{ site.data.pro
 1. In a new browser window, log in to Google Cloud Console, go to **Private Service Connect** section, and create a new endpoint in the same VPC as your application. For details, refer to [Create an endpoint](https://cloud.google.com/vpc/docs/configure-private-service-connect-services#create-endpoint) in the Google Cloud documentation.
     - Set **Target** to **Published service**.
     - Set **Target service** to the value you copied from CockroachDB {{ site.data.products.cloud }} Console. If the endpoint's configured target service does not match, validation will fail.
-    - Provide a value for **Endpoint name**. This is not used by CockroachDB {{ site.data.products.cloud }}.
+    - Provide a value for **Endpoint name**. You will need to provide this **Endpoint name** when connecting to the cluster using Command Line, Connection String or Connection Parameters. {{ site.data.products.cloud }}.
     - If it is not enabled, enable the Service Directory API, click **Enable global access**, and create a namespace in each region where your cluster is deployed.
     - Click **Add endpoint**.
     - After the endpoint is created, copy the connection ID.


### PR DESCRIPTION
Docs are misleading as to when to use Endpoint Name when connecting to the cluster. Updated the docs to reflect when Endpoint Name should be used when connecting