### PR TITLE
Replace errant colon with semicolon

### DIFF
--- a/src/current/v23.1/authentication.md
+++ b/src/current/v23.1/authentication.md
@@ -21,7 +21,7 @@ Users may connect with CockroachDB {{ site.data.products.core }} clusters in 2 m
 
 ## Using digital certificates with CockroachDB
 
-Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional: the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
+Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional; the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
 
 - The hostname or address (IP address or DNS name) used to reach a node, either directly or through a load balancer, must be listed in the **Common Name** or **Subject Alternative Names** fields of the certificate:
 

--- a/src/current/v23.2/authentication.md
+++ b/src/current/v23.2/authentication.md
@@ -21,7 +21,7 @@ Users may connect with CockroachDB {{ site.data.products.core }} clusters in 2 m
 
 ## Using digital certificates with CockroachDB
 
-Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional: the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
+Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional; the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
 
 - The hostname or address (IP address or DNS name) used to reach a node, either directly or through a load balancer, must be listed in the **Common Name** or **Subject Alternative Names** fields of the certificate:
 

--- a/src/current/v24.1/authentication.md
+++ b/src/current/v24.1/authentication.md
@@ -21,7 +21,7 @@ Users may connect with CockroachDB {{ site.data.products.core }} clusters in 2 m
 
 ## Using digital certificates with CockroachDB
 
-Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional: the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
+Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional; the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
 
 - The hostname or address (IP address or DNS name) used to reach a node, either directly or through a load balancer, must be listed in the **Common Name** or **Subject Alternative Names** fields of the certificate:
 

--- a/src/current/v24.3/authentication.md
+++ b/src/current/v24.3/authentication.md
@@ -21,7 +21,7 @@ Users may connect with CockroachDB {{ site.data.products.core }} clusters in 2 m
 
 ## Using digital certificates with CockroachDB
 
-Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional: the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
+Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional; the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
 
 - The hostname or address (IP address or DNS name) used to reach a node, either directly or through a load balancer, must be listed in the **Common Name** or **Subject Alternative Names** fields of the certificate:
 

--- a/src/current/v25.1/authentication.md
+++ b/src/current/v25.1/authentication.md
@@ -21,7 +21,7 @@ Users may connect with CockroachDB {{ site.data.products.core }} clusters in 2 m
 
 ## Using digital certificates with CockroachDB
 
-Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional: the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
+Each CockroachDB node in a secure cluster must have a **node certificate**, which is a TLS 1.3 certificate. This certificate is multi-functional; the same certificate is presented irrespective of whether the node is acting as a server or a client. The nodes use these certificates to establish secure connections with clients and with other nodes. Node certificates have the following requirements:
 
 - The hostname or address (IP address or DNS name) used to reach a node, either directly or through a load balancer, must be listed in the **Common Name** or **Subject Alternative Names** fields of the certificate:
 


### PR DESCRIPTION
Quick PR correcting some punctuation that seems wrong to me. Please feel free to close if my proposed change violates style, I just wanted to find something extremely simple to test the docs toolchain.

Addresses: DOC-13075

- Corrects an errant colon in `authentication.md`