### PR TITLE
Add SSL fix script for local Jekyll builds

### DIFF
--- a/src/current/README_SSL_FIX.md
+++ b/src/current/README_SSL_FIX.md
@@ -1,0 +1,17 @@
+# SSL Fix for Jekyll Build
+
+If you encounter SSL certificate verification errors when running Jekyll builds, you can use the provided `openssl_fix.rb` script as a workaround.
+
+## Usage
+
+Run the Jekyll build with the `RUBYOPT` environment variable:
+
+```bash
+RUBYOPT="-r./openssl_fix.rb" bundle exec jekyll build --incremental --config _config_base.yml,_config_cockroachdb.yml
+```
+
+## What it does
+
+This script disables SSL certificate verification for Ruby's OpenSSL library. It's intended as a temporary workaround for local development environments where SSL certificate issues may occur.
+
+⚠️ **Warning**: This script disables SSL verification and should only be used in local development environments. Do not use in production.

--- a/src/current/openssl_fix.rb
+++ b/src/current/openssl_fix.rb
@@ -1,0 +1,27 @@
+require "openssl"
+require "net/http"
+
+# Monkey patch to completely disable SSL verification
+module OpenSSL
+  module SSL
+    remove_const :VERIFY_PEER
+    VERIFY_PEER = VERIFY_NONE
+  end
+end
+
+# Override Net::HTTP SSL context creation
+class Net::HTTP
+  alias_method :original_use_ssl=, :use_ssl=
+
+  def use_ssl=(flag)
+    self.original_use_ssl = flag
+    if flag
+      @ssl_context = OpenSSL::SSL::SSLContext.new
+      @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      @ssl_context.verify_hostname = false
+    end
+  end
+end
+
+# Set environment variable as fallback
+ENV['SSL_VERIFY'] = 'false'


### PR DESCRIPTION
- Add openssl_fix.rb to disable SSL verification for local development
- Add README_SSL_FIX.md with usage instructions

This provides a workaround for SSL certificate verification errors that may occur in local development environments when running Jekyll builds.