### PR TITLE
Add Ruby 3.4+ compatibility gems for Jekyll

### DIFF
--- a/src/current/Gemfile
+++ b/src/current/Gemfile
@@ -13,6 +13,11 @@ gem "redcarpet", "~> 3.6"
 gem "rss"
 gem "webrick"
 gem "jekyll-minifier"
+gem 'csv'
+gem 'logger'
+gem 'base64'
+gem 'bigdecimal'
+gem 'mutex_m'
 
 group :jekyll_plugins do
     gem "jekyll-include-cache"


### PR DESCRIPTION
Adds explicit dependencies for gems removed from Ruby 3.4+ default bundle:
- csv: Required by Jekyll but no longer in default gems
- logger: Generates warnings in Jekyll 4.3.4
- base64: Standard library gem needed for encoding
- bigdecimal: Required for decimal operations
- mutex_m: Mutex operations support

Resolves Jekyll startup error and eliminates warnings when running bundle exec jekyll serve on Ruby 3.4+.