### PR TITLE
Update cloud.md

### DIFF
--- a/src/current/releases/cloud.md
+++ b/src/current/releases/cloud.md
@@ -16,7 +16,7 @@ Get future release notes emailed to you:
 
 ## February 18, 2025
 
-CockroachDB v25.1 is now generally available for select CockroachDB Cloud clusters. CockroachDB v25.1 is an [Innovation release]({% link releases/release-support-policy.md %}#innovation-releases). Refer to [Create a CockroachDB {{ site.data.products.standard }} cluster]({% link cockroachcloud/create-your-cluster.md %}) or [Upgrade to v25.1]({% link cockroachcloud/upgrade-cockroach-version.md %}).
+CockroachDB v25.1 is now generally available for select CockroachDB Cloud Advanced clusters. CockroachDB v25.1 is an [Innovation release]({% link releases/release-support-policy.md %}#innovation-releases). Refer to [Create a CockroachDB {{ site.data.products.advanced }} cluster]({% link cockroachcloud/create-your-cluster.md %}) or [Upgrade to v25.1]({% link cockroachcloud/upgrade-cockroach-version.md %}).
 
 ## January 16, 2025
 

--- a/src/current/releases/cloud.md
+++ b/src/current/releases/cloud.md
@@ -16,7 +16,7 @@ Get future release notes emailed to you:
 
 ## February 18, 2025
 
-CockroachDB v25.1 is now generally available for select CockroachDB Cloud Advanced clusters. CockroachDB v25.1 is an [Innovation release]({% link releases/release-support-policy.md %}#innovation-releases). Refer to [Create a CockroachDB {{ site.data.products.advanced }} cluster]({% link cockroachcloud/create-your-cluster.md %}) or [Upgrade to v25.1]({% link cockroachcloud/upgrade-cockroach-version.md %}).
+CockroachDB v25.1 is now generally available for select CockroachDB Cloud {{ site.data.products.advanced }} clusters. CockroachDB v25.1 is an [Innovation release]({% link releases/release-support-policy.md %}#innovation-releases). Refer to [Create a CockroachDB {{ site.data.products.advanced }} cluster]({% link cockroachcloud/create-an-advanced-cluster.md %}) or [Upgrade to v25.1]({% link cockroachcloud/upgrade-cockroach-version.md %}).
 
 ## January 16, 2025
 


### PR DESCRIPTION
Standard/Basic tier clusters will do not have the option to upgrade to 25.1 as of Feb 18 release. Updated release notes to reflect 