### PR TITLE
Clarify the monthly Basic resource benefit

### DIFF
--- a/src/current/cockroachcloud/basic-cluster-management.md
+++ b/src/current/cockroachcloud/basic-cluster-management.md
@@ -35,7 +35,7 @@ The monthly cost estimate is calculated using simple extrapolation that assumes 
 1. On the **Edit cluster** page, navigate to **Capacity**.
 1. Under the **Estimate cost based on usage** section, select a time period in which your workload was active.
 
-    Your used [RUs]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units), used storage, and accrued costs during the time period will be shown along with a monthly cost estimate. The accrued costs and monthly cost estimate do not account for the [$15 of free resources each month]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) granted to each non-contract organization, which you would have to use up before being charged.
+    Your used [RUs]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units), used storage, and accrued costs during the time period will be shown along with a monthly cost estimate. The accrued costs and monthly cost estimate do not account for the [$15 of free resources each month]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) granted to each organization (excluding those with annual or multi-year contracts), which you would have to use up before being charged.
 
 ## Edit cluster capacity
 

--- a/src/current/cockroachcloud/basic-cluster-management.md
+++ b/src/current/cockroachcloud/basic-cluster-management.md
@@ -35,7 +35,7 @@ The monthly cost estimate is calculated using simple extrapolation that assumes 
 1. On the **Edit cluster** page, navigate to **Capacity**.
 1. Under the **Estimate cost based on usage** section, select a time period in which your workload was active.
 
-    Your used [RUs]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units), used storage, and accrued costs during the time period will be shown along with a monthly cost estimate. The accrued costs and monthly cost estimate do not account for the [free resources]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) granted to each non-contract organization, which you would have to use up before being charged.
+    Your used [RUs]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units), used storage, and accrued costs during the time period will be shown along with a monthly cost estimate. The accrued costs and monthly cost estimate do not account for the [$15 of free resources each month]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) granted to each non-contract organization, which you would have to use up before being charged.
 
 ## Edit cluster capacity
 

--- a/src/current/cockroachcloud/costs.md
+++ b/src/current/cockroachcloud/costs.md
@@ -92,7 +92,7 @@ This section supplements the details in [Costs across CockroachDB Cloud plans](#
 
 <section class="filter-content" markdown="1" data-scope="basic">
 
-For CockroachDB Basic, compute cost is usage-based through its consumption of [Request Units]({% link cockroachcloud/resource-usage-basic.md %}#understand-resource-consumption). For non-contract customers, the first 50 million Request Units and 10 GiB of storage (equivalent to [$15 of resource consumption]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage)) spent each month is free and credited back on a monthly invoice.
+For CockroachDB Basic, compute cost is usage-based through its consumption of [Request Units]({% link cockroachcloud/resource-usage-basic.md %}#understand-resource-consumption). For non-contract customers, the first [$15 of resource consumption]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) (equivalent to 50 million Request Units and 10 GiB of storage) spent each month is free and credited back on their monthly invoice.
 
 </section>
 

--- a/src/current/cockroachcloud/costs.md
+++ b/src/current/cockroachcloud/costs.md
@@ -92,7 +92,7 @@ This section supplements the details in [Costs across CockroachDB Cloud plans](#
 
 <section class="filter-content" markdown="1" data-scope="basic">
 
-For CockroachDB Basic, compute cost is usage-based through its consumption of [Request Units]({% link cockroachcloud/resource-usage-basic.md %}#understand-resource-consumption).
+For CockroachDB Basic, compute cost is usage-based through its consumption of [Request Units]({% link cockroachcloud/resource-usage-basic.md %}#understand-resource-consumption). For non-contract customers, the first 50 million Request Units and 10 GiB of storage (equivalent to [$15 of resource consumption]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage)) spent each month is free and credited back on a monthly invoice.
 
 </section>
 

--- a/src/current/cockroachcloud/costs.md
+++ b/src/current/cockroachcloud/costs.md
@@ -92,7 +92,11 @@ This section supplements the details in [Costs across CockroachDB Cloud plans](#
 
 <section class="filter-content" markdown="1" data-scope="basic">
 
-For CockroachDB Basic, compute cost is usage-based through its consumption of [Request Units]({% link cockroachcloud/resource-usage-basic.md %}#understand-resource-consumption). For non-contract customers, the first [$15 of resource consumption]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) (equivalent to 50 million Request Units and 10 GiB of storage) spent each month is free and credited back on their monthly invoice.
+For CockroachDB Basic, compute cost is usage-based through its consumption of [Request Units]({% link cockroachcloud/resource-usage-basic.md %}#understand-resource-consumption). For customers who pay monthly, the first [$15 of resource consumption]({% link cockroachcloud/plan-your-cluster-basic.md %}#free-vs-paid-usage) (equivalent to 50 million Request Units and 10 GiB of storage) spent each month is free and credited back on their monthly invoice.
+
+{{site.data.alerts.callout_info}}
+Customers with annual or multi-year contracts are not eligible for the free monthly resource benefit.
+{{site.data.alerts.end}}
 
 </section>
 

--- a/src/current/cockroachcloud/free-trial.md
+++ b/src/current/cockroachcloud/free-trial.md
@@ -5,7 +5,7 @@ toc: true
 cloud: true
 ---
 
-When you sign up for CockroachDB Cloud, your new organization's account starts with $400 in free credits, allowing you to try the product at no cost.
+When you sign up for CockroachDB Cloud, your new organization's account starts with $400 in free credits, allowing you to try the product at no cost. Non-contract accounts with CockroachDB {{ site.data.products.basic }} clusters are also elegible for an additional $15 per month of resource utilization.
 
 ## Free trial credits
 
@@ -22,6 +22,12 @@ The free trial offer does not apply to organizations that are billed by invoice.
 ### View your credit balance
 
 To check your free credit balance and see how much time is remaining before your free credit expires, navigate to the [Get Started](https://cockroachlabs.cloud/get-started) page or your [Billing](https://cockroachlabs.cloud/billing/overview) overview in the CockroachDB Cloud Console.
+
+## Monthly free {{ site.data.products.basic }} credits
+
+Accounts with CockroachDB {{ site.data.products.basic }} clusters receive $15 of free resource utilization (equivalent to 50 million [Request Units]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units) and 10 GiB storage) across all clusters. This benefit applies as a $15 credit on their monthly invoice.
+
+A payment method must be added to the account to be elegible for this benefit. Contract customers are not elegible for the free monthly resource benefit.
 
 ## Free trial notifications
 

--- a/src/current/cockroachcloud/free-trial.md
+++ b/src/current/cockroachcloud/free-trial.md
@@ -5,7 +5,11 @@ toc: true
 cloud: true
 ---
 
-When you sign up for CockroachDB Cloud, your new organization's account starts with $400 in free credits, allowing you to try the product at no cost. Non-contract accounts with CockroachDB {{ site.data.products.basic }} clusters are also elegible for an additional $15 per month of resource utilization.
+When you sign up for CockroachDB Cloud, your new organization's account starts with $400 in free credits, allowing you to try the product at no cost. Pay-as-you-go accounts with CockroachDB {{ site.data.products.basic }} clusters are also elegible for an additional $15 per month of resource utilization.
+
+{{site.data.alerts.callout_info}}
+Customers with annual or multi-year contracts are not eligible for the free monthly resource benefit.
+{{site.data.alerts.end}}
 
 ## Free trial credits
 
@@ -27,7 +31,7 @@ To check your free credit balance and see how much time is remaining before your
 
 Accounts with CockroachDB {{ site.data.products.basic }} clusters receive $15 of free resource utilization (equivalent to 50 million [Request Units]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units) and 10 GiB storage) across all clusters. This benefit applies as a $15 credit on their monthly invoice.
 
-A payment method must be added to the account to be elegible for this benefit. Contract customers are not elegible for the free monthly resource benefit.
+A payment method must be added to the account to be elegible for this benefit, though it will only be charged for any usage above the $15 of free credits. Customers with annual or multi-year contracts are not elegible for the free monthly resource benefit.
 
 ## Free trial notifications
 

--- a/src/current/cockroachcloud/plan-your-cluster-basic.md
+++ b/src/current/cockroachcloud/plan-your-cluster-basic.md
@@ -29,10 +29,10 @@ Refer to [Pricing](https://cockroachlabs.com/pricing) to see cost estimates of c
 
 ## Free vs. paid usage
 
-CockroachDB {{ site.data.products.basic }} clusters scale based on your workload so that you will only pay for what you use beyond the free resources. Each non-contract CockroachDB {{ site.data.products.cloud }} organization is given $15 of resource consumption (equivalent to 50 million [Request Units](#request-units) and 10 GiB of storage) for free each month. Every monthly billing cycle, this free monthly resource benefit can be spent across all CockroachDB {{ site.data.products.basic }} clusters in an organization. The free usage appears as a $15 deduction on your monthly invoice.
+CockroachDB {{ site.data.products.basic }} clusters scale based on your workload so that you will only pay for what you use beyond the free resources. Each pay-as-you-go CockroachDB {{ site.data.products.cloud }} organization - those paying monthly by credit card or marketplace - is given $15 of resource consumption (equivalent to 50 million [Request Units](#request-units) and 10 GiB of storage) for free each month. Every monthly billing cycle, this free monthly resource benefit can be spent across all CockroachDB {{ site.data.products.basic }} clusters in an organization. The free usage appears as a $15 deduction on your monthly invoice.
 
 {{site.data.alerts.callout_info}}
-Contract customers are not elegible for the free monthly resource benefit.
+Customers with annual or multi-year contracts are not eligible for the free monthly resource benefit.
 {{site.data.alerts.end}}
 
 Setting resource limits will allow your cluster to scale to meet your application's needs and maintain a high level of performance. You must [set resource limits]({% link cockroachcloud/basic-cluster-management.md %}#edit-cluster-capacity) if you've already created one free CockroachDB {{ site.data.products.basic }} cluster. To set your limits, you can either set storage and RU limits individually, or enter a dollar amount that will be split automatically between both resources. You can also choose an unlimited amount of resources to prevent your cluster from ever being throttled or disabled.

--- a/src/current/cockroachcloud/plan-your-cluster-basic.md
+++ b/src/current/cockroachcloud/plan-your-cluster-basic.md
@@ -29,7 +29,11 @@ Refer to [Pricing](https://cockroachlabs.com/pricing) to see cost estimates of c
 
 ## Free vs. paid usage
 
-CockroachDB {{ site.data.products.basic }} clusters scale based on your workload so that you will only pay for what you use beyond the free resources. Each non-contract CockroachDB {{ site.data.products.cloud }} organization is given 50 million [Request Units](#request-units) and 10 GiB of storage for free each month. Free resources do not apply to contract customers. Free resources can be spent across all CockroachDB {{ site.data.products.basic }} clusters in an organization and will appear as a deduction on your monthly invoice.
+CockroachDB {{ site.data.products.basic }} clusters scale based on your workload so that you will only pay for what you use beyond the free resources. Each non-contract CockroachDB {{ site.data.products.cloud }} organization is given 50 million [Request Units](#request-units) and 10 GiB of storage (equivalent to $15 of resource consumption) for free each month. Every monthly billing cycle, this free monthly resource benefit can be spent across all CockroachDB {{ site.data.products.basic }} clusters in an organization. The free usage appears as a $15 deduction on your monthly invoice.
+
+{{site.data.alerts.callout_info}}
+Contract customers are not elegible for the free monthly resource benefit.
+{{site.data.alerts.end}}
 
 Setting resource limits will allow your cluster to scale to meet your application's needs and maintain a high level of performance. You must [set resource limits]({% link cockroachcloud/basic-cluster-management.md %}#edit-cluster-capacity) if you've already created one free CockroachDB {{ site.data.products.basic }} cluster. To set your limits, you can either set storage and RU limits individually, or enter a dollar amount that will be split automatically between both resources. You can also choose an unlimited amount of resources to prevent your cluster from ever being throttled or disabled.
 

--- a/src/current/cockroachcloud/plan-your-cluster-basic.md
+++ b/src/current/cockroachcloud/plan-your-cluster-basic.md
@@ -29,7 +29,7 @@ Refer to [Pricing](https://cockroachlabs.com/pricing) to see cost estimates of c
 
 ## Free vs. paid usage
 
-CockroachDB {{ site.data.products.basic }} clusters scale based on your workload so that you will only pay for what you use beyond the free resources. Each non-contract CockroachDB {{ site.data.products.cloud }} organization is given 50 million [Request Units](#request-units) and 10 GiB of storage (equivalent to $15 of resource consumption) for free each month. Every monthly billing cycle, this free monthly resource benefit can be spent across all CockroachDB {{ site.data.products.basic }} clusters in an organization. The free usage appears as a $15 deduction on your monthly invoice.
+CockroachDB {{ site.data.products.basic }} clusters scale based on your workload so that you will only pay for what you use beyond the free resources. Each non-contract CockroachDB {{ site.data.products.cloud }} organization is given $15 of resource consumption (equivalent to 50 million [Request Units](#request-units) and 10 GiB of storage) for free each month. Every monthly billing cycle, this free monthly resource benefit can be spent across all CockroachDB {{ site.data.products.basic }} clusters in an organization. The free usage appears as a $15 deduction on your monthly invoice.
 
 {{site.data.alerts.callout_info}}
 Contract customers are not elegible for the free monthly resource benefit.

--- a/src/current/releases/cloud.md
+++ b/src/current/releases/cloud.md
@@ -545,7 +545,7 @@ The following changes were made to CockroachDB {{ site.data.products.serverless 
 
 - The price of [Request Units (RUs)]({% link cockroachcloud/plan-your-cluster-basic.md %}#request-units) increased from $1 per 10M RU to $2 per 10M RUs.
 - The price of storage decreased from $1 per 1 GiB storage to $0.50 per 1 GiB storage.
-- Free resources are allocated on a per-organization basis instead of a per-cluster basis. All All non-contract organizations will now receive 50M Request Units per month and 10 GiB of storage for free. Free resources do not apply to contract customers.
+- Free resources are allocated on a per-organization basis instead of a per-cluster basis. All non-contract organizations will now receive 50M Request Units per month and 10 GiB of storage for free. Free resources do not apply to customers with annual or multi-year contracts.
 - All resources are available instantly at the beginning of each month (burst and baseline RUs are now deprecated).
 - You can now [set separate RU and storage limits]({% link cockroachcloud/basic-cluster-management.md %}#edit-cluster-capacity) for your clusters, or set a spend limit that will be divided between resources automatically.
 - You can now [set unlimited resources]({% link cockroachcloud/basic-cluster-management.md %}#edit-cluster-capacity) for a cluster so your workload is never restricted.


### PR DESCRIPTION
Per @jaiayu , customers and support have expressed confusion over the $15 monthly resource benefit available to non-contract Basic customers. Primarily that it is distinct from the $400 free usage benefit offered to new customers, but also that it appears as a credit on the monthly invoice.

- Translate the "50 million RU/10 GiB storage" benefit into $15 to match the invoice language and distinguish from the one-time $400 benefit
- Add mentions of the benefit to other places where we discuss Basic cluster costs