### PR TITLE
Bring v25.3.0 out of cloud-only phase

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -9451,7 +9451,7 @@
     linux_arm: true
     linux_arm_experimental: false
     linux_arm_limited_access: false
-    linux_intel_fips: false
+    linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach

--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -9460,12 +9460,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.3.0-rc.1
-  cloud_only: true
-  cloud_only_message_short: 'Currently available for CockroachDB Advanced only'
-  cloud_only_message: >
-      This version is currently available only for
-      CockroachDB Cloud clusters on the Advanced plan.
-
 
 
 - release_name: v24.3.18


### PR DESCRIPTION
REL-2952

Removes `cloud-only*` parameters and sets `linux_intel_fips` to `true`.