### PR TITLE
Add Ruby 3.4 compatibility gems to Gemfile

### DIFF
--- a/src/current/Gemfile
+++ b/src/current/Gemfile
@@ -13,6 +13,11 @@ gem "redcarpet", "~> 3.6"
 gem "rss"
 gem "webrick"
 gem "jekyll-minifier"
+# Ruby 3.4+ compatibility - these were removed from default gems
+gem "csv"
+gem "logger"
+gem "base64"
+gem "bigdecimal"
 
 group :jekyll_plugins do
     gem "jekyll-include-cache"


### PR DESCRIPTION
Adds explicit dependencies for `csv`, `logger`, `base64`, and `bigdecimal` gems to support Ruby 3.4+.

### Background

Starting in Ruby 3.4.0, several gems that were previously included in the standard library were removed from the default gems bundle.

This causes build failures when running Jekyll on Ruby 3.4+ with errors like:

`cannot load such file -- csv (LoadError)`  
`cannot load such file -- logger (LoadError)`  
`cannot load such file -- base64 (LoadError)`  
`cannot load such file -- bigdecimal (LoadError)`  

I upgraded to Ruby 3.4 locally given the likelihood that it would improve build times, and so it was necessary to add these gems to my Gemfile explicitly. There is no harm in adding these to the Gemfile in the repo—they are still bundled with 3.2 by default. Explicitly adding them to the Gemfile doesn't cause any issues - Bundler will just use the versions that are already available.

However, the benefit is that we can freely upgrade Ruby on team members machines, as well as our preview and production deployment environments. 

### Changes

Explicitly adds these gems to the Gemfile:

- `csv` - required by Jekyll
- `logger` - required by Jekyll
- `base64` - required by safe_yaml (Jekyll dependency)
- `bigdecimal` - required by Liquid (Jekyll dependency)

### Compatibility

These changes are **fully backward compatible** with Ruby 3.2.x:

- Ruby 3.2.x (production/Netlify): These gems are bundled by default, so explicitly declaring them has no effect
- Ruby 3.4.x (local dev): Now works properly with explicit dependencies

No changes required for existing workflows or production builds running Ruby 3.2.1.

### Testing

- [x] Verified `make standard` works with Ruby 3.4.7
- [x] No impact on Ruby 3.2.x environments (per Claude, and verified through Netlify Preview build)