### PR TITLE
Fix Slack notification: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/slack-notify-doc-review.yml
+++ b/.github/workflows/slack-notify-doc-review.yml
@@ -1,7 +1,7 @@
 name: Notify Slack on Doc Review Request
 
 on:
-  pull_request_target:
+  pull_request:
     types: [review_requested]
 
 jobs:


### PR DESCRIPTION
## Problem
The workflow was not triggering when `docs-prs` was requested as a reviewer, even though it was configured correctly with `pull_request_target` and `review_requested`.

## Root Cause
Through testing (see PR #23384), I confirmed that `pull_request_target` does **not** fire for `review_requested` events in this repository, despite being listed as a valid activity type in [GitHub's documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows).

## Solution
Switch to `pull_request` event, which successfully triggers on `review_requested`.

## Trade-off
`pull_request` doesn't have access to secrets from forked PRs, but this is acceptable since we're only targeting internal `docs-prs` team reviews.

## Testing
- Debug PR #23384 confirmed the workflow fires correctly with `pull_request`
- Event payload shows `github.event.requested_team.slug == 'docs-prs'` works as expected
- Will close and clean up PR #23384 after this is merged