### PR TITLE
ref-docs: sql/schemachanger: add support for renaming of enum types

### DIFF
--- a/src/current/v26.1/sql-statements.md
+++ b/src/current/v26.1/sql-statements.md
@@ -220,3 +220,9 @@ Statement | Usage
 [`CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/create-external-connection.md %}) | Create an external connection, which represents a provider-specific URI, to interact with resources that are external from CockroachDB.
 [`SHOW CREATE EXTERNAL CONNECTION`]({% link {{ page.version.version }}/show-create-external-connection.md %}) | Display the connection name and the creation statements for active external connections.
 [`DROP EXTERNAL CONNECTION`]({% link {{ page.version.version }}/drop-external-connection.md %}) | Drop an external connection.
+
+<!-- REF DOC DRAFT: The following content was auto-generated. Please integrate into the sections above and remove this comment block. -->
+
+Prompt 'sql_statements_draft' could not be found or contains no messages
+
+<!-- END REF DOC DRAFT -->


### PR DESCRIPTION
Reference doc draft for **sql/schemachanger: add support for renaming of enum types** (update to existing page).

**File:** [`src/current/v26.1/sql-statements.md`](https://github.com/cockroachdb/docs/blob/main/src/current/v26.1/sql-statements.md)
**Type:** Update - draft content appended at the bottom of the existing file
**Source PR:** https://github.com/cockroachdb/cockroach/pull/166593/files

---
_Created from the docs dashboard. The AI draft is appended at the bottom of the existing file between `<!-- REF DOC DRAFT -->` comments. Please integrate the draft content into the appropriate sections above and remove the comment markers._

---
Source: cockroachdb/cockroach#166593
_Created from the docs dashboard._
