### PR TITLE
ref-docs: logstore: use SingleDelete for raft log entries

### DIFF
--- a/src/current/v26.1/cockroach-commands.md
+++ b/src/current/v26.1/cockroach-commands.md
@@ -57,3 +57,9 @@ CockroachDB prioritizes command flags, environment variables, and defaults as fo
 1. If there's no flag default, CockroachDB gives an error.
 
 For more details, see [Client Connection Parameters]({% link {{ page.version.version }}/connection-parameters.md %}).
+
+<!-- REF DOC DRAFT: The following content was auto-generated. Please integrate into the sections above and remove this comment block. -->
+
+Prompt 'cli_commands_draft' could not be found or contains no messages
+
+<!-- END REF DOC DRAFT -->


### PR DESCRIPTION
Reference doc draft for **logstore: use SingleDelete for raft log entries** (update to existing page).

**File:** [`src/current/v26.1/cockroach-commands.md`](https://github.com/cockroachdb/docs/blob/main/src/current/v26.1/cockroach-commands.md)
**Type:** Update - draft content appended at the bottom of the existing file
**Source PR:** https://github.com/cockroachdb/cockroach/pull/169641/files

---
_Created from the docs dashboard. The AI draft is appended at the bottom of the existing file between `<!-- REF DOC DRAFT -->` comments. Please integrate the draft content into the appropriate sections above and remove the comment markers._

---
Source: cockroachdb/cockroach#169641
_Created from the docs dashboard._
