### PR TITLE
Add note to clarify column-level encryption timing

### DIFF
--- a/src/current/v23.2/column-level-encryption.md
+++ b/src/current/v23.2/column-level-encryption.md
@@ -92,7 +92,7 @@ Use of the `encrypt` built-in function can have anywhere from 10-40% overhead de
 
 Cockroach Labs measured baseline performance in a 3-node CockroachDB cluster running on three [`n1-standard-4` machines on GCP](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines).
 
-Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms:
+Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms (note: in this and the following examples, the timings we report are for 10,000 operations):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/v24.1/column-level-encryption.md
+++ b/src/current/v24.1/column-level-encryption.md
@@ -92,7 +92,7 @@ Use of the `encrypt` built-in function can have anywhere from 10-40% overhead de
 
 Cockroach Labs measured baseline performance in a 3-node CockroachDB cluster running on three [`n1-standard-4` machines on GCP](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines).
 
-Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms:
+Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms (note: in this and the following examples, the timings we report are for 10,000 operations):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/v24.2/column-level-encryption.md
+++ b/src/current/v24.2/column-level-encryption.md
@@ -92,7 +92,7 @@ Use of the `encrypt` built-in function can have anywhere from 10-40% overhead de
 
 Cockroach Labs measured baseline performance in a 3-node CockroachDB cluster running on three [`n1-standard-4` machines on GCP](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines).
 
-Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms:
+Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms (note: in this and the following examples, the timings we report are for 10,000 operations):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/v24.3/column-level-encryption.md
+++ b/src/current/v24.3/column-level-encryption.md
@@ -92,7 +92,7 @@ Use of the `encrypt` built-in function can have anywhere from 10-40% overhead de
 
 Cockroach Labs measured baseline performance in a 3-node CockroachDB cluster running on three [`n1-standard-4` machines on GCP](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines).
 
-Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms:
+Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms (note: in this and the following examples, the timings we report are for 10,000 operations):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/src/current/v25.1/column-level-encryption.md
+++ b/src/current/v25.1/column-level-encryption.md
@@ -92,7 +92,7 @@ Use of the `encrypt` built-in function can have anywhere from 10-40% overhead de
 
 Cockroach Labs measured baseline performance in a 3-node CockroachDB cluster running on three [`n1-standard-4` machines on GCP](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines).
 
-Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms:
+Without using `encrypt` or `decrypt`, the following statement generally ran in 60-80 ms (note: in this and the following examples, the timings we report are for 10,000 operations):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql


### PR DESCRIPTION
Clarify that performance timings in column-level-encryption.md refer to 10k operations, not single operations.

Takes over from cockroachdb/docs#18074

h/t @mgoddard 