### PR TITLE
REL-2964 v25.3.1: [Docs] Adjust release notes for download/SH

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -9334,7 +9334,7 @@
     linux_arm: true
     linux_arm_experimental: false
     linux_arm_limited_access: false
-    linux_intel_fips: false
+    linux_intel_fips: true
     linux_arm_fips: false
   docker:
     docker_image: cockroachdb/cockroach
@@ -9343,10 +9343,4 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.3.0
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
+


### PR DESCRIPTION
Fixes REL-2964

In releases.yml, for v25.3.1, removed cloud fields to enable binary download links and set linux_intel_fips to true.

Rendered preview

- [v25.3.1](https://deploy-preview-20270--cockroachdb-docs.netlify.app/docs/releases/v25.3.html#v25-3-1-downloads)
- [FIPS production releases](https://deploy-preview-20270--cockroachdb-docs.netlify.app/docs/v25.3/fips.html#production-releases)
