### PR TITLE
ref-docs: Empty test

### DIFF
--- a/src/current/v26.1/cluster-api.md
+++ b/src/current/v26.1/cluster-api.md
@@ -80,3 +80,9 @@ The Cluster API version is defined in the request path. For example: `<cluster>/
 Future versions of CockroachDB may provide multiple API versions and will continue to provide access to this v2.0 API until it is deprecated.
 
 All endpoint paths and payloads will remain available within a major API version number (`v2.x`). Patch versions could add new endpoints but will not remove existing endpoints. For more information, see [API Support Policy]({% link {{ page.version.version }}/api-support-policy.md %}).
+
+<!-- REF DOC DRAFT: The following content was auto-generated. Please integrate into the sections above and remove this comment block. -->
+
+No new API endpoints detected in this pull request.
+
+<!-- END REF DOC DRAFT -->


### PR DESCRIPTION
Reference doc draft for **Empty test** (update to existing page).

**File:** [`src/current/v26.1/cluster-api.md`](https://github.com/cockroachdb/docs/blob/main/src/current/v26.1/cluster-api.md)
**Type:** Update - draft content appended at the bottom of the existing file
**Source PR:** https://github.com/cockroachdb/cockroach/pull/167903/files

---
_Created from the docs dashboard. The AI draft is appended at the bottom of the existing file between `<!-- REF DOC DRAFT -->` comments. Please integrate the draft content into the appropriate sections above and remove the comment markers._

---
Source: cockroachdb/cockroach#167903
_Created from the docs dashboard._
