### PR TITLE
Add documentation for new backup and restore cloud API endpoints

### DIFF
--- a/src/current/_includes/cockroachcloud/backups/cloud-api-backup-settings.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-backup-settings.md
@@ -14,7 +14,7 @@ Set the following:
 - `{cluster_id}` is the unique ID of the cluster. Use this ID when making API requests. You can find the cluster ID in the cluster's Cloud Console page. Find your cluster ID in the URL of the single cluster overview page: `https://cockroachlabs.cloud/cluster/{your_cluster_id}/overview`. The ID should resemble `f78b7feb-b6cf-4396-9d7f-494982d7d81e`.
 - `{secret_key}` is your API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}#api-access) for more details.
 
-If the request was successful, the API will return details about the managed backup settings:
+If the request is successful, the API will return details about the managed backup settings:
 
 ~~~json
 {
@@ -53,7 +53,7 @@ Set the following:
 - `{frequency_minutes}` determines [how often](#frequency) the managed backup will run in minutes. Possible values are: `5`, `10`, `15`, `30`, `60`, `240` (4 hours), `1440` (24 hours).
 - `{retention_days}` sets the number of days Cockroach Labs will [retain](#retention) the managed backup in storage. You can change `retention_days` for the cluster **once** (whether in the Cloud API or [Cloud Console](#cloud-console)). Possible values are: `2`, `7`, `30`, `90`, `365`.
 
-    If `{retention_days}` has previously been modified (in the Cloud API or Cloud Console), you will receive the message "cluster already has a retention policy set, open a support ticket to change it". To modify the setting again, contact the [Cockroach Labs Support team]({% link {{site.current_cloud_version}}/support-resources.md %}).
+    If `{retention_days}` has previously been modified (in the Cloud API or Cloud Console), you receive the message "cluster already has a retention policy set, open a support ticket to change it". To modify the setting again, contact the [Cockroach Labs Support team]({% link {{site.current_cloud_version}}/support-resources.md %}).
 - `{secret_key}` is your API key. Refer to [API Access]({% link cockroachcloud/managing-access.md %}#api-access) for more details.
 
-If the request was successful, the client will receive an empty HTTP 200 OK status response.
+If the request is successful, the client recieves an empty HTTP 200 OK status response.

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-backup-settings.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-backup-settings.md
@@ -1,9 +1,3 @@
-You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) and [modify](#modify-backup-settings-on-a-cluster) managed backup settings.
-
-{{site.data.alerts.callout_info}}
-The [service account]({% link cockroachcloud/authorization.md %}#service-accounts) associated with the secret key must have the [Cluster Admin]({% link cockroachcloud/authorization.md %}#cluster-admin) role.
-{{site.data.alerts.end}}
-
 ### Get information on backup settings
 
 To retrieve information about a specific cluster, make a `GET` request to the `/v1/clusters/{cluster_id}/backups/config` endpoint.

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-backup-view.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-backup-view.md
@@ -9,7 +9,7 @@ curl --request GET \
 --header 'Authorization: Bearer {secret_key}' \
 ~~~
 
-If the request was successful, the client will receive a JSON response listing backups with their unique `{id}` and `{as_of_time}` creation timestamp:
+If the request is successful, the client recieves a JSON response listing backups with their unique `{id}`. The `{as_of_time}` timestamp describes the system time of the cluster when the backup was created:
 
 ~~~ json
 {

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-backup-view.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-backup-view.md
@@ -1,5 +1,9 @@
 ### View managed backups
 
+{{site.data.alerts.callout_info}}
+{% include feature-phases/limited-access.md %}
+{{site.data.alerts.end}}
+
 To view a list of managed backups on a cluster with timestamps and their respective IDs, send a `GET` request to the `/v1/clusters/{cluster_id}/backups` endpoint:
 
 {% include_cached copy-clipboard.html %}

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-backup-view.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-backup-view.md
@@ -1,0 +1,39 @@
+### View managed backups
+
+To view a list of managed backups on a cluster with timestamps and their respective IDs, send a `GET` request to the `/v1/clusters/{cluster_id}/backups` endpoint:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+--url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/backups \
+--header 'Authorization: Bearer {secret_key}' \
+~~~
+
+If the request was successful, the client will receive a JSON response listing backups with their unique `{id}` and `{as_of_time}` creation timestamp:
+
+~~~ json
+{
+  "backups": [
+    {
+      "id": "example-157a-4b04-8f72-3179369a50d9",
+      "as_of_time": "2025-07-25T15:45:00Z"
+    },
+    {
+      "id": "example-c090-429c-9f84-2b1297f5de89",
+      "as_of_time": "2025-07-25T15:35:32Z"
+    },
+    {
+      "id": "example-4e41-44ec-926a-0cc368efdea2",
+      "as_of_time": "2025-07-25T15:00:00Z"
+    },
+    {
+      "id": "example-3c67-4822-b7b9-90c2d8cc06a3",
+      "as_of_time": "2025-07-25T14:56:15Z"
+    },
+    {
+      "id": "example-abef-4191-aa98-36a019da97c2",
+      "as_of_time": "2025-07-25T14:52:05.637170Z"
+    }
+  ],
+  "pagination": null
+~~~

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
@@ -1,7 +1,7 @@
 {% if page.name == "managed-backups-basic.md" %}
-You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) and [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) or [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
 {% else %}
-You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) or [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), and [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) and [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), or [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
 {% endif %}
 
 {{site.data.alerts.callout_info}}

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
@@ -1,0 +1,9 @@
+{% if page.name == "managed-backups-basic.md" %}
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) and [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
+{% else %}
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) or [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), and [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
+{% endif %}
+
+{{site.data.alerts.callout_info}}
+The [service account]({% link cockroachcloud/authorization.md %}#service-accounts) associated with the secret key must have the [Cluster Admin]({% link cockroachcloud/authorization.md %}#cluster-admin) role.
+{{site.data.alerts.end}}

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
@@ -1,5 +1,7 @@
 {% if page.name == "managed-backups-basic.md" %}
-You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) or [restore clusters/databases/tables](#restore-from-a-managed-backup) from a managed backup.
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) or [restore clusters](#restore-from-a-managed-backup) from a managed backup.
+{% else if page.name == "managed-backups.md"  %}
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) and [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), or [restore clusters](#restore-from-a-managed-backup) from a managed backup.
 {% else %}
 You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) and [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), or [restore clusters/databases/tables](#restore-from-a-managed-backup) from a managed backup.
 {% endif %}

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-managed-backup-intro.md
@@ -1,7 +1,7 @@
 {% if page.name == "managed-backups-basic.md" %}
-You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) or [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view managed backups](#view-managed-backups) or [restore clusters/databases/tables](#restore-from-a-managed-backup) from a managed backup.
 {% else %}
-You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) and [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), or [restore clusters/databases/tables](#restore-a-managed-backup) from a managed backup.
+You can use the [CockroachDB Cloud API]({% link cockroachcloud/cloud-api.md %}) to [view](#get-information-on-backup-settings) and [modify managed backup settings](#modify-backup-settings-on-a-cluster), [view managed backups](#view-managed-backups), or [restore clusters/databases/tables](#restore-from-a-managed-backup) from a managed backup.
 {% endif %}
 
 {{site.data.alerts.callout_info}}

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
@@ -1,5 +1,9 @@
 ### Restore from a managed backup
 
+{{site.data.alerts.callout_info}}
+{% include feature-phases/limited-access.md %}
+{{site.data.alerts.end}}
+
 You can use the `/v1/clusters/{destination_cluster_id}/restores` endpoint to restore the contents of a managed backup to a specified destination cluster.
 
 {% if page.name == "managed-backups-advanced.md" %}
@@ -279,6 +283,10 @@ If the request is successful, the client recieves a response containing JSON des
 {% endif %}
 
 ### Get status of a restore operation
+
+{{site.data.alerts.callout_info}}
+{% include feature-phases/limited-access.md %}
+{{site.data.alerts.end}}
 
 To view the status of a restore operation using the cloud API, send a `GET` request to the `/v1/clusters/{cluster_id}/restores/{restore_id}` endpoint where `restore_id` is the `id` from the JSON response:
 

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
@@ -87,7 +87,7 @@ curl --request POST \
             "database": "tpcc"
         }
     ]
-}
+}'
 ~~~
 
 By default the database will be restored into the original database name from the cluster backup. To restore the database contents into a new database, include the field `restore_opts.new_db_name` with the new database name:
@@ -107,7 +107,7 @@ curl --request POST \
     "restore_opts": {
         "new_db_name": "tpcc2"
     }
-}
+}'
 ~~~
 
 To restore a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
@@ -125,8 +125,28 @@ curl --request POST \
             "database": "tpcc"
         }
     ],
-}
+}'
 ~~~
+
+{% if page.name == "managed-backups-advanced.md" %}
+To restore a database from a managed backup into a different cluster, send the restore request to the target cluster ID. Specify the ID of the backup's cluster as `source_cluster_id`. Both the source cluster and the target cluster must use the Advanced plan.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{target_cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "source_cluster_id": "{source_cluster_id}",
+    "type": "DATABASE",
+    "objects": [
+        {
+            "database": "tpcc"
+        }
+    ],
+}'
+~~~
+{% endif %}
 
 You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
 
@@ -161,7 +181,7 @@ curl --request POST \
             "table": "warehouse"
         }
     ]
-}
+}'
 ~~~
 
 By default the table will be restored into the original database name from the cluster backup. To restore the table into a different database, include the field `restore_opts.into_name` with the database name. The following example restores the `tpcc.public.warehouse` table from the most recent managed backup into `tpcc2.public.warehouse` on the cluster:
@@ -183,7 +203,7 @@ curl --request POST \
     "restore_opts": {
         "into_db": "tpcc2"
     }
-}
+}'
 ~~~
 
 To restore a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
@@ -203,8 +223,30 @@ curl --request POST \
             "table": "warehouse"
         }
     ]
-}
+}'
 ~~~
+
+{% if page.name == "managed-backups-advanced.md" %}
+To restore a table from a managed backup into a different cluster, send the restore request to the target cluster ID. Specify the ID of the backup's cluster as `source_cluster_id`. Both the source cluster and the target cluster must use the Advanced plan.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{target_cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "source_cluster_id": "{source_cluster_id}",
+    "type": "TABLE",
+    "objects": [
+        {
+            "database": "tpcc",
+            "schema": "public",
+            "table": "warehouse"
+        }
+    ]
+}'
+~~~
+{% endif %}
 
 You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
 

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
@@ -1,4 +1,4 @@
-### Restore a managed backup
+### Restore from a managed backup
 
 You can use the `/v1/clusters/{cluster_id}/restores` endpoint to restore the contents of a managed backup at the cluster, database, or table level.
 
@@ -11,7 +11,7 @@ On Standard and Basic clusters, restore operations can only be performed into th
 #### Restore a cluster
 
 {{site.data.alerts.callout_danger}}
-The restore completely erases all data in the destination cluster. All cluster data is replaced with the data from the backup. The destination cluster will be unavailable while the job is in progress.
+The restore operation completely erases all data in the destination cluster. All cluster data is replaced with the data from the backup. The destination cluster will be unavailable while the job is in progress.
 
 This operation is disruptive and is to be performed with caution. Use the [Principle of Least Privilege (PoLP)](https://wikipedia.org/wiki/Principle_of_least_privilege) as a golden rule when designing your system of privilege grants.
 {{site.data.alerts.end}}
@@ -73,7 +73,7 @@ If the request was successful, the client will receive a response containing JSO
 
 #### Restore a database
 
-To restore a managed backup of a database to a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "DATABASE"`. Specify the name of the source database in `objects.database`:
+To restore a database from a managed backup to a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "DATABASE"`. Specify the name of the source database in `objects.database`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -90,7 +90,7 @@ curl --request POST \
 }'
 ~~~
 
-By default the database will be restored into the original database name from the cluster backup. To restore the database contents into a new database, include the field `restore_opts.new_db_name` with the new database name:
+By default the database will be restored into the original database name from the managed backup. To restore the database contents into a new database, include the field `restore_opts.new_db_name` with the new database name:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -110,7 +110,7 @@ curl --request POST \
 }'
 ~~~
 
-To restore a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
+To restore from a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -165,7 +165,7 @@ If the request was successful, the client will receive a response containing JSO
 
 #### Restore a table
 
-To restore a managed backup of a table to a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "DATABASE"`. Specify the fully qualified name of the source database in `objects`:
+To restore a table from a managed backup to a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "TABLE"`. Specify the fully qualified name of the source table in `objects`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -184,7 +184,7 @@ curl --request POST \
 }'
 ~~~
 
-By default the table will be restored into the original database name from the cluster backup. To restore the table into a different database, include the field `restore_opts.into_name` with the database name. The following example restores the `tpcc.public.warehouse` table from the most recent managed backup into `tpcc2.public.warehouse` on the cluster:
+By default the table will be restored into the original database name from the managed backup. To restore the table into a different database, include the field `restore_opts.into_name` with the desired database name. The following example restores the `tpcc.public.warehouse` table from the most recent managed backup into `tpcc2.public.warehouse` on the cluster:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -206,7 +206,7 @@ curl --request POST \
 }'
 ~~~
 
-To restore a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
+To restore from a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
@@ -1,0 +1,246 @@
+### Restore a managed backup
+
+You can use the `/v1/clusters/{cluster_id}/restores` endpoint to restore the contents of a managed backup at the cluster, database, or table level.
+
+{% if page.name == "managed-backups-advanced.md" %}
+On Advanced clusters, restore operations can be performed into the same cluster or a different Advanced cluster in the same organization.
+{% else %}
+On Standard and Basic clusters, restore operations can only be performed into the same cluster where the managed backup is stored.
+{% endif %}
+
+#### Restore a cluster
+
+{{site.data.alerts.callout_danger}}
+The restore completely erases all data in the destination cluster. All cluster data is replaced with the data from the backup. The destination cluster will be unavailable while the job is in progress.
+
+This operation is disruptive and is to be performed with caution. Use the [Principle of Least Privilege (PoLP)](https://wikipedia.org/wiki/Principle_of_least_privilege) as a golden rule when designing your system of privilege grants.
+{{site.data.alerts.end}}
+
+To restore a managed backup of a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "CLUSTER"`:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "type": "CLUSTER"
+}'
+~~~
+
+By default the restore operation will use the most recent backup. To restore a specific backup, include the `backup_id` field specifying a backup ID:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+    "type": "CLUSTER"
+}'
+~~~
+
+{% if page.name == "managed-backups-advanced.md" %}
+To restore a cluster backup into a new cluster, first create the target cluster. Send the restore request to the target cluster ID, specifying the ID of the source cluster as `source_cluster_id`. Both the source cluster and the target cluster must use the Advanced plan.
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{target_cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "source_cluster_id": "{source_cluster_id}",
+    "type": "CLUSTER"
+}'
+~~~
+{% endif %}
+
+You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+
+If the request was successful, the client will receive a response containing JSON describing the request operation:
+
+~~~ json
+{
+  "id": "example-aeb7-4daa-9e2c-eda541765f8a",
+  "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+  "status": "PENDING",
+  "created_at": "2025-07-25T16:45:14.064208710Z",
+  "type": "CLUSTER",
+  "completion_percent": 0
+}
+~~~
+
+#### Restore a database
+
+To restore a managed backup of a database to a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "DATABASE"`. Specify the name of the source database in `objects.database`:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "type": "DATABASE",
+    "objects": [
+        {
+            "database": "tpcc"
+        }
+    ]
+}
+~~~
+
+By default the database will be restored into the original database name from the cluster backup. To restore the database contents into a new database, include the field `restore_opts.new_db_name` with the new database name:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "type": "DATABASE",
+    "objects": [
+        {
+            "database": "tpcc"
+        }
+    ],
+    "restore_opts": {
+        "new_db_name": "tpcc2"
+    }
+}
+~~~
+
+To restore a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+    "type": "DATABASE",
+    "objects": [
+        {
+            "database": "tpcc"
+        }
+    ],
+}
+~~~
+
+You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+
+If the request was successful, the client will receive a response containing JSON describing the request operation:
+
+~~~ json
+{
+  "id": "example-aeb7-4daa-9e2c-eda541765f8a",
+  "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+  "status": "PENDING",
+  "created_at": "2025-07-25T16:45:14.064208710Z",
+  "type": "DATABASE",
+  "completion_percent": 0
+}
+~~~
+
+#### Restore a table
+
+To restore a managed backup of a table to a cluster, send a `POST` request to the `/v1/clusters/{cluster_id}/restores` endpoint of `"type": "DATABASE"`. Specify the fully qualified name of the source database in `objects`:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "type": "TABLE",
+    "objects": [
+        {
+            "database": "tpcc",
+            "schema": "public",
+            "table": "warehouse"
+        }
+    ]
+}
+~~~
+
+By default the table will be restored into the original database name from the cluster backup. To restore the table into a different database, include the field `restore_opts.into_name` with the database name. The following example restores the `tpcc.public.warehouse` table from the most recent managed backup into `tpcc2.public.warehouse` on the cluster:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "type": "TABLE",
+    "objects": [
+        {
+            "database": "tpcc",
+            "schema": "public",
+            "table": "warehouse"
+        }
+    ],
+    "restore_opts": {
+        "into_db": "tpcc2"
+    }
+}
+~~~
+
+To restore a specific backup rather than the most recently created managed backup, include the `backup_id` field specifying a backup ID:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request POST \
+--url 'https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores' \
+--header "Authorization: Bearer {secret_key}" \
+--json '{
+    "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+    "type": "TABLE",
+    "objects": [
+        {
+            "database": "tpcc",
+            "schema": "public",
+            "table": "warehouse"
+        }
+    ]
+}
+~~~
+
+You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+
+If the request was successful, the client will receive a response containing JSON describing the request operation:
+
+~~~ json
+{
+  "id": "example-aeb7-4daa-9e2c-eda541765f8a",
+  "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+  "status": "PENDING",
+  "created_at": "2025-07-25T16:45:14.064208710Z",
+  "type": "table",
+  "completion_percent": 0
+}
+~~~
+
+### Get status of a restore operation
+
+To view the status of a restore operation using the cloud API, send a `GET` request to the `/v1/clusters/{cluster_id}/restores/{restore_id}` endpoint:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+curl --request GET \
+--url https://cockroachlabs.cloud/api/v1/clusters/{cluster_id}/restores/{restore_id} \
+--header 'Authorization: Bearer {secret_key}' \
+~~~
+
+If the request was successful, the client will receive a response containing JSON describing the status of the specified request operation:
+
+~~~ json
+{
+  "id": "example-aeb7-4daa-9e2c-eda541765f8a",
+  "backup_id": "example-2d25-4a64-8172-28af7a0d41cc",
+  "status": "SUCCESS",
+  "created_at": "2025-07-25T16:45:14.064208710Z",
+  "type": "CLUSTER",
+  "completion_percent": 100
+}
+~~~

--- a/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
@@ -53,9 +53,10 @@ curl --request POST \
     "type": "CLUSTER"
 }'
 ~~~
-{% endif %}
 
 You can specify additional options for the restore operation in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+
+{% endif %}
 
 If the request is successful, the client recieves a JSON response that describes the request operation:
 

--- a/src/current/cockroachcloud/cloud-api.md
+++ b/src/current/cockroachcloud/cloud-api.md
@@ -631,6 +631,10 @@ Where `{cluster_id}` is the ID of your cluster and `{secret_key}` is your API ke
 
 ## Managed backups and restores
 
+{{site.data.alerts.callout_info}}
+{% include feature-phases/limited-access.md %}
+{{site.data.alerts.end}}
+
 For information on using the Cloud API to handle [managed backups and restore operations]({% link cockroachcloud/backup-and-restore-overview.md %}), see the respective managed backup documentation for [Basic]({% link cockroachcloud/managed-backups-basic.md %}#cloud-api), [Standard]({% link cockroachcloud/managed-backups.md %}#cloud-api), and [Advanced]({% link cockroachcloud/managed-backups-advanced.md %}#cloud-api) plans.
 
 ## Change a cluster's plan

--- a/src/current/cockroachcloud/cloud-api.md
+++ b/src/current/cockroachcloud/cloud-api.md
@@ -629,6 +629,10 @@ curl --request PATCH \
 
 Where `{cluster_id}` is the ID of your cluster and `{secret_key}` is your API key.
 
+## Managed backups and restores
+
+For information on using the Cloud API to handle [managed backups and restore operations]({% link cockroachcloud/backup-and-restore-overview.md %}), see the respective managed backup documentation for [Basic]({% link cockroachcloud/managed-backups-basic.md %}#cloud-api), [Standard]({% link cockroachcloud/managed-backups.md %}#cloud-api), and [Advanced]({% link cockroachcloud/managed-backups-advanced.md %}#cloud-api) plans.
+
 ## Change a cluster's plan
 
 This section shows how to change a cluster's plan using the CockroachDB {{ site.data.products.cloud }} API. To use Terraform instead, refer to [Provision a cluster with Terraform]({% link cockroachcloud/provision-a-cluster-with-terraform.md %}#change-a-clusters-plan).

--- a/src/current/cockroachcloud/managed-backups-advanced.md
+++ b/src/current/cockroachcloud/managed-backups-advanced.md
@@ -246,7 +246,13 @@ For each restore job, the tab will display:
 
 ## Cloud API
 
-{% include cockroachcloud/backups/cloud-api-get-put.md %}
+{% include cockroachcloud/backups/cloud-api-managed-backup-intro.md %}
+
+{% include cockroachcloud/backups/cloud-api-backup-settings.md %}
+
+{% include cockroachcloud/backups/cloud-api-backup-view.md %}
+
+{% include cockroachcloud/backups/cloud-api-restore-endpoint.md %}
 
 ## CockroachDB Cloud Terraform provider
 

--- a/src/current/cockroachcloud/managed-backups-advanced.md
+++ b/src/current/cockroachcloud/managed-backups-advanced.md
@@ -144,10 +144,8 @@ Users with the [Organization Admin]({% link cockroachcloud/authorization.md %}#o
 
 #### Restore an Advanced cluster
 
-{{site.data.alerts.callout_danger}}
-The restore completely erases all data in the destination cluster. All cluster data is replaced with the data from the backup. The destination cluster will be unavailable while the job is in progress.
-
-This operation is disruptive and is to be performed with caution. Use the [Principle of Least Privilege (PoLP)](https://wikipedia.org/wiki/Principle_of_least_privilege) as a golden rule when designing your system of privilege grants.
+{{site.data.alerts.callout_info}}
+Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore operation fails if the destination cluster contains any databases/schemas/tables.
 {{site.data.alerts.end}}
 
 To restore a cluster:

--- a/src/current/cockroachcloud/managed-backups-basic.md
+++ b/src/current/cockroachcloud/managed-backups-basic.md
@@ -75,3 +75,11 @@ To restore a cluster:
     {{site.data.alerts.end}}
 
 1. Click **Restore**.
+
+## Cloud API
+
+{% include cockroachcloud/backups/cloud-api-managed-backup-intro.md %}
+
+{% include cockroachcloud/backups/cloud-api-backup-view.md %}
+
+{% include cockroachcloud/backups/cloud-api-restore-endpoint.md %}

--- a/src/current/cockroachcloud/managed-backups-basic.md
+++ b/src/current/cockroachcloud/managed-backups-basic.md
@@ -53,10 +53,8 @@ For each backup, the following details display:
 
 ### Restore a cluster
 
-{{site.data.alerts.callout_danger}}
-The restore completely erases all data in the destination cluster. All cluster data is replaced with the data from the backup. The destination cluster will be unavailable while the job is in progress.
-
-This operation is disruptive and is to be performed with caution. Use the [Principle of Least Privilege (PoLP)](https://wikipedia.org/wiki/Principle_of_least_privilege) as a golden rule when designing your system of privilege grants.
+{{site.data.alerts.callout_info}}
+Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore operation fails if the destination cluster contains any databases/schemas/tables.
 {{site.data.alerts.end}}
 
 Performing a restore will cause your cluster to be unavailable for the duration of the restore. All current data is deleted, and the cluster will be restored to the state it was in at the time of the backup.

--- a/src/current/cockroachcloud/managed-backups.md
+++ b/src/current/cockroachcloud/managed-backups.md
@@ -136,6 +136,8 @@ To restore a cluster:
 
 {% include cockroachcloud/backups/cloud-api-backup-settings.md %}
 
+{% include cockroachcloud/backups/cloud-api-backup-view.md %}
+
 {% include cockroachcloud/backups/cloud-api-restore-endpoint.md %}
 
 ## CockroachDB Cloud Terraform provider

--- a/src/current/cockroachcloud/managed-backups.md
+++ b/src/current/cockroachcloud/managed-backups.md
@@ -132,7 +132,11 @@ To restore a cluster:
 
 ## Cloud API
 
-{% include cockroachcloud/backups/cloud-api-get-put.md %}
+{% include cockroachcloud/backups/cloud-api-managed-backup-intro.md %}
+
+{% include cockroachcloud/backups/cloud-api-backup-settings.md %}
+
+{% include cockroachcloud/backups/cloud-api-restore-endpoint.md %}
 
 ## CockroachDB Cloud Terraform provider
 

--- a/src/current/cockroachcloud/managed-backups.md
+++ b/src/current/cockroachcloud/managed-backups.md
@@ -107,10 +107,8 @@ To modify the [retention](#retention) of backups, click on **Retain backups for*
 
 ### Restore a cluster
 
-{{site.data.alerts.callout_danger}}
-The restore completely erases all data in the destination cluster. All cluster data is replaced with the data from the backup. The destination cluster will be unavailable while the job is in progress.
-
-This operation is disruptive and is to be performed with caution. Use the [Principle of Least Privilege (PoLP)](https://wikipedia.org/wiki/Principle_of_least_privilege) as a golden rule when designing your system of privilege grants.
+{{site.data.alerts.callout_info}}
+Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore operation fails if the destination cluster contains any databases/schemas/tables.
 {{site.data.alerts.end}}
 
 Performing a restore will cause your cluster to be unavailable for the duration of the restore. All current data is deleted, and the cluster will be restored to the state it was in at the time of the backup.

--- a/src/current/v25.3/cockroachdb-feature-availability.md
+++ b/src/current/v25.3/cockroachdb-feature-availability.md
@@ -37,6 +37,9 @@ Any feature made available in a phase prior to GA is provided without any warran
 ### Export metrics to Azure Monitor
 [Exporting Metrics to Azure Monitor]({% link cockroachcloud/export-metrics-advanced.md %}?filters=azure-monitor-metrics-export) from a CockroachDB {{ site.data.products.advanced }} cluster hosted on Azure is in limited access. Once the export is configured, metrics will flow from all nodes in all regions of your CockroachDB {{ site.data.products.advanced }} cluster to your chosen cloud metrics sink. To express interest and try it out, contact [Support](https://support.cockroachlabs.com/hc).
 
+### Backup and restore with the Cloud API
+You can use the [Cloud API]({% link cockroachcloud/cloud-api.md %}#managed-backups-and-restores) to handle [managed backups and restore operations]({% link cockroachcloud/backup-and-restore-overview.md %}). To express interest and try out these API endpoints, contact [Support](https://support.cockroachlabs.com/hc).
+
 ### Cluster SSO backed by LDAP
 
 [Cluster SSO]({% link {{ page.version.version }}/sso-sql.md %}) using an identity stored in LDAP is in Limited Access. The [cluster setting]({% link {{ page.version.version }}/cluster-settings.md %}) `server.auth_log.sql_sessions.enabled`, which logs more details about cluster authentication failures, is also in Limited Access.


### PR DESCRIPTION
Fixes DOC-11599

Add task-oriented guidance to our docs around using the cloud API to:
- View managed backups
- Restore cluster objects
- Restore database objects
- Restore table objects
- View restore operations on a cluster

Opted to break out our existing include(s) for human readability due to different functionality between Cloud plans.

TODO:
- Update release note date to the actual release date