### PR TITLE
Update Ruby requirement to >= 3.3.0 for SSL compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ _site
 .jekyll-cache
 /bootstrap
 /vendor/
-Gemfile.lock
 tmp/
 node_modules
 /src/*/bootstrap

--- a/src/current/Gemfile
+++ b/src/current/Gemfile
@@ -2,6 +2,9 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+# Ruby version requirement (needed for SSL compatibility)
+ruby ">= 3.3.0"
+
 # If you modify this file, you'll need to build a new version of the
 # docs-builder Docker image to keep things speedy in CI. See ci/README.md for
 # instructions.
@@ -13,6 +16,10 @@ gem "redcarpet", "~> 3.6"
 gem "rss"
 gem "webrick"
 gem "jekyll-minifier"
+gem "csv"
+gem "base64"
+gem "bigdecimal"
+gem "logger"
 
 group :jekyll_plugins do
     gem "jekyll-include-cache"

--- a/src/current/Gemfile.lock
+++ b/src/current/Gemfile.lock
@@ -1,0 +1,178 @@
+GIT
+  remote: https://github.com/ianjevans/jekyll-remote-include.git
+  revision: 231b7ccbd097167e40d1f2184c50e0868ba412bb
+  tag: v1.1.7
+  specs:
+    jekyll-remote-include (1.1.7)
+
+PATH
+  remote: jekyll-algolia-dev
+  specs:
+    jekyll-algolia (1.6.0)
+      algolia_html_extractor (~> 2.6)
+      algoliasearch (~> 1.26)
+      filesize (~> 0.1)
+      jekyll (>= 3.6, < 5.0)
+      json (~> 2.0)
+      nokogiri (~> 1.6)
+      progressbar (~> 1.9)
+      verbal_expressions (~> 0.1.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    algolia_html_extractor (2.6.4)
+      json (~> 2.0)
+      nokogiri (~> 1.10)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    cssminify2 (2.1.0)
+    csv (3.3.5)
+    deep_merge (1.2.2)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    execjs (2.10.0)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    filesize (0.2.0)
+    forwardable-extended (2.6.0)
+    htmlcompressor (0.4.0)
+    http_parser.rb (0.8.0)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-get-json (1.0.0)
+      deep_merge (~> 1.2)
+      jekyll (>= 3.0)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.2)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-minifier (0.2.2)
+      cssminify2 (~> 2.1.0)
+      htmlcompressor (~> 0.4)
+      jekyll (~> 4.0)
+      json-minify (~> 0.0.3)
+      terser (~> 1.2.3)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.2)
+    json-minify (0.0.3)
+      json (> 0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    liquid-c (4.0.1)
+      liquid (>= 3.0.0)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    mutex_m (0.3.0)
+    nokogiri (1.18.9-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-linux-musl)
+      racc (~> 1.4)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    progressbar (1.13.0)
+    public_suffix (6.0.2)
+    racc (1.8.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    redcarpet (3.6.1)
+    rexml (3.4.2)
+    rouge (4.6.0)
+    rss (0.3.1)
+      rexml
+    safe_yaml (1.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.6)
+      execjs (>= 0.3.0, < 3)
+    unicode-display_width (2.6.0)
+    verbal_expressions (0.1.5)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  base64
+  bigdecimal
+  csv
+  jekyll (= 4.3.4)
+  jekyll-algolia (~> 1.0)!
+  jekyll-get-json
+  jekyll-include-cache
+  jekyll-last-modified-at
+  jekyll-minifier
+  jekyll-remote-include!
+  jekyll-sass-converter (~> 2.0)
+  liquid-c (~> 4.0.0)
+  logger
+  redcarpet (~> 3.6)
+  rss
+  webrick
+
+BUNDLED WITH
+   2.5.18


### PR DESCRIPTION
- Remove Gemfile.lock from .gitignore (application repos should commit lockfile)
- Add ruby >= 3.3.0 requirement to Gemfile
- Add missing gem dependencies (csv, base64, bigdecimal, logger)
- Update Gemfile.lock with compatible dependencies

This resolves SSL issues encountered with older Ruby versions when building Jekyll docs. Team members will need to upgrade to Ruby 3.3.0+ and run `bundle install`.