### PR TITLE
molt: narrow MySQL supported version range to 5.7-8.4

### DIFF
--- a/src/current/molt/migration-overview.md
+++ b/src/current/molt/migration-overview.md
@@ -56,19 +56,19 @@ MOLT [Fetch](#fetch), [Replicator](#replicator), and [Verify](#verify) are CLI-b
   <tr>
     <td class="comparison-chart__feature"><a href="#fetch"><b>Fetch</b></a></td>
     <td>Initial data load</td>
-    <td>PostgreSQL 11-16, MySQL 5.7-8.0+, Oracle Database 19c (Enterprise Edition) and 21c (Express Edition), CockroachDB</td>
+    <td>PostgreSQL 11-16, MySQL 5.7-8.4, Oracle Database 19c (Enterprise Edition) and 21c (Express Edition), CockroachDB</td>
     <td>GA</td>
   </tr>
   <tr>
     <td class="comparison-chart__feature"><a href="#replicator"><b>Replicator</b></a></td>
     <td>Continuous replication</td>
-    <td>CockroachDB, PostgreSQL 11-16, MySQL 5.7+ and 8.0+, Oracle Database 19c+</td>
+    <td>CockroachDB, PostgreSQL 11-16, MySQL 5.7-8.4, Oracle Database 19c+</td>
     <td>GA</td>
   </tr>
   <tr>
     <td class="comparison-chart__feature"><a href="#verify"><b>Verify</b></a></td>
     <td>Schema and data validation</td>
-    <td>PostgreSQL 12-16, MySQL 5.7-8.0+, Oracle Database 19c (Enterprise Edition) and 21c (Express Edition), CockroachDB</td>
+    <td>PostgreSQL 12-16, MySQL 5.7-8.4, Oracle Database 19c (Enterprise Edition) and 21c (Express Edition), CockroachDB</td>
     <td><a href="{% link {{ site.current_cloud_version }}/cockroachdb-feature-availability.md %}">Preview</a></td>
   </tr>
 </table>

--- a/src/current/molt/molt-fetch.md
+++ b/src/current/molt/molt-fetch.md
@@ -22,7 +22,7 @@ MOLT Fetch uses [`IMPORT INTO`]({% link {{site.current_cloud_version}}/import-in
 The following source databases are supported:
 
 - PostgreSQL 11-16
-- MySQL 5.7, 8.0 and later
+- MySQL 5.7-8.4
 - Oracle Database 19c (Enterprise Edition) and 21c (Express Edition)
 
 ### Database configuration

--- a/src/current/molt/molt-replicator.md
+++ b/src/current/molt/molt-replicator.md
@@ -23,7 +23,7 @@ MOLT Replicator consumes change data from PostgreSQL [logical replication](https
 MOLT Replicator supports the following source and target databases:
 
 - PostgreSQL 11-16
-- MySQL 5.7, 8.0 and later
+- MySQL 5.7-8.4
 - Oracle Database 19c (Enterprise Edition) and 21c (Express Edition)
 - CockroachDB (all currently [supported versions]({% link releases/release-support-policy.md %}#supported-versions))
 

--- a/src/current/molt/molt-verify.md
+++ b/src/current/molt/molt-verify.md
@@ -26,7 +26,7 @@ For a demo of MOLT Verify, watch the following video:
 The following source databases are supported:
 
 - PostgreSQL 12-16
-- MySQL 5.7, 8.0 and later
+- MySQL 5.7-8.4
 - Oracle Database 19c (Enterprise Edition) and 21c (Express Edition)
 
 ## Installation


### PR DESCRIPTION
Replace open-ended "5.7-8.0+" / "5.7+ and 8.0+" / "5.7, 8.0 and later" phrasing with the specific tested range "5.7-8.4" across the MOLT Fetch, Replicator, Verify, and migration overview pages.