### PR TITLE
ref-docs: release-26.2: cloud/amazon: retry s3 requests on credential-expiry errors

### DIFF
--- a/src/current/v26.1/system-catalogs.md
+++ b/src/current/v26.1/system-catalogs.md
@@ -43,3 +43,9 @@ To see all of the system catalogs for the [current database]({% link {{ page.ver
 - [`SHOW`]({% link {{ page.version.version }}/show-vars.md %})
 - [`SHOW SCHEMAS`]({% link {{ page.version.version }}/show-schemas.md %})
 - [SQL Name Resolution]({% link {{ page.version.version }}/sql-name-resolution.md %})
+
+<!-- REF DOC DRAFT: The following content was auto-generated. Please integrate into the sections above and remove this comment block. -->
+
+Prompt 'system_tables_draft' could not be found or contains no messages
+
+<!-- END REF DOC DRAFT -->


### PR DESCRIPTION
Reference doc draft for **release-26.2: cloud/amazon: retry s3 requests on credential-expiry errors** (update to existing page).

**File:** [`src/current/v26.1/system-catalogs.md`](https://github.com/cockroachdb/docs/blob/main/src/current/v26.1/system-catalogs.md)
**Type:** Update - draft content appended at the bottom of the existing file
**Source PR:** https://github.com/cockroachdb/cockroach/pull/169775/files

---
_Created from the docs dashboard. The AI draft is appended at the bottom of the existing file between `<!-- REF DOC DRAFT -->` comments. Please integrate the draft content into the appropriate sections above and remove the comment markers._

---
Source: cockroachdb/cockroach#169775
_Created from the docs dashboard._
