### PR TITLE
DOC-12744 Adjust release date for version 25.1.1

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -8398,7 +8398,7 @@
 
 - release_name: v25.1.1
   major_version: v25.1
-  release_date: '2025-03-12'
+  release_date: '2025-03-11'
   release_type: Production
   go_version: go1.23.6
   sha: a5c682ed7f4b1e42717616d676ff14d6e6a8b192


### PR DESCRIPTION
Fixes DOC-12744

In releases.yml, modified date for v25.1.1 to not be the same as v25.1.2 as workaround for version selector.