### PR TITLE
ref-docs: cockroach start --turbo

### DIFF
--- a/src/current/v26.1/cli.md
+++ b/src/current/v26.1/cli.md
@@ -1,0 +1,10 @@
+---
+title: cockroach start --turbo
+summary: New Flag
+toc: true
+docs_area: reference.cli
+---
+
+## New Flag
+
+--turbo enables turbo mode.


### PR DESCRIPTION
Reference doc draft for **cockroach start --turbo** (new page).

**File:** `src/current/v26.1/cli.md`
**Type:** New page with Jekyll frontmatter
**Source PR:** https://github.com/cockroachdb/cockroach/pull/170001/files

---
_Created from the docs dashboard. Review the generated content and merge when ready._

---
Source: cockroachdb/cockroach#170001
_Created from the docs dashboard._
