### PR TITLE
ci: declare workflow-level `contents: read` on 1 workflows

### DIFF
--- a/.github/workflows/mark-epic-done.yml
+++ b/.github/workflows/mark-epic-done.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   mark-epic-done:
     # Only run if PR was merged and title contains "Release notes for"


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 1 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `changed_files.yml`, `cross-version-links.yml`, `pr-reviews.yml`, `validate-branch-existence.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.