### PR TITLE
DOC-14576 v25.3.0 download URL for the latest FIPS binary getting 404 error

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -9451,7 +9451,7 @@
     linux_arm: true
     linux_arm_experimental: false
     linux_arm_limited_access: false
-    linux_intel_fips: true
+    linux_intel_fips: false
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach


### PR DESCRIPTION
Fixes DOC-14576

In releases.yml, for v25.3.0 set linux_intel_fips: false.

Rendered preview

- [Download FIPS-ready runtimes](https://deploy-preview-20109--cockroachdb-docs.netlify.app/docs/v25.3/fips.html#download-fips-ready-runtimes) (Production section is removed)
