### PR TITLE
Add missing updates to releases page for v25.1

### DIFF
--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -115,7 +115,10 @@ As of 2024, CockroachDB is released under a staged delivery process. New release
 | :---: | :---: | :---: |
 | [v25.1](#v25-1) | Innovation | 2025-02-18 |
 | [v24.3](#v24-3) | Regular | 2024-11-18 |
+| [v24.2]({% link releases/unsupported-versions.md %}#v24-2) | Innovation | 2024-08-12 |
 | [v24.1](#v24-1) | Regular | 2024-05-20 |
+| [v23.2](#v23-2) | Regular | 2024-02-05 |
+| [v23.1](#v23-1) | Regular | 2023-05-15 |
 
 ### Upcoming releases
 

--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -113,10 +113,9 @@ As of 2024, CockroachDB is released under a staged delivery process. New release
 
 | Version | Release Type | GA date |
 | :---: | :---: | :---: |
+| [v25.1](#v25-1) | Innovation | 2025-02-18 |
 | [v24.3](#v24-3) | Regular | 2024-11-18 |
 | [v24.1](#v24-1) | Regular | 2024-05-20 |
-| [v23.2](#v23-2) | Regular | 2024-02-05 |
-| [v23.1](#v23-1) | Regular | 2023-05-15 |
 
 ### Upcoming releases
 
@@ -124,10 +123,10 @@ The following releases and their descriptions represent proposed plans that are 
 
 | Version | Release Type | Expected GA date |
 | :---: | :---: | :---: |
-| v25.1 | Innovation | 2025 Q1    |
 | v25.2 | Regular    | 2025 Q2    |
 | v25.3 | Innovation | 2025 Q3    |
 | v25.4 | Regular    | 2025 Q4    |
+| v26.1 | Innovation | 2026 Q1    |
 
 
 ## Downloads


### PR DESCRIPTION
Update current/upcoming releases tables to account for v25.1 release and remove recent EOS releases.