### PR TITLE
Direct users to official Linux install instruction

### DIFF
--- a/src/current/_includes/v25.2/performance/scale-cluster.md
+++ b/src/current/_includes/v25.2/performance/scale-cluster.md
@@ -1,11 +1,10 @@
 1. SSH to one of the `n2-standard-4` instances in the `us-west1-a` zone.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
     {% include_cached copy-clipboard.html %}
@@ -31,12 +30,11 @@
 
 1. SSH to one of the `n2-standard-4` instances in the `us-west2-a` zone.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/_includes/v25.2/performance/start-cluster.md
+++ b/src/current/_includes/v25.2/performance/start-cluster.md
@@ -2,12 +2,11 @@
 
 1. SSH to the first `n2-standard-4` instance.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
     {% include_cached copy-clipboard.html %}
@@ -35,12 +34,11 @@
 
 1. SSH to the fourth instance, the one not running a CockroachDB node.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/_includes/v25.2/prod-deployment/insecure-scale-cluster.md
+++ b/src/current/_includes/v25.2/prod-deployment/insecure-scale-cluster.md
@@ -12,12 +12,11 @@ For each additional node you want to add to the cluster, complete the following 
 
 1. SSH to the machine where you want the node to run.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/_includes/v25.2/prod-deployment/insecure-start-nodes.md
+++ b/src/current/_includes/v25.2/prod-deployment/insecure-start-nodes.md
@@ -59,12 +59,11 @@ After completing these steps, nodes will not yet be live. They will complete the
 
 1. SSH to the machine where you want the node to run. Ensure you are logged in as the `root` user.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/_includes/v25.2/prod-deployment/insecure-test-load-balancing.md
+++ b/src/current/_includes/v25.2/prod-deployment/insecure-test-load-balancing.md
@@ -12,12 +12,11 @@ For comprehensive guidance on benchmarking CockroachDB with TPC-C, see [Performa
 
     This should be a machine that is not running a CockroachDB node.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/_includes/v25.2/prod-deployment/secure-scale-cluster.md
+++ b/src/current/_includes/v25.2/prod-deployment/secure-scale-cluster.md
@@ -12,12 +12,11 @@ For each additional node you want to add to the cluster, complete the following 
 
 1. SSH to the machine where you want the node to run.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/_includes/v25.2/prod-deployment/secure-start-nodes.md
+++ b/src/current/_includes/v25.2/prod-deployment/secure-start-nodes.md
@@ -59,12 +59,11 @@ After completing these steps, nodes will not yet be live. They will complete the
 
 1. SSH to the machine where you want the node to run. Ensure you are logged in as the `root` user.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/_includes/v25.2/prod-deployment/secure-test-load-balancing.md
+++ b/src/current/_includes/v25.2/prod-deployment/secure-test-load-balancing.md
@@ -10,12 +10,11 @@ For comprehensive guidance on benchmarking CockroachDB with TPC-C, refer to [Per
 
     This should be a machine that is not running a CockroachDB node, and it should already have a `certs` directory containing `ca.crt`, `client.root.crt`, and `client.root.key` files.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:

--- a/src/current/v25.2/deploy-cockroachdb-on-premises-insecure.md
+++ b/src/current/v25.2/deploy-cockroachdb-on-premises-insecure.md
@@ -55,17 +55,16 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 1. Install HAProxy:
 
-  {% include_cached copy-clipboard.html %}
-  ~~~ shell
-  $ apt-get install haproxy
-  ~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ apt-get install haproxy
+    ~~~
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), and extract the binary:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
 1. Copy the binary into the `PATH`:
@@ -75,7 +74,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
     $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
     ~~~
 
-  If you get a permissions error, prefix the command with `sudo`.
+    If you get a permissions error, prefix the command with `sudo`.
 
 1. Run the [`cockroach gen haproxy`]({% link {{ page.version.version }}/cockroach-gen.md %}) command, specifying the address of any CockroachDB node:
 
@@ -90,10 +89,10 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 1. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 
-  {% include_cached copy-clipboard.html %}
-  ~~~ shell
-  $ haproxy -f haproxy.cfg
-  ~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ haproxy -f haproxy.cfg
+    ~~~
 
 1. Repeat these steps for each additional instance of HAProxy you want to run.
 

--- a/src/current/v25.2/performance-benchmarking-with-tpcc-large.md
+++ b/src/current/v25.2/performance-benchmarking-with-tpcc-large.md
@@ -173,12 +173,11 @@ CockroachDB comes with a number of [built-in workloads]({% link {{ page.version.
 
 1. SSH to the VM where you want to run TPC-C.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/v25.2/performance-benchmarking-with-tpcc-medium.md
+++ b/src/current/v25.2/performance-benchmarking-with-tpcc-medium.md
@@ -165,12 +165,11 @@ CockroachDB comes with a number of [built-in workloads]({% link {{ page.version.
 
 1. SSH to the VM where you want to run TPC-C.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
     {% include_cached copy-clipboard.html %}

--- a/src/current/v25.2/performance-benchmarking-with-tpcc-small.md
+++ b/src/current/v25.2/performance-benchmarking-with-tpcc-small.md
@@ -106,12 +106,11 @@ CockroachDB comes with a number of [built-in workloads]({% link {{ page.version.
 
 1. SSH to the VM where you want to run TPC-C.
 
-1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
+1. Download [CockroachDB for Linux]({% link {{ page.version.version }}/install-cockroachdb-linux.md %}), extract the binary, and copy it into the `PATH`:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
-    | tar -xz
+    tar -xz cockroach-{{ page.release_info.version }}.linux-amd64.tgz
     ~~~
 
     {% include_cached copy-clipboard.html %}


### PR DESCRIPTION
... not bespoke `curl` commands that can break.

Fixes DOC-13739