### PR TITLE
docs: clarify CHAR padding behavior

### DIFF
--- a/src/current/v23.1/string.md
+++ b/src/current/v23.1/string.md
@@ -41,7 +41,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v23.2/string.md
+++ b/src/current/v23.2/string.md
@@ -41,7 +41,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v24.1/string.md
+++ b/src/current/v24.1/string.md
@@ -41,7 +41,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v24.2/string.md
+++ b/src/current/v24.2/string.md
@@ -41,7 +41,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v24.3/string.md
+++ b/src/current/v24.3/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v25.1/string.md
+++ b/src/current/v25.1/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v25.2/string.md
+++ b/src/current/v25.2/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v25.3/string.md
+++ b/src/current/v25.3/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v25.4/string.md
+++ b/src/current/v25.4/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v26.1/string.md
+++ b/src/current/v26.1/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------

--- a/src/current/v26.2/string.md
+++ b/src/current/v26.2/string.md
@@ -42,7 +42,11 @@ When inserting a `STRING` value or a `STRING`-related-type value:
 - If the value is cast with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit. This applies to `STRING(n)` and all related types.
 - If the value exceeds the column's length limit, CockroachDB returns an error. This applies to `STRING(n)` and all related types.
 - For `STRING(n)` and `VARCHAR(n)`/`CHARACTER VARYING(n)` types, if the value is under the column's length limit, CockroachDB does **not** add space padding to the end of the value.
-- For `CHAR(n)`/`CHARACTER(n)` types, if the value is under the column's length limit, CockroachDB adds space padding from the end of the value to the length limit.
+- For `CHAR(n)`/`CHARACTER(n)` types, values shorter than the column length are displayed to SQL clients with trailing spaces added to the length limit. SQL expressions treat trailing spaces as insignificant, so functions such as `length()` evaluate the unpadded value.
+
+{{site.data.alerts.callout_info}}
+Changefeeds evaluate `CHAR(n)` values through SQL expressions, so trailing padding is not emitted unless you add it explicitly in the changefeed query, for example with `rpad()`. Use `STRING(n)`/`VARCHAR(n)` if trailing spaces must be preserved as stored data.
+{{site.data.alerts.end}}
 
                         Type                      |          Length
 --------------------------------------------------|------------------------------


### PR DESCRIPTION
Summary:
- Clarify that `CHAR(n)` values can be displayed to SQL clients with trailing padding, while SQL expressions evaluate trailing spaces as insignificant.
- Add a changefeed note explaining that trailing padding is not emitted unless explicitly restored in the changefeed query.
- Apply the update across the current versioned `string.md` pages.

Verification:
- `git diff --check`
- Confirmed the previous misleading sentence no longer appears in `src/current/*/string.md`.
- Confirmed the new changefeed note appears in 11 versioned `string.md` pages.
- `make vale` could not be run locally because `make` is not installed in this Windows shell.

This was prepared with Codex assistance, with the final diff reviewed before opening.

Fixes #23365