### PR TITLE
DOC-12824 Correct release type for CockroachDB v25.1 to Innovation

### DIFF
--- a/src/current/releases/cloud.md
+++ b/src/current/releases/cloud.md
@@ -16,7 +16,7 @@ Get future release notes emailed to you:
 
 ## February 18, 2025
 
-CockroachDB v25.1 is now generally available for select CockroachDB Cloud clusters. CockroachDB v25.1 is a [Regular release]({% link releases/release-support-policy.md %}#regular-releases). Refer to [Create a CockroachDB {{ site.data.products.standard }} cluster]({% link cockroachcloud/create-your-cluster.md %}) or [Upgrade to v25.1]({% link cockroachcloud/upgrade-cockroach-version.md %}).
+CockroachDB v25.1 is now generally available for select CockroachDB Cloud clusters. CockroachDB v25.1 is an [Innovation release]({% link releases/release-support-policy.md %}#innovation-releases). Refer to [Create a CockroachDB {{ site.data.products.standard }} cluster]({% link cockroachcloud/create-your-cluster.md %}) or [Upgrade to v25.1]({% link cockroachcloud/upgrade-cockroach-version.md %}).
 
 ## January 16, 2025
 


### PR DESCRIPTION
Fixes DOC-12824

In cloud.md, replaced Regular innovation with Innovation release.

Rendered preview

- [CockroachDB Cloud Releases: February 18, 2025](https://deploy-preview-19464--cockroachdb-docs.netlify.app/docs/releases/cloud#february-18-2025)