### PR TITLE
Update monitor-cockroachdb-with-prometheus.md

### DIFF
--- a/src/current/v25.1/monitor-cockroachdb-with-prometheus.md
+++ b/src/current/v25.1/monitor-cockroachdb-with-prometheus.md
@@ -69,11 +69,6 @@ This tutorial explores the CockroachDB {{ site.data.products.core }} integration
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cd rules
-    ~~~
-
-    {% include_cached copy-clipboard.html %}
-    ~~~ shell
     curl -o rules/aggregation.rules.yml https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/rules/aggregation.rules.yml
     ~~~
 


### PR DESCRIPTION
No need to `cd rules` - the output files already include the `rules/` prefix.