### PR TITLE
release notes: remove duplicate bug-fix bullet from v24.1.29

### DIFF
--- a/src/current/_includes/releases/v24.1/v24.1.29.md
+++ b/src/current/_includes/releases/v24.1/v24.1.29.md
@@ -6,11 +6,8 @@ Release Date: May 12, 2026
 
 <h3 id="v24-1-29-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where concurrent updates to a table using multiple column families during a partial index creation could result in data loss, incorrect `NULL` values, or validation failures in the resulting index. #168782
 - Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels. #169973
 - Fixed a bug that allowed foreign-key violations to result from some combinations of concurrent `READ COMMITTED` and `SERIALIZABLE` transactions. If both `SERIALIZABLE` and weaker-isolation transactions will concurrently modify rows involved in foreign-key relationships, the `SERIALIZABLE` transactions must have the following session variables set in order to prevent any possible foreign-key violations: 
   - `SET enable_implicit_fk_locking_for_serializable = on;`
   - `SET enable_shared_locking_for_serializable = on;`
   - `SET enable_durable_locking_for_serializable = on;` #169973
-
-


### PR DESCRIPTION
The following bullet was inadvertently duplicated from the v24.1.28 release notes into v24.1.29. It does not apply to v24.1.29 and is removed here.

> Fixed a bug where concurrent updates to a table using multiple column families during a partial index creation could result in data loss, incorrect `NULL` values, or validation failures in the resulting index.
