### PR TITLE
Fix broken VS Code extension link in MCP integration docs

### DIFF
--- a/src/current/docs-mcp-integration.md
+++ b/src/current/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v23.1/docs-mcp-integration.md
+++ b/src/current/v23.1/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v23.2/docs-mcp-integration.md
+++ b/src/current/v23.2/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v24.1/docs-mcp-integration.md
+++ b/src/current/v24.1/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v24.2/docs-mcp-integration.md
+++ b/src/current/v24.2/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v24.3/docs-mcp-integration.md
+++ b/src/current/v24.3/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v25.1/docs-mcp-integration.md
+++ b/src/current/v25.1/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v25.2/docs-mcp-integration.md
+++ b/src/current/v25.2/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v25.3/docs-mcp-integration.md
+++ b/src/current/v25.3/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v25.4/docs-mcp-integration.md
+++ b/src/current/v25.4/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:

--- a/src/current/v26.1/docs-mcp-integration.md
+++ b/src/current/v26.1/docs-mcp-integration.md
@@ -33,7 +33,7 @@ Connect your AI assistant to CockroachDB documentation by configuring the MCP se
 
 ### VS Code
 
-1. Install the [Claude for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude) extension
+1. Install the [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) extension
 2. Open VS Code Settings (⌘+,)
 3. Search for "Claude MCP"
 4. Add the following to your MCP configuration:


### PR DESCRIPTION
## Summary
- Fixes the broken VS Code Marketplace link in the MCP integration documentation
- The previous link (`Anthropic.claude`) returned a 404 error
- Updated to the correct extension ID (`anthropic.claude-code`) for "Claude Code for VS Code"

## Test plan
- [x] Verify the new link works: https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code