### PR TITLE
Fix Slack notification workflow trigger

### DIFF
--- a/.github/workflows/slack-notify-doc-review.yml
+++ b/.github/workflows/slack-notify-doc-review.yml
@@ -1,7 +1,7 @@
 name: Notify Slack on Doc Review Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [review_requested]
 
 jobs:


### PR DESCRIPTION
The `pull_request` event doesn't always fire for `review_requested`, especially for team review requests. Using `pull_request_target` ensures the workflow runs with access to secrets, matching the pattern used in other workflows like `pr-reviews.yml`.

This fixes the issue where the Slack notification wasn't triggering when docs-prs was requested as a reviewer.