### PR TITLE
ref-docs: cli,server: add --exclude-log-severities flag to debug zip

### DIFF
--- a/src/current/cli.md
+++ b/src/current/cli.md
@@ -1,0 +1,34 @@
+Based on the PR diff, I can see that this change adds a new `--exclude-log-severities` flag to the `debug zip` command. Here's the reference documentation:
+
+### `cockroach debug zip`
+
+**Synopsis**: `cockroach debug zip <file> [flags]`
+
+**Description**: Collects cluster debug information into a zip file for troubleshooting. The command gathers logs, cluster settings, node information, and other diagnostic data from all nodes in the cluster.
+
+**Flags**:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--exclude-log-severities` | List of log severities to exclude from the collected log files. The list can be specified as a comma-delimited list of severity names, or by using the flag multiple times. Valid severity names are: `INFO`, `WARNING`, `ERROR`, `FATAL`. For example, `--exclude-log-severities=INFO` will skip all INFO-level log entries, significantly reducing zip file size for large clusters. | none |
+
+**Examples**:
+
+```shell
+# Collect debug information excluding INFO-level log entries
+cockroach debug zip debug.zip --exclude-log-severities=INFO
+
+# Exclude multiple severities using comma-separated values
+cockroach debug zip debug.zip --exclude-log-severities=INFO,WARNING
+
+# Exclude multiple severities using multiple flags
+cockroach debug zip debug.zip --exclude-log-severities=INFO --exclude-log-severities=WARNING
+
+# Standard debug zip collection (no filtering)
+cockroach debug zip debug.zip
+```
+
+**Notes**:
+- Excluding INFO-level logs can significantly reduce the size of the debug zip file, especially for large clusters with verbose logging
+- The severity filtering is applied server-side during log file collection
+- Invalid severity names will result in an error with the message: "unknown log severity; valid values are INFO, WARNING, ERROR, FATAL"


### PR DESCRIPTION
Auto-generated reference doc update for **cli,server: add --exclude-log-severities flag to debug zip**.

Source: https://github.com/cockroachdb/cockroach/pull/165802/files

_Created from the docs dashboard. Review and merge when ready._