### PR TITLE
Remove errantly published release note for v25.2-alpha.3

### DIFF
--- a/src/current/_includes/releases/v25.2/v25.2.0-alpha.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-alpha.3.md
@@ -24,8 +24,6 @@ Release Date: April 7, 2025
  [#143588][#143588]
 - `like_regex` predicate evaluation is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"hello" like_regex "^he.*$"');`.
  [#143240][#143240]
-- Added the `EXPERIMENTAL COPY` option to `RESTORE`, which runs online `RESTORE`, but waits to publish the tables until all data is downloaded.
- [#143674][#143674]
 
 <h3 id="v25-2-0-alpha-3-operational-changes">Operational changes</h3>
 


### PR DESCRIPTION
Delete release note for https://cockroachlabs.atlassian.net/browse/DOC-13015 which shouldn't have been published (feature is a private preview)