### PR TITLE
Fix trigger privilege documentation

### DIFF
--- a/src/current/_includes/v24.3/sql/privileges.md
+++ b/src/current/_includes/v24.3/sql/privileges.md
@@ -23,6 +23,7 @@ Privilege | Levels | Description
 `REPLICATION` | System | Grants the ability to create a [logical data replication]({% link {{ page.version.version }}/logical-data-replication-overview.md %}) or [physical cluster replication]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}) stream.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/query-data.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update-data.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/_includes/v25.1/sql/privileges.md
+++ b/src/current/_includes/v25.1/sql/privileges.md
@@ -23,6 +23,7 @@ Privilege | Levels | Description
 `REPLICATION` | System | Grants the ability to create a [logical data replication]({% link {{ page.version.version }}/logical-data-replication-overview.md %}) or [physical cluster replication]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}) stream.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/query-data.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update-data.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/_includes/v25.2/sql/privileges.md
+++ b/src/current/_includes/v25.2/sql/privileges.md
@@ -25,6 +25,7 @@ Privilege | Levels | Description
 <a id="replicationsource"></a><span class="version-tag">New in v25.2:</span> `REPLICATIONSOURCE` | Table | Grants the ability to run logical data replication from a table on the source cluster. For more details, refer to the [Set Up Logical Data Replication]({% link {{ page.version.version }}/set-up-logical-data-replication.md %}) tutorial.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/query-data.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update-data.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/_includes/v25.3/sql/privileges.md
+++ b/src/current/_includes/v25.3/sql/privileges.md
@@ -26,6 +26,7 @@ Privilege | Levels | Description
 <a id="replicationsource"></a>`REPLICATIONSOURCE` | Table | Grants the ability to run logical data replication from a table on the source cluster. For more details, refer to the [Set Up Logical Data Replication]({% link {{ page.version.version }}/set-up-logical-data-replication.md %}) tutorial.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/query-data.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update-data.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/_includes/v25.4/sql/privileges.md
+++ b/src/current/_includes/v25.4/sql/privileges.md
@@ -26,6 +26,7 @@ Privilege | Levels | Description
 <a id="replicationsource"></a>`REPLICATIONSOURCE` | Table | Grants the ability to run logical data replication from a table on the source cluster. For more details, refer to the [Set Up Logical Data Replication]({% link {{ page.version.version }}/set-up-logical-data-replication.md %}) tutorial.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/query-data.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update-data.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/_includes/v26.1/sql/privileges.md
+++ b/src/current/_includes/v26.1/sql/privileges.md
@@ -27,6 +27,7 @@ Privilege | Levels | Description
 <a id="replicationsource"></a>`REPLICATIONSOURCE` | Table | Grants the ability to run logical data replication from a table on the source cluster. For more details, refer to the [Set Up Logical Data Replication]({% link {{ page.version.version }}/set-up-logical-data-replication.md %}) tutorial.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/selection-queries.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/_includes/v26.2/sql/privileges.md
+++ b/src/current/_includes/v26.2/sql/privileges.md
@@ -28,6 +28,7 @@ Privilege | Levels | Description
 <a id="replicationsource"></a>`REPLICATIONSOURCE` | Table | Grants the ability to run logical data replication from a table on the source cluster. For more details, refer to the [Set Up Logical Data Replication]({% link {{ page.version.version }}/set-up-logical-data-replication.md %}) tutorial.
 `RESTORE` | System, Database | Grants the ability to restore [backups]({% link {{ page.version.version }}/backup-and-restore-overview.md %}) at the system or database level. Refer to `RESTORE` [Required privileges]({% link {{ page.version.version }}/restore.md %}#required-privileges) for more details.
 `SELECT` | Table, Sequence | Grants the ability to run [selection queries]({% link {{ page.version.version }}/selection-queries.md %}) at the table or sequence level.
+`TRIGGER` | Table | Grants the ability to create [triggers]({% link {{ page.version.version }}/triggers.md %}) on a table.
 `UPDATE` | Table, Sequence | Grants the ability to run [update statements]({% link {{ page.version.version }}/update.md %}) at the table or sequence level.
 `USAGE` | Schema, Sequence, Type | Grants the ability to use [schemas]({% link {{ page.version.version }}/schema-design-overview.md %}), [sequences]({% link {{ page.version.version }}/create-sequence.md %}), or [user-defined types]({% link {{ page.version.version }}/create-type.md %}).
 <a id="viewactivity"></a>`VIEWACTIVITY` | System | Grants the ability to view other user's activity statistics of a cluster.

--- a/src/current/v24.3/create-trigger.md
+++ b/src/current/v24.3/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v24.3/drop-trigger.md
+++ b/src/current/v24.3/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 

--- a/src/current/v25.1/create-trigger.md
+++ b/src/current/v25.1/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v25.1/drop-trigger.md
+++ b/src/current/v25.1/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 

--- a/src/current/v25.2/create-trigger.md
+++ b/src/current/v25.2/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v25.2/drop-trigger.md
+++ b/src/current/v25.2/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 

--- a/src/current/v25.3/create-trigger.md
+++ b/src/current/v25.3/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v25.3/drop-trigger.md
+++ b/src/current/v25.3/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 

--- a/src/current/v25.4/create-trigger.md
+++ b/src/current/v25.4/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v25.4/drop-trigger.md
+++ b/src/current/v25.4/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 

--- a/src/current/v26.1/create-trigger.md
+++ b/src/current/v26.1/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v26.1/drop-trigger.md
+++ b/src/current/v26.1/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 

--- a/src/current/v26.2/create-trigger.md
+++ b/src/current/v26.2/create-trigger.md
@@ -10,7 +10,7 @@ The `CREATE TRIGGER` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To create a trigger, a user must have [`CREATE` privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#supported-privileges) on the schema of the trigger.
+To create a trigger, a user must have the `TRIGGER` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `EXECUTE` privilege on the trigger function. By default, the `public` role has `EXECUTE` privilege on all functions, so this is granted automatically unless it has been revoked.
 
 ## Synopsis
 

--- a/src/current/v26.2/drop-trigger.md
+++ b/src/current/v26.2/drop-trigger.md
@@ -10,7 +10,7 @@ The `DROP TRIGGER` [statement]({% link {{ page.version.version }}/sql-statements
 
 ## Required privileges
 
-To drop a trigger, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the trigger.
+To drop a trigger, the user must be the owner of the table on which the trigger is defined.
 
 ## Synopsis
 


### PR DESCRIPTION
The CREATE TRIGGER and DROP TRIGGER pages had incorrect required- privilege descriptions. Corrected based on the actual privilege checks in pkg/sql/schemachanger/scbuild/internal/scbuildstmt:

- DROP TRIGGER requires ownership of the table on which the trigger is defined, not a `DROP` privilege on the trigger (no such privilege exists).
- CREATE TRIGGER requires the `TRIGGER` privilege on the table and `EXECUTE` on the trigger function, not `CREATE` on the schema. The `EXECUTE` privilege is granted by default via the `public` role.

Also added the `TRIGGER` privilege to the supported privileges table in the authorization reference, where it was previously undocumented.

Applied to v24.3 through v26.2.

The mistake was introduced in b93b0b998.

Refs:
- Slack: https://cockroachlabs.slack.com/archives/C04U1BTF8/p1778688732548209?thread_ts=1778687470.432449&cid=C04U1BTF8
- CRDB-42942
- DOC-11410