### PR TITLE
[Docs] Adjust release notes for download/SH v25.2.2, v25.1.8, v24.3.15, v24.1.20, v23.2.27

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -8883,7 +8883,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v24.1.19
-  cloud_only: true
 
 
 - release_name: v25.1.8

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -8827,13 +8827,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v23.2.26
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
 
 
 - release_name: v24.3.15
@@ -8862,13 +8855,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v24.3.14
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
 
 
 - release_name: v24.1.20
@@ -8898,12 +8884,6 @@
   source: true
   previous_release: v24.1.19
   cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
 
 
 - release_name: v25.1.8
@@ -8932,13 +8912,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.1.7
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
  
     
 - release_name: v25.2.2
@@ -8967,10 +8940,4 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.2.1
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
+


### PR DESCRIPTION
Fixes
REL-2651 
REL-2615
REL-2642
REL-2633
REL-2624

In releases.yml, removed cloud fields to show download links.

Rendered preview

- [Release downloads](https://deploy-preview-19856--cockroachdb-docs.netlify.app/docs/releases/#downloads)
