### PR TITLE
Fix bad formatting in v25.1.3 release notes bug fixes section 

### DIFF
--- a/src/current/_includes/releases/v25.1/v25.1.3.md
+++ b/src/current/_includes/releases/v25.1/v25.1.3.md
@@ -27,8 +27,7 @@ Release Date: April 2, 2025
 - Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument.
  [#143632][#143632]
 - A step in the 25.1 upgrade finalization process that required backfilling jobs now uses locks to ensure it makes progress even when there is contention on the jobs table to prevent the possibility of becoming stuck under heavy load.
-  
-  Epic: none. [#142223][#142223]
+ [#142223][#142223]
 - Fixed a bug where the declarative schema changer allowed `CREATE SEQUENCE` operations to proceed even while a `DROP SCHEMA` or `DROP DATABASE` was in progress. Such operations now retry if the parent object has a schema change in progress, preventing new child objects from being created under deleted parent objects.
  [#142764][#142764]
 - Fixed a bug when running with the `autocommit_before_ddl` session variable that could cause a runtime error when binding a previously prepared DDL statement.


### PR DESCRIPTION
Fixes DOC-13165

In v25.1.3.md, fixed formatting by removing line with Epic: none.

Rendered previews:

- [v25.1.3 release notes](https://deploy-preview-19512--cockroachdb-docs.netlify.app/docs/releases/v25.1#v25-1-3-bug-fixes)