### PR TITLE
Change usages of restore operations to restore jobs

### DIFF
--- a/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
+++ b/src/current/_includes/cockroachcloud/backups/cloud-api-restore-endpoint.md
@@ -31,7 +31,7 @@ curl --request POST \
 }'
 ~~~
 
-By default, the restore operation uses the most recent backup stored within the last 7 days on the cluster specified in `source_cluster_id`. To restore a specific backup, include the `backup_id` field and specify a backup ID from the [managed backups list](#view-managed-backups):
+By default, the restore job uses the most recent backup stored within the last 7 days on the cluster specified in `source_cluster_id`. To restore a specific backup, include the `backup_id` field and specify a backup ID from the [managed backups list](#view-managed-backups):
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
@@ -58,7 +58,7 @@ curl --request POST \
 }'
 ~~~
 
-You can specify additional options for the restore operation in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+You can specify additional options for the restore job in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
 
 {% endif %}
 
@@ -156,7 +156,7 @@ curl --request POST \
 }'
 ~~~
 
-You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+You can specify additional options for the restore jobs in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
 
 If the request is successful, the client recieves a response containing JSON describing the request operation:
 
@@ -266,7 +266,7 @@ curl --request POST \
 }'
 ~~~
 
-You can specify additional options for the restore operations in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
+You can specify additional options for the restore jobs in the `restore_opts` object. For more information, see the [API endpoint documentation](https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/clusters/-cluster_id-/restores-config).
 
 If the request is successful, the client recieves a response containing JSON describing the request operation:
 
@@ -282,13 +282,13 @@ If the request is successful, the client recieves a response containing JSON des
 ~~~
 {% endif %}
 
-### Get status of a restore operation
+### Get status of a restore job
 
 {{site.data.alerts.callout_info}}
 {% include feature-phases/limited-access.md %}
 {{site.data.alerts.end}}
 
-To view the status of a restore operation using the cloud API, send a `GET` request to the `/v1/clusters/{cluster_id}/restores/{restore_id}` endpoint where `restore_id` is the `id` from the JSON response:
+To view the status of a restore job using the cloud API, send a `GET` request to the `/v1/clusters/{cluster_id}/restores/{restore_id}` endpoint where `restore_id` is the `id` from the JSON response:
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell

--- a/src/current/_includes/cockroachcloud/backups/managed-backup-perms.md
+++ b/src/current/_includes/cockroachcloud/backups/managed-backup-perms.md
@@ -1,6 +1,6 @@
 To restore a managed backup successfully in CockroachDB {{ site.data.products.cloud }}, you must have the appropriate [permissions]({% link cockroachcloud/authorization.md %}) on both the source and destination clusters:
 
-- You must have either the [Cluster Admin]({% link cockroachcloud/authorization.md %}#cluster-admin) or [Cluster Operator]({% link cockroachcloud/authorization.md %}#cluster-operator) role on the **destination cluster**, or at the [organization level]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model). Without one of these roles, the restore operation will fail.
+- You must have either the [Cluster Admin]({% link cockroachcloud/authorization.md %}#cluster-admin) or [Cluster Operator]({% link cockroachcloud/authorization.md %}#cluster-operator) role on the **destination cluster**, or at the [organization level]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model). Without one of these roles, the restore job will fail.
 - You must also have either the [Cluster Admin]({% link cockroachcloud/authorization.md %}#cluster-admin) or [Cluster Operator]({% link cockroachcloud/authorization.md %}#cluster-operator) role on the **source cluster** (the cluster from which the backup was taken), or at the [organization level]({% link cockroachcloud/authorization.md %}#overview-of-the-cockroachdb-cloud-authorization-model). If you do not have the required permissions on the source cluster, the restore will fail.
 
 {{site.data.alerts.callout_info}}

--- a/src/current/cockroachcloud/cloud-api.md
+++ b/src/current/cockroachcloud/cloud-api.md
@@ -635,7 +635,7 @@ Where `{cluster_id}` is the ID of your cluster and `{secret_key}` is your API ke
 {% include feature-phases/limited-access.md %}
 {{site.data.alerts.end}}
 
-For information on using the Cloud API to handle [managed backups and restore operations]({% link cockroachcloud/backup-and-restore-overview.md %}), see the respective managed backup documentation for [Basic]({% link cockroachcloud/managed-backups-basic.md %}#cloud-api), [Standard]({% link cockroachcloud/managed-backups.md %}#cloud-api), and [Advanced]({% link cockroachcloud/managed-backups-advanced.md %}#cloud-api) plans.
+For information on using the Cloud API to handle [managed backups and restore jobs]({% link cockroachcloud/backup-and-restore-overview.md %}), see the respective managed backup documentation for [Basic]({% link cockroachcloud/managed-backups-basic.md %}#cloud-api), [Standard]({% link cockroachcloud/managed-backups.md %}#cloud-api), and [Advanced]({% link cockroachcloud/managed-backups-advanced.md %}#cloud-api) plans.
 
 ## Change a cluster's plan
 

--- a/src/current/cockroachcloud/managed-backups-advanced.md
+++ b/src/current/cockroachcloud/managed-backups-advanced.md
@@ -145,7 +145,7 @@ Users with the [Organization Admin]({% link cockroachcloud/authorization.md %}#o
 #### Restore an Advanced cluster
 
 {{site.data.alerts.callout_info}}
-Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore operation fails if the destination cluster contains any databases/schemas/tables.
+Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore job fails if the destination cluster contains any databases/schemas/tables.
 {{site.data.alerts.end}}
 
 To restore a cluster:

--- a/src/current/cockroachcloud/managed-backups-basic.md
+++ b/src/current/cockroachcloud/managed-backups-basic.md
@@ -54,7 +54,7 @@ For each backup, the following details display:
 ### Restore a cluster
 
 {{site.data.alerts.callout_info}}
-Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore operation fails if the destination cluster contains any databases/schemas/tables.
+Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore job fails if the destination cluster contains any databases/schemas/tables.
 {{site.data.alerts.end}}
 
 Performing a restore will cause your cluster to be unavailable for the duration of the restore. All current data is deleted, and the cluster will be restored to the state it was in at the time of the backup.

--- a/src/current/cockroachcloud/managed-backups.md
+++ b/src/current/cockroachcloud/managed-backups.md
@@ -108,7 +108,7 @@ To modify the [retention](#retention) of backups, click on **Retain backups for*
 ### Restore a cluster
 
 {{site.data.alerts.callout_info}}
-Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore operation fails if the destination cluster contains any databases/schemas/tables.
+Before a cluster can be restored from a managed backup, the destination cluster must be completely wiped of data. A cluster restore job fails if the destination cluster contains any databases/schemas/tables.
 {{site.data.alerts.end}}
 
 Performing a restore will cause your cluster to be unavailable for the duration of the restore. All current data is deleted, and the cluster will be restored to the state it was in at the time of the backup.


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-14703

- "Restore operations" can be used to describe the broad, non-specific act of restoration to a CockroachDB cluster. Not a reference to a specific action that may be described in the product (which likely uses the "job" label anyway)
- "Restore jobs" should be used to describe instances of restore procedures taking place in CockroachDB, especially when a it may be described in the product UI or the underlying jobs subsystem/jobs table.