### PR TITLE
Remove the SST Bytes graph from the DB Console page for PCR

### DIFF
--- a/src/current/v24.3/physical-cluster-replication-monitoring.md
+++ b/src/current/v24.3/physical-cluster-replication-monitoring.md
@@ -50,7 +50,6 @@ id | name | source_tenant_name |              source_cluster_uri                
 You can use the [**Physical Cluster Replication** dashboard]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}) of the standby cluster's [DB Console]({% link {{ page.version.version }}/ui-overview.md %}) to monitor:
 
 - [Logical bytes]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#logical-bytes)
-- [SST bytes]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#sst-bytes)
 - [Replication Lag]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#replication-lag)
 
 ## Prometheus

--- a/src/current/v24.3/ui-physical-cluster-replication-dashboard.md
+++ b/src/current/v24.3/ui-physical-cluster-replication-dashboard.md
@@ -34,17 +34,6 @@ Hovering over the graph displays:
 When you [start a replication stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#step-4-start-replication), the **Logical Bytes** graph will record a spike of throughput as the initial scan completes. {% comment %}link to technical details here{% endcomment %}
 {{site.data.alerts.end}}
 
-## SST bytes
-
-<img src="{{ 'images/v24.2/ui-sst-bytes.png' | relative_url }}" alt="DB Console SST bytes graph showing results over the past hour" style="border:1px solid #eee;max-width:100%" />
-
-The **SST Bytes** graph displays the rate at which all [SST]({% link {{ page.version.version }}/architecture/storage-layer.md %}#ssts) bytes are sent to the [KV layer]({% link {{ page.version.version }}/architecture/storage-layer.md %}) by physical cluster replication jobs.
-
-Hovering over the graph displays:
-
-- The date and time.
-- The number of SST bytes replicated.
-
 ## Replication lag
 
 <img src="{{ 'images/v24.2/ui-replication-lag.png' | relative_url }}" alt="DB Console Replication Lag graph showing results over the past hour" style="border:1px solid #eee;max-width:100%" />

--- a/src/current/v25.1/physical-cluster-replication-monitoring.md
+++ b/src/current/v25.1/physical-cluster-replication-monitoring.md
@@ -50,7 +50,6 @@ id | name | source_tenant_name |              source_cluster_uri                
 You can use the [**Physical Cluster Replication** dashboard]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}) of the standby cluster's [DB Console]({% link {{ page.version.version }}/ui-overview.md %}) to monitor:
 
 - [Logical bytes]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#logical-bytes)
-- [SST bytes]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#sst-bytes)
 - [Replication Lag]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#replication-lag)
 
 ## Prometheus

--- a/src/current/v25.1/ui-physical-cluster-replication-dashboard.md
+++ b/src/current/v25.1/ui-physical-cluster-replication-dashboard.md
@@ -34,17 +34,6 @@ Hovering over the graph displays:
 When you [start a replication stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#step-4-start-replication), the **Logical Bytes** graph will record a spike of throughput as the initial scan completes. {% comment %}link to technical details here{% endcomment %}
 {{site.data.alerts.end}}
 
-## SST bytes
-
-<img src="{{ 'images/v24.2/ui-sst-bytes.png' | relative_url }}" alt="DB Console SST bytes graph showing results over the past hour" style="border:1px solid #eee;max-width:100%" />
-
-The **SST Bytes** graph displays the rate at which all [SST]({% link {{ page.version.version }}/architecture/storage-layer.md %}#ssts) bytes are sent to the [KV layer]({% link {{ page.version.version }}/architecture/storage-layer.md %}) by physical cluster replication jobs.
-
-Hovering over the graph displays:
-
-- The date and time.
-- The number of SST bytes replicated.
-
 ## Replication lag
 
 <img src="{{ 'images/v24.2/ui-replication-lag.png' | relative_url }}" alt="DB Console Replication Lag graph showing results over the past hour" style="border:1px solid #eee;max-width:100%" />

--- a/src/current/v25.2/physical-cluster-replication-monitoring.md
+++ b/src/current/v25.2/physical-cluster-replication-monitoring.md
@@ -50,7 +50,6 @@ id | name | source_tenant_name |              source_cluster_uri                
 You can use the [**Physical Cluster Replication** dashboard]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}) of the standby cluster's [DB Console]({% link {{ page.version.version }}/ui-overview.md %}) to monitor:
 
 - [Logical bytes]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#logical-bytes)
-- [SST bytes]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#sst-bytes)
 - [Replication Lag]({% link {{ page.version.version }}/ui-physical-cluster-replication-dashboard.md %}#replication-lag)
 
 ## Prometheus

--- a/src/current/v25.2/ui-physical-cluster-replication-dashboard.md
+++ b/src/current/v25.2/ui-physical-cluster-replication-dashboard.md
@@ -34,17 +34,6 @@ Hovering over the graph displays:
 When you [start a replication stream]({% link {{ page.version.version }}/set-up-physical-cluster-replication.md %}#step-4-start-replication), the **Logical Bytes** graph will record a spike of throughput as the initial scan completes. {% comment %}link to technical details here{% endcomment %}
 {{site.data.alerts.end}}
 
-## SST bytes
-
-<img src="{{ 'images/v24.2/ui-sst-bytes.png' | relative_url }}" alt="DB Console SST bytes graph showing results over the past hour" style="border:1px solid #eee;max-width:100%" />
-
-The **SST Bytes** graph displays the rate at which all [SST]({% link {{ page.version.version }}/architecture/storage-layer.md %}#ssts) bytes are sent to the [KV layer]({% link {{ page.version.version }}/architecture/storage-layer.md %}) by physical cluster replication jobs.
-
-Hovering over the graph displays:
-
-- The date and time.
-- The number of SST bytes replicated.
-
 ## Replication lag
 
 <img src="{{ 'images/v24.2/ui-replication-lag.png' | relative_url }}" alt="DB Console Replication Lag graph showing results over the past hour" style="border:1px solid #eee;max-width:100%" />


### PR DESCRIPTION
Fixes DOC-13812

Removes the SST Bytes graph section from the PCR Console metrics page. Also, removes the reference to the graph on the monitoring page.