### PR TITLE
Pin Bundler 2.x in build.sh to restore Netlify builds

### DIFF
--- a/src/current/netlify/build.sh
+++ b/src/current/netlify/build.sh
@@ -149,15 +149,18 @@ function build_with_retries {
     fi
 }
 
-echo " Installing dependencies..."
+echo "Installing dependencies..."
 
 # Install a Bundler 2.x release compatible with our setup
+echo "  Installing Bundler 2.4..."
 gem install bundler -v '~> 2.4' --silent
 
 # Configure bundle path in the modern way (instead of using --path)
+echo "  Setting Bundler config path..."
 bundle config set path '/opt/build/cache/bundle'
 
 # Install gems
+echo "  Installing gems..."
 bundle install --quiet
 
 echo ""


### PR DESCRIPTION
Bundler 3 in Netlify’s environment rejects the deprecated `--path` flag used internally, causing preview builds to fail. The expectation of this PR is that installing Bundler 2.x and setting the bundle path explicitly fixes the issue.

1. I pushed this initial commit immediately after updating the `NETLIFY_SKIP_DEPENDENCY_INSTALL` environment variable on our Netlify project—for all environments—to `true`.
1. The initial Deploy Preview on this PR failed, but when selecting `Retry without cache with latest branch commit` on that build, the new build **passed** the Initializing phase and succeeded. This success doesn't get picked up by the PR check, so I pushed another commit to the branch, which succeeded.
1. I am not certain if clearing the cache may have been the only necessary step and if either change - the environment variable change and/or this PR - are also necessary.
1. I have removed the variable and am 're-running without cache' another recently failed Preview build (on https://github.com/cockroachdb/docs/pull/21474) to test this.
1. Re-running without cache works for that and other new PRs, after their initial failed build, so that may be a temporary workaround on its own, per-PR, but is not sustainable.
1. After merging that first PR (https://github.com/cockroachdb/docs/pull/21474), the resulting Production build fails, so I am also doing a re-try there.

It turns out that every Preview and Production build works after a retry, and this change (the env variable and build.sh on this branch) had no apparent effect on that, so I'm closing this PR and will seek further assistance.