### PR TITLE
Include updated root-restriction flag and debug_user release notes

### DIFF
--- a/src/current/_includes/releases/v26.1/v26.1.0-alpha.2.md
+++ b/src/current/_includes/releases/v26.1/v26.1.0-alpha.2.md
@@ -10,7 +10,7 @@ Release Date: December 11, 2025
   - A new `debug_user` certificate has also been introduced for privileged RPC access to collect [debug zip]({% link v26.1/cockroach-debug-zip.md %}) information, which would otherwise be unavailable when `root` is restricted. `debug_user` must be created manually with the `CREATE USER` command and can be audited using `SHOW USERS`. It has privileged access to the `serverpb` admin and status endpoints required for debug zip collection.
   - Ensure that none of the certificates used by the cluster or SQL/RPC clients have "root" in the SAN (Subject Alternative Name) fields, as the flag will block access to those clients.
 
-  [#155216][#155216]
+    [#155216][#155216]
 
 <h3 id="v26-1-0-alpha-2-sql-language-changes">SQL language changes</h3>
 


### PR DESCRIPTION
Refined release notes from https://github.com/cockroachdb/cockroach/pull/155216 per discussion with @biplav-crl and @souravcrl.

[Preview](https://deploy-preview-21602--cockroachdb-docs.netlify.app/docs/releases/v26.1#v26-1-0-alpha-2-security-updates)