### PR TITLE
remove Preview designation for Oracle support in MOLT

### DIFF
--- a/src/current/_includes/molt/molt-install.md
+++ b/src/current/_includes/molt/molt-install.md
@@ -1,6 +1,6 @@
 To install MOLT, download the binary that matches your architecture and source database:
 
-| Operating System | Architecture |                                 PostgreSQL/MySQL                                |                                   Oracle (Preview)                                   |
+| Operating System | Architecture |                                 PostgreSQL/MySQL                                |                                        Oracle                                        |
 |------------------|--------------|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | Windows          | AMD 64-bit   | [Download](https://molt.cockroachdb.com/molt/cli/molt-latest.windows-amd64.tgz) | N/A                                                                                  |
 |                  | ARM 64-bit   | [Download](https://molt.cockroachdb.com/molt/cli/molt-latest.windows-arm64.tgz) | N/A                                                                                  |

--- a/src/current/_includes/molt/molt-setup.md
+++ b/src/current/_includes/molt/molt-setup.md
@@ -4,11 +4,6 @@
     <button class="filter-button" data-scope="oracle">Oracle</button>
 </div>
 
-<section class="filter-content" markdown="1" data-scope="oracle">
-{{site.data.alerts.callout_info}}
-{% include feature-phases/preview.md %}
-{{site.data.alerts.end}}
-</section>
 
 ## Before you begin
 


### PR DESCRIPTION
Removed the Preview designation for MOLT Oracle support.