### PR TITLE
DOC-13940 Remove duplicate release note of backported change

### DIFF
--- a/src/current/_includes/releases/v25.2/v25.2.1.md
+++ b/src/current/_includes/releases/v25.2/v25.2.1.md
@@ -6,8 +6,6 @@ Release Date: June 4, 2025
 
 <h3 id="v25-2-1-sql-language-changes">SQL language changes</h3>
 
-- Added new cluster settings: `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled`. These settings default to `false` and can be set to `true` to display the application name and database name, respectively, on supported metrics.
- [#144610][#144610]
 - Added the `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` cluster settings. These settings default to `false`. Set them to `true` to include the application and database name, respectively, in supported metrics.
  [#144932][#144932]
 


### PR DESCRIPTION
Fixes DOC-13940

In v25.2.1.md, removed duplicate release note of backported change.