### PR TITLE
ref-docs: docs: document pg_get_function_sqlbody function from PR #169716

### DIFF
--- a/src/current/v26.1/functions.md
+++ b/src/current/v26.1/functions.md
@@ -1,0 +1,57 @@
+---
+title: docs: document pg_get_function_sqlbody function from PR #169716
+summary: New Built-in Function
+toc: true
+docs_area: reference.sql
+---
+
+## New Built-in Function
+
+### `pg_get_function_sqlbody()`
+
+**Category**: System Info
+
+**Signature**: `pg_get_function_sqlbody(func_oid OID) → STRING`
+
+**Description**: Returns the SQL-standard body of the specified function, or `NULL` if the function was not defined with the SQL-standard inline body syntax. This function provides compatibility with PostgreSQL 14+ tools that probe `pg_catalog`.
+
+CockroachDB does not yet support the SQL-standard inline body syntax (`RETURN expr` or `BEGIN ATOMIC ... END`), so this function currently returns `NULL` for all inputs, matching PostgreSQL's behavior for functions defined with the legacy `AS $$...$$` syntax.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `func_oid` | `OID` | The object identifier of the function to query |
+
+**Returns**: `STRING` - The SQL body of the function, or `NULL`
+
+**Example**:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+-- Query the SQL body of a user-defined function
+SELECT pg_get_function_sqlbody('my_function'::regproc::oid);
+~~~
+
+~~~
+pg_get_function_sqlbody
+-------------------------
+NULL
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+-- Query with a built-in function
+SELECT pg_get_function_sqlbody('upper'::regproc::oid);
+~~~
+
+~~~
+pg_get_function_sqlbody
+-------------------------
+NULL
+~~~
+
+**See also**:
+- [`pg_get_functiondef()`]({% link {{ page.version.version }}/functions-and-operators.md %}#system-info-functions) - Get the complete definition of a function
+- [`pg_proc`]({% link {{ page.version.version }}/pg-catalog.md %}) - PostgreSQL system catalog for functions
+- [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})


### PR DESCRIPTION
Reference doc draft for **docs: document pg_get_function_sqlbody function from PR #169716** (new page).

**File:** `src/current/v26.1/functions.md`
**Type:** New page with Jekyll frontmatter
**Source PR:** https://github.com/cockroachdb/cockroach/pull/169716/files

---
_Created from the docs dashboard. Review the generated content and merge when ready._

---
Source: cockroachdb/cockroach#169716
_Created from the docs dashboard._
