### PR TITLE
Document SHOW TRIGGERS and SHOW CREATE TRIGGER

### DIFF
--- a/src/current/_includes/v25.3/sidebar-data/sql.json
+++ b/src/current/_includes/v25.3/sidebar-data/sql.json
@@ -827,6 +827,12 @@
               ]
             },
             {
+              "title": "<code>SHOW TRIGGERS</code>",
+              "urls": [
+                "/${VERSION}/show-triggers.html"
+              ]
+            },
+            {
               "title": "<code>SHOW TYPES</code>",
               "urls": [
                 "/${VERSION}/show-types.html"

--- a/src/current/_includes/v25.4/sidebar-data/sql.json
+++ b/src/current/_includes/v25.4/sidebar-data/sql.json
@@ -833,6 +833,12 @@
               ]
             },
             {
+              "title": "<code>SHOW TRIGGERS</code>",
+              "urls": [
+                "/${VERSION}/show-triggers.html"
+              ]
+            },
+            {
               "title": "<code>SHOW TYPES</code>",
               "urls": [
                 "/${VERSION}/show-types.html"

--- a/src/current/_includes/v26.1/sidebar-data/sql.json
+++ b/src/current/_includes/v26.1/sidebar-data/sql.json
@@ -851,6 +851,12 @@
               ]
             },
             {
+              "title": "<code>SHOW TRIGGERS</code>",
+              "urls": [
+                "/${VERSION}/show-triggers.html"
+              ]
+            },
+            {
               "title": "<code>SHOW TYPES</code>",
               "urls": [
                 "/${VERSION}/show-types.html"

--- a/src/current/_includes/v26.2/sidebar-data/sql.json
+++ b/src/current/_includes/v26.2/sidebar-data/sql.json
@@ -851,6 +851,12 @@
               ]
             },
             {
+              "title": "<code>SHOW TRIGGERS</code>",
+              "urls": [
+                "/${VERSION}/show-triggers.html"
+              ]
+            },
+            {
               "title": "<code>SHOW TYPES</code>",
               "urls": [
                 "/${VERSION}/show-types.html"

--- a/src/current/v25.3/create-trigger.md
+++ b/src/current/v25.3/create-trigger.md
@@ -185,6 +185,8 @@ SELECT * FROM stock;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v25.3/drop-trigger.md
+++ b/src/current/v25.3/drop-trigger.md
@@ -69,4 +69,6 @@ DROP TRIGGER log_update_timestamp ON users;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})

--- a/src/current/v25.3/show-create.md
+++ b/src/current/v25.3/show-create.md
@@ -1,15 +1,15 @@
 ---
 title: SHOW CREATE
-summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, view, or sequence.
+summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, trigger, view, or sequence.
 toc: true
 docs_area: reference.sql
 ---
 
-The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
+The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [trigger]({% link {{ page.version.version }}/create-trigger.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
 
 ## Required privileges
 
-The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence.
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence. To run `SHOW CREATE TRIGGER`, the user must have any privilege on the table on which the trigger is defined.
 
 ## Synopsis
 
@@ -22,6 +22,7 @@ The user must have any [privilege]({% link {{ page.version.version }}/security-r
 Parameter | Description
 ----------|------------
 `object_name` | The name of the database, function, table, view, or sequence for which to show the `CREATE` statement.
+`TRIGGER trigger_name ON table_name` | Show the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}) on the specified table.
 `ALL TABLES` | Show the `CREATE` statements for all tables, views, and sequences in the current database.<br>This option is intended to provide the statements required to recreate the objects in the current database. As a result, `SHOW CREATE ALL TABLES` also returns the [`ALTER` statements]({% link {{ page.version.version }}/alter-table.md %}) that add, modify, and validate an object's [constraints]({% link {{ page.version.version }}/constraints.md %}). The `ALTER` statements follow the `CREATE` statements to guarantee that all objects are added before their references.
 `ALL SCHEMAS` | Show the `CREATE` statements for all [schemas]({% link {{ page.version.version }}/create-schema.md %}) in the current database.
 `ALL TYPES` | Show the `CREATE` statements for all [types]({% link {{ page.version.version }}/create-type.md %}) in the current database.
@@ -33,7 +34,8 @@ Field | Description
 `table_name` | The name of the table, view, or sequence.
 `database_name` | The name of the database.
 `function_name` | The name of the function.
-`create_statement` | The `CREATE` statement for the database, function, table, view, or sequence.
+`trigger_name` | The name of the trigger (when running `SHOW CREATE TRIGGER`).
+`create_statement` | The `CREATE` statement for the database, function, table, trigger, view, or sequence.
 
 ## Example
 
@@ -343,6 +345,48 @@ The following statement defines a function to return the number of rows in the `
 (1 row)
 ~~~
 
+### Show the `CREATE TRIGGER` statement for a trigger
+
+To return the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}), use `SHOW CREATE TRIGGER` and specify the trigger name and the table on which the trigger is defined.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE FUNCTION update_timestamp()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE 'Current timestamp: %', now();
+    RETURN NEW;
+  END;
+  $$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TRIGGER log_update_timestamp
+  AFTER UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION update_timestamp();
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TRIGGER log_update_timestamp ON users;
+~~~
+
+~~~
+      trigger_name     |                                                               create_statement
+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------
+  log_update_timestamp | CREATE TRIGGER log_update_timestamp AFTER UPDATE ON defaultdb.public.users FOR EACH ROW EXECUTE FUNCTION defaultdb.public.update_timestamp()
+(1 row)
+~~~
+
+To list the triggers on a table, use [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}).
+
 ### Show the statements needed to recreate all tables, views, and sequences in the current database
 
 To return the `CREATE` statements for all of the tables, views, and sequences in the current database, use `SHOW CREATE ALL TABLES`.
@@ -510,7 +554,9 @@ The `SHOW CREATE DATABASE` output includes the database regions.
 
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-table.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`CREATE VIEW`]({% link {{ page.version.version }}/create-view.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-sequence.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
 - [Information Schema]({% link {{ page.version.version }}/information-schema.md %})
 - [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v25.3/show-triggers.md
+++ b/src/current/v25.3/show-triggers.md
@@ -1,0 +1,81 @@
+---
+title: SHOW TRIGGERS
+summary: The SHOW TRIGGERS statement lists the triggers on a table.
+toc: true
+docs_area: reference.sql
+---
+
+The `SHOW TRIGGERS` [statement]({% link {{ page.version.version }}/sql-statements.md %}) lists the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
+
+## Required privileges
+
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target table.
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_triggers.html %}
+</div>
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table for which to list triggers.
+
+## Response
+
+Field | Description
+------|------------
+`trigger_name` | The name of the trigger.
+`enabled` | Whether the trigger is enabled.
+
+## Example
+
+Create a sample table and trigger:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'Current timestamp: %', now();
+  RETURN NEW;
+END;
+$$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TRIGGER log_update_timestamp
+AFTER UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_timestamp();
+~~~
+
+List the triggers on the table:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TRIGGERS FROM users;
+~~~
+
+~~~
+      trigger_name     | enabled
+-----------------------+----------
+  log_update_timestamp |    t
+(1 row)
+~~~
+
+## See also
+
+- [Triggers]({% link {{ page.version.version }}/triggers.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
+- [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v25.3/sql-statements.md
+++ b/src/current/v25.3/sql-statements.md
@@ -53,7 +53,7 @@ Statement | Usage
 [`REFRESH`]({% link {{ page.version.version }}/refresh.md %}) | Refresh the stored query results of a [materialized view]({% link {{ page.version.version }}/views.md %}#materialized-views).
 [`SHOW COLUMNS`]({% link {{ page.version.version }}/show-columns.md %}) | View details about columns in a table.
 [`SHOW CONSTRAINTS`]({% link {{ page.version.version }}/show-constraints.md %}) | List constraints on a table.
-[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, or view.
+[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, [trigger]({% link {{ page.version.version }}/triggers.md %}), or view.
 [`SHOW DATABASES`]({% link {{ page.version.version }}/show-databases.md %}) | List databases in the cluster.
 [`SHOW DEFAULT SESSION VARIABLES FOR ROLE`]({% link {{ page.version.version }}/show-default-session-variables-for-role.md %}) | List the values for updated [session variables]({% link {{ page.version.version }}/set-vars.md %}) that are applied to a given [user or role]({% link {{ page.version.version }}/security-reference/authorization.md %}#roles).
 [`SHOW ENUMS`]({% link {{ page.version.version }}/show-enums.md %}) | List user-defined, [enumerated data types]({% link {{ page.version.version }}/enum.md %}) in a database.
@@ -66,6 +66,7 @@ Statement | Usage
 [`SHOW SCHEMAS`]({% link {{ page.version.version }}/show-schemas.md %}) | List the schemas in a database.
 [`SHOW SEQUENCES`]({% link {{ page.version.version }}/show-sequences.md %}) | List the sequences in a database.
 [`SHOW TABLES`]({% link {{ page.version.version }}/show-tables.md %}) | List tables or views in a database or virtual schema.
+[`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}) | List the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
 [`SHOW TYPES`]({% link {{ page.version.version }}/show-types.md %}) | List user-defined [data types]({% link {{ page.version.version }}/data-types.md %}) in a database.
 [`SHOW RANGES`]({% link {{ page.version.version }}/show-ranges.md %}) | Show range information for all data in a table or index.
 [`SHOW RANGE FOR ROW`]({% link {{ page.version.version }}/show-range-for-row.md %}) | Show range information for a single row in a table or index.

--- a/src/current/v25.3/triggers.md
+++ b/src/current/v25.3/triggers.md
@@ -522,6 +522,8 @@ For a deep-dive demo on triggers, play the following video:
 
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v25.4/create-trigger.md
+++ b/src/current/v25.4/create-trigger.md
@@ -185,6 +185,8 @@ SELECT * FROM stock;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v25.4/drop-trigger.md
+++ b/src/current/v25.4/drop-trigger.md
@@ -69,4 +69,6 @@ DROP TRIGGER log_update_timestamp ON users;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})

--- a/src/current/v25.4/show-create.md
+++ b/src/current/v25.4/show-create.md
@@ -1,15 +1,15 @@
 ---
 title: SHOW CREATE
-summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, view, or sequence.
+summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, trigger, view, or sequence.
 toc: true
 docs_area: reference.sql
 ---
 
-The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
+The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [trigger]({% link {{ page.version.version }}/create-trigger.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
 
 ## Required privileges
 
-The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence.
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence. To run `SHOW CREATE TRIGGER`, the user must have any privilege on the table on which the trigger is defined.
 
 ## Synopsis
 
@@ -22,6 +22,7 @@ The user must have any [privilege]({% link {{ page.version.version }}/security-r
 Parameter | Description
 ----------|------------
 `object_name` | The name of the database, function, table, view, or sequence for which to show the `CREATE` statement.
+`TRIGGER trigger_name ON table_name` | Show the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}) on the specified table.
 `ALL TABLES` | Show the `CREATE` statements for all tables, views, and sequences in the current database.<br>This option is intended to provide the statements required to recreate the objects in the current database. As a result, `SHOW CREATE ALL TABLES` also returns the [`ALTER` statements]({% link {{ page.version.version }}/alter-table.md %}) that add, modify, and validate an object's [constraints]({% link {{ page.version.version }}/constraints.md %}). The `ALTER` statements follow the `CREATE` statements to guarantee that all objects are added before their references.
 `ALL SCHEMAS` | Show the `CREATE` statements for all [schemas]({% link {{ page.version.version }}/create-schema.md %}) in the current database.
 `ALL TYPES` | Show the `CREATE` statements for all [types]({% link {{ page.version.version }}/create-type.md %}) in the current database.
@@ -33,7 +34,8 @@ Field | Description
 `table_name` | The name of the table, view, or sequence.
 `database_name` | The name of the database.
 `function_name` | The name of the function.
-`create_statement` | The `CREATE` statement for the database, function, table, view, or sequence.
+`trigger_name` | The name of the trigger (when running `SHOW CREATE TRIGGER`).
+`create_statement` | The `CREATE` statement for the database, function, table, trigger, view, or sequence.
 
 ## Example
 
@@ -343,6 +345,48 @@ The following statement defines a function to return the number of rows in the `
 (1 row)
 ~~~
 
+### Show the `CREATE TRIGGER` statement for a trigger
+
+To return the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}), use `SHOW CREATE TRIGGER` and specify the trigger name and the table on which the trigger is defined.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE FUNCTION update_timestamp()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE 'Current timestamp: %', now();
+    RETURN NEW;
+  END;
+  $$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TRIGGER log_update_timestamp
+  AFTER UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION update_timestamp();
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TRIGGER log_update_timestamp ON users;
+~~~
+
+~~~
+      trigger_name     |                                                               create_statement
+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------
+  log_update_timestamp | CREATE TRIGGER log_update_timestamp AFTER UPDATE ON defaultdb.public.users FOR EACH ROW EXECUTE FUNCTION defaultdb.public.update_timestamp()
+(1 row)
+~~~
+
+To list the triggers on a table, use [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}).
+
 ### Show the statements needed to recreate all tables, views, and sequences in the current database
 
 To return the `CREATE` statements for all of the tables, views, and sequences in the current database, use `SHOW CREATE ALL TABLES`.
@@ -510,7 +554,9 @@ The `SHOW CREATE DATABASE` output includes the database regions.
 
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-table.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`CREATE VIEW`]({% link {{ page.version.version }}/create-view.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-sequence.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
 - [Information Schema]({% link {{ page.version.version }}/information-schema.md %})
 - [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v25.4/show-triggers.md
+++ b/src/current/v25.4/show-triggers.md
@@ -1,0 +1,81 @@
+---
+title: SHOW TRIGGERS
+summary: The SHOW TRIGGERS statement lists the triggers on a table.
+toc: true
+docs_area: reference.sql
+---
+
+The `SHOW TRIGGERS` [statement]({% link {{ page.version.version }}/sql-statements.md %}) lists the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
+
+## Required privileges
+
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target table.
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_triggers.html %}
+</div>
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table for which to list triggers.
+
+## Response
+
+Field | Description
+------|------------
+`trigger_name` | The name of the trigger.
+`enabled` | Whether the trigger is enabled.
+
+## Example
+
+Create a sample table and trigger:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'Current timestamp: %', now();
+  RETURN NEW;
+END;
+$$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TRIGGER log_update_timestamp
+AFTER UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_timestamp();
+~~~
+
+List the triggers on the table:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TRIGGERS FROM users;
+~~~
+
+~~~
+      trigger_name     | enabled
+-----------------------+----------
+  log_update_timestamp |    t
+(1 row)
+~~~
+
+## See also
+
+- [Triggers]({% link {{ page.version.version }}/triggers.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
+- [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v25.4/sql-statements.md
+++ b/src/current/v25.4/sql-statements.md
@@ -54,7 +54,7 @@ Statement | Usage
 [`REFRESH`]({% link {{ page.version.version }}/refresh.md %}) | Refresh the stored query results of a [materialized view]({% link {{ page.version.version }}/views.md %}#materialized-views).
 [`SHOW COLUMNS`]({% link {{ page.version.version }}/show-columns.md %}) | View details about columns in a table.
 [`SHOW CONSTRAINTS`]({% link {{ page.version.version }}/show-constraints.md %}) | List constraints on a table.
-[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, or view.
+[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, [trigger]({% link {{ page.version.version }}/triggers.md %}), or view.
 [`SHOW DATABASES`]({% link {{ page.version.version }}/show-databases.md %}) | List databases in the cluster.
 [`SHOW DEFAULT SESSION VARIABLES FOR ROLE`]({% link {{ page.version.version }}/show-default-session-variables-for-role.md %}) | List the values for updated [session variables]({% link {{ page.version.version }}/set-vars.md %}) that are applied to a given [user or role]({% link {{ page.version.version }}/security-reference/authorization.md %}#roles).
 [`SHOW ENUMS`]({% link {{ page.version.version }}/show-enums.md %}) | List user-defined, [enumerated data types]({% link {{ page.version.version }}/enum.md %}) in a database.
@@ -67,6 +67,7 @@ Statement | Usage
 [`SHOW SCHEMAS`]({% link {{ page.version.version }}/show-schemas.md %}) | List the schemas in a database.
 [`SHOW SEQUENCES`]({% link {{ page.version.version }}/show-sequences.md %}) | List the sequences in a database.
 [`SHOW TABLES`]({% link {{ page.version.version }}/show-tables.md %}) | List tables or views in a database or virtual schema.
+[`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}) | List the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
 [`SHOW TYPES`]({% link {{ page.version.version }}/show-types.md %}) | List user-defined [data types]({% link {{ page.version.version }}/data-types.md %}) in a database.
 [`SHOW RANGES`]({% link {{ page.version.version }}/show-ranges.md %}) | Show range information for all data in a table or index.
 [`SHOW RANGE FOR ROW`]({% link {{ page.version.version }}/show-range-for-row.md %}) | Show range information for a single row in a table or index.

--- a/src/current/v25.4/triggers.md
+++ b/src/current/v25.4/triggers.md
@@ -522,6 +522,8 @@ For a deep-dive demo on triggers, play the following video:
 
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v26.1/create-trigger.md
+++ b/src/current/v26.1/create-trigger.md
@@ -185,6 +185,8 @@ SELECT * FROM stock;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v26.1/drop-trigger.md
+++ b/src/current/v26.1/drop-trigger.md
@@ -69,4 +69,6 @@ DROP TRIGGER log_update_timestamp ON users;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})

--- a/src/current/v26.1/show-create.md
+++ b/src/current/v26.1/show-create.md
@@ -1,15 +1,15 @@
 ---
 title: SHOW CREATE
-summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, view, or sequence.
+summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, trigger, view, or sequence.
 toc: true
 docs_area: reference.sql
 ---
 
-The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
+The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [trigger]({% link {{ page.version.version }}/create-trigger.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
 
 ## Required privileges
 
-The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence.
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence. To run `SHOW CREATE TRIGGER`, the user must have any privilege on the table on which the trigger is defined.
 
 ## Synopsis
 
@@ -22,6 +22,7 @@ The user must have any [privilege]({% link {{ page.version.version }}/security-r
 Parameter | Description
 ----------|------------
 `object_name` | The name of the database, function, table, view, or sequence for which to show the `CREATE` statement.
+`TRIGGER trigger_name ON table_name` | Show the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}) on the specified table.
 `ALL TABLES` | Show the `CREATE` statements for all tables, views, and sequences in the current database.<br>This option is intended to provide the statements required to recreate the objects in the current database. As a result, `SHOW CREATE ALL TABLES` also returns the [`ALTER` statements]({% link {{ page.version.version }}/alter-table.md %}) that add, modify, and validate an object's [constraints]({% link {{ page.version.version }}/constraints.md %}). The `ALTER` statements follow the `CREATE` statements to guarantee that all objects are added before their references.
 `ALL SCHEMAS` | Show the `CREATE` statements for all [schemas]({% link {{ page.version.version }}/create-schema.md %}) in the current database.
 `ALL TYPES` | Show the `CREATE` statements for all [types]({% link {{ page.version.version }}/create-type.md %}) in the current database.
@@ -33,7 +34,8 @@ Field | Description
 `table_name` | The name of the table, view, or sequence.
 `database_name` | The name of the database.
 `function_name` | The name of the function.
-`create_statement` | The `CREATE` statement for the database, function, table, view, or sequence.
+`trigger_name` | The name of the trigger (when running `SHOW CREATE TRIGGER`).
+`create_statement` | The `CREATE` statement for the database, function, table, trigger, view, or sequence.
 
 ## Example
 
@@ -343,6 +345,48 @@ The following statement defines a function to return the number of rows in the `
 (1 row)
 ~~~
 
+### Show the `CREATE TRIGGER` statement for a trigger
+
+To return the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}), use `SHOW CREATE TRIGGER` and specify the trigger name and the table on which the trigger is defined.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE FUNCTION update_timestamp()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE 'Current timestamp: %', now();
+    RETURN NEW;
+  END;
+  $$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TRIGGER log_update_timestamp
+  AFTER UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION update_timestamp();
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TRIGGER log_update_timestamp ON users;
+~~~
+
+~~~
+      trigger_name     |                                                               create_statement
+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------
+  log_update_timestamp | CREATE TRIGGER log_update_timestamp AFTER UPDATE ON defaultdb.public.users FOR EACH ROW EXECUTE FUNCTION defaultdb.public.update_timestamp()
+(1 row)
+~~~
+
+To list the triggers on a table, use [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}).
+
 ### Show the statements needed to recreate all tables, views, and sequences in the current database
 
 To return the `CREATE` statements for all of the tables, views, and sequences in the current database, use `SHOW CREATE ALL TABLES`.
@@ -510,7 +554,9 @@ The `SHOW CREATE DATABASE` output includes the database regions.
 
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-table.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`CREATE VIEW`]({% link {{ page.version.version }}/create-view.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-sequence.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
 - [Information Schema]({% link {{ page.version.version }}/information-schema.md %})
 - [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v26.1/show-triggers.md
+++ b/src/current/v26.1/show-triggers.md
@@ -1,0 +1,81 @@
+---
+title: SHOW TRIGGERS
+summary: The SHOW TRIGGERS statement lists the triggers on a table.
+toc: true
+docs_area: reference.sql
+---
+
+The `SHOW TRIGGERS` [statement]({% link {{ page.version.version }}/sql-statements.md %}) lists the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
+
+## Required privileges
+
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target table.
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_triggers.html %}
+</div>
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table for which to list triggers.
+
+## Response
+
+Field | Description
+------|------------
+`trigger_name` | The name of the trigger.
+`enabled` | Whether the trigger is enabled.
+
+## Example
+
+Create a sample table and trigger:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'Current timestamp: %', now();
+  RETURN NEW;
+END;
+$$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TRIGGER log_update_timestamp
+AFTER UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_timestamp();
+~~~
+
+List the triggers on the table:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TRIGGERS FROM users;
+~~~
+
+~~~
+      trigger_name     | enabled
+-----------------------+----------
+  log_update_timestamp |    t
+(1 row)
+~~~
+
+## See also
+
+- [Triggers]({% link {{ page.version.version }}/triggers.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
+- [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v26.1/sql-statements.md
+++ b/src/current/v26.1/sql-statements.md
@@ -54,7 +54,7 @@ Statement | Usage
 [`REFRESH`]({% link {{ page.version.version }}/refresh.md %}) | Refresh the stored query results of a [materialized view]({% link {{ page.version.version }}/views.md %}#materialized-views).
 [`SHOW COLUMNS`]({% link {{ page.version.version }}/show-columns.md %}) | View details about columns in a table.
 [`SHOW CONSTRAINTS`]({% link {{ page.version.version }}/show-constraints.md %}) | List constraints on a table.
-[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, or view.
+[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, [trigger]({% link {{ page.version.version }}/triggers.md %}), or view.
 [`SHOW DATABASES`]({% link {{ page.version.version }}/show-databases.md %}) | List databases in the cluster.
 [`SHOW DEFAULT SESSION VARIABLES FOR ROLE`]({% link {{ page.version.version }}/show-default-session-variables-for-role.md %}) | List the values for updated [session variables]({% link {{ page.version.version }}/set-vars.md %}) that are applied to a given [user or role]({% link {{ page.version.version }}/security-reference/authorization.md %}#roles).
 [`SHOW ENUMS`]({% link {{ page.version.version }}/show-enums.md %}) | List user-defined, [enumerated data types]({% link {{ page.version.version }}/enum.md %}) in a database.
@@ -67,6 +67,7 @@ Statement | Usage
 [`SHOW SCHEMAS`]({% link {{ page.version.version }}/show-schemas.md %}) | List the schemas in a database.
 [`SHOW SEQUENCES`]({% link {{ page.version.version }}/show-sequences.md %}) | List the sequences in a database.
 [`SHOW TABLES`]({% link {{ page.version.version }}/show-tables.md %}) | List tables or views in a database or virtual schema.
+[`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}) | List the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
 [`SHOW TYPES`]({% link {{ page.version.version }}/show-types.md %}) | List user-defined [data types]({% link {{ page.version.version }}/data-types.md %}) in a database.
 [`SHOW RANGES`]({% link {{ page.version.version }}/show-ranges.md %}) | Show range information for all data in a table or index.
 [`SHOW RANGE FOR ROW`]({% link {{ page.version.version }}/show-range-for-row.md %}) | Show range information for a single row in a table or index.

--- a/src/current/v26.1/triggers.md
+++ b/src/current/v26.1/triggers.md
@@ -522,6 +522,8 @@ For a deep-dive demo on triggers, play the following video:
 
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v26.2/create-trigger.md
+++ b/src/current/v26.2/create-trigger.md
@@ -185,6 +185,8 @@ SELECT * FROM stock;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})

--- a/src/current/v26.2/drop-trigger.md
+++ b/src/current/v26.2/drop-trigger.md
@@ -65,4 +65,6 @@ DROP TRIGGER log_update_timestamp ON users;
 
 - [Triggers]({% link {{ page.version.version }}/triggers.md %})
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})

--- a/src/current/v26.2/show-create.md
+++ b/src/current/v26.2/show-create.md
@@ -1,15 +1,15 @@
 ---
 title: SHOW CREATE
-summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, view, or sequence.
+summary: The SHOW CREATE statement shows the CREATE statement for an existing database, function, table, trigger, view, or sequence.
 toc: true
 docs_area: reference.sql
 ---
 
-The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
+The `SHOW CREATE` [statement]({% link {{ page.version.version }}/sql-statements.md %}) shows the `CREATE` statement for an existing [database]({% link {{ page.version.version }}/create-database.md %}), [function]({% link {{ page.version.version }}/create-function.md %}), [table]({% link {{ page.version.version }}/create-table.md %}), [trigger]({% link {{ page.version.version }}/create-trigger.md %}), [view]({% link {{ page.version.version }}/create-view.md %}), or [sequence]({% link {{ page.version.version }}/create-sequence.md %}).
 
 ## Required privileges
 
-The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence.
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target database, function, table, view, or sequence. To run `SHOW CREATE TRIGGER`, the user must have any privilege on the table on which the trigger is defined.
 
 ## Synopsis
 
@@ -22,6 +22,7 @@ The user must have any [privilege]({% link {{ page.version.version }}/security-r
 Parameter | Description
 ----------|------------
 `object_name` | The name of the database, function, table, view, or sequence for which to show the `CREATE` statement.
+`TRIGGER trigger_name ON table_name` | Show the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}) on the specified table.
 `ALL TABLES` | Show the `CREATE` statements for all tables, views, and sequences in the current database.<br>This option is intended to provide the statements required to recreate the objects in the current database. As a result, `SHOW CREATE ALL TABLES` also returns the [`ALTER` statements]({% link {{ page.version.version }}/alter-table.md %}) that add, modify, and validate an object's [constraints]({% link {{ page.version.version }}/constraints.md %}). The `ALTER` statements follow the `CREATE` statements to guarantee that all objects are added before their references.
 `ALL SCHEMAS` | Show the `CREATE` statements for all [schemas]({% link {{ page.version.version }}/create-schema.md %}) in the current database.
 `ALL TYPES` | Show the `CREATE` statements for all [types]({% link {{ page.version.version }}/create-type.md %}) in the current database.
@@ -33,7 +34,8 @@ Field | Description
 `table_name` | The name of the table, view, or sequence.
 `database_name` | The name of the database.
 `function_name` | The name of the function.
-`create_statement` | The `CREATE` statement for the database, function, table, view, or sequence.
+`trigger_name` | The name of the trigger (when running `SHOW CREATE TRIGGER`).
+`create_statement` | The `CREATE` statement for the database, function, table, trigger, view, or sequence.
 
 ## Example
 
@@ -343,6 +345,48 @@ The following statement defines a function to return the number of rows in the `
 (1 row)
 ~~~
 
+### Show the `CREATE TRIGGER` statement for a trigger
+
+To return the `CREATE TRIGGER` statement for a [trigger]({% link {{ page.version.version }}/create-trigger.md %}), use `SHOW CREATE TRIGGER` and specify the trigger name and the table on which the trigger is defined.
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE FUNCTION update_timestamp()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE 'Current timestamp: %', now();
+    RETURN NEW;
+  END;
+  $$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> CREATE TRIGGER log_update_timestamp
+  AFTER UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION update_timestamp();
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TRIGGER log_update_timestamp ON users;
+~~~
+
+~~~
+      trigger_name     |                                                               create_statement
+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------
+  log_update_timestamp | CREATE TRIGGER log_update_timestamp AFTER UPDATE ON defaultdb.public.users FOR EACH ROW EXECUTE FUNCTION defaultdb.public.update_timestamp()
+(1 row)
+~~~
+
+To list the triggers on a table, use [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}).
+
 ### Show the statements needed to recreate all tables, views, and sequences in the current database
 
 To return the `CREATE` statements for all of the tables, views, and sequences in the current database, use `SHOW CREATE ALL TABLES`.
@@ -510,7 +554,9 @@ The `SHOW CREATE DATABASE` output includes the database regions.
 
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-table.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`CREATE VIEW`]({% link {{ page.version.version }}/create-view.md %})
 - [`CREATE TABLE`]({% link {{ page.version.version }}/create-sequence.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
 - [Information Schema]({% link {{ page.version.version }}/information-schema.md %})
 - [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v26.2/show-triggers.md
+++ b/src/current/v26.2/show-triggers.md
@@ -1,0 +1,81 @@
+---
+title: SHOW TRIGGERS
+summary: The SHOW TRIGGERS statement lists the triggers on a table.
+toc: true
+docs_area: reference.sql
+---
+
+The `SHOW TRIGGERS` [statement]({% link {{ page.version.version }}/sql-statements.md %}) lists the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
+
+## Required privileges
+
+The user must have any [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the target table.
+
+## Synopsis
+
+<div>
+{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/{{ page.release_info.crdb_branch_name }}/grammar_svg/show_triggers.html %}
+</div>
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table for which to list triggers.
+
+## Response
+
+Field | Description
+------|------------
+`trigger_name` | The name of the trigger.
+`enabled` | Whether the trigger is enabled.
+
+## Example
+
+Create a sample table and trigger:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TABLE users (id INT PRIMARY KEY, name STRING);
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'Current timestamp: %', now();
+  RETURN NEW;
+END;
+$$ LANGUAGE PLpgSQL;
+~~~
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE TRIGGER log_update_timestamp
+AFTER UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_timestamp();
+~~~
+
+List the triggers on the table:
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+SHOW TRIGGERS FROM users;
+~~~
+
+~~~
+      trigger_name     | enabled
+-----------------------+----------
+  log_update_timestamp |    t
+(1 row)
+~~~
+
+## See also
+
+- [Triggers]({% link {{ page.version.version }}/triggers.md %})
+- [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
+- [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
+- [SQL Statements]({% link {{ page.version.version }}/sql-statements.md %})

--- a/src/current/v26.2/sql-statements.md
+++ b/src/current/v26.2/sql-statements.md
@@ -54,7 +54,7 @@ Statement | Usage
 [`REFRESH`]({% link {{ page.version.version }}/refresh.md %}) | Refresh the stored query results of a [materialized view]({% link {{ page.version.version }}/views.md %}#materialized-views).
 [`SHOW COLUMNS`]({% link {{ page.version.version }}/show-columns.md %}) | View details about columns in a table.
 [`SHOW CONSTRAINTS`]({% link {{ page.version.version }}/show-constraints.md %}) | List constraints on a table.
-[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, or view.
+[`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %}) | View the `CREATE` statement for a database, function, sequence, table, [trigger]({% link {{ page.version.version }}/triggers.md %}), or view.
 [`SHOW DATABASES`]({% link {{ page.version.version }}/show-databases.md %}) | List databases in the cluster.
 [`SHOW DEFAULT SESSION VARIABLES FOR ROLE`]({% link {{ page.version.version }}/show-default-session-variables-for-role.md %}) | List the values for updated [session variables]({% link {{ page.version.version }}/set-vars.md %}) that are applied to a given [user or role]({% link {{ page.version.version }}/security-reference/authorization.md %}#roles).
 [`SHOW ENUMS`]({% link {{ page.version.version }}/show-enums.md %}) | List user-defined, [enumerated data types]({% link {{ page.version.version }}/enum.md %}) in a database.
@@ -67,6 +67,7 @@ Statement | Usage
 [`SHOW SCHEMAS`]({% link {{ page.version.version }}/show-schemas.md %}) | List the schemas in a database.
 [`SHOW SEQUENCES`]({% link {{ page.version.version }}/show-sequences.md %}) | List the sequences in a database.
 [`SHOW TABLES`]({% link {{ page.version.version }}/show-tables.md %}) | List tables or views in a database or virtual schema.
+[`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %}) | List the [triggers]({% link {{ page.version.version }}/triggers.md %}) defined on a table.
 [`SHOW TYPES`]({% link {{ page.version.version }}/show-types.md %}) | List user-defined [data types]({% link {{ page.version.version }}/data-types.md %}) in a database.
 [`SHOW RANGES`]({% link {{ page.version.version }}/show-ranges.md %}) | Show range information for all data in a table or index.
 [`SHOW RANGE FOR ROW`]({% link {{ page.version.version }}/show-range-for-row.md %}) | Show range information for a single row in a table or index.

--- a/src/current/v26.2/triggers.md
+++ b/src/current/v26.2/triggers.md
@@ -518,6 +518,8 @@ For a deep-dive demo on triggers, play the following video:
 
 - [`CREATE TRIGGER`]({% link {{ page.version.version }}/create-trigger.md %})
 - [`DROP TRIGGER`]({% link {{ page.version.version }}/drop-trigger.md %})
+- [`SHOW TRIGGERS`]({% link {{ page.version.version }}/show-triggers.md %})
+- [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [User-defined functions]({% link {{ page.version.version }}/user-defined-functions.md %})
 - [`CREATE FUNCTION`]({% link {{ page.version.version }}/create-function.md %})
 - [PL/pgSQL]({% link {{ page.version.version }}/plpgsql.md %})


### PR DESCRIPTION
Triggers became GA in v26.2, but the corresponding `SHOW` statements were not documented yet. This change:

- Adds a new `show-triggers.md` reference page covering the `SHOW TRIGGERS FROM <table>` statement.
- Extends `show-create.md` to cover `SHOW CREATE TRIGGER <name> ON <table>`, including a worked example.
- Adds both statements to `sql-statements.md` and the SQL sidebar.
- Adds cross-references from `triggers.md`, `create-trigger.md`, and `drop-trigger.md`.

Privilege requirements (any privilege on the target table) and example output were verified against a live cluster using a non-admin user.

Closes DOC-16395
Closes DOC-11754
Closes DOC-11755
Closes DOC-11804
Closes DOC-11805