### PR TITLE
Fix hyperlink issue for S3-compatible services

### DIFF
--- a/src/current/_includes/v23.1/misc/s3-compatible-warning.md
+++ b/src/current/_includes/v23.1/misc/s3-compatible-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
+While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test{% if page.name == "cloud-storage-authentication.md" %} S3-compatible services {% else %} [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) {% endif %} (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
 {{site.data.alerts.end}}

--- a/src/current/_includes/v23.2/misc/s3-compatible-warning.md
+++ b/src/current/_includes/v23.2/misc/s3-compatible-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
+While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test{% if page.name == "cloud-storage-authentication.md" %} S3-compatible services {% else %} [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) {% endif %} (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
 {{site.data.alerts.end}}

--- a/src/current/_includes/v24.1/misc/s3-compatible-warning.md
+++ b/src/current/_includes/v24.1/misc/s3-compatible-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
+While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test{% if page.name == "cloud-storage-authentication.md" %} S3-compatible services {% else %} [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) {% endif %} (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
 {{site.data.alerts.end}}

--- a/src/current/_includes/v24.3/misc/s3-compatible-warning.md
+++ b/src/current/_includes/v24.3/misc/s3-compatible-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
+While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test{% if page.name == "cloud-storage-authentication.md" %} S3-compatible services {% else %} [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) {% endif %} (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
 {{site.data.alerts.end}}

--- a/src/current/_includes/v25.1/misc/s3-compatible-warning.md
+++ b/src/current/_includes/v25.1/misc/s3-compatible-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
+While Cockroach Labs actively tests Amazon S3, Google Cloud Storage, and Azure Storage, we **do not** test{% if page.name == "cloud-storage-authentication.md" %} S3-compatible services {% else %} [S3-compatible services]({% link {{ page.version.version }}/cloud-storage-authentication.md %}) {% endif %} (e.g., [MinIO](https://min.io/), [Red Hat Ceph](https://docs.ceph.com/en/pacific/radosgw/s3/)).
 {{site.data.alerts.end}}


### PR DESCRIPTION
Fixes DOC-12919

In s3-compatible-warning.md, added check for cloud-storage-authentication.md page.

Rendered Preview

- [Cloud Storage Authentication](https://deploy-preview-19471--cockroachdb-docs.netlify.app/docs/v25.1/cloud-storage-authentication?filters=s3compatible)
- [RESTORE](https://deploy-preview-19471--cockroachdb-docs.netlify.app/docs/v25.1/restore#source-privileges)
