### PR TITLE
fix: remove duplicate 'v' prefix in search version tag

### DIFF
--- a/src/current/js/algoliaAutocomplete.js
+++ b/src/current/js/algoliaAutocomplete.js
@@ -120,7 +120,7 @@
               ${truncatedContent ? `<div class="result-snippet">${truncatedContent}</div>` : ''}
               <div class="result-meta">
                 ${docType ? `<span class="doc-type">${docType}</span>` : ''}
-                ${version ? `<span class="version">v${version}</span>` : ''}
+                ${version ? `<span class="version">${version}</span>` : ''}
               </div>
             </div>
           `;


### PR DESCRIPTION
## Summary
- Fixes search autocomplete showing "vv26.1" instead of "v26.1" in version tags
- The Algolia index already stores versions with a `v` prefix, so the template was doubling it

## Test plan
- [ ] Search for any term in the autocomplete and verify version tags display correctly (e.g. `v26.1`, not `vv26.1`)