### PR TITLE
DOC-15940: Fix markdown rendering on LDR page 

### DIFF
--- a/src/current/v25.4/manage-logical-data-replication.md
+++ b/src/current/v25.4/manage-logical-data-replication.md
@@ -120,7 +120,7 @@ To manage an entry in the DLQ:
 
 1. Determine a course of action based on the results of the previous steps:
 
-    - If the values for the entry are the same in both the destination table and the source table, delete the entry from the DLQ on the destination database:
+    1. If the values for the entry are the same in both the destination table and the source table, delete the entry from the DLQ on the destination database:
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
@@ -128,7 +128,7 @@ To manage an entry in the DLQ:
         DELETE FROM crdb_replication.dlq_271_foo WHERE id = 106677386757203;
         ~~~
 
-    - If the entry's values in the destination table are different from its values in the source table, but the entry's values in the source table equal its values in the DLQ, update the entry in the destination table to have the same values as in the source table:
+    1. If the entry's values in the destination table are different from its values in the source table, but the entry's values in the source table equal its values in the DLQ, update the entry in the destination table to have the same values as in the source table:
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
@@ -138,7 +138,7 @@ To manage an entry in the DLQ:
 
         If this upsert fails due to a constraint violation, you must either delete the row that the upsert conflicts with or delete the DLQ entry. If the destination table has unique or foreign key constraints, the DLQ will likely continue to accumulate entries.
 
-    - If the entry's values in the destination table are different from its values in the source table, and the entry's values in the source table do not equal its values in the DLQ, refresh the replicated time and retry the equality queries above. If the same results hold after a few retries with refreshed replicated times, there is likely a more recent entry for the same row in the DLQ. 
+    1. If the entry's values in the destination table are different from its values in the source table, and the entry's values in the source table do not equal its values in the DLQ, refresh the replicated time and retry the equality queries above. If the same results hold after a few retries with refreshed replicated times, there is likely a more recent entry for the same row in the DLQ. 
     
         1. To find the more recent entry, find all entries in the DLQ with the matching primary key:
 

--- a/src/current/v26.1/manage-logical-data-replication.md
+++ b/src/current/v26.1/manage-logical-data-replication.md
@@ -120,7 +120,7 @@ To manage an entry in the DLQ:
 
 1. Determine a course of action based on the results of the previous steps:
 
-    - If the values for the entry are the same in both the destination table and the source table, delete the entry from the DLQ on the destination database:
+    1. If the values for the entry are the same in both the destination table and the source table, delete the entry from the DLQ on the destination database:
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
@@ -128,7 +128,7 @@ To manage an entry in the DLQ:
         DELETE FROM crdb_replication.dlq_271_foo WHERE id = 106677386757203;
         ~~~
 
-    - If the entry's values in the destination table are different from its values in the source table, but the entry's values in the source table equal its values in the DLQ, update the entry in the destination table to have the same values as in the source table:
+    1. If the entry's values in the destination table are different from its values in the source table, but the entry's values in the source table equal its values in the DLQ, update the entry in the destination table to have the same values as in the source table:
 
         {% include_cached copy-clipboard.html %}
         ~~~ sql
@@ -138,7 +138,7 @@ To manage an entry in the DLQ:
 
         If this upsert fails due to a constraint violation, you must either delete the row that the upsert conflicts with or delete the DLQ entry. If the destination table has unique or foreign key constraints, the DLQ will likely continue to accumulate entries.
 
-    - If the entry's values in the destination table are different from its values in the source table, and the entry's values in the source table do not equal its values in the DLQ, refresh the replicated time and retry the equality queries above. If the same results hold after a few retries with refreshed replicated times, there is likely a more recent entry for the same row in the DLQ. 
+    1. If the entry's values in the destination table are different from its values in the source table, and the entry's values in the source table do not equal its values in the DLQ, refresh the replicated time and retry the equality queries above. If the same results hold after a few retries with refreshed replicated times, there is likely a more recent entry for the same row in the DLQ. 
     
         1. To find the more recent entry, find all entries in the DLQ with the matching primary key:
 


### PR DESCRIPTION
Fixed DOC-15940

In manage-logical-data-replication.md, fixed markdown rendering.

Rendered preview

- [Manage entries in the DLQ](https://deploy-preview-22310--cockroachdb-docs.netlify.app/docs/v25.4/manage-logical-data-replication.html#manage-entries-in-the-dlq)