### PR TITLE
remove leader leases 26.2 feature highlight

### DIFF
--- a/src/current/_includes/releases/v26.2/v26.2.0.md
+++ b/src/current/_includes/releases/v26.2/v26.2.0.md
@@ -208,17 +208,6 @@ You can also search the docs for sections labeled [New in v26.2](https://www.coc
  <tbody>
   <tr>
    <td>
-    <p class="feature-summary">Leader leases</p>
-    <p class="feature-description"><a href="{% link v26.2/architecture/replication-layer.md %}#leader-leases">Leader leases</a> are now generally available. This feature maintains more stable leadership across nodes by reducing unnecessary lease transfers, resulting in more consistent query response times and fewer latency spikes.</p>
-   </td>
-   <td class="icon-center">GA</td>
-   <td class="icon-center">{% include icon-yes.html %}</td>
-   <td class="icon-center">{% include icon-yes.html %}</td>
-   <td class="icon-center">{% include icon-yes.html %}</td>
-   <td class="icon-center">{% include icon-yes.html %}</td>
-  </tr>
-  <tr>
-   <td>
     <p class="feature-summary">Buffered writes</p>
     <p class="feature-description"><a href="{% link v26.2/architecture/transaction-layer.md %}#buffered-writes">Buffered writes</a> are now generally available. This feature improves throughput and reducing tail latency under heavy write workloads by batching writes efficiently before flushing to disk.</p>
    </td>


### PR DESCRIPTION
Leader leases went GA in 25.2. No additional docs work was done on leader leases in 26.2. Removing the feature highlight in the 26.2 GA release notes.

cc @rmloveland for visibility