### PR TITLE
Update Gemfile to specify Jekyll 4.3.4

### DIFF
--- a/src/current/Gemfile
+++ b/src/current/Gemfile
@@ -6,7 +6,8 @@ source "https://rubygems.org"
 # docs-builder Docker image to keep things speedy in CI. See ci/README.md for
 # instructions.
 
-gem "jekyll", "~> 4.3"
+# gem "jekyll", "~> 4.3" Removed until conflict with our use of ianjevins/jekyll-remote-include is resolved
+gem "jekyll", "4.3.4"
 gem "liquid-c", "~> 4.0.0"
 gem "redcarpet", "~> 3.6"
 gem "rss"

--- a/src/current/Gemfile
+++ b/src/current/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 # docs-builder Docker image to keep things speedy in CI. See ci/README.md for
 # instructions.
 
-# gem "jekyll", "~> 4.3" Removed until conflict with our use of ianjevins/jekyll-remote-include is resolved
+# Removed `gem "jekyll", "~> 4.3"`` until conflict with our use of ianjevins/jekyll-remote-include is resolved (DOC-13509)
 gem "jekyll", "4.3.4"
 gem "liquid-c", "~> 4.0.0"
 gem "redcarpet", "~> 3.6"


### PR DESCRIPTION
Removed ~> 4.3 until conflict with our use of ianjevins/jekyll-remote-include is resolved