### PR TITLE
Add zed settings files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules
 /src/*/vendor/
 spec_30_enriched.json
 .bundle/config
+.zed


### PR DESCRIPTION
Zed 1.0 moves its workplace settings file to .zed in the root directory. Adding to gitignore for myself and others who may switch to the editor.