### PR TITLE
ref-docs: sql: support security_invoker for views

### DIFF
--- a/src/current/v26.1/alter-view.md
+++ b/src/current/v26.1/alter-view.md
@@ -141,3 +141,186 @@ SHOW CREATE cockroach_labs.expensive_rides;
 - [`SHOW CREATE`]({% link {{ page.version.version }}/show-create.md %})
 - [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %})
 - [Online Schema Changes]({% link {{ page.version.version }}/online-schema-changes.md %})
+
+<!-- REF DOC DRAFT: The following content was auto-generated. Please integrate into the sections above and remove this comment block. -->
+
+## ALTER VIEW SET OPTIONS
+
+```yaml
+---
+title: ALTER VIEW SET OPTIONS
+summary: Set options on an existing view to control privilege behavior.
+toc: true
+docs_area: reference.sql
+---
+```
+
+Use the `ALTER VIEW SET OPTIONS` statement to configure options on an existing view. Currently, this statement supports setting the `SECURITY_INVOKER` option, which controls whether the view executes with the privileges of the view creator or the user invoking the view.
+
+## Required privileges
+
+The user must be the owner of the view.
+
+## Synopsis
+
+{% include_cached copy-clipboard.html %}
+~~~
+ALTER VIEW [IF EXISTS] view_name SET (option_name = option_value)
+~~~
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `IF EXISTS` | Do not return an error if the view does not exist |
+| `view_name` | The name of the view to modify |
+| `option_name` | The name of the option to set. Currently supports `SECURITY_INVOKER` |
+| `option_value` | The value for the option. For `SECURITY_INVOKER`, accepts `TRUE`, `FALSE`, or an integer constant |
+
+## Supported options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `SECURITY_INVOKER` | When `TRUE`, the view executes with the privileges of the user invoking the view. When `FALSE`, the view executes with the privileges of the view creator | `FALSE` |
+
+## Examples
+
+### Set security invoker to true
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER VIEW my_view SET (SECURITY_INVOKER = TRUE);
+~~~
+
+### Set security invoker to false
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER VIEW my_view SET (SECURITY_INVOKER = FALSE);
+~~~
+
+### Set security invoker with IF EXISTS
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER VIEW IF EXISTS my_view SET (SECURITY_INVOKER = TRUE);
+~~~
+
+## See also
+
+- [`CREATE VIEW`]({% link {{ page.version.version }}/create-view.md %})
+- [`ALTER VIEW RESET OPTIONS`]({% link {{ page.version.version }}/alter-view-reset-options.md %})
+- [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %})
+
+---
+
+## ALTER VIEW RESET OPTIONS
+
+```yaml
+---
+title: ALTER VIEW RESET OPTIONS
+summary: Reset view options to their default values.
+toc: true
+docs_area: reference.sql
+---
+```
+
+Use the `ALTER VIEW RESET OPTIONS` statement to reset view options to their default values. This statement currently supports resetting the `SECURITY_INVOKER` option.
+
+## Required privileges
+
+The user must be the owner of the view.
+
+## Synopsis
+
+{% include_cached copy-clipboard.html %}
+~~~
+ALTER VIEW [IF EXISTS] view_name RESET (option_name)
+~~~
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `IF EXISTS` | Do not return an error if the view does not exist |
+| `view_name` | The name of the view to modify |
+| `option_name` | The name of the option to reset. Currently supports `SECURITY_INVOKER` |
+
+## Examples
+
+### Reset security invoker option
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER VIEW my_view RESET (SECURITY_INVOKER);
+~~~
+
+### Reset with IF EXISTS
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+ALTER VIEW IF EXISTS my_view RESET (SECURITY_INVOKER);
+~~~
+
+## See also
+
+- [`CREATE VIEW`]({% link {{ page.version.version }}/create-view.md %})
+- [`ALTER VIEW SET OPTIONS`]({% link {{ page.version.version }}/alter-view-set-options.md %})
+- [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %})
+
+---
+
+## CREATE VIEW (enhanced)
+
+{{site.data.alerts.callout_info}}
+The `CREATE VIEW` statement has been enhanced to support the `WITH` clause for setting view options.
+{{site.data.alerts.end}}
+
+### Enhanced synopsis
+
+{% include_cached copy-clipboard.html %}
+~~~
+CREATE [OR REPLACE] [TEMP | TEMPORARY] VIEW [IF NOT EXISTS] view_name [(column_list)]
+  [WITH (option_name = option_value)]
+  AS select_stmt
+~~~
+
+### Additional parameters for WITH clause
+
+| Parameter | Description |
+|-----------|-------------|
+| `WITH (option_name = option_value)` | Set view options during creation |
+
+### Examples with view options
+
+#### Create a view with security invoker enabled
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE VIEW secure_view WITH (SECURITY_INVOKER = TRUE) AS 
+  SELECT * FROM sensitive_table WHERE user_id = current_user();
+~~~
+
+#### Create or replace a view with security invoker disabled
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+CREATE OR REPLACE VIEW public_view WITH (SECURITY_INVOKER = FALSE) AS
+  SELECT id, name FROM users;
+~~~
+
+## Version compatibility
+
+{{site.data.alerts.callout_info}}
+View options including `SECURITY_INVOKER` are supported in CockroachDB v26.2 and later.
+{{site.data.alerts.end}}
+
+## Behavior notes
+
+- The `SECURITY_INVOKER` option controls privilege context for view execution:
+  - When `TRUE` (security invoker), the view executes with the privileges of the current user
+  - When `FALSE` (security definer, default), the view executes with the privileges of the view creator
+- This setting affects both privilege checks and Row-Level Security (RLS) policy application
+- Previously, CockroachDB views used creator privileges for access control but invoker context for RLS, leading to inconsistent behavior [HUMAN REVIEW: Verify this behavior description is accurate]
+
+<!-- END REF DOC DRAFT -->


### PR DESCRIPTION
Reference doc draft for **sql: support security_invoker for views** (update to existing page).

**File:** [`src/current/v26.1/alter-view.md`](https://github.com/cockroachdb/docs/blob/main/src/current/v26.1/alter-view.md)
**Type:** Update - draft content appended at the bottom of the existing file
**Source PR:** https://github.com/cockroachdb/cockroach/pull/164184/files

---
_Created from the docs dashboard. The AI draft is appended at the bottom of the existing file between `<!-- REF DOC DRAFT -->` comments. Please integrate the draft content into the appropriate sections above and remove the comment markers._

---
Source: cockroachdb/cockroach#164184
_Created from the docs dashboard._
