### PR TITLE
Allow DB owner to set session var defaults in DB

### DIFF
--- a/src/current/v23.2/alter-database.md
+++ b/src/current/v23.2/alter-database.md
@@ -349,7 +349,7 @@ For usage, see [Synopsis](#synopsis).
 
 ### `RESET {session variable}`
 
-`ALTER DATABASE ... RESET {session variable}` resets a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for a database to its default value for the client session.
+`ALTER DATABASE ... RESET {session variable}` clears a database-level override of a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) so that future sessions use the default value.
 
 #### Required privileges
 

--- a/src/current/v24.1/alter-database.md
+++ b/src/current/v24.1/alter-database.md
@@ -349,7 +349,7 @@ For usage, see [Synopsis](#synopsis).
 
 ### `RESET {session variable}`
 
-`ALTER DATABASE ... RESET {session variable}` resets a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for a database to its default value for the client session.
+`ALTER DATABASE ... RESET {session variable}` clears a database-level override of a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) so that future sessions use the default value.
 
 {% include {{page.version.version}}/sql/show-default-session-variables-for-role.md %}
 

--- a/src/current/v24.3/alter-database.md
+++ b/src/current/v24.3/alter-database.md
@@ -349,7 +349,7 @@ For usage, see [Synopsis](#synopsis).
 
 ### `RESET {session variable}`
 
-`ALTER DATABASE ... RESET {session variable}` resets a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for a database to its default value for the client session.
+`ALTER DATABASE ... RESET {session variable}` clears a database-level override of a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) so that future sessions use the default value.
 
 {% include {{page.version.version}}/sql/show-default-session-variables-for-role.md %}
 

--- a/src/current/v25.2/alter-database.md
+++ b/src/current/v25.2/alter-database.md
@@ -349,7 +349,7 @@ For usage, see [Synopsis](#synopsis).
 
 ### `RESET {session variable}`
 
-`ALTER DATABASE ... RESET {session variable}` resets a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for a database to its default value for the client session.
+`ALTER DATABASE ... RESET {session variable}` clears a database-level override of a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) so that future sessions use the default value.
 
 {% include {{page.version.version}}/sql/show-default-session-variables-for-role.md %}
 

--- a/src/current/v25.3/alter-database.md
+++ b/src/current/v25.3/alter-database.md
@@ -349,7 +349,7 @@ For usage, see [Synopsis](#synopsis).
 
 ### `RESET {session variable}`
 
-`ALTER DATABASE ... RESET {session variable}` resets a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for a database to its default value for the client session.
+`ALTER DATABASE ... RESET {session variable}` clears a database-level override of a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) so that future sessions use the default value.
 
 {% include {{page.version.version}}/sql/show-default-session-variables-for-role.md %}
 

--- a/src/current/v25.4/alter-database.md
+++ b/src/current/v25.4/alter-database.md
@@ -349,13 +349,13 @@ For usage, see [Synopsis](#synopsis).
 
 ### `RESET {session variable}`
 
-`ALTER DATABASE ... RESET {session variable}` resets a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for a database to its default value for the client session.
+`ALTER DATABASE ... RESET {session variable}` clears a database-level override of a [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) so that future sessions use the default value.
 
 {% include {{page.version.version}}/sql/show-default-session-variables-for-role.md %}
 
 #### Required privileges
 
-No [privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) are required to reset a session setting.
+To reset default session variable values for a database with `ALTER DATABASE ... RESET {session variable}`, the user must be a member of the [`admin` role]({% link {{ page.version.version }}/security-reference/authorization.md %}#admin-role) or the [owner]({% link {{ page.version.version }}/security-reference/authorization.md %}#object-ownership) of the target database.
 
 #### Parameters
 
@@ -379,7 +379,9 @@ In CockroachDB, the following are aliases for `ALTER DATABASE ... RESET {session
 
 #### Required privileges
 
-To set the `role` session variable, the current user must be a member of the `admin` role, or a member of the target role.
+To set default session variable values for a database with `ALTER DATABASE ... SET {session variable}`, the user must be a member of the [`admin` role]({% link {{ page.version.version }}/security-reference/authorization.md %}#admin-role) or the [owner]({% link {{ page.version.version }}/security-reference/authorization.md %}#object-ownership) of the target database.
+
+Additionally, to set the `role` session variable, the current user must be a member of the `admin` role or a member of the target role.
 
 All other session variables do not require [privileges]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) to modify.
 

--- a/src/current/v25.4/alter-role.md
+++ b/src/current/v25.4/alter-role.md
@@ -23,6 +23,7 @@ Password creation and alteration is supported only in secure clusters.
 
 - To alter an [`admin` role]({% link {{ page.version.version }}/security-reference/authorization.md %}#admin-role), the user must be a member of the `admin` role.
 - To alter other roles, the user must be a member of the `admin` role or have the [`CREATEROLE`]({% link {{ page.version.version }}/create-role.md %}#create-a-role-that-can-create-other-roles-and-manage-authentication-methods-for-the-new-roles) [role option](#role-options).
+- {% include_cached new-in.html version="v25.4" %} For [per-database defaults](#set-default-session-variable-values-for-a-specific-database), the [owner]({% link {{ page.version.version }}/security-reference/authorization.md %}#object-ownership) of a database can execute `ALTER ROLE ALL IN DATABASE ... {SET|RESET}` for that database (in addition to users who meet the general requirements above).
 
 ## Synopsis
 
@@ -227,6 +228,8 @@ SHOW statement_timeout;
 ### Set default session variable values for a specific database
 
 In the following example, the `root` user creates a database named `movr`, and sets the default value of the `timezone` [session variable]({% link {{ page.version.version }}/set-vars.md %}#supported-variables) for all roles in that database.
+
+{% include_cached new-in.html version="v25.4" %} The [owner]({% link {{ page.version.version }}/security-reference/authorization.md %}#object-ownership) of a database can also execute `ALTER ROLE ALL IN DATABASE ... {SET|RESET}` for that database.
 
 ~~~ sql
 CREATE DATABASE IF NOT EXISTS movr;


### PR DESCRIPTION
Fixes DOC-14457

Also updated the `ALTER DATABASE ... RESET` description to fix an inaccuracy, and backported that change to all supported versions v23.2+