### PR TITLE
Fix function/procedure DROP privilege documentation

### DIFF
--- a/src/current/v24.3/drop-function.md
+++ b/src/current/v24.3/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v24.3/drop-procedure.md
+++ b/src/current/v24.3/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 

--- a/src/current/v25.1/drop-function.md
+++ b/src/current/v25.1/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v25.1/drop-procedure.md
+++ b/src/current/v25.1/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 

--- a/src/current/v25.2/drop-function.md
+++ b/src/current/v25.2/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v25.2/drop-procedure.md
+++ b/src/current/v25.2/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 

--- a/src/current/v25.3/drop-function.md
+++ b/src/current/v25.3/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v25.3/drop-procedure.md
+++ b/src/current/v25.3/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 

--- a/src/current/v25.4/drop-function.md
+++ b/src/current/v25.4/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v25.4/drop-procedure.md
+++ b/src/current/v25.4/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 

--- a/src/current/v26.1/drop-function.md
+++ b/src/current/v26.1/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v26.1/drop-procedure.md
+++ b/src/current/v26.1/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 

--- a/src/current/v26.2/drop-function.md
+++ b/src/current/v26.2/drop-function.md
@@ -12,7 +12,7 @@ The `DROP FUNCTION` [statement]({% link {{ page.version.version }}/sql-statement
 
 ## Required privileges
 
-To drop a function, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the function.
+To drop a function, the user must be the owner of the function.
 
 ## Synopsis
 

--- a/src/current/v26.2/drop-procedure.md
+++ b/src/current/v26.2/drop-procedure.md
@@ -10,7 +10,7 @@ The `DROP PROCEDURE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-To drop a procedure, a user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the procedure.
+To drop a procedure, the user must be the owner of the procedure.
 
 ## Synopsis
 


### PR DESCRIPTION
The DROP FUNCTION and DROP PROCEDURE pages incorrectly stated that
a user must have the `DROP` privilege on the function/procedure.
There is no such privilege for routines — `GRANT DROP ON FUNCTION ...`
errors with `invalid privilege type DROP for routine`.

Verified against running v24.3.17 and v26.3-dev servers: dropping a
function or procedure requires that the user be the owner of the
routine. Neither `EXECUTE` nor any other granted privilege is
sufficient.

Applied to v24.3 through v26.2.

Mirrors the trigger-privilege fix in #23314.

Refs:
- Slack: https://cockroachlabs.slack.com/archives/C04U1BTF8/p1778777578301199?thread_ts=1778687470.432449&cid=C04U1BTF8