### PR TITLE
ref-docs: security: add certificate rotation timestamp and expiry days metrics

### DIFF
--- a/src/current/v26.1/system-tables.md
+++ b/src/current/v26.1/system-tables.md
@@ -1,0 +1,19 @@
+---
+title: security: add certificate rotation timestamp and expiry days metrics
+summary: Based on the pull request diff, I can see that this PR introduces new certificate lifecycle metrics rather than system tables or views. The changes are in the metrics subsystem, adding new Prometheus-style metrics for certificate rotation timestamps and expiry days.
+toc: true
+docs_area: reference.sql
+---
+
+Based on the pull request diff, I can see that this PR introduces new certificate lifecycle metrics rather than system tables or views. The changes are in the metrics subsystem, adding new Prometheus-style metrics for certificate rotation timestamps and expiry days.
+
+Since no new system tables or views were detected in the diff (as confirmed by the "No system tables detected" note), there is no reference documentation to generate for system tables or views in this case.
+
+The PR adds two families of certificate metrics:
+
+1. **Rotation timestamp metrics** (`security.certificate.last_rotation.*`) - Unix timestamps of last certificate rotations
+2. **Expiry day metrics** (`security.certificate.expiry_days.*`) - Days remaining until certificate expiration
+
+These are exposed as Prometheus metrics through the `/_status/vars` endpoint, not as queryable system tables or views. The appropriate documentation for these would be in the monitoring/metrics reference section rather than the system tables reference.
+
+If you need documentation for these new metrics, that would be generated in a different format focused on Prometheus metric names, types, and usage for monitoring systems rather than SQL table documentation.


### PR DESCRIPTION
Reference doc draft for **security: add certificate rotation timestamp and expiry days metrics** (new page).

**File:** `src/current/v26.1/system-tables.md`
**Type:** New page with Jekyll frontmatter
**Source PR:** https://github.com/cockroachdb/cockroach/pull/167902/files

---
_Created from the docs dashboard. Review the generated content and merge when ready._

---
Source: cockroachdb/cockroach#167902
_Created from the docs dashboard._
