### PR TITLE
ci: declare workflow-level `contents: read` on 3 PR-validation workflows

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -3,6 +3,9 @@ name: List files changed as GitHub comment
 on:
   pull_request
 
+permissions:
+  contents: read
+
 jobs:
   list-files-changed:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/cross-version-links.yml
+++ b/.github/workflows/cross-version-links.yml
@@ -7,6 +7,9 @@ on:
       - 'src/current/**/*.md'
       - 'src/current/_includes/**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   check-cross-version-links:
     name: Check for cross-version links

--- a/.github/workflows/validate-branch-existence.yml
+++ b/.github/workflows/validate-branch-existence.yml
@@ -15,6 +15,9 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-branch-existence:
     name: Check crdb_branch_name entries against generated-diagrams


### PR DESCRIPTION
Three PR-validation workflows just read the PR diff:

- `changed_files.yml`
- `cross-version-links.yml`
- `validate-branch-existence.yml`

No GitHub API writes from the workflows. Workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.