### PR TITLE
add retroactive plan_cache_mode release note

### DIFF
--- a/src/current/_includes/releases/v25.2/v25.2.0-alpha.1.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-alpha.1.md
@@ -22,6 +22,7 @@ Release Date: March 24, 2025
 
 <h3 id="v25-2-0-alpha-1-sql-language-changes">SQL language changes</h3>
 
+- The `plan_cache_mode` session setting now defaults to `auto`, enabling generic query plans for some queries. [#135668][#135668]
 - `SHOW JOBS` is now based on a new mechanism for storing information about the progress and status of running jobs. [#138104][#138104]
 - `SHOW VIRTUAL CLUSTER WITH REPLICATION STATUS` now displays the `ingestion_job_id` column after the `name` column. [#138967][#138967]
 - Since v23.2 table statistics histograms have been collected for non-indexed JSON columns. Histograms are no longer collected for these columns. This reduces memory usage during table statistics collection, for both automatic and manual collection via `ANALYZE` and `CREATE STATISTICS`. This can be reverted by setting the cluster setting `sql.stats.non_indexed_json_histograms.enabled` to `true`. [#139766][#139766]
@@ -259,3 +260,4 @@ Release Date: March 24, 2025
 [#142760]: https://github.com/cockroachdb/cockroach/pull/142760
 [#142829]: https://github.com/cockroachdb/cockroach/pull/142829
 [#142838]: https://github.com/cockroachdb/cockroach/pull/142838
+[#135668]: https://github.com/cockroachdb/cockroach/pull/135668


### PR DESCRIPTION
DOC-13811

This PR retroactively adds a release note stating that `plan_cache_mode` defaults to `auto`. For reasons detailed in the ticket, there was no release note generated for this change in 25.2.