### PR TITLE
docs: add v24.1.28 to TA a166122 fixed versions

### DIFF
--- a/src/current/advisories/a166122.md
+++ b/src/current/advisories/a166122.md
@@ -3,7 +3,7 @@ title: Technical Advisory 166122
 advisory: A-166122
 summary: A bug in CockroachDB can cause partial index corruption when a partial index is backfilled on a table with multiple column families while concurrent updates are occurring.
 toc: true
-affected_versions: v24.1, v24.2, v24.3.0 to v24.3.30, v25.1, v25.2.0 to v25.2.16, v25.3, v25.4.0 to v25.4.8, v26.1.0 to v26.1.2, v26.2.0-alpha.1 to v26.2.0-beta.1
+affected_versions: v24.1.0 to v24.1.27, v24.2, v24.3.0 to v24.3.30, v25.1, v25.2.0 to v25.2.16, v25.3, v25.4.0 to v25.4.8, v26.1.0 to v26.1.2, v26.2.0-alpha.1 to v26.2.0-beta.1
 advisory_date: 2026-04-20
 docs_area: releases
 ---
@@ -16,7 +16,7 @@ A bug in CockroachDB can cause partial index corruption when a partial index is 
 
 This advisory applies to the following versions of CockroachDB:
 
-- v24.1: All versions
+- v24.1: v24.1.0 through v24.1.27
 - v24.2: All versions
 - v24.3: v24.3.0 through v24.3.30
 - v25.1: All versions
@@ -41,6 +41,7 @@ This is resolved in CockroachDB by [PR #166123](https://github.com/cockroachdb/c
 
 A fix has been applied to the following maintenance releases of CockroachDB:
 
+- v24.1.28
 - v24.3.31
 - v25.2.17
 - v25.4.9
@@ -51,7 +52,7 @@ This public issue is tracked by [#166122](https://github.com/cockroachdb/cockroa
 
 ## Mitigation
 
-Users of affected CockroachDB versions are encouraged to upgrade to v24.3.31, v25.2.17, v25.4.9, v26.1.3, v26.2.0-beta.2, or a later version.
+Users of affected CockroachDB versions are encouraged to upgrade to v24.1.28, v24.3.31, v25.2.17, v25.4.9, v26.1.3, v26.2.0-beta.2, or a later version.
 
 Users who have created partial indexes on tables with multiple column families while concurrent updates were occurring may have been affected. To determine whether your cluster was affected:
 


### PR DESCRIPTION
Updates Technical Advisory [a166122](https://www.cockroachlabs.com/docs/advisories/a166122) to include **v24.1.28** as a fixed version. The fix was backported via [cockroachdb/cockroach#168782](https://github.com/cockroachdb/cockroach/pull/168782) and is already referenced in the [v24.1.28 release notes](https://www.cockroachlabs.com/docs/releases/v24.1#v24-1-28-bug-fixes). [[Thread](https://cockroachlabs.slack.com/archives/CSPK16V51/p1777388141735249)]
## Changes

- `affected_versions` frontmatter mention of `v24.1` changed to `v24.1.0 to v24.1.27`
- Description section: updated `v24.1: All versions` → `v24.1: v24.1.0 through v24.1.27`
- Statement section: added `v24.1.28` to the fixed releases list
- Mitigation section: added `v24.1.28` to the recommended upgrade versions