### PR TITLE
adjust spacing and alignment for lists inside tables

### DIFF
--- a/src/current/css/components/_comparison-chart.scss
+++ b/src/current/css/components/_comparison-chart.scss
@@ -53,7 +53,6 @@
   }
 
   td {
-    vertical-align: middle;
     border: none;
     border-left: 1px solid $cl_gray_light;
     @include sourcesanspro_r(12px);

--- a/src/current/css/customstyles.scss
+++ b/src/current/css/customstyles.scss
@@ -113,7 +113,9 @@ table {
           line-height: 22px;
         }
         ul {
-          font-size: 14px;
+          font-size: inherit;
+          margin-top: 10px;
+          margin-bottom: 0px !important;
         }
       }
     }


### PR DESCRIPTION
Adjusted how lists are formatted inside tables.

- Added top margin.
- Cleared bottom spacing.
- Changed "comparison chart" tables to vertically align content from the top, not the middle. This is more readable IMO.

**Before:**

<img width="553" alt="image" src="https://github.com/user-attachments/assets/7a23e00c-93a5-4cbb-9067-a0d27b132932" />

**After:**

<img width="557" alt="image" src="https://github.com/user-attachments/assets/8acfd827-a67d-4914-9438-92f94297e675" />
