### PR TITLE
ref-docs: docs: document pg_get_function_sqlbody builtin from PR #169716

### DIFF
--- a/src/current/v26.1/pg-get-function-sqlbody.md
+++ b/src/current/v26.1/pg-get-function-sqlbody.md
@@ -1,0 +1,8 @@
+---
+title: docs: document pg_get_function_sqlbody builtin from PR #169716
+summary: **Summary**: No CLI reference documentation required for this PR.
+toc: true
+docs_area: reference
+---
+
+**Summary**: No CLI reference documentation required for this PR.


### PR DESCRIPTION
Reference doc draft for **docs: document pg_get_function_sqlbody builtin from PR #169716** (new page).

**File:** `src/current/v26.1/pg-get-function-sqlbody.md`
**Type:** New page with Jekyll frontmatter
**Source PR:** https://github.com/cockroachdb/cockroach/pull/169716/files

---
_Created from the docs dashboard. Review the generated content and merge when ready._

---
Source: cockroachdb/cockroach#169716
_Created from the docs dashboard._
