### PR TITLE
Remove references to annual cloud report

### DIFF
--- a/src/current/_includes/v23.1/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v23.1/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/_includes/v23.2/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v23.2/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/_includes/v24.1/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v24.1/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/_includes/v24.2/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v24.2/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/_includes/v24.3/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v24.3/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/_includes/v25.1/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v25.1/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/_includes/v25.2/prod-deployment/cloud-report.md
+++ b/src/current/_includes/v25.2/prod-deployment/cloud-report.md
@@ -1,1 +1,0 @@
-Cockroach Labs creates a yearly cloud report focused on evaluating hardware performance. For more information, see the [2022 Cloud Report](https://www.cockroachlabs.com/guides/2022-cloud-report/).

--- a/src/current/v23.1/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v23.1/performance-benchmarking-with-tpcc-large.md
@@ -467,8 +467,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.1/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v23.1/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.1/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v23.1/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.1/performance.md
+++ b/src/current/v23.1/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.1/recommended-production-settings.md
+++ b/src/current/v23.1/recommended-production-settings.md
@@ -193,9 +193,6 @@ Results:
 | Data per RAM          | ~135 GiB / GiB  |
 
 ### Cloud-specific recommendations
-
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.

--- a/src/current/v23.2/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v23.2/performance-benchmarking-with-tpcc-large.md
@@ -466,8 +466,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.2/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v23.2/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.2/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v23.2/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.2/performance.md
+++ b/src/current/v23.2/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v23.2/recommended-production-settings.md
+++ b/src/current/v23.2/recommended-production-settings.md
@@ -194,8 +194,6 @@ Results:
 
 ### Cloud-specific recommendations
 
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.

--- a/src/current/v24.1/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v24.1/performance-benchmarking-with-tpcc-large.md
@@ -466,8 +466,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.1/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v24.1/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.1/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v24.1/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.1/performance.md
+++ b/src/current/v24.1/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.1/recommended-production-settings.md
+++ b/src/current/v24.1/recommended-production-settings.md
@@ -194,8 +194,6 @@ Results:
 
 ### Cloud-specific recommendations
 
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.

--- a/src/current/v24.2/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v24.2/performance-benchmarking-with-tpcc-large.md
@@ -466,8 +466,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.2/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v24.2/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.2/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v24.2/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.2/performance.md
+++ b/src/current/v24.2/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.2/recommended-production-settings.md
+++ b/src/current/v24.2/recommended-production-settings.md
@@ -194,8 +194,6 @@ Results:
 
 ### Cloud-specific recommendations
 
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.

--- a/src/current/v24.3/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v24.3/performance-benchmarking-with-tpcc-large.md
@@ -466,8 +466,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.3/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v24.3/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.3/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v24.3/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.3/performance.md
+++ b/src/current/v24.3/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v24.3/recommended-production-settings.md
+++ b/src/current/v24.3/recommended-production-settings.md
@@ -194,8 +194,6 @@ Results:
 
 ### Cloud-specific recommendations
 
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.

--- a/src/current/v25.1/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v25.1/performance-benchmarking-with-tpcc-large.md
@@ -466,8 +466,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.1/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v25.1/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.1/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v25.1/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.1/performance.md
+++ b/src/current/v25.1/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.1/recommended-production-settings.md
+++ b/src/current/v25.1/recommended-production-settings.md
@@ -194,8 +194,6 @@ Results:
 
 ### Cloud-specific recommendations
 
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.

--- a/src/current/v25.2/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v25.2/performance-benchmarking-with-tpcc-large.md
@@ -466,8 +466,6 @@ $(cat addrs)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.2/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v25.2/performance-benchmarking-with-tpcc-medium.md
@@ -251,8 +251,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.2/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v25.2/performance-benchmarking-with-tpcc-small.md
@@ -170,8 +170,6 @@ _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
-- Performance Tuning
+- Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.2/performance.md
+++ b/src/current/v25.2/performance.md
@@ -89,8 +89,6 @@ CockroachDB has no theoretical limitations to scaling, throughput, latency, or c
 
     CockroachDB works well on commodity hardware in public cloud, private cloud, on-prem, and hybrid environments. For hardware recommendations, see our [Production Checklist]({% link {{ page.version.version }}/recommended-production-settings.md %}#hardware).
 
-    {% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 - Performance tuning
 
     For guidance on tuning a real workload's performance, see [SQL Best Practices]({% link {{ page.version.version }}/performance-best-practices-overview.md %}), and for guidance on techniques to minimize network latency in multi-region or global clusters, see [Multi-Region Capabilities Overview]({% link {{ page.version.version }}/multiregion-overview.md %}).

--- a/src/current/v25.2/recommended-production-settings.md
+++ b/src/current/v25.2/recommended-production-settings.md
@@ -194,8 +194,6 @@ Results:
 
 ### Cloud-specific recommendations
 
-{% include {{ page.version.version }}/prod-deployment/cloud-report.md %}
-
 Based on our internal testing, we recommend the following cloud-specific configurations. Before using configurations not recommended here, be sure to test them exhaustively. Also consider the following workload-specific observations:
 
 - For OLTP applications, small instance types may outperform larger instance types.


### PR DESCRIPTION
After a conversation with marketing, we agreed that the outdated references to the annual cloud report are better off removed than updated.