### PR TITLE
Updated examples to include postgresql:// in order to specify scheme

### DIFF
--- a/src/current/v25.2/set-up-logical-data-replication.md
+++ b/src/current/v25.2/set-up-logical-data-replication.md
@@ -187,7 +187,7 @@ You can use the `cockroach encode-uri` command to generate a connection string c
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:
@@ -224,7 +224,7 @@ Once the source cluster has made a connection to the destination cluster, the de
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:

--- a/src/current/v25.3/set-up-logical-data-replication.md
+++ b/src/current/v25.3/set-up-logical-data-replication.md
@@ -187,7 +187,7 @@ You can use the `cockroach encode-uri` command to generate a connection string c
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:
@@ -224,7 +224,7 @@ Once the source cluster has made a connection to the destination cluster, the de
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:

--- a/src/current/v25.4/set-up-logical-data-replication.md
+++ b/src/current/v25.4/set-up-logical-data-replication.md
@@ -187,7 +187,7 @@ You can use the `cockroach encode-uri` command to generate a connection string c
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:
@@ -224,7 +224,7 @@ Once the source cluster has made a connection to the destination cluster, the de
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:

--- a/src/current/v26.1/set-up-logical-data-replication.md
+++ b/src/current/v26.1/set-up-logical-data-replication.md
@@ -187,7 +187,7 @@ You can use the `cockroach encode-uri` command to generate a connection string c
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:
@@ -224,7 +224,7 @@ Once the source cluster has made a connection to the destination cluster, the de
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach encode-uri {user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
+    cockroach encode-uri postgresql://{user}:{password}@{node IP}:26257 --ca-cert {path to CA certificate} --inline
     ~~~
 
     The connection string output contains the source cluster's certificate:


### PR DESCRIPTION
Fixes: [DOC-15753](https://cockroachlabs.atlassian.net/browse/DOC-15753)

Updated examples to include postgresql:// in order to specify scheme