### PR TITLE
ref-docs: Error Handling Improvements

### DIFF
--- a/src/current/v26.1/statements.md
+++ b/src/current/v26.1/statements.md
@@ -1,0 +1,10 @@
+---
+title: Error Handling Improvements
+summary: Error Handling
+toc: true
+docs_area: reference.sql
+---
+
+## Error Handling
+
+When a query failed due to a transient error, CockroachDB now retries the request automatically. This avoids anthropic-style cascading failures.


### PR DESCRIPTION
Reference doc draft for **Error Handling Improvements** (new page).

**File:** `src/current/v26.1/statements.md`
**Type:** New page with Jekyll frontmatter
**Source PR:** https://github.com/cockroachdb/cockroach/pull/180002/files

---
_Created from the docs dashboard. Review the generated content and merge when ready._

---
Source: cockroachdb/cockroach#180002
_Created from the docs dashboard._
