### PR TITLE
DOC-15662: Fix v26.1.0-alpha.2 release note rendering

### DIFF
--- a/src/current/_includes/releases/v26.1/v26.1.0-alpha.2.md
+++ b/src/current/_includes/releases/v26.1/v26.1.0-alpha.2.md
@@ -38,20 +38,16 @@ Release Date: December 11, 2025
 
 <h3 id="v26-1-0-alpha-2-operational-changes">Operational changes</h3>
 
-- All queries to system and crdb_internal by
-  default will begin failing, notifying users that they must override the
-  access gate if they wish to use those namespaces.
-  
-The `allow_unsafe_internals` setting now defaults to `false`, restricting access to the `system` and `crdb_internal` namespaces. Queries to these namespaces will now fail unless access is manually enabled. Usage is also audited. [#158085][#158085]
+- The `allow_unsafe_internals` setting now defaults to `false`, restricting access to the `system` and `crdb_internal` namespaces. Queries to these namespaces will now fail unless access is manually enabled. Usage is also audited. [#158085][#158085]
 - Jobs that are paused due to a specific reason, including jobs which pause themselves when encountering errors such as running out of disk space, now record that reason in their displayed status field of `SHOW JOBS`. [#158350][#158350]
 - The following metrics are now marked as essential to support end-user troubleshooting of authentication latency issues:
-- `auth.jwt.conn.latency`
-- `auth.cert.conn.latency`
-- `auth.password.conn.latency`
-- `auth.ldap.conn.latency`
-- `auth.gss.conn.latency`
-- `auth.scram.conn.latency`
-- `auth.ldap.conn.latency.internal` [#158424][#158424]
+  - `auth.jwt.conn.latency`
+  - `auth.cert.conn.latency`
+  - `auth.password.conn.latency`
+  - `auth.ldap.conn.latency`
+  - `auth.gss.conn.latency`
+  - `auth.scram.conn.latency`
+  - `auth.ldap.conn.latency.internal` [#158424][#158424]
 
 <h3 id="v26-1-0-alpha-2-db-console-changes">DB Console changes</h3>
 


### PR DESCRIPTION
Fixes DOC-15662

In v26.1.0-alpha.2.md, fixed release notes for PRs 158085 and 158424.

Rendered preview

- [Operational changes](https://deploy-preview-21657--cockroachdb-docs.netlify.app/docs/releases/v26.1.html#v26-1-0-alpha-2-operational-changes)