### PR TITLE
DOC-14610 Change recent release link for v25.1 to unsupported page

### DIFF
--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -109,8 +109,9 @@ As of 2024, CockroachDB is released under a staged delivery process. New release
 
 | Version | Release Type | GA date |
 | :---: | :---: | :---: |
+| [v25.3](#v25-3) | Innovation | 2025-08-04 |
 | [v25.2](#v25-2) | Regular | 2025-05-12 |
-| [v25.1](#v25-1) | Innovation | 2025-02-18 |
+| [v25.1]({% link releases/unsupported-versions.md %}#v25-1) | Innovation | 2025-02-18 |
 | [v24.3](#v24-3) | Regular | 2024-11-18 |
 | [v24.2]({% link releases/unsupported-versions.md %}#v24-2) | Innovation | 2024-08-12 |
 | [v24.1](#v24-1) | Regular | 2024-05-20 |
@@ -123,7 +124,6 @@ The following releases and their descriptions represent proposed plans that are 
 
 | Version | Release Type | Expected GA date |
 | :---: | :---: | :---: |
-| v25.3 | Innovation | 2025 Q3    |
 | v25.4 | Regular    | 2025 Q4    |
 | v26.1 | Innovation | 2026 Q1    |
 | v26.2 | Regular    | 2026 Q2    |


### PR DESCRIPTION
Fixes DOC-14610

In releases/index.md, updated Recent Releases for v25.1 and v25.3.

Rendered preview

- [Recent releases](https://deploy-preview-20150--cockroachdb-docs.netlify.app/docs/releases/index.html#recent-releases)
