### PR TITLE
Revert: Replace default search with Kapa AI search mode

### DIFF
--- a/src/current/_includes/head.html
+++ b/src/current/_includes/head.html
@@ -161,11 +161,8 @@ var pageConfig = {
   data-mcp-enabled="true"
   data-mcp-server-url="https://cockroachdb.mcp.kapa.ai"
   data-search-mode-enabled="true"
-  data-search-mode-default="true"
   data-search-source-ids-include="142a5371-2b4f-4d42-91aa-9c18142991d5"
   data-modal-open-on-command-k="true"
-  data-modal-command-k-search-mode-default="true"
-  data-modal-override-open-selector-search="#search-input"
 ></script>
 
 <style>

--- a/src/current/_includes/sidebar.html
+++ b/src/current/_includes/sidebar.html
@@ -1,8 +1,8 @@
 <div class="col-sidebar" data-nosnippet>
   <div class="col-sidebar-content">
     <div class="mb-3 px-3">
-      <form action="/docs/search" id="sidebar-search-form">
-        <input class="form-control" name="query" type="text" placeholder="Search" id="sidebar-search-input">
+      <form action="/docs/search">
+        <input class="form-control" name="query" type="text" placeholder="Search">
       </form>
     </div>
     <ul id="sidebar" class="js-sidebar nav {{ include.sidebar_class }}pt-0" style="display: none">

--- a/src/current/js/algoliaAutocomplete.js
+++ b/src/current/js/algoliaAutocomplete.js
@@ -1,17 +1,10 @@
 // Algolia Autocomplete with Kapa Integration
 // Following: https://docs.kapa.ai/integrations/website-widget/examples/algolia-integration
-// NOTE: Disabled when Kapa search mode overrides the search input
 (function() {
   // Wait for DOM and dependencies
   function initializeAutocomplete() {
     if (typeof algoliasearch === 'undefined' || !document.getElementById('search-input')) {
       setTimeout(initializeAutocomplete, 100);
-      return;
-    }
-
-    // Skip Algolia autocomplete - Kapa search mode handles search via data-modal-override-open-selector-search
-    const kapaScript = document.querySelector('script[data-modal-override-open-selector-search]');
-    if (kapaScript) {
       return;
     }
 

--- a/src/current/js/searchInputRendering.js
+++ b/src/current/js/searchInputRendering.js
@@ -30,39 +30,18 @@ $(document).ready(function() {
     }
   });
 
-  // Handle search inputs (topnav and sidebar)
-  // Check if Kapa search mode is handling the input
-  const kapaScript = document.querySelector('script[data-modal-override-open-selector-search]');
-  if (kapaScript) {
-    // Kapa is configured - intercept clicks to open Kapa modal
-    $('#search-input, #sidebar-search-input').on('click', function(e) {
+  // Handle search input in topnav - redirect to Algolia search page
+  $('#search-input').on('keypress', function(e) {
+    if (e.which === 13) { // Enter key
       e.preventDefault();
-      e.stopPropagation();
-      $(this).blur();
-      if (window.Kapa && window.Kapa.open) {
-        window.Kapa.open({ mode: 'search' });
+      const query = $(this).val().trim();
+      if (query) {
+        // Redirect to Algolia search page
+        const searchPath = getSearchPath();
+        window.location.href = searchPath + '?query=' + encodeURIComponent(query);
       }
-    });
-    // Prevent sidebar search form submission
-    $('#sidebar-search-form').on('submit', function(e) {
-      e.preventDefault();
-      if (window.Kapa && window.Kapa.open) {
-        window.Kapa.open({ mode: 'search' });
-      }
-    });
-  } else {
-    // No Kapa - use Algolia search page redirect on Enter
-    $('#search-input').on('keypress', function(e) {
-      if (e.which === 13) { // Enter key
-        e.preventDefault();
-        const query = $(this).val().trim();
-        if (query) {
-          const searchPath = getSearchPath();
-          window.location.href = searchPath + '?query=' + encodeURIComponent(query);
-        }
-      }
-    });
-  }
+    }
+  });
 
   // Disable old suggestions - now handled by kapaLiveSuggestions.js
   // which provides real-time search results from Kapa API


### PR DESCRIPTION
## Summary
Reverts PR #22375 which replaced the default search with Kapa AI search mode.

Reverting to restore the original Algolia search behavior.

## Test plan
- Verify search input works as before (typing and Enter redirects to Algolia search page)
- Verify Cmd+K behavior is restored to original