### PR TITLE
Add missing Kubernetes upgrade content

### DIFF
--- a/src/current/v24.3/upgrade-cockroachdb-kubernetes.md
+++ b/src/current/v24.3/upgrade-cockroachdb-kubernetes.md
@@ -58,6 +58,8 @@ If you [deployed CockroachDB on Red Hat OpenShift]({% link {{ page.version.versi
 
 ## Disable auto-finalization
 
+{% include common/upgrade/disable-auto-finalization.md %}
+
 ## Troubleshooting
 
 {% include common/upgrade/troubleshooting-self-hosted.md %}

--- a/src/current/v25.1/upgrade-cockroachdb-kubernetes.md
+++ b/src/current/v25.1/upgrade-cockroachdb-kubernetes.md
@@ -58,6 +58,8 @@ If you [deployed CockroachDB on Red Hat OpenShift]({% link {{ page.version.versi
 
 ## Disable auto-finalization
 
+{% include common/upgrade/disable-auto-finalization.md %}
+
 ## Troubleshooting
 
 {% include common/upgrade/troubleshooting-self-hosted.md %}

--- a/src/current/v25.2/upgrade-cockroachdb-kubernetes.md
+++ b/src/current/v25.2/upgrade-cockroachdb-kubernetes.md
@@ -58,6 +58,8 @@ If you [deployed CockroachDB on Red Hat OpenShift]({% link {{ page.version.versi
 
 ## Disable auto-finalization
 
+{% include common/upgrade/disable-auto-finalization.md %}
+
 ## Troubleshooting
 
 {% include common/upgrade/troubleshooting-self-hosted.md %}


### PR DESCRIPTION
Adds an include that was missing in the 24.3 docs reorg. Rendered:

<img width="781" alt="Screenshot 2025-04-14 at 4 32 02 PM" src="https://github.com/user-attachments/assets/10b05325-7cb5-43b1-a94a-d889359cd6d8" />
