### PR TITLE
add RETURNS TABLE example for Pl/pgSQL

### DIFF
--- a/src/current/v25.2/plpgsql.md
+++ b/src/current/v25.2/plpgsql.md
@@ -374,15 +374,16 @@ In the following example, `RETURN NEXT` returns a new row during each loop itera
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-CREATE FUNCTION get_numbers() RETURNS SETOF INT AS $$
+CREATE FUNCTION get_numbers() RETURNS TABLE (n INT) AS $$
 DECLARE
 	i INT := 1;
 BEGIN
 	WHILE i <= 5 LOOP
-		RETURN NEXT i;
+		n := i;
+		RETURN NEXT;
 		i := i + 1;
 	END LOOP;
-END
+END;
 $$ LANGUAGE PLpgSQL;
 ~~~
 


### PR DESCRIPTION
Updated one of the `RETURNS SETOF` examples to use `RETURNS TABLE` instead. This demonstrates that `RETURNS TABLE` is now valid PL/pgSQL syntax. cc @mikeCRL 