### PR TITLE
add latest testing release links to Downloads Archive

### DIFF
--- a/src/current/_includes/releases/downloads-archive-testing-releases.md
+++ b/src/current/_includes/releases/downloads-archive-testing-releases.md
@@ -1,0 +1,241 @@
+{% comment %}
+This include generates testing release download tables for the downloads archive page.
+It should only be shown when a GA release has cloud_only: true (between Cloud GA and binary GA).
+Parameters:
+  - major_version: The major version to generate testing releases for (e.g., "v26.2")
+{% endcomment %}
+
+{% comment %} Fetch all Testing releases for this major version {% endcomment %}
+{% assign all_testing = site.data.releases | where_exp: "r", "r.major_version == include.major_version" | where_exp: "r", "r.release_type == 'Testing'" | sort: "release_date" | reverse %}
+
+{% comment %} Filter out withdrawn releases by manually building the array {% endcomment %}
+{% assign testing_releases = "" | split: "" %}
+{% for r in all_testing %}
+    {% if r.withdrawn != true %}
+        {% assign testing_releases = testing_releases | push: r %}
+    {% endif %}
+{% endfor %}
+
+{% if testing_releases.size > 0 %}
+
+#### Testing Releases
+
+{{site.data.alerts.callout_danger}}
+Testing releases are not qualified for production use and not eligible for support or uptime SLA commitments.
+{{site.data.alerts.end}}
+
+{% comment %}Assign the JS for the experimental download prompt{% endcomment %}
+{% capture experimental_download_js %}{% include_cached releases/experimental_download_dialog.md %}{% endcapture %}
+{% capture onclick_string %}onclick="{{ experimental_download_js }}"{% endcapture %}
+
+<div id="os-tabs" class="filters filters-big clearfix">
+    <button id="linux" class="filter-button" data-scope="linux">Linux</button>
+    <button id="mac" class="filter-button" data-scope="mac">Mac</button>
+    <button id="windows" class="filter-button" data-scope="windows">Windows</button>
+    <button id="docker" class="filter-button" data-scope="docker">Docker</button>
+    <button id="source" class="filter-button" data-scope="source">Source</button>
+</div>
+
+{% comment %}Determine if any testing releases have ARM support{% endcomment %}
+{% assign has_linux_arm = false %}
+{% assign has_mac_arm = false %}
+{% assign has_docker_arm = false %}
+{% for r in testing_releases %}
+    {% if r.linux.linux_arm == true %}
+        {% assign has_linux_arm = true %}
+    {% endif %}
+    {% if r.mac.mac_arm == true %}
+        {% assign has_mac_arm = true %}
+    {% endif %}
+    {% if r.docker.docker_arm == true %}
+        {% assign has_docker_arm = true %}
+    {% endif %}
+{% endfor %}
+
+<section class="filter-content" markdown="1" data-scope="linux">
+
+<table class="release-table">
+<thead>
+    <tr>
+        <td>Version</td>
+        <td>Date</td>
+        <td>Intel 64-bit Downloads</td>
+        {% if has_linux_arm == true %}
+        <td>ARM 64-bit Downloads</td>
+        {% endif %}
+    </tr>
+</thead>
+<tbody>
+{% for r in testing_releases %}
+    <tr>
+        <td>
+            {{ r.release_name }}
+        </td>
+        <td>{{ r.release_date }}</td>
+        <td>
+            <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-amd64.tgz" class="binary-link">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-amd64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% if r.has_sql_only == true %}
+            <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.linux-amd64.tgz" class="binary-link">SQL Shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.linux-amd64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% endif %}
+        </td>
+        {% if r.linux.linux_arm == true and has_linux_arm == true %}
+        <td>
+            {% if r.linux.linux_arm_experimental == true %}<b>Experimental:</b>{% endif %}
+            <div><a {% if r.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-arm64.tgz" class="binary-link">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.linux-arm64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% if r.has_sql_only == true %}
+            <div><a {% if r.linux.linux_arm_experimental == true %}{{ onclick_string }}{% endif %} href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.linux-arm64.tgz" class="binary-link">SQL Shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.linux-arm64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% endif %}
+        </td>
+        {% elsif has_linux_arm == true %}
+        <td>N/A</td>
+        {% endif %}
+    </tr>
+{% endfor %}
+</tbody>
+</table>
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="mac">
+
+macOS downloads are **experimental**. Experimental downloads are not yet qualified for production use and not eligible for support or uptime SLA commitments, whether they are for testing releases or production releases.
+
+<table class="release-table">
+<thead>
+    <tr>
+        <td>Version</td>
+        <td>Date</td>
+        <td>Intel 64-bit (Experimental) Downloads</td>
+        {% if has_mac_arm == true %}
+        <td>ARM 64-bit (Experimental) Downloads</td>
+        {% endif %}
+    </tr>
+</thead>
+<tbody>
+{% for r in testing_releases %}
+    <tr>
+        <td>
+            {{ r.release_name }}
+        </td>
+        <td>{{ r.release_date }}</td>
+        <td>
+            <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-10.9-amd64.tgz" class="binary-link">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-10.9-amd64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% if r.has_sql_only == true %}
+            <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-10.9-amd64.tgz" class="binary-link">SQL Shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-10.9-amd64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% endif %}
+        </td>
+        {% if r.mac.mac_arm == true and has_mac_arm == true %}
+        <td>
+            <div><a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-11.0-arm64.tgz" class="binary-link">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.darwin-11.0-arm64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% if r.has_sql_only == true %}
+            <div><a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-11.0-arm64.tgz" class="binary-link">SQL Shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.darwin-11.0-arm64.tgz.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% endif %}
+        </td>
+        {% elsif has_mac_arm == true %}
+        <td>N/A</td>
+        {% endif %}
+    </tr>
+{% endfor %}
+</tbody>
+</table>
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="windows">
+    
+Windows 8 or higher is required. Windows downloads are **experimental**. Experimental downloads are not yet qualified for production use and not eligible for support or uptime SLA commitments, whether they are for testing releases or production releases.
+
+<table class="release-table">
+<thead>
+    <tr>
+        <td>Version</td>
+        <td>Date</td>
+        <td>Intel 64-bit (<b>Experimental</b>) Downloads</td>
+    </tr>
+</thead>
+<tbody>
+{% for r in testing_releases %}
+    <tr>
+        <td>
+            {{ r.release_name }}
+        </td>
+        <td>{{ r.release_date }}</td>
+        <td>
+            {% if r.windows == true %}
+            <div><a {{ onclick_string }} href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.windows-6.2-amd64.zip" class="binary-link">Full Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-{{ r.release_name }}.windows-6.2-amd64.zip.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% if r.has_sql_only == true %}
+            <div><a {{ onclick_string }} href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.windows-6.2-amd64.zip" class="binary-link">SQL Shell Binary</a>{% if r.has_sha256sum == true %} (<a href="https://binaries.cockroachdb.com/cockroach-sql-{{ r.release_name }}.windows-6.2-amd64.zip.sha256sum" class="binary-link">SHA256</a>){% endif %}</div>
+            {% endif %}
+            {% else %}
+            N/A
+            {% endif %}
+        </td>
+    </tr>
+{% endfor %}
+</tbody>
+</table>
+</section>
+
+<section class="filter-content" markdown="1" data-scope="docker">
+
+Docker images for CockroachDB are published on [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach/tags).
+
+<table class="release-table">
+<thead>
+    <tr>
+        <td>Version</td>
+        <td>Date</td>
+        <td>Docker image tag</td>
+    </tr>
+</thead>
+<tbody>
+{% for r in testing_releases %}
+    <tr>
+        <td>
+            {{ r.release_name }}
+        </td>
+        <td>{{ r.release_date }}</td>
+        <td>
+            {% if r.source == false %}
+            N/A
+            {% else %}
+            <code>{{ r.docker.docker_image }}:{{ r.release_name }}</code>
+            {% endif %}
+        </td>
+    </tr>
+{% endfor %}
+</tbody>
+</table>
+</section>
+
+<section class="filter-content" markdown="1" data-scope="source">
+<p>The source code for CockroachDB is hosted in the <a href="https://github.com/cockroachdb/cockroach/releases/" class="binary-link">cockroachdb/cockroach</a> repository on Github.</p>
+<table class="release-table">
+<thead>
+    <tr>
+        <td>Version</td>
+        <td>Date</td>
+        <td>Source</td>
+    </tr>
+</thead>
+<tbody>
+{% for r in testing_releases %}
+    <tr>
+        <td>
+            {{ r.release_name }}
+        </td>
+        <td>{{ r.release_date }}</td>
+        <td>
+            {% if r.source == true %}
+            <a class="external" href="https://github.com/cockroachdb/cockroach/releases/tag/{{ r.release_name }}" class="binary-link">View on Github</a>
+            {% else %}
+            N/A
+            {% endif %}
+        </td>
+    </tr>
+{% endfor %}
+</tbody>
+</table>
+</section>
+
+{% endif %}

--- a/src/current/releases/downloads-archive.md
+++ b/src/current/releases/downloads-archive.md
@@ -4,12 +4,6 @@ summary: Archive of downloads for versions of CockroachDB that are no longer sup
 toc: true
 docs_area: releases
 ---
-{{site.data.alerts.callout_danger}}
-This page hosts download links to CockroachDB versions that are no longer supported. For more information about CockroachDB version support, refer to [Release Support Policy]({% link releases/release-support-policy.md %}#unsupported-versions). To download and learn about currently supported CockroachDB versions, refer to [CockroachDB Releases]({% link releases/index.md %}).
-{{site.data.alerts.end}}
-## Downloads
-
-{{ experimental_js_warning }}
 
 {% assign sections = site.data.releases | map: "release_type" | uniq | reverse %}
 {% comment %} Fetch the list of all release types (currently Testing, Production) {% endcomment %}
@@ -20,6 +14,23 @@ This page hosts download links to CockroachDB versions that are no longer suppor
 {% assign versions = site.data.versions | where_exp: "versions", "released_versions contains versions.major_version" | sort: "release_date" | reverse %}
 {% comment %} Fetch all major versions (e.g., v21.2), sorted in reverse chronological order. {% endcomment %}
 
+{% comment %} Check if any version has cloud_only: true to determine if we should mention testing releases in the page description {% endcomment %}
+{% assign has_cloud_only_version = false %}
+{% for v in versions %}
+    {% capture ga_release_name %}{{ v.major_version }}.0{% endcapture %}
+    {% assign ga_release = site.data.releases | where: "major_version", v.major_version | where: "release_name", ga_release_name | first %}
+    {% if ga_release and ga_release.cloud_only == true %}
+        {% assign has_cloud_only_version = true %}
+        {% break %}
+    {% endif %}
+{% endfor %}
+
+This page hosts download links to {% if has_cloud_only_version %}the latest CockroachDB testing releases and to {% endif %}CockroachDB production releases that are no longer supported. For more information about CockroachDB version support, refer to [Release Support Policy]({% link releases/release-support-policy.md %}#unsupported-versions).
+
+## Downloads
+
+{{ experimental_js_warning }}
+
 {% assign latest_hotfix = site.data.releases | where_exp: "latest_hotfix", "latest_hotfix.major_version == site.versions['stable']" | where_exp: "latest_hotfix", "latest_hotfix.withdrawn != true"  | sort: "release_date" | reverse | first %}
 {% comment %} For the latest GA version, find the latest hotfix that is not withdrawn. {% endcomment %}
 
@@ -29,6 +40,27 @@ This page hosts download links to CockroachDB versions that are no longer suppor
 
 {% assign is_not_downloadable_message = "No longer available for download." %}
 {% assign current_date = 'now' | date: '%Y-%m-%d' %}
+
+{% comment %}
+  Check for major versions with cloud_only GA releases.
+  These versions are between Cloud GA and binary GA, and should display testing releases.
+{% endcomment %}
+{% for v in versions %}
+    {% comment %} Find the GA release (X.Y.0) for this major version {% endcomment %}
+    {% capture ga_release_name %}{{ v.major_version }}.0{% endcapture %}
+    {% assign ga_release = site.data.releases | where: "major_version", v.major_version | where: "release_name", ga_release_name | first %}
+    
+    {% comment %} If the GA release exists and has cloud_only: true, show testing releases {% endcomment %}
+    {% if ga_release and ga_release.cloud_only == true %}
+
+### {{ v.major_version }}
+
+[CockroachDB {{ v.major_version }}]({% link releases/{{ v.major_version }}.md %}) is generally available on CockroachDB Cloud.
+
+{% include releases/downloads-archive-testing-releases.md major_version=v.major_version %}
+
+    {% endif %}
+{% endfor %}
 
 {% for v in versions %} {% comment %} Iterate through all major versions {% endcomment %}
 
@@ -116,6 +148,11 @@ CockroachDB {{ v.major_version }} is partially supported. Pre-LTS patches (befor
 </div>
 
             {% for s in sections %} {% comment %} For each major version, iterate through the sections. {% endcomment %}
+        
+                {% comment %} Skip Testing releases for unsupported versions - they're only relevant during cloud_only period {% endcomment %}
+                {% if s == "Testing" %}
+                    {% continue %}
+                {% endif %}
         
                 {% assign releases = site.data.releases | where_exp: "releases", "releases.major_version == v.major_version" | where_exp: "releases", "releases.release_type == s" | sort: "release_date" | reverse %} {% comment %} Fetch all releases for that major version based on release type (Production/Testing). {% endcomment %}
         
@@ -321,7 +358,8 @@ CockroachDB {{ v.major_version }} is partially supported. Pre-LTS patches (befor
         </section>
         
         <section class="filter-content" markdown="1" data-scope="windows">
-            Windows 8 or higher is required. Windows downloads are **experimental**. Experimental downloads are not yet qualified for production use and not eligible for support or uptime SLA commitments, whether they are for testing releases or production releases.
+        
+        Windows 8 or higher is required. Windows downloads are **experimental**. Experimental downloads are not yet qualified for production use and not eligible for support or uptime SLA commitments, whether they are for testing releases or production releases.
         
             <table class="release-table">
             <thead>


### PR DESCRIPTION
- Add binary links to the latest (26.2) testing releases to the Downloads Archive.
  - These are removed as soon as GA binaries become available on the GA release notes page.
- Remove testing release links from earlier unsupported versions (with the same reasoning applied to above).
- Minor wording tweaks.