### PR TITLE
DOC-15730: Fix spelling in release note in v26.1-beta.1

### DIFF
--- a/src/current/_includes/releases/v26.1/v26.1.0-beta.1.md
+++ b/src/current/_includes/releases/v26.1/v26.1.0-beta.1.md
@@ -14,7 +14,7 @@ Release Date: December 17, 2025
 
 <h3 id="v26-1-0-beta-1-sql-language-changes">SQL language changes</h3>
 
-- `crdb_internal.index_usage_stats` and `crdb_internal.datums_to_bytes` are now available in the `information_schema` system catalog as `information_schema.crdb_index_usage_stats` and `information_schema.crdb_datums_to_bytes`, respectively. [#156963][#156963]
+- `crdb_internal.index_usage_statistics` and `crdb_internal.datums_to_bytes` are now available in the `information_schema` system catalog as `information_schema.crdb_index_usage_statistics` and `information_schema.crdb_datums_to_bytes`, respectively. [#156963][#156963]
 - The `ALTER COLUMN ...` sequence identity
   commands are run by the declarative schema changer. [#157030][#157030]
 - Added support for `EXECUTE SCHEDULE {schedule_id}` to allow immediate execution of a scheduled job. This does not apply to `ALTER BACKUP SCHEDULE`; attempting to execute a backup schedule will result in an error. [#158694][#158694]


### PR DESCRIPTION
Fixes DOC-15730

In v26.1.0-beta.1.md, corrected stats to statistics.

Rendered previews

- [SQL language changes](https://deploy-preview-21747--cockroachdb-docs.netlify.app/docs/releases/v26.1.html#v26-1-0-beta-1-sql-language-changes)