### PR TITLE
DOC-12287 Feedback: Monitor CockroachDB Self-Hosted Clusters with Datadog (remove guidance on disable DB console)

### DIFF
--- a/src/current/v23.1/datadog.md
+++ b/src/current/v23.1/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v23.1/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Limitations
 
 - The CockroachDB {{ site.data.products.core }} integration with Datadog only supports displaying cluster-wide averages of reported metrics. Filtering by a specific node is unsupported.

--- a/src/current/v23.2/datadog.md
+++ b/src/current/v23.2/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v23.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Limitations
 
 - The CockroachDB {{ site.data.products.core }} integration with Datadog only supports displaying cluster-wide averages of reported metrics. Filtering by a specific node is unsupported.

--- a/src/current/v24.1/datadog.md
+++ b/src/current/v24.1/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v24.1/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Known limitations
 
 - {% include {{ page.version.version }}/known-limitations/datadog-self-hosted-limitations.md %}

--- a/src/current/v24.2/datadog.md
+++ b/src/current/v24.2/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v24.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Known limitations
 
 - {% include {{ page.version.version }}/known-limitations/datadog-self-hosted-limitations.md %}

--- a/src/current/v24.3/datadog.md
+++ b/src/current/v24.3/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v24.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Known limitations
 
 - {% include {{ page.version.version }}/known-limitations/datadog-self-hosted-limitations.md %}

--- a/src/current/v25.1/datadog.md
+++ b/src/current/v25.1/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v24.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Known limitations
 
 - {% include {{ page.version.version }}/known-limitations/datadog-self-hosted-limitations.md %}

--- a/src/current/v25.2/datadog.md
+++ b/src/current/v25.2/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v24.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/monitoring-and-alerting.md %}#prometheus-endpoint). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Known limitations
 
 - {% include {{ page.version.version }}/known-limitations/datadog-self-hosted-limitations.md %}

--- a/src/current/v25.3/datadog.md
+++ b/src/current/v25.3/datadog.md
@@ -171,12 +171,6 @@ The timeseries graph at the top of the page indicates the configured metric and 
 
 <img src="{{ 'images/v24.2/datadog-crdb-storage-alert.png' | relative_url }}" alt="CockroachDB Threshold Alert in Datadog" style="border:1px solid #eee;max-width:100%" />
 
-## Step 7. Disable DB Console's local storage of metrics (optional)
-
-If you rely on external tools such as Datadog for storing and visualizing your cluster's time-series metrics, Cockroach Labs recommends that you [disable the DB Console's storage of time-series metrics]({% link {{ page.version.version }}/operational-faqs.md %}#disable-time-series-storage).
-
-When storage of time-series metrics is disabled, the cluster continues to expose its metrics via the [Prometheus endpoint]({% link {{ page.version.version }}/prometheus-endpoint.md %}). The DB Console stops storing new time-series cluster metrics and eventually deletes historical data. The Metrics dashboards in the DB Console are still available, but their visualizations are blank. This is because the dashboards rely on data that is no longer available. You can create queries, visualizations, and alerts in Datadog based on the data it is collecting from your cluster's Prometheus endpoint.
-
 ## Known limitations
 
 - {% include {{ page.version.version }}/known-limitations/datadog-self-hosted-limitations.md %}


### PR DESCRIPTION
Fixes DOC-12287

In datadog.md, remove step 7 Disable DB Console local storage of metrics (optional).

Rendered preview

- [Monitor CockroachDB Self-Hosted Clusters with Datadog](https://deploy-preview-20164--cockroachdb-docs.netlify.app/docs/v25.3/datadog)