### PR TITLE
TEST: docs-prs Slack notification

### DIFF
--- a/.github/workflows/slack-notify-doc-review.yml
+++ b/.github/workflows/slack-notify-doc-review.yml
@@ -2,15 +2,22 @@ name: Notify Slack on Doc Review Request
 
 on:
   pull_request:
-    types: [review_requested]
+    types: [opened, reopened, synchronize, review_requested]
 
 jobs:
   notify-slack:
-    # Only run if docs-prs team was requested as reviewer
-    if: github.event.requested_team.slug == 'docs-prs'
     runs-on: ubuntu-latest
     steps:
+      - name: Debug event payload
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Action: ${{ github.event.action }}"
+          echo "Requested team: ${{ github.event.requested_team.slug }}"
+          echo "All requested teams:"
+          echo '${{ toJSON(github.event.pull_request.requested_teams) }}' | jq -r '.[].slug'
+
       - name: Send Slack notification
+        if: contains(fromJSON(toJSON(github.event.pull_request.requested_teams.*.slug)), 'docs-prs')
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOC_REVIEW_WEBHOOK_URL }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/test-slack-notification.md
+++ b/test-slack-notification.md
@@ -1,0 +1,1 @@
+# Test PR for docs-prs Slack notification


### PR DESCRIPTION
Testing that requesting docs-prs as reviewer triggers Slack notification in #doc_review. Will close immediately after testing.