### PR TITLE
Fix broken copy to clipboard widgets

### DIFF
--- a/src/current/_includes/v23.1/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v23.1/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v23.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v23.1/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v23.2/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v23.2/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v23.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v23.2/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v24.1/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v24.1/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v24.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v24.1/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v24.2/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v24.2/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v24.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v24.2/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v24.3/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v24.3/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v24.3/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v24.3/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v25.1/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v25.1/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v25.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v25.1/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v25.2/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v25.2/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v25.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v25.2/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~

--- a/src/current/_includes/v25.3/orchestration/kubernetes-stop-cluster.md
+++ b/src/current/_includes/v25.3/orchestration/kubernetes-stop-cluster.md
@@ -79,7 +79,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     pod "cockroachdb-client-secure" deleted
     ~~~
 
-{% capture get_issuers_command %}{% include_cached copy-clipboard.html %}
+{% capture get_issuers_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get issuer
     ~~~
@@ -88,7 +90,9 @@ Do **not** use the `--all` flag to `kubectl delete`, to avoid the risk of data l
     ~~~
 {% endcapture %}
 
-{% capture get_csrs_command %}{% include_cached copy-clipboard.html %}
+{% capture get_csrs_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl get csr
     ~~~

--- a/src/current/_includes/v25.3/orchestration/start-cockroachdb-operator-secure.md
+++ b/src/current/_includes/v25.3/orchestration/start-cockroachdb-operator-secure.md
@@ -1,7 +1,9 @@
 ### Install the Operator
 
 {% capture latest_operator_version %}{% include_cached latest_operator_version.md %}{% endcapture %}
-{% capture apply_default_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_default_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
@@ -17,12 +19,16 @@
     deployment.apps/cockroach-operator created
     ~~~
 {% endcapture %}
-{% capture download_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture download_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     curl -O https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v{{ latest_operator_version }}/install/operator.yaml
     ~~~
 {% endcapture %}
-{% capture apply_local_operator_manifest_command %}{% include_cached copy-clipboard.html %}
+{% capture apply_local_operator_manifest_command %}
+
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
     kubectl apply -f operator.yaml
     ~~~


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-14408

Found a simple fix for an issue that caused the copy to clipboard widget to sit outside of its corresponding code snippet, rendering it non-functional, specifically in cases where the code snippet was embedded inside of a liquid include. The added whitespace appears to resolve the issue without affecting rendering.

Before:
<img width="912" height="219" alt="Screenshot 2025-08-15 at 4 46 40 PM" src="https://github.com/user-attachments/assets/14a1b930-0d68-480e-bed1-caa80919338f" />

After:
<img width="918" height="207" alt="Screenshot 2025-08-15 at 4 46 54 PM" src="https://github.com/user-attachments/assets/fe7c1ee6-4349-41f5-bc83-92e0751e1e6c" />
