### PR TITLE
DOC-13170 Product Change- PR #143536 - metric: add /metrics endpoint with static labels

### DIFF
--- a/src/current/_includes/v25.3/sidebar-data/self-hosted-deployments.json
+++ b/src/current/_includes/v25.3/sidebar-data/self-hosted-deployments.json
@@ -356,6 +356,12 @@
                     ]
                   },
                   {
+                    "title": "Prometheus Endpoint",
+                    "urls": [
+                      "/${VERSION}/prometheus-endpoint.html"
+                    ]
+                  },
+                  {
                     "title": "Use Prometheus and Alertmanager",
                     "urls": [
                       "/${VERSION}/monitor-cockroachdb-with-prometheus.html"

--- a/src/current/v25.3/monitoring-and-alerting.md
+++ b/src/current/v25.3/monitoring-and-alerting.md
@@ -158,35 +158,12 @@ The [`cockroach node status`]({% link {{ page.version.version }}/cockroach-node.
 
 ### Prometheus endpoint
 
-Every node of a CockroachDB cluster exports granular time-series metrics at `http://<host>:<http-port>/_status/vars`. The metrics are formatted for easy integration with [Prometheus]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %}), an open source tool for storing, aggregating, and querying time-series data. The Prometheus format is human-readable and can be processed to work with other third-party monitoring systems such as [Sysdig](https://sysdig.atlassian.net/wiki/plugins/servlet/mobile?contentId=64946336#content/view/64946336) and [stackdriver](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd). Many of the [third-party monitoring integrations]({% link {{ page.version.version }}/third-party-monitoring-tools.md %}), such as [Datadog]({% link {{ page.version.version }}/datadog.md %}) and [Kibana]({% link {{ page.version.version }}/kibana.md %}), collect metrics from a cluster's Prometheus endpoint.
+Each node in a CockroachDB cluster exports granular time-series metrics at two available endpoints:
 
-To access the Prometheus endpoint of a cluster running on `localhost:8080`:
+- [`http://<host>:<http-port>/_status/vars`]({% link {{ page.version.version }}/prometheus-endpoint.md %}#status-vars)
+- {% include_cached new-in.html version="v25.3" %}[`http://<host>:<http-port>/metrics`]({% link {{ page.version.version }}/prometheus-endpoint.md %}#metrics)
 
-{% include_cached copy-clipboard.html %}
-~~~ shell
-$ curl http://localhost:8080/_status/vars
-~~~
-
-~~~
-# HELP gossip_infos_received Number of received gossip Info objects
-# TYPE gossip_infos_received counter
-gossip_infos_received 0
-# HELP sys_cgocalls Total number of cgo calls
-# TYPE sys_cgocalls gauge
-sys_cgocalls 3501
-# HELP sys_cpu_sys_percent Current system cpu percentage
-# TYPE sys_cpu_sys_percent gauge
-sys_cpu_sys_percent 1.098855319644276e-10
-...
-~~~
-
-{{site.data.alerts.callout_info}}
-In addition to using the exported time-series data to monitor a cluster via an external system, you can write alerting rules against them to make sure you are promptly notified of critical events or issues that may require intervention or investigation. See [Events to alert on](#events-to-alert-on) for more details.
-{{site.data.alerts.end}}
-
-If you rely on external tools for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the DB Console Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available.
+For more information, refer to the [Prometheus Endpoint page]({% link {{ page.version.version }}/prometheus-endpoint.md %}).
 
 ### Critical nodes endpoint
 

--- a/src/current/v25.3/monitoring-and-alerting.md
+++ b/src/current/v25.3/monitoring-and-alerting.md
@@ -160,7 +160,7 @@ The [`cockroach node status`]({% link {{ page.version.version }}/cockroach-node.
 
 Each node in a CockroachDB cluster exports granular time-series metrics at two available endpoints:
 
-- [`http://<host>:<http-port>/_status/vars`]({% link {{ page.version.version }}/prometheus-endpoint.md %}#status-vars)
+- [`http://<host>:<http-port>/_status/vars`]({% link {{ page.version.version }}/prometheus-endpoint.md %}#_status-vars)
 - {% include_cached new-in.html version="v25.3" %}[`http://<host>:<http-port>/metrics`]({% link {{ page.version.version }}/prometheus-endpoint.md %}#metrics)
 
 For more information, refer to the [Prometheus Endpoint page]({% link {{ page.version.version }}/prometheus-endpoint.md %}).

--- a/src/current/v25.3/prometheus-endpoint.md
+++ b/src/current/v25.3/prometheus-endpoint.md
@@ -1,0 +1,159 @@
+---
+title: Prometheus Endpoint
+summary: Export granular time-series metrics in Prometheus format to monitor a cluster's health and performance.
+toc: true
+---
+
+Each node in a CockroachDB cluster exports granular time-series metrics at two available endpoints:
+
+- [`http://<host>:<http-port>/_status/vars`](#_status-vars)
+- {% include_cached new-in.html version="v25.3" %}[`http://<host>:<http-port>/metrics`](#metrics): an enhanced endpoint that includes additional static labels
+
+The metrics are formatted for integration with [Prometheus](https://prometheus.io/), an open source tool for storing, aggregating, and querying time-series data. For details on how to pull these metrics into Prometheus, refer to [Monitor CockroachDB with Prometheus]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %}). The Prometheus format is human-readable and can be processed to work with other Prometheus-compatible third-party monitoring systems such as [Sysdig](https://sysdig.com/integrations/prometheus/) and [Google Cloud Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus). Many of the [third-party monitoring integrations]({% link {{ page.version.version }}/third-party-monitoring-tools.md %}), such as [Datadog]({% link {{ page.version.version }}/datadog.md %}) and [Kibana]({% link {{ page.version.version }}/kibana.md %}), collect metrics from a cluster's Prometheus endpoint.
+
+{{site.data.alerts.callout_info}}
+In addition to using the exported time-series data to monitor a cluster through an external system, you can write alerting rules to ensure prompt notification of critical events or issues that may require intervention or investigation. Refer to [Essential Alerts]({% link {{ page.version.version }}/essential-alerts-self-hosted.md %}) for more details.
+{{site.data.alerts.end}}
+
+If you rely on external tools for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
+
+When storage of time-series metrics is disabled, the [DB Console Metrics dashboards]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#metrics-dashboards) in the DB Console are still available, but their visualizations are blank. This occurs because the dashboards rely on data that is no longer available.
+
+## `_status/vars`
+
+To access the `_status/vars` Prometheus endpoint of a cluster running on `localhost:8080`:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ curl http://localhost:8080/_status/vars
+~~~
+
+The output will be similar to the following. Note that the metric names are unique for `sql_*_count*`.
+
+~~~
+# HELP sys_cgocalls Total number of cgo calls
+# TYPE sys_cgocalls counter
+sys_cgocalls{node_id="1",tenant="demoapp"} 13737
+# HELP sys_cpu_sys_percent Current system cpu percentage consumed by the CRDB process
+# TYPE sys_cpu_sys_percent gauge
+sys_cpu_sys_percent{node_id="1",tenant="demoapp"} 0.0021986027879282717
+...
+# HELP sql_select_count_internal Number of SQL SELECT statements successfully executed (internal queries)
+# TYPE sql_select_count_internal counter
+sql_select_count_internal{node_id="1",tenant="demoapp"} 2115
+...
+# HELP sql_delete_count Number of SQL DELETE statements successfully executed
+# TYPE sql_delete_count counter
+sql_delete_count{node_id="1",tenant="demoapp"} 0
+...
+# HELP sql_delete_count_internal Number of SQL DELETE statements successfully executed (internal queries)
+# TYPE sql_delete_count_internal counter
+sql_delete_count_internal{node_id="1",tenant="demoapp"} 996
+...
+# HELP sql_select_count Number of SQL SELECT statements successfully executed
+# TYPE sql_select_count counter
+sql_select_count{node_id="1",tenant="demoapp"} 9
+...
+# HELP sql_insert_count_internal Number of SQL INSERT statements successfully executed (internal queries)
+# TYPE sql_insert_count_internal counter
+sql_insert_count_internal{node_id="1",tenant="demoapp"} 1201
+...
+# HELP sql_update_count Number of SQL UPDATE statements successfully executed
+# TYPE sql_update_count counter
+sql_update_count{node_id="1",tenant="demoapp"} 0
+...
+# HELP sql_update_count_internal Number of SQL UPDATE statements successfully executed (internal queries)
+# TYPE sql_update_count_internal counter
+sql_update_count_internal{node_id="1",tenant="demoapp"} 1907
+...
+# HELP sql_insert_count Number of SQL INSERT statements successfully executed
+# TYPE sql_insert_count counter
+sql_insert_count{node_id="1",tenant="system"} 12
+sql_insert_count{node_id="1",tenant="demoapp"} 15
+...
+~~~
+
+## `metrics`
+
+{% include_cached new-in.html version="v25.3" %}
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/preview.md %}
+{{site.data.alerts.end}}
+
+The `metrics` Prometheus endpoint is commonly used and is the default in Prometheus configurations.
+
+To access the `metrics` Prometheus endpoint of a cluster running on `localhost:8080`:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+$ curl http://localhost:8080/metrics
+~~~
+
+The output will be similar to the following. Note that there is one metric name for `sql_count`, with static labels for `query_type` (with values of `insert`, `select`, `update`, and `delete`) and `query_internal` (with value of `true`).
+
+~~~
+# HELP sys_cgocalls Total number of cgo calls
+# TYPE sys_cgocalls counter
+sys_cgocalls{node_id="1",tenant="demoapp"} 13737
+# HELP sys_cpu_sys_percent Current system cpu percentage consumed by the CRDB process
+# TYPE sys_cpu_sys_percent gauge
+sys_cpu_sys_percent{node_id="1",tenant="demoapp"} 0.0021986027879282717
+...
+# HELP sql_count Number of SQL INSERT statements successfully executed (internal queries)
+# TYPE sql_count counter
+sql_count{node_id="1",tenant="demoapp",query_type="insert",query_internal="true"} 1281
+sql_count{node_id="1",tenant="demoapp",query_type="delete"} 0
+sql_count{node_id="1",tenant="demoapp",query_type="update"} 0
+sql_count{node_id="1",tenant="demoapp",query_type="select",query_internal="true"} 2280
+sql_count{node_id="1",tenant="demoapp",query_type="select"} 9
+sql_count{node_id="1",tenant="demoapp",query_type="insert"} 15
+sql_count{node_id="1",tenant="demoapp",query_type="update",query_internal="true"} 2102
+sql_count{node_id="1",tenant="demoapp",query_type="delete",query_internal="true"} 1067
+...
+~~~
+
+### Static labels
+
+Static labels allow segmentation of a metric across various facets for later querying and aggregation.
+
+Unlabeled metrics from the `_status/vars` endpoint | Labeled metrics from the `metrics` endpoint
+-----------------------------------------------|-----------------------------------------
+`sql_insert_count` | `sql_count{query_type="insert"}`
+`sql_select_count` | `sql_count{query_type="select"}`
+`sql_update_count` | `sql_count{query_type="update"}`
+`sql_delete_count` | `sql_count{query_type="delete"}`
+
+At metrics query time, labels provide a smoother user experience:
+
+Unlabeled sum query from the `_status/vars` endpoint | Labeled sum query from the `metrics` endpoint
+-----------------------------------------------|-------------------------------
+`sum(sql_insert_count, sql_delete_count, sql_select_count)` | `sum(sql_count)`
+This query must be modified if new types are added because they will have new metric names. | This query is resilient to new type additions.
+Related metrics can be found via autocomplete in a third-party tool, but it may be unclear. | All label values can be found through a third-party query engine and used to easily construct a graph with individual lines for each label value.
+
+Another common scenario occurs when each label value represents a disjoint set of categories. An example here is the various certificate expiration metrics, which differ only by the specific certificate they refer to. Operators are unlikely to aggregate these, but may still want to view all certificate expiration metrics on a dashboard.
+
+For example, the output from the `metrics` endpoint will be similar to the following:
+
+~~~
+# HELP security_certificate_expiration Expiration for the CA certificate
+# TYPE security_certificate_expiration gauge
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="ca"} 1.998766953e+09
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="ca-client-tenant"} 0
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="node-client"} 0
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="client-tenant"} 0
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="ui"} 0
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="client"} 1.840654953e+09
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="client-ca"} 0
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="ui-ca"} 0
+security_certificate_expiration{node_id="1",tenant="demoapp",certificate_type="node"} 1.840654953e+09
+~~~
+
+## See also
+
+- [Monitor CockroachDB with Prometheus]({% link {{ page.version.version }}/monitor-cockroachdb-with-prometheus.md %})
+- [Third-party Monitoring Integrations]({% link {{ page.version.version }}/third-party-monitoring-tools.md %})
+- [Monitor CockroachDB Self-Hosted Clusters with Datadog]({% link {{ page.version.version }}/datadog.md %})
+- [Monitor CockroachDB with Kibana]({% link {{ page.version.version }}/kibana.md %})
+- [Essential Alerts]({% link {{ page.version.version }}/essential-alerts-self-hosted.md %})


### PR DESCRIPTION
Fixes DOC-13170

Added [prometheus-endpoing.md](http://prometheus-endpoing.md/) with info about metrics endpoint.
In [monitoring-and-alerting.md](http://monitoring-and-alerting.md/), moved info in the existing Prometheus endpoint section to the new page.
In self-hosted-deployments.json, added link to new page.

Rendered preview

- [Prometheus endpoint](https://deploy-preview-19739--cockroachdb-docs.netlify.app/docs/v25.3/prometheus-endpoin