### PR TITLE
DOC-16068: Update releases/index.html#recent-releases for v26.1

### DIFF
--- a/src/current/releases/index.md
+++ b/src/current/releases/index.md
@@ -109,8 +109,9 @@ A cluster that is upgraded to an alpha binary of CockroachDB or a binary that wa
 
 | Version | Release Type | GA date |
 | :---: | :---: | :---: |
+| [v26.1](#v26-1) | Innovation | 2026-02-02 |
 | [v25.4](#v25-4) | Regular | 2025-11-03 |
-| [v25.3](#v25-3) | Innovation | 2025-08-04 |
+| [v25.3]({% link releases/unsupported-versions.md %}#v25-3) | Innovation | 2025-08-04 |
 | [v25.2](#v25-2) | Regular | 2025-05-12 |
 | [v25.1]({% link releases/unsupported-versions.md %}#v25-1) | Innovation | 2025-02-18 |
 | [v24.3](#v24-3) | Regular | 2024-11-18 |
@@ -124,7 +125,6 @@ The following releases and their descriptions represent proposed plans that are 
 
 | Version | Release Type | Expected GA date |
 | :---: | :---: | :---: |
-| v26.1 | Innovation | 2026 Q1    |
 | v26.2 | Regular    | 2026 Q2    |
 
 ## Downloads


### PR DESCRIPTION
Fixes DOC-16068

In releases/index.md, updated for v26.1 and v25.3.

Rendered preview

- [Recent releases](https://deploy-preview-22480--cockroachdb-docs.netlify.app/docs/releases/index.html#recent-releases)