### PR TITLE
REL-2085 v25.1.2 (was 25.1.1): [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -8450,11 +8450,4 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.1.1
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-    This version is currently available only for select
-    CockroachDB Cloud clusters. To request to upgrade
-    a CockroachDB self-hosted cluster to this version,
-    [contact support](https://support.cockroachlabs.com/hc/requests/new).
 


### PR DESCRIPTION
Fixes REL-2085

In releases.yml, removed cloud fields for v25.1.2 to enable download links for binaries.