### PR TITLE
DOC-15628: Product Change- PR #158527 - sqlstats: flush ingester buffer if above max statements per txn

### DIFF
--- a/src/current/_includes/v26.1/ui/transaction-details.md
+++ b/src/current/_includes/v26.1/ui/transaction-details.md
@@ -24,7 +24,7 @@ The **Insights** table is displayed when CockroachDB has detected a problem with
 The **Statements Fingerprints** table displays the statement fingerprints of all the statements in the transaction. To display the [details of a statement fingerprint]({{ page_prefix }}statements-page.html#statement-fingerprint-page), click a statement fingerprint.
 
 {{site.data.alerts.callout_info}}
-Statement statistics in the **Statements Fingerprints** table are inaccurate when a transaction includes a large number of statements.
+Statement statistics in the **Statement Fingerprints** table are not accurate when a transaction includes more than 100,000 statements.
 
-At most 100,000 statement statistics can be associated with a single transaction statistic. If a transaction exceeds this threshold, CockroachDB automatically flushes buffered statement statistics before the transaction commits. As a result, the flushed statement statistics do not have an associated transaction fingerprint ID because the transaction has not yet completed. In these cases, the transaction fingerprint ID cannot be backfilled, and these statement statistics are not included in aggregated results.
+At most 100,000 statement statistics can be associated with a single transaction statistic. If a transaction exceeds this limit, CockroachDB automatically flushes buffered statement statistics before the transaction commits. Flushed statement statistics do not have an associated transaction fingerprint ID because the transaction has not yet completed. Because the transaction fingerprint ID cannot be backfilled in these cases, these flushed statement statistics are not included in aggregated results.
 {{site.data.alerts.end}}


### PR DESCRIPTION
Fixes DOC-15628

In transaction-details.md, added note about inaccurate statement statistics in large transactions.

Rendered preview

- [Transaction Details page](https://deploy-preview-22072--cockroachdb-docs.netlify.app/docs/v26.1/ui-transactions-page.html#transaction-details-page)
