### PR TITLE
Update diagnostics page re: telemetry info

### DIFF
--- a/src/current/v23.1/diagnostics-reporting.md
+++ b/src/current/v23.1/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v23.2/diagnostics-reporting.md
+++ b/src/current/v23.2/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v24.1/diagnostics-reporting.md
+++ b/src/current/v24.1/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v24.2/diagnostics-reporting.md
+++ b/src/current/v24.2/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v24.3/diagnostics-reporting.md
+++ b/src/current/v24.3/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v25.1/diagnostics-reporting.md
+++ b/src/current/v25.1/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v25.2/diagnostics-reporting.md
+++ b/src/current/v25.2/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})

--- a/src/current/v25.3/diagnostics-reporting.md
+++ b/src/current/v25.3/diagnostics-reporting.md
@@ -5,7 +5,7 @@ toc: true
 docs_area: reference.diagnostics_reporting
 ---
 
-By default, the DB Console and each node of a CockroachDB cluster share anonymous usage details with Cockroach Labs. These details, which are completely scrubbed of identifiable information, greatly help us understand and improve how the system behaves in real-world scenarios.
+By default, the DB Console and each node of a CockroachDB cluster share usage details with Cockroach Labs. Sensitive data is redacted from this usage information; these details help Cockroach Labs understand and improve how the system behaves in real-world scenarios.
 
 This page summarizes the details that get shared, how to view the details yourself, and how to opt out of sharing.
 
@@ -15,10 +15,7 @@ For insights into your cluster's performance and health, use the built-in [DB Co
 
 ## What gets shared
 
-When diagnostics reporting is on, each node of a CockroachDB cluster shares anonymized details on an hourly basis, including (but not limited to):
-
-- Deployment and configuration characteristics, such as size of hardware, [cluster settings]({% link {{ page.version.version }}/cluster-settings.md %}) that have been altered from defaults, number of [replication zones]({% link {{ page.version.version }}/configure-replication-zones.md %}) configured, etc.
-- Usage and cluster health details, such as crashes, unexpected errors, attempts to use unsupported features, types of queries run and their execution characteristics as well as types of schemas used, etc.
+When diagnostics reporting is on, each node of a CockroachDB cluster shares obfuscated usage details on a periodic basis. For more information about what information is shared, refer to [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %}).
 
 To view the full diagnostics details that a node reports to Cockroach Labs, use the `http://<node-address>:<http-port>/_status/diagnostics/local` JSON endpoint.
 
@@ -67,5 +64,6 @@ If the setting is `false`, diagnostics reporting is off; if the setting is `true
 
 ## See also
 
+- [Telemetry Collected by CockroachDB]({% link {{ page.version.version }}/telemetry.md %})
 - [Cluster Settings]({% link {{ page.version.version }}/cluster-settings.md %})
 - [Start a Node]({% link {{ page.version.version }}/cockroach-start.md %})


### PR DESCRIPTION
Fixes DOC-13703

Summary of changes:

- Replace mentions of 'anonymous' with 'obfuscated/redacted'

- Remove mention of details, and point users to the 'Telemetry Collected by CockroachDB' page, which is intended to be the comprehensive reference