### PR TITLE
Fix: Restore search-input ID to sidebar for autocomplete

### DIFF
--- a/src/current/_includes/sidebar.html
+++ b/src/current/_includes/sidebar.html
@@ -2,7 +2,7 @@
   <div class="col-sidebar-content">
     <div class="mb-3 px-3">
       <form action="/docs/search">
-        <input class="form-control" name="query" type="text" placeholder="Search">
+        <input id="search-input" class="form-control" name="query" type="text" placeholder="Search">
       </form>
     </div>
     <ul id="sidebar" class="js-sidebar nav {{ include.sidebar_class }}pt-0" style="display: none">


### PR DESCRIPTION
## Summary
Restores `id="search-input"` to the sidebar search input that was accidentally removed during merge conflict resolution.

This ID is needed for the Algolia autocomplete to bind to the sidebar search input.

## Test plan
- Verify Algolia autocomplete dropdown appears when typing in the sidebar search input