### PR TITLE
REL-2375 v23.2.25: [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -9016,13 +9016,7 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.24
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
+
 
 - release_name: v24.3.12
   major_version: v24.3


### PR DESCRIPTION
Fixes REL-2375

In releases.yml, removed cloud fields for v23.2.25.