### PR TITLE
DOC-15572: Product Change- PR #158961 - cli: set database user name in debug.zip and tsdump generation

### DIFF
--- a/src/current/v26.1/cockroach-debug-tsdump.md
+++ b/src/current/v26.1/cockroach-debug-tsdump.md
@@ -61,7 +61,7 @@ Flag | Description
 `--host` | The server host and port number to connect to. This can be the address of any node in the cluster.<br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
 `--insecure` | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
 <a name="sql-flag-url"></a> `--url` | A [connection URL]({% link {{ page.version.version }}/connection-parameters.md %}#connect-using-a-url) to use instead of the other arguments. To convert a connection URL to the syntax that works with your client driver, run [`cockroach convert-url`]({% link {{ page.version.version }}/connection-parameters.md %}#convert-a-url-for-different-drivers).<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
-`--user` |  The [SQL user]({% link {{ page.version.version }}/create-user.md %}) that will own the client session.<br><br>**Default:** `root`
+`--user` |  The SQL user that will own the client session. Valid values are `root` and `debug_user`.<br><br>**Default:** `root`
 
 ### Logging
 

--- a/src/current/v26.1/cockroach-debug-zip.md
+++ b/src/current/v26.1/cockroach-debug-zip.md
@@ -131,7 +131,7 @@ Flag | Description
 `--host` | The server host and port number to connect to. This can be the address of any node in the cluster. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
 `--insecure` | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
 <a name="sql-flag-url"></a> `--url` | A [connection URL]({% link {{ page.version.version }}/connection-parameters.md %}#connect-using-a-url) to use instead of the other arguments. To convert a connection URL to the syntax that works with your client driver, run [`cockroach convert-url`]({% link {{ page.version.version }}/connection-parameters.md %}#convert-a-url-for-different-drivers).<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
-`--user` |  The [SQL user]({% link {{ page.version.version }}/create-user.md %}) that will own the client session.<br><br>**Default:** `root`
+`--user` |  The SQL user that will own the client session. Valid values are `root` and `debug_user`.<br><br>**Default:** `root`
 
 ### Logging
 


### PR DESCRIPTION
Fixes DOC-15572

In cockroach-debug-zip.md and cockroach-debug-tsdump.md, added --user flag to Client connection section.

Rendered previews

- [cockroach debug zip](https://deploy-preview-22035--cockroachdb-docs.netlify.app/docs/v26.1/cockroach-debug-zip.html#client-connection)
- [cockroach debug tsdump](https://deploy-preview-22035--cockroachdb-docs.netlify.app/docs/v26.1/cockroach-debug-tsdump.html#client-connection)
