### PR TITLE
make bold text in tables match font size

### DIFF
--- a/src/current/css/customstyles.scss
+++ b/src/current/css/customstyles.scss
@@ -115,6 +115,10 @@ table {
         ul {
           font-size: 14px;
         }
+        strong,
+        b {
+          font-size: inherit;
+        }
       }
     }
   }


### PR DESCRIPTION
Added CSS to make bold text in tables inherit the font size. Presently the font sizes are mismatched.

**Before:**

<img width="394" alt="image" src="https://github.com/user-attachments/assets/f8e03186-28c2-48ac-bc25-9a8f5390b340" />

**After:**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6ebb6f5f-0d26-4b86-99b9-0848755f81a1" />
