### PR TITLE
docs: remove v19.2 references from Jekyll data files

### DIFF
--- a/src/current/_data/redirects.yml
+++ b/src/current/_data/redirects.yml
@@ -81,7 +81,7 @@
 
 - destination: admin-ui-overview.md
   sources: ['explore-the-admin-ui.md']
-  versions: ['v1.1', 'v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1']
+  versions: ['v1.1', 'v2.0', 'v2.1', 'v19.1', '', 'v20.1']
 
 - destination: architecture/distribution-layer.md#range-merges
   sources: ['range-merges.md']
@@ -89,11 +89,11 @@
 
 - destination: architecture/overview.md
   sources: ['architecture/index.md']
-  versions: ['v1.1', 'v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v1.1', 'v2.0', 'v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: authorization.md
   sources: ['create-and-manage-users.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: authorization.md
   sources: ['roles.md']
@@ -103,7 +103,7 @@
   sources:
     - backup-data.md
     - restore-data.md
-  versions: ['v2.1', 'v19.1', 'v19.2', 'v20.1']
+  versions: ['v2.1', 'v19.1', '', 'v20.1']
 
 - destination: cdc-queries.md
   sources: ['cdc-transformations.md']
@@ -119,59 +119,59 @@
 
 - destination: cockroach-cert.md
   sources: ['create-security-certificates.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-debug-ballast.md
   sources: ['debug-ballast.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-debug-encryption-active-key.md
   sources: ['debug-encryption-active-key.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-debug-merge-logs.md
   sources: ['debug-merge-logs.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-debug-zip.md
   sources: ['debug-zip.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-dump.md
   sources: ['sql-dump.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-gen.md
   sources: ['generate-cockroachdb-resources.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-init.md
   sources: ['initialize-a-cluster.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-node.md
   sources: ['view-node-details.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-quit.md
   sources: ['stop-a-node.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-sql.md
   sources: ['use-the-built-in-sql-client.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1', 'v21.2', 'v21.2', 'v22.2', 'v23.1', 'v23.2']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1', 'v21.2', 'v21.2', 'v22.2', 'v23.1', 'v23.2']
 
 - destination: cockroach-sqlfmt.md
   sources: ['use-the-query-formatter.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-start.md
   sources: ['start-a-node.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroach-version.md
   sources: ['view-version-details.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: cockroachdb-feature-availability.md
   sources:
@@ -205,13 +205,13 @@
 
 - destination: demo-low-latency-multi-region-deployment.md
   sources: ['demo-geo-partitioning.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: demo-replication-and-rebalancing.md
   sources:
   - demo-automatic-rebalancing.md
   - demo-data-replication.md
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: v23.2/disaster-recovery-planning.md
   sources: ['v23.2/disaster-recovery.md']
@@ -275,7 +275,7 @@
 
 - destination: manual-deployment.md
   sources: ['cloud-deployment.md']
-  versions: ['v1.1', 'v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v1.1', 'v2.0', 'v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: plan-your-cluster-serverless.md
   sources:
@@ -307,7 +307,7 @@
 
 - destination: molt/migration-overview.md
   sources: ['import-data.md']
-  versions: ['v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: molt/migration-overview.md
   sources:
@@ -330,11 +330,11 @@
 
 - destination: orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
   sources: ['orchetrate-cockroachdb-with-kubernetes-multi-region.md']
-  versions: ['v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v2.0', 'v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: performance-benchmarking-with-tpc-c-1k-warehouses.md
   sources: ['performance-benchmarking-with-tpc-c.md']
-  versions: ['v19.2', 'v20.1']
+  versions: ['', 'v20.1']
 
 - destination: performance-benchmarking-with-tpcc-large.md
   sources: ['performance-benchmarking-with-tpc-c-100k-warehouses.md']
@@ -355,7 +355,7 @@
 
 - destination: postgresql-compatibility.md
   sources: ['porting-postgres.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: regional-tables.md
   sources:
@@ -369,15 +369,15 @@
 
 - destination: scalar-expressions.md
   sources: ['sql-expressions.md']
-  versions: ['v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v2.0', 'v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: select-clause.md
   sources: ['select.md']
-  versions: ['v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v2.0', 'v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: selection-queries.md
   sources: ['selection-clauses.md']
-  versions: ['v2.0', 'v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v2.0', 'v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: serverless-faqs.md
   sources: ['free-faqs.md']
@@ -395,7 +395,7 @@
     - show-create-sequence.md
     - show-create-table.md
     - show-create-view.md
-  versions: ['v2.1', 'v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v2.1', 'v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: show-experimental-ranges.md
   sources: ['show-testing-ranges.md']
@@ -403,7 +403,7 @@
 
 - destination: show-ranges.md
   sources: ['show-experimental-ranges.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: show-statements.md
   sources: ['show-queries.md']
@@ -429,7 +429,7 @@
 
 - destination: start-a-local-cluster-in-docker-mac.md
   sources: ['start-a-local-cluster-in-docker.md']
-  versions: ['v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: stream-data-out-of-cockroachdb-using-changefeeds.md
   sources: ['change-data-capture.md']
@@ -453,7 +453,7 @@
 
 - destination: topology-patterns.md
   sources: ['cluster-topology-patterns.md']
-  versions: ['v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: ui-cdc-dashboard.md
   sources: ['admin-ui-cdc-dashboard.md']
@@ -766,7 +766,7 @@
     - simplified-deployment.md
     - sql.md
     - strong-consistency.md
-  versions: ['v19.1', 'v19.2', 'v20.1', 'v20.2', 'v21.1']
+  versions: ['v19.1', '', 'v20.1', 'v20.2', 'v21.1']
 
 - destination: https://docs.peewee-orm.com/en/latest/peewee/playhouse.html
   sources: [':version/build-a-python-app-with-cockroachdb-peewee.md']

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -1458,16 +1458,6 @@
   previous_release: v19.1.0
  
 
-- release_name: v19.2.0-alpha.20190606
-  major_version: v19.2
-  release_date: '2019-06-06'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 53fada85741a2a096c240b2e8a2347b523c4a463
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
- 
 
 - release_name: v19.1.2
   major_version: v19.1
@@ -1481,17 +1471,6 @@
   previous_release: v19.1.1
  
 
-- release_name: v19.2.0-alpha.20190701
-  major_version: v19.2
-  release_date: '2019-07-01'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 2c865eeb3e3b244468ffc509a62778bd1f46740f
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-alpha.20190606
- 
 
 - release_name: v2.1.8
   major_version: v2.1
@@ -1517,17 +1496,6 @@
   previous_release: v19.1.2
  
 
-- release_name: v19.2.0-alpha.20190805
-  major_version: v19.2
-  release_date: '2019-08-05'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 5bd37e8eb58ca66b9293c234bc572411057fec3a
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-alpha.20190701
- 
 
 - release_name: v19.1.4
   major_version: v19.1
@@ -1565,90 +1533,12 @@
   previous_release: v19.1.4
  
 
-- release_name: v19.2.0-beta.20190930
-  major_version: v19.2
-  release_date: '2019-09-30'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 250f4c36de2b88eff443cf9be9cd5d2759312c88
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-alpha.20190805
- 
 
-- release_name: v19.2.0-beta.20191014
-  major_version: v19.2
-  release_date: '2019-10-14'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 27ea46b456d6b3dabac2c0f6c5c120ed316fffce
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-beta.20190930
- 
 
-- release_name: v19.2.0-rc.1
-  major_version: v19.2
-  release_date: '2019-10-21'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 239513342a2d23f683bbc1d386f87ff59cc78d10
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-beta.20191014
- 
 
-- release_name: v19.2.0-rc.2
-  major_version: v19.2
-  release_date: '2019-10-28'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 918d925bcb7d3b42e3f201d2e0f534a9d0d26684
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-rc.1
- 
 
-- release_name: v19.2.0-rc.3
-  major_version: v19.2
-  release_date: '2019-11-04'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 62801ce77d9055c00b0e30010f5998ea2cd86686
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-rc.2
- 
 
-- release_name: v19.2.0-rc.4
-  major_version: v19.2
-  release_date: '2019-11-07'
-  release_type: Testing
-  go_version: go1.12.12
-  sha: 2535f0363b5d9b1e466ca3144fe5bcf7ff17e63c
-  docker:
-    docker_image: cockroachdb/cockroach-unstable
-  source: true
-  previous_release: v19.2.0-rc.3
- 
 
-- release_name: v19.2.0
-  major_version: v19.2
-  release_date: '2019-11-12'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 338deb20a6e34750635d6be5385498d5871ff68c
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.0-rc.4
- 
 
 - release_name: v20.1.0-alpha.20191118
   major_version: v20.1
@@ -1660,18 +1550,6 @@
   docker:
     docker_image: cockroachdb/cockroach-unstable
   source: true
-- release_name: v19.2.1
-  major_version: v19.2
-  release_date: '2019-11-25'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 53eef0857d14cc3af720e136ddaff4eeab026fd0
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.0
- 
 
 - release_name: v2.1.10
   major_version: v2.1
@@ -1697,18 +1575,6 @@
   previous_release: v19.1.5
  
 
-- release_name: v19.2.2
-  major_version: v19.2
-  release_date: '2019-12-16'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 3cbd05602d4aeaebbccea18d66ad0fdf8db482a5
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.1
- 
 
 - release_name: v20.1.0-alpha20191216
   major_version: v20.1
@@ -1756,18 +1622,6 @@
     docker_image: cockroachdb/cockroach-unstable
   source: true
   previous_release: v20.1.0-alpha20191216
-- release_name: v19.2.3
-  major_version: v19.2
-  release_date: '2020-02-03'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 2353f82b598b216a594ed7e6fc2eca66fe9d75e7
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.2
- 
 
 - release_name: v19.1.8
   major_version: v19.1
@@ -1781,18 +1635,6 @@
   previous_release: v19.1.7
  
 
-- release_name: v19.2.4
-  major_version: v19.2
-  release_date: '2020-02-11'
-  release_type: Production
-  go_version: go1.12.12
-  sha: eb883734bcdafd85d98eb0e49126749bc2cc1284
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.3
- 
 
 - release_name: v20.1.0-beta.1
   major_version: v20.1
@@ -1816,18 +1658,6 @@
     docker_image: cockroachdb/cockroach-unstable
   source: true
   previous_release: v20.1.0-beta.1
-- release_name: v19.2.5
-  major_version: v19.2
-  release_date: '2020-03-23'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 4f36d0c62435596ca103454e113ebe8e55f005de
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.4
- 
 
 - release_name: v20.1.0-beta.3
   major_version: v20.1
@@ -1851,18 +1681,6 @@
     docker_image: cockroachdb/cockroach-unstable
   source: true
   previous_release: v20.1.0-beta.3
-- release_name: v19.2.6
-  major_version: v19.2
-  release_date: '2020-04-13'
-  release_type: Production
-  go_version: go1.12.12
-  sha: ee759892738f7f203ff95ec7627b90d7c47b4350
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.5
- 
 
 - release_name: v20.1.0-rc.1
   major_version: v20.1
@@ -1909,18 +1727,6 @@
     docker_image: cockroachdb/cockroach
   source: true
   previous_release: v20.1.0-rc.2
-- release_name: v19.2.7
-  major_version: v19.2
-  release_date: '2020-05-20'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 2e19ff0576ff21e243f00f2e2acdaeea57aee6f3
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.6
- 
 
 - release_name: v20.1.1
   major_version: v20.1
@@ -1967,18 +1773,6 @@
   previous_release: v19.1.9
  
 
-- release_name: v19.2.8
-  major_version: v19.2
-  release_date: '2020-06-29'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 04216787bfef5c0a577d93b16c9e91fd44637ecf
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.7
- 
 
 - release_name: v20.1.3
   major_version: v20.1
@@ -1991,18 +1785,6 @@
     docker_image: cockroachdb/cockroach
   source: true
   previous_release: v20.1.2
-- release_name: v19.2.9
-  major_version: v19.2
-  release_date: '2020-07-06'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 5930d185b895e7deae41833af8fcce49babd23a1
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.8
- 
 
 - release_name: v19.1.11
   major_version: v19.1
@@ -2040,18 +1822,6 @@
     docker_image: cockroachdb/cockroach
   source: true
   previous_release: v20.1.3
-- release_name: v19.2.10
-  major_version: v19.2
-  release_date: '2020-08-24'
-  release_type: Production
-  go_version: go1.12.12
-  sha: 5a1eb98cf9e0139f58b138f2743a3e0f55408b2f
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.9
- 
 
 - release_name: v20.2.0-alpha.3
   major_version: v20.2
@@ -2131,18 +1901,6 @@
     docker_image: cockroachdb/cockroach-unstable
   source: true
   previous_release: v20.2.0-beta.3
-- release_name: v19.2.11
-  major_version: v19.2
-  release_date: '2020-10-12'
-  release_type: Production
-  go_version: go1.12.12
-  sha: e450c34dbf33745d889f41e1b1ea65197c1506fc
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.10
- 
 
 - release_name: v20.1.7
   major_version: v20.1
@@ -2286,18 +2044,6 @@
     docker_image: cockroachdb/cockroach
   source: true
   previous_release: v20.1.9
-- release_name: v19.2.12
-  major_version: v19.2
-  release_date: '2021-01-19'
-  release_type: Production
-  go_version: go1.12.12
-  sha: eaae94a719759b74ed9f7bb150ee7e4bdd7c6ff1
-  windows: true
-  docker:
-    docker_image: cockroachdb/cockroach
-  source: true
-  previous_release: v19.2.11
- 
 
 - release_name: v20.2.4
   major_version: v20.2

--- a/src/current/v19.1/cockroachdb-in-comparison.md
+++ b/src/current/v19.1/cockroachdb-in-comparison.md
@@ -40,7 +40,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -62,7 +62,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -82,7 +82,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -104,7 +104,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -126,7 +126,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -144,7 +144,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -164,7 +164,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -186,7 +186,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -210,7 +210,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -230,7 +230,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -250,7 +250,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -272,7 +272,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -294,7 +294,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -312,7 +312,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -332,7 +332,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v19.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">

--- a/src/current/v20.1/cockroachdb-in-comparison.md
+++ b/src/current/v20.1/cockroachdb-in-comparison.md
@@ -42,7 +42,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -64,7 +64,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -84,7 +84,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -106,7 +106,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -128,7 +128,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -146,7 +146,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -166,7 +166,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -188,7 +188,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -212,7 +212,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -232,7 +232,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -252,7 +252,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -274,7 +274,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -296,7 +296,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -314,7 +314,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -334,7 +334,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">

--- a/src/current/v20.2/cockroachdb-in-comparison.md
+++ b/src/current/v20.2/cockroachdb-in-comparison.md
@@ -42,7 +42,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -64,7 +64,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -84,7 +84,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -106,7 +106,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -128,7 +128,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -146,7 +146,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -166,7 +166,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -188,7 +188,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -212,7 +212,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -232,7 +232,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -252,7 +252,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -274,7 +274,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -296,7 +296,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -314,7 +314,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -334,7 +334,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v20.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">

--- a/src/current/v21.1/cockroachdb-in-comparison.md
+++ b/src/current/v21.1/cockroachdb-in-comparison.md
@@ -42,7 +42,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -64,7 +64,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -84,7 +84,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -106,7 +106,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -128,7 +128,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -146,7 +146,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -166,7 +166,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -188,7 +188,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -212,7 +212,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -232,7 +232,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -252,7 +252,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -274,7 +274,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -296,7 +296,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -314,7 +314,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -334,7 +334,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">

--- a/src/current/v21.2/cockroachdb-in-comparison.md
+++ b/src/current/v21.2/cockroachdb-in-comparison.md
@@ -43,7 +43,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -65,7 +65,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -85,7 +85,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -107,7 +107,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -129,7 +129,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -147,7 +147,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -167,7 +167,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -189,7 +189,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -213,7 +213,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -233,7 +233,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -253,7 +253,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -275,7 +275,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -297,7 +297,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -315,7 +315,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -335,7 +335,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v21.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">

--- a/src/current/v22.1/cockroachdb-in-comparison.md
+++ b/src/current/v22.1/cockroachdb-in-comparison.md
@@ -43,7 +43,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -65,7 +65,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -85,7 +85,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -107,7 +107,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -129,7 +129,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -147,7 +147,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -167,7 +167,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -189,7 +189,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -213,7 +213,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -233,7 +233,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -253,7 +253,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -275,7 +275,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -297,7 +297,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -315,7 +315,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -335,7 +335,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.1/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">

--- a/src/current/v22.2/cockroachdb-in-comparison.md
+++ b/src/current/v22.2/cockroachdb-in-comparison.md
@@ -43,7 +43,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database horizontal scale
       <a href="#" data-toggle="tooltip" title="Increase capacity of the database by adding more instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -65,7 +65,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database load balancing (internal)
       <a href="#" data-toggle="tooltip" title="Locate data across multiple instances/nodes based on optimization criteria for balancing load">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -85,7 +85,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Failover
       <a href="#" data-toggle="tooltip" title="Provide access to backup data upon failure">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -107,7 +107,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Automated repair and RPO(Recovery Point Objective)
       <a href="#" data-toggle="tooltip" title="Repair the database after failure and the time it takes for the db to come back online">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -129,7 +129,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed reads
       <a href="#" data-toggle="tooltip" title="Reliably read data in any instance/node of the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -147,7 +147,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Distributed transactions
       <a href="#" data-toggle="tooltip" title="Allow for acid writes across multiple instances/nodes">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -168,7 +168,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database isolation levels
       <a href="#" data-toggle="tooltip" title="Transaction isolation levels allowed for writes in the database">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -190,7 +190,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Potential data issues (default)
       <a href="#" data-toggle="tooltip" title="Possible data inconsistency issues at default isolation level">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -214,7 +214,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       SQL
       <a href="#" data-toggle="tooltip" title="Compliance with standard SQL">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -234,7 +234,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Database schema change
       <a href="#" data-toggle="tooltip" title="Modify database schema across all tables">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -254,7 +254,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Cost based optimization
       <a href="#" data-toggle="tooltip" title="Optimize execution of queries based on transaction analytics">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -276,7 +276,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Data Geo-partitioning
       <a href="#" data-toggle="tooltip" title="Tie data to an instance/node to comply with regulations or optimize access latency">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -298,7 +298,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Upgrade method
       <a href="#" data-toggle="tooltip" title="Upgrade the database software">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -316,7 +316,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-region
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple regions">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">
@@ -336,7 +336,7 @@ This page shows you how the key features of CockroachDB stack up against other d
     <td class="comparison-chart__feature">
       Multi-cloud
       <a href="#" data-toggle="tooltip" title="Deploy a single database across multiple cloud providers or on-prem">
-        <img src="{{ 'images/v19.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
+        <img src="{{ 'images/v22.2/icon_info.svg' | relative_url }}" alt="tooltip icon">
       </a>
     </td>
     <td class="comparison-chart__column-one">


### PR DESCRIPTION
- Remove v19.2 entries from _data/redirects.yml version arrays
- Replace v19.2 release blocks in _data/releases.yml with single lines
- Cleanup to remove archived version from documentation site