### PR TITLE
Fix formatting of PR refs in release notes

### DIFF
--- a/src/current/_includes/releases/v23.2/v23.2.22.md
+++ b/src/current/_includes/releases/v23.2/v23.2.22.md
@@ -6,21 +6,16 @@ Release Date: April 2, 2025
 
 <h3 id="v23-2-22-general-changes">General changes</h3>
 
-- The protected timestamp (PTS) records of running changefeeds are now updated when the set of targets changes, such as when system tables are added to the protected tables list.
- #141157
+- The protected timestamp (PTS) records of running changefeeds are now updated when the set of targets changes, such as when system tables are added to the protected tables list. #141157
 
 <h3 id="v23-2-22-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause gateway nodes to panic when performing an `UPSERT` on a table with a `BOOL` primary key column and a partial index that used the primary key column as the predicate expression.
- #141825
-- Fixed a rare bug in which a query could fail with the error `could not find computed column expression for column in table` while dropping a virtual computed column from a table. This bug was introduced in v23.2.4.
- #139874
-- Fixed a bug that could cause `nil pointer dereference` errors when executing statements with user-defined functions (UDFs). The error could also occur when executing statements with some built-in functions, like `obj_description`.
- #141666
+- Fixed a bug that could cause gateway nodes to panic when performing an `UPSERT` on a table with a `BOOL` primary key column and a partial index that used the primary key column as the predicate expression. #141825
+- Fixed a rare bug in which a query could fail with the error `could not find computed column expression for column in table` while dropping a virtual computed column from a table. This bug was introduced in v23.2.4. #139874
+- Fixed a bug that could cause `nil pointer dereference` errors when executing statements with user-defined functions (UDFs). The error could also occur when executing statements with some built-in functions, like `obj_description`. #141666
 
 <h3 id="v23-2-22-miscellaneous">Miscellaneous</h3>
 
-- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is displayed informing the user that the TTL rate limit is per leaseholder per table with a link to the docs.
- #142831
+- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is displayed informing the user that the TTL rate limit is per leaseholder per table with a link to the docs. #142831
 
 

--- a/src/current/_includes/releases/v23.2/v23.2.23.md
+++ b/src/current/_includes/releases/v23.2/v23.2.23.md
@@ -6,7 +6,6 @@ Release Date: April 9, 2025
 
 <h3 id="v23-2-23-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144062
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144062
 
 

--- a/src/current/_includes/releases/v23.2/v23.2.25.md
+++ b/src/current/_includes/releases/v23.2/v23.2.25.md
@@ -6,20 +6,14 @@ Release Date: April 30, 2025
 
 <h3 id="v23-2-25-sql-language-changes">SQL language changes</h3>
 
-- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE` which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option.
- #142165
+- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE` which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option. #142165
 
 <h3 id="v23-2-25-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2.
- #143312
-- Fixed a bug that caused changefeeds to fail on startup when scanning a single key.
- #143147
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144029
-- Fixed a bug that could leave behind a dangling reference to a dropped role if that role had default privileges granted to itself. The bug was caused by defining privileges such as: `ALTER DEFAULT PRIVILEGES FOR ROLE self_referencing_role GRANT INSERT ON TABLES TO self_referencing_role`.
- #143291
-- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior.
- #143274
+- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2. #143312
+- Fixed a bug that caused changefeeds to fail on startup when scanning a single key. #143147
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144029
+- Fixed a bug that could leave behind a dangling reference to a dropped role if that role had default privileges granted to itself. The bug was caused by defining privileges such as: `ALTER DEFAULT PRIVILEGES FOR ROLE self_referencing_role GRANT INSERT ON TABLES TO self_referencing_role`. #143291
+- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior. #143274
 
 

--- a/src/current/_includes/releases/v24.1/v24.1.16.md
+++ b/src/current/_includes/releases/v24.1/v24.1.16.md
@@ -6,7 +6,6 @@ Release Date: April 9, 2025
 
 <h3 id="v24-1-16-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144061
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144061
 
 

--- a/src/current/_includes/releases/v24.1/v24.1.18.md
+++ b/src/current/_includes/releases/v24.1/v24.1.18.md
@@ -6,28 +6,18 @@ Release Date: April 30, 2025
 
 <h3 id="v24-1-18-sql-language-changes">SQL language changes</h3>
 
-- `EXPLAIN ANALYZE` statements now display the number of transaction retries and time spent retrying, if non-zero, in the plan output.
- #142931
-- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE` which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option.
- #142164
+- `EXPLAIN ANALYZE` statements now display the number of transaction retries and time spent retrying, if non-zero, in the plan output. #142931
+- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE` which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option. #142164
 
 <h3 id="v24-1-18-bug-fixes">Bug fixes</h3>
 
 - Fixed a rare corruption bug that impacts import and materialized views. #144689
-- Fixed a bug that caused changefeeds to fail on startup when scanning a single key.
- #143148
-- Fixed a bug in the client certificate expiration metrics `security.certificate.expiration.client` and `security.certificate.ttl.client`.
- #142915
-- Fixed a bug in v24.1.14, v24.3.7, v24.3.8, and v25.1 that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument.
- #143638
-- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior.
- #143275
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144035
-- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2.
- #143313
-- Fixed a bug where calling a stored procedure could drop the procedure if it had `OUT` parameters that were not used by the calling routine. This bug had existed since PL/pgSQL `CALL` statements were introduced in v24.1.
- #143288
-- Previously, the fields `maximum memory usage` and `max sql temp disk usage` in the `EXPLAIN ANALYZE` output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. This is now fixed. The bug existed in v22.1 and later.
- #143792
+- Fixed a bug that caused changefeeds to fail on startup when scanning a single key. #143148
+- Fixed a bug in the client certificate expiration metrics `security.certificate.expiration.client` and `security.certificate.ttl.client`. #142915
+- Fixed a bug in v24.1.14, v24.3.7, v24.3.8, and v25.1 that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument. #143638
+- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior. #143275
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144035
+- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2. #143313
+- Fixed a bug where calling a stored procedure could drop the procedure if it had `OUT` parameters that were not used by the calling routine. This bug had existed since PL/pgSQL `CALL` statements were introduced in v24.1. #143288
+- Previously, the fields `maximum memory usage` and `max sql temp disk usage` in the `EXPLAIN ANALYZE` output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. This is now fixed. The bug existed in v22.1 and later. #143792
 

--- a/src/current/_includes/releases/v24.1/v24.1.19.md
+++ b/src/current/_includes/releases/v24.1/v24.1.19.md
@@ -6,41 +6,29 @@ Release Date: May 28, 2025
 
 <h3 id="v24-1-19-operational-changes">Operational changes</h3>
 
-- Changed the default value of the cluster setting `admission.l0_file_count_overload_threshold` to `4000`.
- #145920
+- Changed the default value of the cluster setting `admission.l0_file_count_overload_threshold` to `4000`. #145920
 
 <h3 id="v24-1-19-db-console-changes">DB Console changes</h3>
 
-- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory.
- #145987
+- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory. #145987
 
 <h3 id="v24-1-19-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where CockroachDB could encounter a `cannot specify timestamp older than ...` error during table statistics collection in some cases (e.g., when the cluster is overloaded). The bug was present since v19.1.
- #144519
-- Fixed a bug in the DB Console where tables with page size dropdowns failed to update when a new page size option was selected. Tables now update correctly.
- #144768
+- Fixed a bug where CockroachDB could encounter a `cannot specify timestamp older than ...` error during table statistics collection in some cases (e.g., when the cluster is overloaded). The bug was present since v19.1. #144519
+- Fixed a bug in the DB Console where tables with page size dropdowns failed to update when a new page size option was selected. Tables now update correctly. #144768
 - Fixed the following bugs in the **Schedules** page of the DB Console:
   - Fixed a bug where the **Schedules** page displayed only a subset of a cluster's schedules. The **Schedules** page now correctly displays all schedules.
   - Fixed a bug where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load.
   #144804
-- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected.
- #144853
-- Improved the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects.
- #145077
-- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues.
- #145542
-- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed.
- #145577
-- Fixed a bug where orphaned leases were not properly cleaned up.
- #146111
-- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present.
- #146199
-- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks.
- #146310
+- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected. #144853
+- Improved the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects. #145077
+- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues. #145542
+- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed. #145577
+- Fixed a bug where orphaned leases were not properly cleaned up. #146111
+- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present. #146199
+- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks. #146310
 - Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index.
  #146323\
-- Fixed a rare corruption bug that impacts import and materialized views.
- #144660
+- Fixed a rare corruption bug that impacts import and materialized views. #144660
 
 

--- a/src/current/_includes/releases/v24.1/v24.1.20.md
+++ b/src/current/_includes/releases/v24.1/v24.1.20.md
@@ -6,22 +6,15 @@ Release Date: June 25, 2025
 
 <h3 id="v24-1-20-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could potentially cause a changefeed to complete erroneously when one of its watched tables encounters a schema change.
- #147039
-- Fixed a bug that caused the **SQL Activity** > **Statement Fingerprint** page to fail to load details for statements run with application names containing a `#` character.
- #147220
-- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console).
- #147338
-- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha.
- #147457
-- Fixed a bug where prepared statements on schema changes could fail with runtime errors.
- #147668
-- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence.
- #147771
+- Fixed a bug that could potentially cause a changefeed to complete erroneously when one of its watched tables encounters a schema change. #147039
+- Fixed a bug that caused the **SQL Activity** > **Statement Fingerprint** page to fail to load details for statements run with application names containing a `#` character. #147220
+- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console). #147338
+- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha. #147457
+- Fixed a bug where prepared statements on schema changes could fail with runtime errors. #147668
+- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence. #147771
 
 <h3 id="v24-1-20-performance-improvements">Performance improvements</h3>
 
-- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes.
- #147213
+- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes. #147213
 
 

--- a/src/current/_includes/releases/v24.1/v24.1.21.md
+++ b/src/current/_includes/releases/v24.1/v24.1.21.md
@@ -6,9 +6,7 @@ Release Date: July 28, 2025
 
 <h3 id="v24-1-21-bug-fixes">Bug fixes</h3>
 
-- Fixed a data race in the `cloudstorage` sink.
- #147160
-- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg).
- #148472
+- Fixed a data race in the `cloudstorage` sink. #147160
+- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg). #148472
 
 

--- a/src/current/_includes/releases/v24.1/v24.1.22.md
+++ b/src/current/_includes/releases/v24.1/v24.1.22.md
@@ -6,7 +6,6 @@ Release Date: August 1, 2025
 
 <h3 id="v24-1-22-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups.
- #151098
+- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups. #151098
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.10.md
+++ b/src/current/_includes/releases/v24.3/v24.3.10.md
@@ -6,7 +6,6 @@ Release Date: April 9, 2025
 
 <h3 id="v24-3-10-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144060
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144060
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.13.md
+++ b/src/current/_includes/releases/v24.3/v24.3.13.md
@@ -6,8 +6,7 @@ Release Date: May 15, 2025
 
 <h3 id="v24-3-13-operational-changes">Operational changes</h3>
 
-- The default value of the `admission.l0_file_count_overload_threshold` cluster setting is now `4000`. This change improves stability under high write load and during Write-Ahead Log (WAL) failover by addressing token exhaustion.
- #146597
+- The default value of the `admission.l0_file_count_overload_threshold` cluster setting is now `4000`. This change improves stability under high write load and during Write-Ahead Log (WAL) failover by addressing token exhaustion. #146597
 
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.14.md
+++ b/src/current/_includes/releases/v24.3/v24.3.14.md
@@ -6,55 +6,35 @@ Release Date: May 28, 2025
 
 <h3 id="v24-3-14-operational-changes">Operational changes</h3>
 
-- Changed the default value of the cluster setting `admission.l0_file_count_overload_threshold` to `4000`.
- #145919
-- SQL queries run on the source cluster by logical data replication (LDR) and physical cluster replication (PCR) will account to internal metrics like `sql.statements.active.internal` instead of the metrics like `sql.statements.active` that are used to monitor application workload.
- #145114
+- Changed the default value of the cluster setting `admission.l0_file_count_overload_threshold` to `4000`. #145919
+- SQL queries run on the source cluster by logical data replication (LDR) and physical cluster replication (PCR) will account to internal metrics like `sql.statements.active.internal` instead of the metrics like `sql.statements.active` that are used to monitor application workload. #145114
 
 <h3 id="v24-3-14-db-console-changes">DB Console changes</h3>
 
-- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory.
- #145988
+- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory. #145988
 
 <h3 id="v24-3-14-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where using values `changefeed.aggregator.flush_jitter` and `min_checkpoint_frequency` such that `changefeed.aggregator.flush_jitter * min_checkpoint_frequency < 1` would cause a panic. Jitter will now be disabled in this case.
- #144425
-- Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the table details page.
- #144652
+- Fixed a bug where using values `changefeed.aggregator.flush_jitter` and `min_checkpoint_frequency` such that `changefeed.aggregator.flush_jitter * min_checkpoint_frequency < 1` would cause a panic. Jitter will now be disabled in this case. #144425
+- Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the table details page. #144652
 - Fixed the following bugs in the **Schedules** page of the DB Console:
   - Fixed a bug where the **Schedules** page displayed only a subset of a cluster's schedules. The **Schedules** page now correctly displays all schedules.
   - Fixed a bug where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load.
   #144805
-- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected.
- #144854
-- Improved the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects.
- #145073
-- Fixed a bug where running `DROP INDEX` on a hash-sharded index did not properly detect dependencies from functions and procedures on the shard column. This caused the `DROP INDEX` statement to fail with an internal validation error. Now the statement returns a correct error message, and using `DROP INDEX ... CASCADE` works as expected by dropping the dependent functions and procedures.
- #145392
-- Fixed a bug where a node that was drained as part of decommissioning may have interrupted SQL connections that were still active during drain (and for which drain would have been expected to wait).
- #145447
-- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues.
- #145543
-- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed.
- #145574
-- Fixed a bug that could cause a row-level TTL job to fail with the error "comparison of two different versions of enum" if an `ENUM` type referenced by the table experienced a schema change.
- #145915
-- Fixed a bug where the physical cluster replication (PCR) reader catalog job could hit validation errors when schema objects had dependencies between them (for example, when a sequence's default expression was being removed).
- #145997
-- Fixed a bug where orphaned leases were not properly cleaned up.
- #146096
-- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present.
- #146198
-- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks.
- #146222
-- Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index.
- #146324
-- Fixed a bug where an invalid comment in the `system.comment` table for a schema object could make it inaccessible.
- #146416
-- Fixed a bug in the rangefeed restarts metric that was introduced in v23.2.
- #133978
-- Fixed a rare corruption bug that impacts import and materialized views.
- #144661
+- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected. #144854
+- Improved the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects. #145073
+- Fixed a bug where running `DROP INDEX` on a hash-sharded index did not properly detect dependencies from functions and procedures on the shard column. This caused the `DROP INDEX` statement to fail with an internal validation error. Now the statement returns a correct error message, and using `DROP INDEX ... CASCADE` works as expected by dropping the dependent functions and procedures. #145392
+- Fixed a bug where a node that was drained as part of decommissioning may have interrupted SQL connections that were still active during drain (and for which drain would have been expected to wait). #145447
+- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues. #145543
+- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed. #145574
+- Fixed a bug that could cause a row-level TTL job to fail with the error "comparison of two different versions of enum" if an `ENUM` type referenced by the table experienced a schema change. #145915
+- Fixed a bug where the physical cluster replication (PCR) reader catalog job could hit validation errors when schema objects had dependencies between them (for example, when a sequence's default expression was being removed). #145997
+- Fixed a bug where orphaned leases were not properly cleaned up. #146096
+- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present. #146198
+- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks. #146222
+- Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index. #146324
+- Fixed a bug where an invalid comment in the `system.comment` table for a schema object could make it inaccessible. #146416
+- Fixed a bug in the rangefeed restarts metric that was introduced in v23.2. #133978
+- Fixed a rare corruption bug that impacts import and materialized views. #144661
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.15.md
+++ b/src/current/_includes/releases/v24.3/v24.3.15.md
@@ -6,35 +6,23 @@ Release Date: June 25, 2025
 
 <h3 id="v24-3-15-sql-language-changes">SQL language changes</h3>
 
-- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors.
- #148229
-- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`).
- #148229
+- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors. #148229
+- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`). #148229
 
 <h3 id="v24-3-15-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause an `AFTER` trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug had existed since `AFTER` triggers were introduced in v24.3.
- #146974
-- Fixed a bug that could potentially cause a changefeed to complete erroneously when one of its watched tables encounters a schema change.
- #147031
-- Fixed a bug that caused the SQL Activity > Statement Fingerprint page to fail to load details for statements run with application names containing a `#` character.
- #147221
-- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console).
- #147337
-- Fixed a bug that caused the optimizer to ignore index hints when optimizing some forms of prepared statements. This could result in one of two unexpected behaviors: a query errors with the message `index cannot be used for this query` when the index can actually be used; or a query uses an index that does not adhere to the hint. The hints relevant to this bug are regular index hints, e.g., `SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX`, and `FORCE_ZIGZAG`.
- #147415
-- Fixed the database filter in the DB Console's Hot Ranges page, which was broken in v24.3.3, and updated the locality filter to remove duplicate entries.
- #147444
-- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha.
- #147458
-- Fixed a bug where prepared statements on schema changes could fail with runtime errors.
- #147669
-- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence.
- #147768
+- Fixed a bug that could cause an `AFTER` trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug had existed since `AFTER` triggers were introduced in v24.3. #146974
+- Fixed a bug that could potentially cause a changefeed to complete erroneously when one of its watched tables encounters a schema change. #147031
+- Fixed a bug that caused the SQL Activity > Statement Fingerprint page to fail to load details for statements run with application names containing a `#` character. #147221
+- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console). #147337
+- Fixed a bug that caused the optimizer to ignore index hints when optimizing some forms of prepared statements. This could result in one of two unexpected behaviors: a query errors with the message `index cannot be used for this query` when the index can actually be used; or a query uses an index that does not adhere to the hint. The hints relevant to this bug are regular index hints, e.g., `SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX`, and `FORCE_ZIGZAG`. #147415
+- Fixed the database filter in the DB Console's Hot Ranges page, which was broken in v24.3.3, and updated the locality filter to remove duplicate entries. #147444
+- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha. #147458
+- Fixed a bug where prepared statements on schema changes could fail with runtime errors. #147669
+- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence. #147768
 - Fixed an issue with logical data replication (LDR) where the presence of a unique index could have caused spurious dead-letter queue (DLQ) entries if the unique index had a smaller index ID than the primary key index. #147354
 
 <h3 id="v24-3-15-performance-improvements">Performance improvements</h3>
 
-- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes.
- #147211
+- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes. #147211
 

--- a/src/current/_includes/releases/v24.3/v24.3.16.md
+++ b/src/current/_includes/releases/v24.3/v24.3.16.md
@@ -6,24 +6,18 @@ Release Date: July 28, 2025
 
 <h3 id="v24-3-16-sql-language-changes">SQL language changes</h3>
 
-- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`).
- #148228
-- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors.
- #148228
+- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`). #148228
+- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors. #148228
 
 <h3 id="v24-3-16-operational-changes">Operational changes</h3>
 
-- Introduced a cluster setting, `sql.stats.error_on_concurrent_create_stats.enabled`, which modifies how CockroachDB reacts to concurrent auto stats jobs. The default, `true`, maintains the previous behavior. Setting `sql.stats.error_on_concurrent_create_stats.enabled` to `false` will cause the concurrent auto stats job to be skipped with just a log entry and no increased error counters.
- #149850
+- Introduced a cluster setting, `sql.stats.error_on_concurrent_create_stats.enabled`, which modifies how CockroachDB reacts to concurrent auto stats jobs. The default, `true`, maintains the previous behavior. Setting `sql.stats.error_on_concurrent_create_stats.enabled` to `false` will cause the concurrent auto stats job to be skipped with just a log entry and no increased error counters. #149850
 
 <h3 id="v24-3-16-bug-fixes">Bug fixes</h3>
 
-- Fixed a data race in the `cloudstorage` sink.
- #147161
-- Fixed an error in `crdb_internal.table_spans` that could occur when a table's schema had been dropped.
- #148048
-- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg).
- #148470
+- Fixed a data race in the `cloudstorage` sink. #147161
+- Fixed an error in `crdb_internal.table_spans` that could occur when a table's schema had been dropped. #148048
+- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg). #148470
 - The `RESET ALL` statement no longer affects the following session variables:
   - `is_superuser`
   - `role`
@@ -34,7 +28,6 @@ Release Date: July 28, 2025
   - `transaction_read_only`
   
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled. #149431
-- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels.
- #150342
+- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels. #150342
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.17.md
+++ b/src/current/_includes/releases/v24.3/v24.3.17.md
@@ -6,7 +6,6 @@ Release Date: August 1, 2025
 
 <h3 id="v24-3-17-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups.
- #151094
+- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups. #151094
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.7.md
+++ b/src/current/_includes/releases/v24.3/v24.3.7.md
@@ -10,37 +10,28 @@ Release Date: March 6, 2025
  #140255 #140998
 - Added the `optimizer_prefer_bounded_cardinality` session setting, which instructs the optimizer to prefer query plans where every expression has a guaranteed upper-bound on the number of rows it will process. This may help the optimizer produce better query plans in some cases. This setting is disabled by default.
  #140255 #140998
-- Added the `optimizer_check_input_min_row_count` session setting to control the minimum row count estimate for buffer scans of foreign key and uniqueness checks. It defaults to `0`.
- #141375
+- Added the `optimizer_check_input_min_row_count` session setting to control the minimum row count estimate for buffer scans of foreign key and uniqueness checks. It defaults to `0`. #141375
 - Since v23.2, table statistics histograms have been collected for non-indexed JSON columns. Histograms are no longer collected for these columns if the `sql.stats.non_indexed_json_histograms.enabled` cluster setting is set to `false`. This reduces memory usage during table statistics collection, for both automatic and manual collection via `ANALYZE` and `CREATE STATISTICS`.
  #139897 #140998
-- Fixed a bug that could cause unexpected errors with SQL `VALUES` clauses that contain function calls with multiple overloads. This bug existed only in pre-release versions of v25.1.
- #140646
+- Fixed a bug that could cause unexpected errors with SQL `VALUES` clauses that contain function calls with multiple overloads. This bug existed only in pre-release versions of v25.1. #140646
 - Added the `optimizer_min_row_count` session setting. This setting sets a lower bound on row count estimates for relational expressions during query planning. A value of `0` (default) indicates no lower bound. If set to a value greater than `0`, a row count of zero can still be estimated for expressions with a cardinality of zero, e.g., for a contradictory filter. Setting this to a value greater than `0`, such as `1`, may yield better query plans in some cases, such as when statistics are frequently stale and inaccurate.
  #140255 #140998  
 
 <h3 id="v24-3-7-operational-changes">Operational changes</h3>
 
-- Reduced noise in dynamically provisioned logging sinks by logging flush errors at most once per minute.
- #139643
-- The `cockroach node decommission` CLI command now waits until the target node is drained before marking it as fully decommissioned. Previously, it would start the drain but not wait, leaving the target node briefly in a state where it would be unable to communicate with the cluster but would still accept client requests (which would then hang or hit unexpected errors).
- #139556
+- Reduced noise in dynamically provisioned logging sinks by logging flush errors at most once per minute. #139643
+- The `cockroach node decommission` CLI command now waits until the target node is drained before marking it as fully decommissioned. Previously, it would start the drain but not wait, leaving the target node briefly in a state where it would be unable to communicate with the cluster but would still accept client requests (which would then hang or hit unexpected errors). #139556
 
 <h3 id="v24-3-7-command-line-changes">Command-line changes</h3>
 
-- Improved the performance of the `cockroachd debug zip` command when retrieving data from `crdb_internal.transaction_contention_events`, reducing the likelihood of `memory budget exceeded` or `query execution canceled due to statement timeout` errors.
- #139754
+- Improved the performance of the `cockroachd debug zip` command when retrieving data from `crdb_internal.transaction_contention_events`, reducing the likelihood of `memory budget exceeded` or `query execution canceled due to statement timeout` errors. #139754
 
 <h3 id="v24-3-7-bug-fixes">Bug fixes</h3>
 
-- Previously, in changefeeds using CDC queries and the Parquet format, the output would include duplicate columns when it contained a user-defined primary key. Now, the columns are de-duplicated columns in the output when writing to Parquet.
- #140153
-- Fixed a bug where dropping a table with a trigger using the legacy schema changer could leave an orphaned reference in the descriptor. This occurred when two tables were dependent on each other via a trigger, and the table containing the trigger was dropped.
- #141179
-- Fixed a bug that could cause `SHOW TABLES` and other introspection operations to encounter a `"batch timestamp must be after replica GC threshold"` error.
- #140284
-- The Data Distribution and Zone Configs report on the DB Console Advanced Debug page will no longer crash if there are `NULL` values for the `raw_sql_config` column in the `crdb_internal.zones` table.
- #140661
+- Previously, in changefeeds using CDC queries and the Parquet format, the output would include duplicate columns when it contained a user-defined primary key. Now, the columns are de-duplicated columns in the output when writing to Parquet. #140153
+- Fixed a bug where dropping a table with a trigger using the legacy schema changer could leave an orphaned reference in the descriptor. This occurred when two tables were dependent on each other via a trigger, and the table containing the trigger was dropped. #141179
+- Fixed a bug that could cause `SHOW TABLES` and other introspection operations to encounter a `"batch timestamp must be after replica GC threshold"` error. #140284
+- The Data Distribution and Zone Configs report on the DB Console Advanced Debug page will no longer crash if there are `NULL` values for the `raw_sql_config` column in the `crdb_internal.zones` table. #140661
 - Fixed possible index corruption caused by triggers that could occur when the following conditions were satisfied:
   1. A query calls a user-defined function (UDF) or stored procedure, and also performs a mutation
      on a table.
@@ -50,17 +41,11 @@ Release Date: March 6, 2025
   4. Either the outer or inner mutation is something other than an `INSERT`
      without an `ON CONFLICT` clause.
  #138361
-- Fixed a bug where activating statement diagnostics sometimes appeared unresponsive, with no state or status update. The status now always indicates whether diagnostics are active or a statement bundle is available for download.
- #139585
-- Fixed a memory leak that could previously occur when evaluating some memory-intensive queries via the vectorized engine in CockroachDB. The leak had been present since v20.2.
- #139095
-- Fixed a bug that could cause `SHOW TABLES` and other introspection operations to encounter a `"batch timestamp must be after replica GC threshold"` error.
- #140084
-- Fixed a bug in the `kafka_sink_config` option for changefeeds where users were previously unable to set negative GZIP compression levels. Users can now configure the `CompressionLevel` field in the range of `[-2, 9]` where `-2` enables Huffman encoding and `-1` sets the default compression.
- #141037
-- Fixed a bug that would cause an internal error when the result of a `RECORD`-returning user-defined function (UDF) was wrapped by another expression (such as `COALESCE`) within a `VALUES` clause.
- #140646
-- Fixed a rare bug in which a query could fail with the error `could not find computed column expression for column in table` while dropping a virtual computed column from a table. This bug was introduced in v23.2.4.
- #139833
+- Fixed a bug where activating statement diagnostics sometimes appeared unresponsive, with no state or status update. The status now always indicates whether diagnostics are active or a statement bundle is available for download. #139585
+- Fixed a memory leak that could previously occur when evaluating some memory-intensive queries via the vectorized engine in CockroachDB. The leak had been present since v20.2. #139095
+- Fixed a bug that could cause `SHOW TABLES` and other introspection operations to encounter a `"batch timestamp must be after replica GC threshold"` error. #140084
+- Fixed a bug in the `kafka_sink_config` option for changefeeds where users were previously unable to set negative GZIP compression levels. Users can now configure the `CompressionLevel` field in the range of `[-2, 9]` where `-2` enables Huffman encoding and `-1` sets the default compression. #141037
+- Fixed a bug that would cause an internal error when the result of a `RECORD`-returning user-defined function (UDF) was wrapped by another expression (such as `COALESCE`) within a `VALUES` clause. #140646
+- Fixed a rare bug in which a query could fail with the error `could not find computed column expression for column in table` while dropping a virtual computed column from a table. This bug was introduced in v23.2.4. #139833
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.8.md
+++ b/src/current/_includes/releases/v24.3/v24.3.8.md
@@ -6,7 +6,6 @@ Release Date: March 12, 2025
 
 <h3 id="v24-3-8-bug-fixes">Bug fixes</h3>
 
-- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters.
- #142679
+- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters. #142679
 
 

--- a/src/current/_includes/releases/v24.3/v24.3.9.md
+++ b/src/current/_includes/releases/v24.3/v24.3.9.md
@@ -6,55 +6,36 @@ Release Date: April 2, 2025
 
 <h3 id="v24-3-9-sql-language-changes">SQL language changes</h3>
 
-- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE`, which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option.
- #143368
+- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE`, which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option. #143368
 
 <h3 id="v24-3-9-operational-changes">Operational changes</h3>
 
-- Added the `sql.transaction_timeout.count` metric to track the number of SQL statements that fail due to exceeding the transaction timeout.
- #142156
-- Added the `sql.statement_timeout.count` to track the number of SQL statements that fail due to exceeding the statement timeout.
- #142156
-- The `server.client_cert_expiration_cache.capacity` cluster setting has been removed. The `security.certificate.expiration.client` and `security.certificate.ttl.client` metrics now report the lowest value observed for a user in the last 24 hours.
- #143593
+- Added the `sql.transaction_timeout.count` metric to track the number of SQL statements that fail due to exceeding the transaction timeout. #142156
+- Added the `sql.statement_timeout.count` to track the number of SQL statements that fail due to exceeding the statement timeout. #142156
+- The `server.client_cert_expiration_cache.capacity` cluster setting has been removed. The `security.certificate.expiration.client` and `security.certificate.ttl.client` metrics now report the lowest value observed for a user in the last 24 hours. #143593
 
 <h3 id="v24-3-9-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that prevented starting multi-table Logical Data Replication (LDR) streams on tables that used user-defined types.
- #141793
-- The TTL deletion job now includes a retry mechanism that progressively reduces the batch size when encountering contention. This improves the chances of successful deletion without requiring manual adjustments to TTL knobs. Also added the `jobs.row_level_ttl.num_delete_batch_retries` metric to track the number of times the TTL job had to reduce the batch size and try again.
- #142323
-- Fixed a bug when running with the `autocommit_before_ddl` session setting that could cause a runtime error when binding a previously prepared DDL statement.
- #141987
-- Fixed a bug where CockroachDB could incorrectly evaluate casts to some OID types (like `REGCLASS`) in some cases. The bug had been present since at least v22.1.
- #141958
-- Fixed a bug that could cause gateway nodes to panic when performing an `UPSERT` on a table with a `BOOL` primary key column and a partial index with the primary key column as the predicate expression.
- #141823
-- Fixed a bug that would prevent the `CREATE TRIGGER` and `DROP TRIGGER` statements from working if the `autocommit_before_ddl` setting was enabled, and if the statement was either sent as a prepared statement or as part of a batch of multiple statements.
- #142303
+- Fixed a bug that prevented starting multi-table Logical Data Replication (LDR) streams on tables that used user-defined types. #141793
+- The TTL deletion job now includes a retry mechanism that progressively reduces the batch size when encountering contention. This improves the chances of successful deletion without requiring manual adjustments to TTL knobs. Also added the `jobs.row_level_ttl.num_delete_batch_retries` metric to track the number of times the TTL job had to reduce the batch size and try again. #142323
+- Fixed a bug when running with the `autocommit_before_ddl` session setting that could cause a runtime error when binding a previously prepared DDL statement. #141987
+- Fixed a bug where CockroachDB could incorrectly evaluate casts to some OID types (like `REGCLASS`) in some cases. The bug had been present since at least v22.1. #141958
+- Fixed a bug that could cause gateway nodes to panic when performing an `UPSERT` on a table with a `BOOL` primary key column and a partial index with the primary key column as the predicate expression. #141823
+- Fixed a bug that would prevent the `CREATE TRIGGER` and `DROP TRIGGER` statements from working if the `autocommit_before_ddl` setting was enabled, and if the statement was either sent as a prepared statement or as part of a batch of multiple statements. #142303
 - Fixed a bug that could cause `SHOW TABLES` and other introspection operations to encounter a `batch timestamp must be after replica GC threshold` error. #141720
 - Fixed a bug where Physical Cluster Replication (PCR) reader catalogs could have orphaned rows in `system.namespace` after an object is renamed. #142873
-- Fixed a bug that could cause `nil pointer dereference` errors when executing statements with user-defined functions (UDFs). The error could also occur when executing statements with some built-in functions, like `obj_description`.
- #141652
-- Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument.
- #143635
-- Fixed a bug that could prevent `SHOW CREATE TABLE` from working if a database was offline (e.g., due to a `RESTORE` on that database).
- #141509
-- Fixed an issue where dropping a database with triggers could fail due to an undropped backreference to a trigger function.
- #142726
-- Fixed a bug where the declarative schema changer allowed `CREATE SEQUENCE` operations to proceed even while a `DROP SCHEMA` or `DROP DATABASE` was in progress. Such operations now retry if the parent object has a schema change in progress, preventing new child objects from being created under deleted parent objects.
- #142763
-- Fixed a potential deadlock that could occur during client certificate updates while metrics were being collected. This issue affected the reliability of certificate expiration reporting.
- #143593
-- Fixed a bug where the fraction completed and internal checkpoints during an index backfill operation would stop getting written if any of the periodic fraction/checkpoint write operations failed. Progress is now logged in addition to being written to the job record. This bug affected schema change operations such as creating an index or adding a non-nullable column to a table.
- #141787
-- Fixed a crash due to `use of enum metadata before hydration` when using logical data replication (LDR) with user-defined types.
- #143389
+- Fixed a bug that could cause `nil pointer dereference` errors when executing statements with user-defined functions (UDFs). The error could also occur when executing statements with some built-in functions, like `obj_description`. #141652
+- Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument. #143635
+- Fixed a bug that could prevent `SHOW CREATE TABLE` from working if a database was offline (e.g., due to a `RESTORE` on that database). #141509
+- Fixed an issue where dropping a database with triggers could fail due to an undropped backreference to a trigger function. #142726
+- Fixed a bug where the declarative schema changer allowed `CREATE SEQUENCE` operations to proceed even while a `DROP SCHEMA` or `DROP DATABASE` was in progress. Such operations now retry if the parent object has a schema change in progress, preventing new child objects from being created under deleted parent objects. #142763
+- Fixed a potential deadlock that could occur during client certificate updates while metrics were being collected. This issue affected the reliability of certificate expiration reporting. #143593
+- Fixed a bug where the fraction completed and internal checkpoints during an index backfill operation would stop getting written if any of the periodic fraction/checkpoint write operations failed. Progress is now logged in addition to being written to the job record. This bug affected schema change operations such as creating an index or adding a non-nullable column to a table. #141787
+- Fixed a crash due to `use of enum metadata before hydration` when using logical data replication (LDR) with user-defined types. #143389
 
 <h3 id="v24-3-9-miscellaneous">Miscellaneous</h3>
 
-- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is now displayed informing the user that the TTL rate limit is per leaseholder per table with a [link to the docs](https://www.cockroachlabs.com/docs/dev/row-level-ttl).
- #142833
+- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is now displayed informing the user that the TTL rate limit is per leaseholder per table with a [link to the docs](https://www.cockroachlabs.com/docs/dev/row-level-ttl). #142833
 - Improved S3 credential caching for AWS Security Token Service (STS) credentials. #142437
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.1.md
+++ b/src/current/_includes/releases/v25.1/v25.1.1.md
@@ -6,7 +6,6 @@ Release Date: March 12, 2025
 
 <h3 id="v25-1-1-bug-fixes">Bug fixes</h3>
 
-- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters.
- #142677
+- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters. #142677
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.10.md
+++ b/src/current/_includes/releases/v25.1/v25.1.10.md
@@ -6,7 +6,6 @@ Release Date: August 1, 2025
 
 <h3 id="v25-1-10-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups.
- #151097
+- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups. #151097
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.2.md
+++ b/src/current/_includes/releases/v25.1/v25.1.2.md
@@ -6,35 +6,23 @@ Release Date: March 12, 2025
 
 <h3 id="v25-1-2-sql-language-changes">SQL language changes</h3>
 
-- Added the `optimizer_check_input_min_row_count` session setting to control the minimum row count estimate for buffer scans of foreign key and uniqueness checks. It defaults to `0`.
- #141374
+- Added the `optimizer_check_input_min_row_count` session setting to control the minimum row count estimate for buffer scans of foreign key and uniqueness checks. It defaults to `0`. #141374
 
 <h3 id="v25-1-2-db-console-changes">DB Console changes</h3>
 
-- The **Paused Follower** graph has been removed from the **Replication Dashboard** in DB Console because followers are no longer paused by default in CockroachDB v25.1 and later.
- #141502
+- The **Paused Follower** graph has been removed from the **Replication Dashboard** in DB Console because followers are no longer paused by default in CockroachDB v25.1 and later. #141502
 
 <h3 id="v25-1-2-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that prevented starting multi-table logical data replication (LDR) streams on tables that contained user-defined types.
- #141643
-- Fixed a bug where dropping a table with a trigger using the legacy schema changer could leave an orphaned reference in the descriptor. This issue occurred when two tables depended on each other via a trigger, and the table containing the trigger was dropped.
- #141181
-- Fixed a bug that could cause the upgrade to v25.1 to crash if a job was missing from the virtual table, such as when a malformed job had no payload information.
- #142312
-- A step in the v25.1 upgrade finalization process that required backfilling jobs now uses locks to ensure it makes progress even when there is contention on the jobs table, which prevents the possibility of becoming stuck under heavy load.
- #141460
-- Fixed a bug that could cause concurrent DML statements to prevent primary key changes from succeeding.
- #141383
-- Fixed a bug that could cause gateway nodes to panic when performing an `UPSERT` on a table with a `BOOL` primary key column and a partial index where the primary key column is used as the predicate expression.
- #141822
-- Fixed a bug that could cause `SHOW CREATE TABLE` to fail if a database was offline (e.g., due to a `RESTORE` on that database).
- #141505
-- Fixed a bug that prevented transaction retry errors encountered during implicit transactions from being automatically retried internally if the `autocommit_before_ddl` session variable was enabled and the statement was a schema change.
- #141393
-- Fixed a bug that could cause `nil pointer dereference` errors when executing statements with user-defined functions (UDFs) or certain built-in functions, such as `obj_description`.
- #141653
-- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters.
- #142690
+- Fixed a bug that prevented starting multi-table logical data replication (LDR) streams on tables that contained user-defined types. #141643
+- Fixed a bug where dropping a table with a trigger using the legacy schema changer could leave an orphaned reference in the descriptor. This issue occurred when two tables depended on each other via a trigger, and the table containing the trigger was dropped. #141181
+- Fixed a bug that could cause the upgrade to v25.1 to crash if a job was missing from the virtual table, such as when a malformed job had no payload information. #142312
+- A step in the v25.1 upgrade finalization process that required backfilling jobs now uses locks to ensure it makes progress even when there is contention on the jobs table, which prevents the possibility of becoming stuck under heavy load. #141460
+- Fixed a bug that could cause concurrent DML statements to prevent primary key changes from succeeding. #141383
+- Fixed a bug that could cause gateway nodes to panic when performing an `UPSERT` on a table with a `BOOL` primary key column and a partial index where the primary key column is used as the predicate expression. #141822
+- Fixed a bug that could cause `SHOW CREATE TABLE` to fail if a database was offline (e.g., due to a `RESTORE` on that database). #141505
+- Fixed a bug that prevented transaction retry errors encountered during implicit transactions from being automatically retried internally if the `autocommit_before_ddl` session variable was enabled and the statement was a schema change. #141393
+- Fixed a bug that could cause `nil pointer dereference` errors when executing statements with user-defined functions (UDFs) or certain built-in functions, such as `obj_description`. #141653
+- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters. #142690
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.3.md
+++ b/src/current/_includes/releases/v25.1/v25.1.3.md
@@ -6,66 +6,40 @@ Release Date: April 2, 2025
 
 <h3 id="v25-1-3-general-changes">General changes</h3>
 
-- When changefeeds are created with a `resolved` option lower than the `min_checkpoint_frequency` option, a message was printed to inform the user. This message is now a notice, and includes extra information if either option was a default.
- #142154
+- When changefeeds are created with a `resolved` option lower than the `min_checkpoint_frequency` option, a message was printed to inform the user. This message is now a notice, and includes extra information if either option was a default. #142154
 
 <h3 id="v25-1-3-operational-changes">Operational changes</h3>
 
-- Added the cluster setting `server.child_metrics.include_aggregate.enabled` (default: `true`) that controls the behavior of Prometheus child metrics reporting (`/_status/vars`). When set to `true`, child metrics include an aggregate time series, maintaining the existing behavior. When set to `false`, it stops reporting the aggregate time series, preventing double counting when querying metrics.
- #142746
-- Added the `sql.statement_timeout.count` metric to track the number of SQL statements that fail due to exceeding the statement timeout.
- #142155
-- Added the `sql.transaction_timeout.count` metric to track the number of SQL statements that fail due to exceeding the transaction timeout.
- #142155
+- Added the cluster setting `server.child_metrics.include_aggregate.enabled` (default: `true`) that controls the behavior of Prometheus child metrics reporting (`/_status/vars`). When set to `true`, child metrics include an aggregate time series, maintaining the existing behavior. When set to `false`, it stops reporting the aggregate time series, preventing double counting when querying metrics. #142746
+- Added the `sql.statement_timeout.count` metric to track the number of SQL statements that fail due to exceeding the statement timeout. #142155
+- Added the `sql.transaction_timeout.count` metric to track the number of SQL statements that fail due to exceeding the transaction timeout. #142155
 
 <h3 id="v25-1-3-bug-fixes">Bug fixes</h3>
 
-- Fixed a crash due to `use of enum metadata before hydration` when using logical data replication (LDR) with user-defined types.
- #143388
-- Fixed an issue where dropping a database with triggers could fail due to an undropped backreference to a trigger function.
- #142727
-- Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument.
- #143632
-- A step in the 25.1 upgrade finalization process that required backfilling jobs now uses locks to ensure it makes progress even when there is contention on the jobs table to prevent the possibility of becoming stuck under heavy load.
- #142223
-- Fixed a bug where the declarative schema changer allowed `CREATE SEQUENCE` operations to proceed even while a `DROP SCHEMA` or `DROP DATABASE` was in progress. Such operations now retry if the parent object has a schema change in progress, preventing new child objects from being created under deleted parent objects.
- #142764
-- Fixed a bug when running with the `autocommit_before_ddl` session variable that could cause a runtime error when binding a previously prepared DDL statement.
- #141851
-- Fixed a bug that would prevent `CREATE TRIGGER` and `DROP TRIGGER` statements from working if the `autocommit_before_ddl` setting was enabled, and if the statement was either sent as a prepared statement or as part of a batch of multiple statements.
- #142302
-- Fixed a bug where CockroachDB could incorrectly evaluate casts to some OID types (like `REGCLASS`) in some cases. The bug had been present since at least v22.1.
- #141956
-- Fixed a bug where replication controls on indexes and partitions would not get properly updated with their new IDs during index backfills, effectively discarding the replication controls set on them before the backfill.
- #142844
-- Fixed a bug where `EXPLAIN ANALYZE` output could incorrectly show `distribution: full` and not `distribution: local` in some cases when the physical plan was only running on the gateway node. The bug had been present since before v23.1, and did not apply to `EXPLAIN` statements.
- #142938
-- The TTL deletion job now includes a retry mechanism that progressively reduces the batch size when encountering contention. This improves the chances of successful deletion without requiring manual adjustments to TTL knobs. Also added the `jobs.row_level_ttl.num_delete_batch_retries` metric to track the number of times the TTL job had to reduce the batch size and try again.
- #142324
-- Fixed a bug where the fraction completed and internal checkpoints during an index backfill operation would stop getting written if any of the periodic fraction/checkpoint write operations failed. Additional logging was added so that progress is logged in addition to being written to the job record. This bug affected schema change operations such as creating an index or adding a non-nullable column to a table.
- #141788
-- Fixed a bug which would send a replica outside of a tenant's known region when `SURVIVE REGION FAILURE` was set and exactly 3 regions were configured.
- #142980
-- Fixed a bug that could cause the upgrade to v25.1 to crash if a job was missing from the virtual table. For example, if a malformed job had no payload information.
- #142311
-- Fixed a bug where during validation of a table-level zone config, inherited values were incorrectly populated from the default range instead of from the parent database.
- #142865
-- Fixed a bug in client certificate expiration metrics, `security.certificate.expiration.client` and `security.certificate.ttl.client`.
- #142916
-- Fixed a bug where a node that was drained as part of decommissioning may have interrupted SQL connections that were still active during drain (and for which drain would have been expected to wait).
- #141769
-- Physical Cluster Replication (PCR) reader catalogs could have orphaned rows in `system.namespace` after an object is renamed.
- #142872
+- Fixed a crash due to `use of enum metadata before hydration` when using logical data replication (LDR) with user-defined types. #143388
+- Fixed an issue where dropping a database with triggers could fail due to an undropped backreference to a trigger function. #142727
+- Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument. #143632
+- A step in the 25.1 upgrade finalization process that required backfilling jobs now uses locks to ensure it makes progress even when there is contention on the jobs table to prevent the possibility of becoming stuck under heavy load. #142223
+- Fixed a bug where the declarative schema changer allowed `CREATE SEQUENCE` operations to proceed even while a `DROP SCHEMA` or `DROP DATABASE` was in progress. Such operations now retry if the parent object has a schema change in progress, preventing new child objects from being created under deleted parent objects. #142764
+- Fixed a bug when running with the `autocommit_before_ddl` session variable that could cause a runtime error when binding a previously prepared DDL statement. #141851
+- Fixed a bug that would prevent `CREATE TRIGGER` and `DROP TRIGGER` statements from working if the `autocommit_before_ddl` setting was enabled, and if the statement was either sent as a prepared statement or as part of a batch of multiple statements. #142302
+- Fixed a bug where CockroachDB could incorrectly evaluate casts to some OID types (like `REGCLASS`) in some cases. The bug had been present since at least v22.1. #141956
+- Fixed a bug where replication controls on indexes and partitions would not get properly updated with their new IDs during index backfills, effectively discarding the replication controls set on them before the backfill. #142844
+- Fixed a bug where `EXPLAIN ANALYZE` output could incorrectly show `distribution: full` and not `distribution: local` in some cases when the physical plan was only running on the gateway node. The bug had been present since before v23.1, and did not apply to `EXPLAIN` statements. #142938
+- The TTL deletion job now includes a retry mechanism that progressively reduces the batch size when encountering contention. This improves the chances of successful deletion without requiring manual adjustments to TTL knobs. Also added the `jobs.row_level_ttl.num_delete_batch_retries` metric to track the number of times the TTL job had to reduce the batch size and try again. #142324
+- Fixed a bug where the fraction completed and internal checkpoints during an index backfill operation would stop getting written if any of the periodic fraction/checkpoint write operations failed. Additional logging was added so that progress is logged in addition to being written to the job record. This bug affected schema change operations such as creating an index or adding a non-nullable column to a table. #141788
+- Fixed a bug which would send a replica outside of a tenant's known region when `SURVIVE REGION FAILURE` was set and exactly 3 regions were configured. #142980
+- Fixed a bug that could cause the upgrade to v25.1 to crash if a job was missing from the virtual table. For example, if a malformed job had no payload information. #142311
+- Fixed a bug where during validation of a table-level zone config, inherited values were incorrectly populated from the default range instead of from the parent database. #142865
+- Fixed a bug in client certificate expiration metrics, `security.certificate.expiration.client` and `security.certificate.ttl.client`. #142916
+- Fixed a bug where a node that was drained as part of decommissioning may have interrupted SQL connections that were still active during drain (and for which drain would have been expected to wait). #141769
+- Physical Cluster Replication (PCR) reader catalogs could have orphaned rows in `system.namespace` after an object is renamed. #142872
 
 <h3 id="v25-1-3-miscellaneous">Miscellaneous</h3>
 
-- Updated the `CREATE TRIGGER` `only implemented in the declarative schema changer` error message to include a helpful suggestion and link to relevant docs.
- #141872
-- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is displayed informing the user that the TTL rate limit is per leaseholder per table with a link to the docs.
- #142834
-- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is displayed informing the user that the TTL rate limit is per leaseholder per table with a link to the docs.
- #142834
-- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters.
- #142438
+- Updated the `CREATE TRIGGER` `only implemented in the declarative schema changer` error message to include a helpful suggestion and link to relevant docs. #141872
+- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is displayed informing the user that the TTL rate limit is per leaseholder per table with a link to the docs. #142834
+- When configuring the `sql.ttl.default_delete_rate_limit` cluster setting, a notice is displayed informing the user that the TTL rate limit is per leaseholder per table with a link to the docs. #142834
+- Improved S3 credential caching for STS credentials to avoid exceeding the Amazon metadata service rate limit and encountering errors related to AssumeRole API calls when accessing large numbers of files in larger clusters. #142438
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.4.md
+++ b/src/current/_includes/releases/v25.1/v25.1.4.md
@@ -6,7 +6,6 @@ Release Date: April 9, 2025
 
 <h3 id="v25-1-4-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144059
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144059
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.6.md
+++ b/src/current/_includes/releases/v25.1/v25.1.6.md
@@ -6,54 +6,33 @@ Release Date: April 30th, 2025
 
 <h3 id="v25-1-6-sql-language-changes">SQL language changes</h3>
 
-- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE` which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option.
- #142161
-- `EXPLAIN ANALYZE` statements now display the number of transaction retries and time spent retrying, if non-zero, in the plan output.
- #142928
-- A new `execution time` statistic is now reported on `EXPLAIN ANALYZE` output for most operators. Previously, this statistic was only available on the DistSQL diagrams in `EXPLAIN ANALYZE (DISTSQL)` output.
- #143895
+- Added the `WITH IGNORE_FOREIGN_KEYS` option to `SHOW CREATE TABLE` which omits foreign key constraints from the output schema. This option is also allowed in `SHOW CREATE VIEW`, but has no effect. It cannot be combined with the `WITH REDACT` option. #142161
+- `EXPLAIN ANALYZE` statements now display the number of transaction retries and time spent retrying, if non-zero, in the plan output. #142928
+- A new `execution time` statistic is now reported on `EXPLAIN ANALYZE` output for most operators. Previously, this statistic was only available on the DistSQL diagrams in `EXPLAIN ANALYZE (DISTSQL)` output. #143895
 
 <h3 id="v25-1-6-operational-changes">Operational changes</h3>
 
-- The `sys.cpu.host.combined.percent-normalized` metric has been updated to include additional counters for more accurate host CPU measurement and to reduce underreporting. It now accounts for time spent processing hardware (`irq`) and software (`softirq`) interrupts, as well as `nice` time, which represents low-priority user-mode activity.
- #142906
-- The `server.client_cert_expiration_cache.capacity` cluster setting has been removed. The `security.certificate.expiration.client` and `security.certificate.ttl.client` metrics now report the lowest value observed for a user in the last 24 hours.
- #143729
+- The `sys.cpu.host.combined.percent-normalized` metric has been updated to include additional counters for more accurate host CPU measurement and to reduce underreporting. It now accounts for time spent processing hardware (`irq`) and software (`softirq`) interrupts, as well as `nice` time, which represents low-priority user-mode activity. #142906
+- The `server.client_cert_expiration_cache.capacity` cluster setting has been removed. The `security.certificate.expiration.client` and `security.certificate.ttl.client` metrics now report the lowest value observed for a user in the last 24 hours. #143729
 
 <h3 id="v25-1-6-bug-fixes">Bug fixes</h3>
 
-- Previously, fast failback for physical cluster replication (PCR) could succeed even if the destination cluster protected timestamp had been removed, causing the reverse stream to enter a crashing loop. This fix ensures the failback command fast fails.
- #142922
-- The reader virtual cluster now starts if the user begins a physical cluster replication (PCR) stream from a cursor via `ALTER VIRTUAL CLUSTER virtual_cluster START REPLICATION OF virtual_cluster ON physical_cluster WITH READ VIRTUAL CLUSTER`.
- #143141
-- Fixed a bug that caused changefeeds to fail on startup when scanning a single key.
- #143150
-- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior.
- #143277
-- Fixed a bug where calling a stored procedure could drop the procedure if it had `OUT` parameters that were not used by the calling routine. This bug had existed since PL/pgSQL `CALL` statements were introduced in v24.1.
- #143290
-- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2.
- #143315
-- Fixed a crash due to `use of enum metadata before hydration` when using logical data replication (LDR) with user-defined types.
- #143373
-- Fixed a bug where a GC threshold error (which appears as "batch timestamp must be after replica GC threshold ...") could cause a schema change that backfills data to fail. Now, the error will cause the backfill to be retried at a higher timestamp to avoid the error.
- #143520
-- Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument.
- #143634
-- Fixed a potential deadlock that could occur during client certificate updates while metrics were being collected. This issue affected the reliability of certificate expiration reporting.
- #143729
-- Previously, the fields `maximum memory usage` and `max sql temp disk usage` in the `EXPLAIN ANALYZE` output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. This is now fixed. The bug existed in v22.1 and later.
- #143794
-- The `ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER` syntax is now supported for adding a reader virtual cluster for an existing Physical Cluster Replication (PCR) standby.
- #143853
-- Fixed a bug where CockroachDB could encounter a `cannot specify timestamp older than ...` error during table statistics collection in some cases (e.g., when the cluster is overloaded). The bug was present since v19.1.
- #144018
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144031
-- Fixed a bug that could lead to a node stall.
- #146410
+- Previously, fast failback for physical cluster replication (PCR) could succeed even if the destination cluster protected timestamp had been removed, causing the reverse stream to enter a crashing loop. This fix ensures the failback command fast fails. #142922
+- The reader virtual cluster now starts if the user begins a physical cluster replication (PCR) stream from a cursor via `ALTER VIRTUAL CLUSTER virtual_cluster START REPLICATION OF virtual_cluster ON physical_cluster WITH READ VIRTUAL CLUSTER`. #143141
+- Fixed a bug that caused changefeeds to fail on startup when scanning a single key. #143150
+- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior. #143277
+- Fixed a bug where calling a stored procedure could drop the procedure if it had `OUT` parameters that were not used by the calling routine. This bug had existed since PL/pgSQL `CALL` statements were introduced in v24.1. #143290
+- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2. #143315
+- Fixed a crash due to `use of enum metadata before hydration` when using logical data replication (LDR) with user-defined types. #143373
+- Fixed a bug where a GC threshold error (which appears as "batch timestamp must be after replica GC threshold ...") could cause a schema change that backfills data to fail. Now, the error will cause the backfill to be retried at a higher timestamp to avoid the error. #143520
+- Fixed a bug in `v24.1.14`, `v24.3.7`, `v24.3.8`, and `v25.1` that could cause a nil-pointer error when a column's default expression contained a volatile expression (like `nextval`) as a UDF argument. #143634
+- Fixed a potential deadlock that could occur during client certificate updates while metrics were being collected. This issue affected the reliability of certificate expiration reporting. #143729
+- Previously, the fields `maximum memory usage` and `max sql temp disk usage` in the `EXPLAIN ANALYZE` output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. This is now fixed. The bug existed in v22.1 and later. #143794
+- The `ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER` syntax is now supported for adding a reader virtual cluster for an existing Physical Cluster Replication (PCR) standby. #143853
+- Fixed a bug where CockroachDB could encounter a `cannot specify timestamp older than ...` error during table statistics collection in some cases (e.g., when the cluster is overloaded). The bug was present since v19.1. #144018
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144031
+- Fixed a bug that could lead to a node stall. #146410
 
 <h3 id="v25-1-6-performance-improvements">Performance improvements</h3>
 
-- Schema changes that require data to be backfilled no longer hold a protected timestamp for the entire duration of the backfill; this means there is less overhead caused by MVCC garbage collection after the backfill completes.
- #143520
+- Schema changes that require data to be backfilled no longer hold a protected timestamp for the entire duration of the backfill; this means there is less overhead caused by MVCC garbage collection after the backfill completes. #143520

--- a/src/current/_includes/releases/v25.1/v25.1.7.md
+++ b/src/current/_includes/releases/v25.1/v25.1.7.md
@@ -6,52 +6,32 @@ Release Date: May 28, 2025
 
 <h3 id="v25-1-7-db-console-changes">DB Console changes</h3>
 
-- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory.
- #145989
+- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory. #145989
 
 <h3 id="v25-1-7-operational-changes">Operational changes</h3>
 
-- SQL queries run on the source cluster by logical data replication (LDR) and physical cluster replication (PCR) will now account to internal metrics like `sql.statements.active.internal` instead of metrics like `sql.statements.active` that are used to monitor application workload.
- #145110
+- SQL queries run on the source cluster by logical data replication (LDR) and physical cluster replication (PCR) will now account to internal metrics like `sql.statements.active.internal` instead of metrics like `sql.statements.active` that are used to monitor application workload. #145110
 
 <h3 id="v25-1-7-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where using values `changefeed.aggregator.flush_jitter` and `min_checkpoint_frequency` such that `changefeed.aggregator.flush_jitter * min_checkpoint_frequency < 1` would cause a panic. Jitter will now be disabled in this case.
- #144426
-- Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the table details page.
- #144655
-- Fixed a bug in the DB Console where tables with page size dropdowns failed to update when a new page size option was selected. Tables now update correctly.
- #144766
+- Fixed a bug where using values `changefeed.aggregator.flush_jitter` and `min_checkpoint_frequency` such that `changefeed.aggregator.flush_jitter * min_checkpoint_frequency < 1` would cause a panic. Jitter will now be disabled in this case. #144426
+- Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the table details page. #144655
+- Fixed a bug in the DB Console where tables with page size dropdowns failed to update when a new page size option was selected. Tables now update correctly. #144766
 - Fixed a bug that could potentially cause a changefeed to erroneously complete when one of its watched tables encounters a schema change. #144779
 - Fixed a bug where the **Schedules** page displayed only a subset of a cluster's schedules. The **Schedules** page now correctly displays all schedules. #144806
-- Fixed a bug where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load.
- #144806
-- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected.
- #144852
-- Improve the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects.
- #145070
-- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks.
- #145371
-- Fixed a bug where running `DROP INDEX` on a hash-sharded index did not properly detect dependencies from functions and procedures on the shard column. This caused the `DROP INDEX` statement to fail with an internal validation error. Now the statement returns a correct error message, and using `DROP INDEX ... CASCADE` works as expected by dropping the dependent functions and procedures.
- #145384
-- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues.
- #145544
-- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed.
- #145575
-- Fixed a bug that could cause a row-level TTL job to fail with the error "comparison of two different versions of enum" if an `ENUM` type referenced by the table experienced a schema change.
- #145916
-- Fixed a bug where the physical cluster replication (PCR) reader catalog job could hit validation errors when schema objects had dependencies between them (for example, when a sequence's default expression was being removed).
- #145998
-- Fixed a bug where orphaned leases were not properly cleaned up.
- #146088
-- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present.
- #146197
-- Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index.
- #146325
-- Fixed a bug that could lead to a node stall.
- #146408
-- Fixed a bug where an invalid comment in the `system.comment` table for a schema object could make it inacessible.
- #146417
-- Fixed a rare corruption bug that impacts import and materialized views.
- #144662
+- Fixed a bug where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load. #144806
+- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected. #144852
+- Improve the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects. #145070
+- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks. #145371
+- Fixed a bug where running `DROP INDEX` on a hash-sharded index did not properly detect dependencies from functions and procedures on the shard column. This caused the `DROP INDEX` statement to fail with an internal validation error. Now the statement returns a correct error message, and using `DROP INDEX ... CASCADE` works as expected by dropping the dependent functions and procedures. #145384
+- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues. #145544
+- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed. #145575
+- Fixed a bug that could cause a row-level TTL job to fail with the error "comparison of two different versions of enum" if an `ENUM` type referenced by the table experienced a schema change. #145916
+- Fixed a bug where the physical cluster replication (PCR) reader catalog job could hit validation errors when schema objects had dependencies between them (for example, when a sequence's default expression was being removed). #145998
+- Fixed a bug where orphaned leases were not properly cleaned up. #146088
+- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present. #146197
+- Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index. #146325
+- Fixed a bug that could lead to a node stall. #146408
+- Fixed a bug where an invalid comment in the `system.comment` table for a schema object could make it inacessible. #146417
+- Fixed a rare corruption bug that impacts import and materialized views. #144662
 

--- a/src/current/_includes/releases/v25.1/v25.1.8.md
+++ b/src/current/_includes/releases/v25.1/v25.1.8.md
@@ -6,31 +6,19 @@ Release Date: June 25, 2025
 
 <h3 id="v25-1-8-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where a CockroachDB node could crash when executing `DO` statements that contain currently unsupported DDL statements like `CREATE TYPE` in a non-default configuration (additional logging needed to be enabled, e.g., via the `sql.log.all_statements.enabled` cluster setting). This bug was introduced in v25.1.
- #146509
-- Fixed a bug where the `kv.rangefeed.closed_timestamp.slow_ranges` would not be incremented when a rangefeed closed timestamp was slower than the target threshold.
- #146973
-- Fixed a bug that caused the SQL Activity > Statement Fingerprint page to fail to load details for statements run with application names containing a `#` character.
- #147222
-- Fixed a bug that could cause an `AFTER` trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug had existed since `AFTER` triggers were introduced in v24.3.
- #147310
-- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console).
- #147332
-- Previously, CockroachDB could incorrectly evaluate the `to_regclass`, `to_regnamespace`, `to_regproc`, `to_regprocedure`, `to_regrole`, and `to_regtype` built-in functions when the query using them was evaluated in a distributed fashion. The bug was introduced with these built-in functions in v23.1 and is now fixed.
- #147375
-- Fixed a bug that caused the optimizer to ignore index hints when optimizing some forms of prepared statements. This could result in one of two unexpected behaviors: a query errors with the message `index cannot be used for this query` when the index can actually be used; or a query uses an index that does not adhere to the hint. The hints relevant to this bug are regular index hints, e.g., `SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX`, and `FORCE_ZIGZAG`.
- #147416
-- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha.
- #147459
-- Fixed a bug where prepared statements on schema changes could fail with runtime errors.
- #147670
-- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence.
- #147710
-- Fixed an issue with logical data replication where the presence of a unique index may cause spurious dead-letter queue (DLQ) entries if the unique index has a smaller index ID than the primary key index.
- #147353
+- Fixed a bug where a CockroachDB node could crash when executing `DO` statements that contain currently unsupported DDL statements like `CREATE TYPE` in a non-default configuration (additional logging needed to be enabled, e.g., via the `sql.log.all_statements.enabled` cluster setting). This bug was introduced in v25.1. #146509
+- Fixed a bug where the `kv.rangefeed.closed_timestamp.slow_ranges` would not be incremented when a rangefeed closed timestamp was slower than the target threshold. #146973
+- Fixed a bug that caused the SQL Activity > Statement Fingerprint page to fail to load details for statements run with application names containing a `#` character. #147222
+- Fixed a bug that could cause an `AFTER` trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug had existed since `AFTER` triggers were introduced in v24.3. #147310
+- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console). #147332
+- Previously, CockroachDB could incorrectly evaluate the `to_regclass`, `to_regnamespace`, `to_regproc`, `to_regprocedure`, `to_regrole`, and `to_regtype` built-in functions when the query using them was evaluated in a distributed fashion. The bug was introduced with these built-in functions in v23.1 and is now fixed. #147375
+- Fixed a bug that caused the optimizer to ignore index hints when optimizing some forms of prepared statements. This could result in one of two unexpected behaviors: a query errors with the message `index cannot be used for this query` when the index can actually be used; or a query uses an index that does not adhere to the hint. The hints relevant to this bug are regular index hints, e.g., `SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX`, and `FORCE_ZIGZAG`. #147416
+- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha. #147459
+- Fixed a bug where prepared statements on schema changes could fail with runtime errors. #147670
+- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence. #147710
+- Fixed an issue with logical data replication where the presence of a unique index may cause spurious dead-letter queue (DLQ) entries if the unique index has a smaller index ID than the primary key index. #147353
 
 <h3 id="v25-1-8-performance-improvements">Performance improvements</h3>
 
-- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes.
- #147208
+- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes. #147208
 

--- a/src/current/_includes/releases/v25.1/v25.1.9.md
+++ b/src/current/_includes/releases/v25.1/v25.1.9.md
@@ -6,24 +6,18 @@ Release Date: July 28, 2025
 
 <h3 id="v25-1-9-sql-language-changes">SQL language changes</h3>
 
-- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`).
- #148223
-- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors.
- #148223
+- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`). #148223
+- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors. #148223
 
 <h3 id="v25-1-9-db-console-changes">DB Console changes</h3>
 
-- Updated the "Learn more" link on the **Hot Ranges** page to direct users to a newer, more comprehensive reference guide about hotspots.
- #148521
+- Updated the "Learn more" link on the **Hot Ranges** page to direct users to a newer, more comprehensive reference guide about hotspots. #148521
 
 <h3 id="v25-1-9-bug-fixes">Bug fixes</h3>
 
-- Fixed a data race in the `cloudstorage` sink.
- #147162
-- Fixed an error in `crdb_internal.table_spans` that could occur when a table's schema had been dropped.
- #147976
-- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg).
- #148469
+- Fixed a data race in the `cloudstorage` sink. #147162
+- Fixed an error in `crdb_internal.table_spans` that could occur when a table's schema had been dropped. #147976
+- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg). #148469
 - The `RESET ALL` statement no longer affects the following session variables:
   - `is_superuser`
   - `role`
@@ -34,12 +28,10 @@ Release Date: July 28, 2025
   - `transaction_read_only`
 
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled.
+
     \#149429
-- In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
- #149624
-- Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.
- #149925
-- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels.
- #150339
+- In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created. #149624
+- Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node. #149925
+- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels. #150339
 
 

--- a/src/current/_includes/releases/v25.1/v25.1.9.md
+++ b/src/current/_includes/releases/v25.1/v25.1.9.md
@@ -34,7 +34,7 @@ Release Date: July 28, 2025
   - `transaction_read_only`
 
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled.
-    #149429
+    \#149429
 - In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
  #149624
 - Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.

--- a/src/current/_includes/releases/v25.1/v25.1.9.md
+++ b/src/current/_includes/releases/v25.1/v25.1.9.md
@@ -32,9 +32,9 @@ Release Date: July 28, 2025
   - `transaction_priority`
   - `transaction_status`
   - `transaction_read_only`
-  
+
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled.
- #149429
+    #149429
 - In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
  #149624
 - Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.

--- a/src/current/_includes/releases/v25.2/v25.2.0-alpha.2.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-alpha.2.md
@@ -6,71 +6,48 @@ Release Date: March 31, 2025
 
 <h3 id="v25-2-0-alpha-2-sql-language-changes">SQL language changes</h3>
 
-- `num_nulls()` and `num_nonnulls()` no longer require that all arguments have the same type.
- #141193
-- `concat()` no longer requires that all arguments have the same type.
- #141193
-- `pg_column_size()` no longer requires that all arguments have the same type.
- #141193
-- Users can now begin logical data replication (LDR) on an existing table if the user has a table-level `REPLICATIONDEST` privilege. Furthermore, users can now begin LDR onto an automatically created table if the user has the parent database level `CREATE` privilege. Finally, during bidirectional LDR, the user in the original source URI, who will begin the reverse LDR stream, will authorize via this table-level `REPLICATIONDEST` privilege.
- #142840
-- `concat_ws()` now accepts arguments of any type in the second and later positions (the separator must still be a string).
- #141193
-- Filters are now supported in JSONPath queries, using the format `$ ? (predicate)`. This allows results to be filtered. For example, `SELECT jsonb_path_query('{"a": [1,2,3]}', '$.a ? (1 == 1)');`.
- #143097
-- `format()` no longer requires that all post-format string arguments have the same type.
- #141193
-- `json_build_object()`, `jsonb_build_object()`, `json_build_array()`, and `jsonb_build_array()` no longer require that all arguments have the same type.
- #141193
-- Added the `jsonb_path_exists` function, which accepts a JSON object and JSONPath query and returns whether the query returned any items.
- #143028
-- Addition, subtraction, multiplication, division, and modulo operators are now supported in JSONPath queries.
- #143210
+- `num_nulls()` and `num_nonnulls()` no longer require that all arguments have the same type. #141193
+- `concat()` no longer requires that all arguments have the same type. #141193
+- `pg_column_size()` no longer requires that all arguments have the same type. #141193
+- Users can now begin logical data replication (LDR) on an existing table if the user has a table-level `REPLICATIONDEST` privilege. Furthermore, users can now begin LDR onto an automatically created table if the user has the parent database level `CREATE` privilege. Finally, during bidirectional LDR, the user in the original source URI, who will begin the reverse LDR stream, will authorize via this table-level `REPLICATIONDEST` privilege. #142840
+- `concat_ws()` now accepts arguments of any type in the second and later positions (the separator must still be a string). #141193
+- Filters are now supported in JSONPath queries, using the format `$ ? (predicate)`. This allows results to be filtered. For example, `SELECT jsonb_path_query('{"a": [1,2,3]}', '$.a ? (1 == 1)');`. #143097
+- `format()` no longer requires that all post-format string arguments have the same type. #141193
+- `json_build_object()`, `jsonb_build_object()`, `json_build_array()`, and `jsonb_build_array()` no longer require that all arguments have the same type. #141193
+- Added the `jsonb_path_exists` function, which accepts a JSON object and JSONPath query and returns whether the query returned any items. #143028
+- Addition, subtraction, multiplication, division, and modulo operators are now supported in JSONPath queries. #143210
 
 <h3 id="v25-2-0-alpha-2-operational-changes">Operational changes</h3>
 
-- All `ALTER VIRTUAL CLUSTER REPLICATION JOB` commands for physical cluster replication (PCR), except for `ALTER VIRTUAL CLUSTER SET REPLICATION SOURCE`, will require the `REPLICATIONDEST` privilege, in addition to `MANAGEVIRTUALCLUSTER`. `ALTER VIRTUAL CLUSTER SET REPLICATION SOURCE` now requires the `REPLICATIONSOURCE` privilege. If the ingestion job was created before v25.1, the user can still alter the replication job without the `REPLICATIONDEST` privilege.
- #142772
+- All `ALTER VIRTUAL CLUSTER REPLICATION JOB` commands for physical cluster replication (PCR), except for `ALTER VIRTUAL CLUSTER SET REPLICATION SOURCE`, will require the `REPLICATIONDEST` privilege, in addition to `MANAGEVIRTUALCLUSTER`. `ALTER VIRTUAL CLUSTER SET REPLICATION SOURCE` now requires the `REPLICATIONSOURCE` privilege. If the ingestion job was created before v25.1, the user can still alter the replication job without the `REPLICATIONDEST` privilege. #142772
 
 <h3 id="v25-2-0-alpha-2-db-console-changes">DB Console changes</h3>
 
-- The lock and latch wait time components of a query's cumulative contention time are now tracked separately and surfaced as annotations in `EXPLAIN ANALYZE` output.
- #113649
-- The metric that measures cumulative contention time now includes time spent waiting to acquire latches, in addition to time spent acquiring locks. This metric is displayed in both the DB Console and the `EXPLAIN ANALYZE` output.
- #113649
+- The lock and latch wait time components of a query's cumulative contention time are now tracked separately and surfaced as annotations in `EXPLAIN ANALYZE` output. #113649
+- The metric that measures cumulative contention time now includes time spent waiting to acquire latches, in addition to time spent acquiring locks. This metric is displayed in both the DB Console and the `EXPLAIN ANALYZE` output. #113649
 - The Replica Quiescence graph on the Replication dashboard in the DB Console now displays the number of replicas quiesced with leader leases. #143215
 
 <h3 id="v25-2-0-alpha-2-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where index backfills unnecessarily merged new data written to an index, which could lead to extra contention.
- #142768
+- Fixed a bug where index backfills unnecessarily merged new data written to an index, which could lead to extra contention. #142768
 - Fixed a bug that could leave behind a dangling reference to a dropped role if that role had default privileges granted to itself. The bug was caused by defining privileges such as: `ALTER DEFAULT
   PRIVILEGES FOR ROLE self_referencing_role GRANT INSERT ON TABLES TO self_referencing_role`. #143287
-- Fixed a bug that caused changefeeds to fail on startup when scanning a single key.
- #143102
-- Fixed a bug where secondary indexes could be unusable by DML statements while a primary key swap was occurring, if the new primary key did not contain columns from the old primary key.
- #141850
+- Fixed a bug that caused changefeeds to fail on startup when scanning a single key. #143102
+- Fixed a bug where secondary indexes could be unusable by DML statements while a primary key swap was occurring, if the new primary key did not contain columns from the old primary key. #141850
 - Fixed a crash due to `use of enum metadata before hydration` when using LDR with user-defined types. #143311
 - MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amounts of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior. #143122
-- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2.
- #143252
-- Fixed a bug where calling a stored procedure could drop the procedure if it had `OUT` parameters that were not used by the calling routine. This bug had existed since PL/pgSQL `CALL` statements were introduced in v24.1.
- #143173
-- Fixed a bug where CockroachDB incorrectly resolved routine overloads in some cases. Previously, it allowed creating routines with signatures differing only in type width (e.g., `f(p VARCHAR(1))` and `f(p VARCHAR(2))`), which is not permitted in PostgreSQL. This required precise type casting during invocation. Similarly, when dropping a routine, CockroachDB previously required exact types, unlike PostgreSQL, which is more lenient (e.g., `DROP FUNCTION f(VARCHAR)` would fail in the preceding example). This bug had existed since v23.1.
- #143159
-- The reader virtual cluster now starts if the user begins a physical cluster replication (PCR) stream from a cursor via `ALTER VIRTUAL CLUSTER virtual_cluster START REPLICATION OF physical_cluster ON pgurl WITH READ VIRTUAL CLUSTER`.
- #143072
+- Fixed a bug where CockroachDB would encounter an internal error when decoding the gists of plans with `CALL` statements. The bug had been present since v23.2. #143252
+- Fixed a bug where calling a stored procedure could drop the procedure if it had `OUT` parameters that were not used by the calling routine. This bug had existed since PL/pgSQL `CALL` statements were introduced in v24.1. #143173
+- Fixed a bug where CockroachDB incorrectly resolved routine overloads in some cases. Previously, it allowed creating routines with signatures differing only in type width (e.g., `f(p VARCHAR(1))` and `f(p VARCHAR(2))`), which is not permitted in PostgreSQL. This required precise type casting during invocation. Similarly, when dropping a routine, CockroachDB previously required exact types, unlike PostgreSQL, which is more lenient (e.g., `DROP FUNCTION f(VARCHAR)` would fail in the preceding example). This bug had existed since v23.1. #143159
+- The reader virtual cluster now starts if the user begins a physical cluster replication (PCR) stream from a cursor via `ALTER VIRTUAL CLUSTER virtual_cluster START REPLICATION OF physical_cluster ON pgurl WITH READ VIRTUAL CLUSTER`. #143072
 
 <h3 id="v25-2-0-alpha-2-performance-improvements">Performance improvements</h3>
 
-- Index backfills and row-level TTL deletions that encounter transaction contention will now be retried with smaller batch sizes more quickly, which reduces the latency of these jobs under high-contention workloads.
- #142702
-- Queries that use `SHOW TABLES` without using the `estimated_row_count` column no longer need to look up the table statistics.
- #59838
+- Index backfills and row-level TTL deletions that encounter transaction contention will now be retried with smaller batch sizes more quickly, which reduces the latency of these jobs under high-contention workloads. #142702
+- Queries that use `SHOW TABLES` without using the `estimated_row_count` column no longer need to look up the table statistics. #59838
 
 <h3 id="v25-2-0-alpha-2-miscellaneous">Miscellaneous</h3>
 
-- `pg_column_size()` is now regarded as Stable, matching PostgreSQL. As a result, it will no longer be allowed in computed column expressions or partial index predicate expressions.
- #141193
+- `pg_column_size()` is now regarded as Stable, matching PostgreSQL. As a result, it will no longer be allowed in computed column expressions or partial index predicate expressions. #141193
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.0-alpha.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-alpha.3.md
@@ -6,61 +6,39 @@ Release Date: April 7, 2025
 
 <h3 id="v25-2-0-alpha-3-sql-language-changes">SQL language changes</h3>
 
-- `last` is now supported for array indexing in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3, 4]', '$[1 to last]');`.
- #143658
-- String comparisons are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"a" < "b"');`.
- #143240
-- Added the `ST_3DLength` function, which returns the 3D or 2D length of `LINESTRING` and `MULTILINESTRING` spatial types.
- #139450
-- Updated edge cases in the `width_bucket()` function to return `count + 1` for a positive infinity operand, and `0` for a negative infinity operand, instead of an error.
- #142932
-- Unary arithmetic operators are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3]', '-$');`.
- #143613
-- Implemented various `power()` and `^` edge cases to match PostgreSQL behaviour. Some expressions that previously returned `NaN` now return specific numbers; some expressions that previously returned `Infinity` or `NaN` now return errors; and some expressions with infinite exponents now return different results.
- #142932
-- Null comparisons are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', 'null != 1');`.
- #143240
-- Wildcard key accessors are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{"a": 1, "b": true}', '$.*');`.
- #143588
-- `like_regex` predicate evaluation is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"hello" like_regex "^he.*$"');`.
- #143240
+- `last` is now supported for array indexing in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3, 4]', '$[1 to last]');`. #143658
+- String comparisons are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"a" < "b"');`. #143240
+- Added the `ST_3DLength` function, which returns the 3D or 2D length of `LINESTRING` and `MULTILINESTRING` spatial types. #139450
+- Updated edge cases in the `width_bucket()` function to return `count + 1` for a positive infinity operand, and `0` for a negative infinity operand, instead of an error. #142932
+- Unary arithmetic operators are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3]', '-$');`. #143613
+- Implemented various `power()` and `^` edge cases to match PostgreSQL behaviour. Some expressions that previously returned `NaN` now return specific numbers; some expressions that previously returned `Infinity` or `NaN` now return errors; and some expressions with infinite exponents now return different results. #142932
+- Null comparisons are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', 'null != 1');`. #143240
+- Wildcard key accessors are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{"a": 1, "b": true}', '$.*');`. #143588
+- `like_regex` predicate evaluation is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"hello" like_regex "^he.*$"');`. #143240
 
 <h3 id="v25-2-0-alpha-3-operational-changes">Operational changes</h3>
 
-- The `server.client_cert_expiration_cache.capacity` cluster setting has been removed. The `security.certificate.expiration.client` and `security.certificate.ttl.client` metrics now report the lowest value observed for a user in the last 24 hours.
- #143384
-- Previously, the user provided in the source URI in the logical data replication (LDR) stream required the `REPLICATIONSOURCE` privilege at the system level. With this change, the user only needs this privilege on the source tables (i.e., a table-level privilege).
- #143456
+- The `server.client_cert_expiration_cache.capacity` cluster setting has been removed. The `security.certificate.expiration.client` and `security.certificate.ttl.client` metrics now report the lowest value observed for a user in the last 24 hours. #143384
+- Previously, the user provided in the source URI in the logical data replication (LDR) stream required the `REPLICATIONSOURCE` privilege at the system level. With this change, the user only needs this privilege on the source tables (i.e., a table-level privilege). #143456
 
 <h3 id="v25-2-0-alpha-3-db-console-changes">DB Console changes</h3>
 
-- The lock and latch wait time components of a query's cumulative contention time are now tracked separately and surfaced as annotations in `EXPLAIN ANALYZE` output.
- #113649
-- The metric that measures cumulative contention time now includes time spent waiting to acquire latches, in addition to time spent acquiring locks. This metric is displayed in both the DB Console and the `EXPLAIN ANALYZE` output.
- #113649
+- The lock and latch wait time components of a query's cumulative contention time are now tracked separately and surfaced as annotations in `EXPLAIN ANALYZE` output. #113649
+- The metric that measures cumulative contention time now includes time spent waiting to acquire latches, in addition to time spent acquiring locks. This metric is displayed in both the DB Console and the `EXPLAIN ANALYZE` output. #113649
 
 <h3 id="v25-2-0-alpha-3-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where index backfills unnecessarily merged new data written to an index, which could lead to extra contention.
- #142768
+- Fixed a bug where index backfills unnecessarily merged new data written to an index, which could lead to extra contention. #142768
 - Column IDs are now validated when starting an `immediate` mode logical data replication stream. #143773
-- Fixed a bug where a GC threshold error (which appears as "batch timestamp must be after replica GC threshold ...") could cause a schema change that backfills data to fail. Now, the error will cause the backfill to be retried at a higher timestamp to avoid the error.
- #143451
-- Fixed a bug where index backfill progress before a `PAUSE`/`RESUME` would not get tracked.
- #142602
-- Fixed a bug that could cause a function reference to be left behind if a procedure referred to another procedure that depended on a a table, and that table was dropped with `CASCADE`.
- #143538
-- Fixed a potential deadlock that could occur during client certificate updates while metrics were being collected. This issue affected the reliability of certificate expiration reporting.
- #143663
-- Previously, the fields `maximum memory usage` and `max sql temp disk usage` in the `EXPLAIN ANALYZE` output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. This is now fixed. The bug existed in v22.1 and later.
- #143777
-- The `ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER` syntax is now supported for adding a reader virtual cluster for an existing physical cluster replication (PCR) standby cluster.
- #143752
+- Fixed a bug where a GC threshold error (which appears as "batch timestamp must be after replica GC threshold ...") could cause a schema change that backfills data to fail. Now, the error will cause the backfill to be retried at a higher timestamp to avoid the error. #143451
+- Fixed a bug where index backfill progress before a `PAUSE`/`RESUME` would not get tracked. #142602
+- Fixed a bug that could cause a function reference to be left behind if a procedure referred to another procedure that depended on a a table, and that table was dropped with `CASCADE`. #143538
+- Fixed a potential deadlock that could occur during client certificate updates while metrics were being collected. This issue affected the reliability of certificate expiration reporting. #143663
+- Previously, the fields `maximum memory usage` and `max sql temp disk usage` in the `EXPLAIN ANALYZE` output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. This is now fixed. The bug existed in v22.1 and later. #143777
+- The `ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER` syntax is now supported for adding a reader virtual cluster for an existing physical cluster replication (PCR) standby cluster. #143752
 
 <h3 id="v25-2-0-alpha-3-performance-improvements">Performance improvements</h3>
 
-- Schema changes that require data to be backfilled no longer hold a protected timestamp for the entire duration of the backfill, which means there is less overhead caused by MVCC garbage collection after the backfill completes.
- #143451
-- Fixed a bug that caused the optimizer to over-estimate the cost of inverted index scans in some cases. Now, plans with inverted index scans should be selected in more cases where they are optimal.
- #120079
+- Schema changes that require data to be backfilled no longer hold a protected timestamp for the entire duration of the backfill, which means there is less overhead caused by MVCC garbage collection after the backfill completes. #143451
+- Fixed a bug that caused the optimizer to over-estimate the cost of inverted index scans in some cases. Now, plans with inverted index scans should be selected in more cases where they are optimal. #120079
 

--- a/src/current/_includes/releases/v25.2/v25.2.0-beta.1.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-beta.1.md
@@ -6,41 +6,28 @@ Release Date: April 14, 2025
 
 <h3 id="v25-2-0-beta-1-sql-language-changes">SQL language changes</h3>
 
-- Set-returning functions (SRF) are now supported in PL/pgSQL. A PL/pgSQL SRF can be created by declaring the return type as `SETOF <type>` or `TABLE`.
- #143820
-- Usage of `TG_ARGV` in trigger functions is now disallowed by default. The session setting `allow_create_trigger_function_with_argv_references` can be set to `true` to allow usage (with 1-based indexing).
- #143827
+- Set-returning functions (SRF) are now supported in PL/pgSQL. A PL/pgSQL SRF can be created by declaring the return type as `SETOF <type>` or `TABLE`. #143820
+- Usage of `TG_ARGV` in trigger functions is now disallowed by default. The session setting `allow_create_trigger_function_with_argv_references` can be set to `true` to allow usage (with 1-based indexing). #143827
 - The return type of the `workload_index_recs` built-in function now includes two columns. The first column, `index_rec`, remains a `STRING` type and contains the index recommendation. The second column, `fingerprint_ids`, is new and has the `BYTES[]` type. #142927
-- The job description for `AUTO CREATE PARTIAL STATS` now clearly indicates that the job is for automatic partial statistics collection, improving `system.jobs` visibility and debugging.
- #143283
-- A new `execution time` statistic is now reported on `EXPLAIN ANALYZE` output for most operators. Previously, this statistic was only available on the DistSQL diagrams in `EXPLAIN ANALYZE (DISTSQL)` output.
- #143857
-- `() is unknown` is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '($ < 1) is unknown');`.
- #143668
+- The job description for `AUTO CREATE PARTIAL STATS` now clearly indicates that the job is for automatic partial statistics collection, improving `system.jobs` visibility and debugging. #143283
+- A new `execution time` statistic is now reported on `EXPLAIN ANALYZE` output for most operators. Previously, this statistic was only available on the DistSQL diagrams in `EXPLAIN ANALYZE (DISTSQL)` output. #143857
+- `() is unknown` is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '($ < 1) is unknown');`. #143668
 - `starts with ""` is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('"abcdef"', '$
   starts with "abc"');`.
  #143675
 
 <h3 id="v25-2-0-beta-1-operational-changes">Operational changes</h3>
 
-- The `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting was retired.
- #143124
-- `debug zip` queries are now attributed to internal SQL metrics. As a result, users will no longer see their impact on the SQL charts in the DB Console.
- #143711
+- The `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting was retired. #143124
+- `debug zip` queries are now attributed to internal SQL metrics. As a result, users will no longer see their impact on the SQL charts in the DB Console. #143711
 
 <h3 id="v25-2-0-beta-1-bug-fixes">Bug fixes</h3>
 
-- Fixed an issue where hot range logging for virtual clusters omitted some hot ranges.
- #143775
-- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior.
- #143122
-- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3.
- #144027
-- Fixed an issue where change data capture queries on tables without columns would fail with an internal error: `unable to determine result columns`.
- #142068
-- Previously, statement bundle collection could encounter `not enough privileges` errors when retrieving necessary information (e.g., cluster settings, table statistics, etc.) when the user that requested the bundle was different from the user that actually ran the query. This is now fixed. The bug was present since v20.2 and would result in partially incomplete bundles.
- #144178
-- Fixed an issue where databases, tables, and indexes were not appearing on the Hot Ranges page for application virtual clusters.
- #143441
+- Fixed an issue where hot range logging for virtual clusters omitted some hot ranges. #143775
+- MVCC garbage collection is now fully subject to IO admission control. Previously, it was possible for MVCC GC to cause store overload (such as LSM inversion) when a large amount of data would become eligible for garbage collection. Should any issues arise from subjecting MVCC GC to admission control, the `kv.mvcc_gc.queue_kv_admission_control.enabled` cluster setting can be set to `false` to restore the previous behavior. #143122
+- Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of v25.2 prior to v25.2.0-alpha.3. #144027
+- Fixed an issue where change data capture queries on tables without columns would fail with an internal error: `unable to determine result columns`. #142068
+- Previously, statement bundle collection could encounter `not enough privileges` errors when retrieving necessary information (e.g., cluster settings, table statistics, etc.) when the user that requested the bundle was different from the user that actually ran the query. This is now fixed. The bug was present since v20.2 and would result in partially incomplete bundles. #144178
+- Fixed an issue where databases, tables, and indexes were not appearing on the Hot Ranges page for application virtual clusters. #143441
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.0-beta.2.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-beta.2.md
@@ -6,31 +6,21 @@ Release Date: April 23, 2025
 
 <h3 id="v25-2-0-beta-2-sql-language-changes">SQL language changes</h3>
 
-- Added the `jsonb_path_match` function, which returns the result of a predicate query.
- #144271
-- The `.type()` method is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3]', '$.type()');`.
- #144405
-- Removed the `ST_3DLength` function.
- #144549
-- Added the `jsonb_path_query_first` function, which returns the first result from `jsonb_path_query`.
- #144271
-- Parenthesized expressions are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{"a": {"b": true}}', '($.a).b');`
- #144298
-- The `.size()` method is now supported in JSONPath expressions. For example, `SELECT jsonb_path_query('[1, 2, 3]', '$.size()');`.
- #144405
-- Added the `jsonb_path_query_array` function, which returns the result of `jsonb_path_query` wrapped in a JSON array.
- #144271
+- Added the `jsonb_path_match` function, which returns the result of a predicate query. #144271
+- The `.type()` method is now supported in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3]', '$.type()');`. #144405
+- Removed the `ST_3DLength` function. #144549
+- Added the `jsonb_path_query_first` function, which returns the first result from `jsonb_path_query`. #144271
+- Parenthesized expressions are now supported in JSONPath queries. For example, `SELECT jsonb_path_query('{"a": {"b": true}}', '($.a).b');` #144298
+- The `.size()` method is now supported in JSONPath expressions. For example, `SELECT jsonb_path_query('[1, 2, 3]', '$.size()');`. #144405
+- Added the `jsonb_path_query_array` function, which returns the result of `jsonb_path_query` wrapped in a JSON array. #144271
 
 <h3 id="v25-2-0-beta-2-operational-changes">Operational changes</h3>
 
-- Logical data replication (LDR) now supports partial indexes by default.
- #144513
+- Logical data replication (LDR) now supports partial indexes by default. #144513
 
 <h3 id="v25-2-0-beta-2-miscellaneous">Miscellaneous</h3>
 
-- Fixed a rare corruption bug that could affect `IMPORT`, physical cluster replication (PCR), `CREATE TABLE AS` (CTAS), and materialized view refreshes.
- #144663
-- Vector indexes created in v25.2.0-beta.1 are not compatible with later releases. Drop and re-create these indexes before using them with later releases.
- #144581
+- Fixed a rare corruption bug that could affect `IMPORT`, physical cluster replication (PCR), `CREATE TABLE AS` (CTAS), and materialized view refreshes. #144663
+- Vector indexes created in v25.2.0-beta.1 are not compatible with later releases. Drop and re-create these indexes before using them with later releases. #144581
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.0-beta.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-beta.3.md
@@ -18,7 +18,7 @@ Release Date: April 28, 2025
 - Fixed the following bugs in the **Schedules** page of the DB Console:
     - Where the **Schedules** page displayed only a subset of a cluster's schedules. The **Schedules** page now correctly displays all schedules.
     - Where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load.
-    #144807
+    \#144807
 - Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected.
  #144851
 - Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the **Table Details** page.

--- a/src/current/_includes/releases/v25.2/v25.2.0-beta.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-beta.3.md
@@ -13,16 +13,14 @@ Release Date: April 28, 2025
 <h3 id="v25-2-0-beta-3-bug-fixes">Bug fixes</h3>
 
 - Fixed a bug that could cause a changefeed to complete erroneously when one of its watched tables encounters a schema change. #144717
-- Fixed a bug in the DB Console where tables with page size dropdowns failed to update when a new page size option was selected. Tables now update correctly.
- #144666
+- Fixed a bug in the DB Console where tables with page size dropdowns failed to update when a new page size option was selected. Tables now update correctly. #144666
 - Fixed the following bugs in the **Schedules** page of the DB Console:
     - Where the **Schedules** page displayed only a subset of a cluster's schedules. The **Schedules** page now correctly displays all schedules.
     - Where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load.
+
     \#144807
-- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected.
- #144851
-- Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the **Table Details** page.
- #144656
+- Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected. #144851
+- Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the **Table Details** page. #144656
 
 <h3 id="v25-2-0-beta-3-performance-improvements">Performance improvements</h3>
 

--- a/src/current/_includes/releases/v25.2/v25.2.0-beta.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-beta.3.md
@@ -18,7 +18,7 @@ Release Date: April 28, 2025
 - Fixed the following bugs in the **Schedules** page of the DB Console:
     - Where the **Schedules** page displayed only a subset of a cluster's schedules. The **Schedules** page now correctly displays all schedules.
     - Where manually updating the `show` or `status` parameters in the URL (e.g., `http://127.0.0.1:8080/#/schedules?status=ACTIVE&show=50`) caused the **Schedules** page to fail to load.
- #144807
+    #144807
 - Fixed a bug in the **SQL Activity Statements** page where filtering by **Statement Type** returned no results. The filter now works as expected.
  #144851
 - Fixed a bug in the DB Console where the **Drop unused index** tag appeared multiple times for an index on the **Indexes** tab of the **Table Details** page.

--- a/src/current/_includes/releases/v25.2/v25.2.0-rc.1.md
+++ b/src/current/_includes/releases/v25.2/v25.2.0-rc.1.md
@@ -6,40 +6,27 @@ Release Date: May 12, 2025
 
 <h3 id="v25-2-0-rc-1-sql-language-changes">SQL language changes</h3>
 
-- Non-integer array indices are now supported in JSONPath queries (e.g., `SELECT jsonb_path_query('[1, 2, 3]', '$[2.5]');`). Indices are rounded toward 0.
- #144819
-- The `vector_l2_ops` operator class can now be specified for a vector index. Because `vector_l2_ops` is the default, it is possible to omit the operator class from an index definition.
- #144902
-- When creating a vector index with the `USING` syntax, `hnsw` can now be specified as the index type, although a `cspann` vector index is still provided. This change increases compatibility with third-party tools.
- #144902
-- Added support for numeric JSONPath methods `.abs()`, `.floor()`, `.ceiling()`. For example, `SELECT jsonb_path_query('-0.5', '$.abs()');`.
- #145121
-- Disabled `IMPORT INTO` for tables with vector indexes, because importing into vector indexes is not implemented.
- #145262
-- Added support for `like_regex` flags in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"a" like_regex ".*" flag "i"');`.
- #145300
-- Vector index creation is now prevented until the entire cluster upgrade has been finalized on v25.2 or later.
- #145449
+- Non-integer array indices are now supported in JSONPath queries (e.g., `SELECT jsonb_path_query('[1, 2, 3]', '$[2.5]');`). Indices are rounded toward 0. #144819
+- The `vector_l2_ops` operator class can now be specified for a vector index. Because `vector_l2_ops` is the default, it is possible to omit the operator class from an index definition. #144902
+- When creating a vector index with the `USING` syntax, `hnsw` can now be specified as the index type, although a `cspann` vector index is still provided. This change increases compatibility with third-party tools. #144902
+- Added support for numeric JSONPath methods `.abs()`, `.floor()`, `.ceiling()`. For example, `SELECT jsonb_path_query('-0.5', '$.abs()');`. #145121
+- Disabled `IMPORT INTO` for tables with vector indexes, because importing into vector indexes is not implemented. #145262
+- Added support for `like_regex` flags in JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"a" like_regex ".*" flag "i"');`. #145300
+- Vector index creation is now prevented until the entire cluster upgrade has been finalized on v25.2 or later. #145449
 
 <h3 id="v25-2-0-rc-1-bug-fixes">Bug fixes</h3>
 
-- `NULL` vectors can now be inserted into tables with vector indexes.
- #144858
-- Fixed a bug that caused vector indexes to return incorrect or no results from a standby reader in a physical cluster replication (PCR) setup. This bug existed in alpha versions of v25.2 and in v25.2.0-beta.1.
- #145157
-- Fixed a bug that allowed a set-returning PL/pgSQL function to be created before the version change was finalized. This bug existed in v25.2 alpha and beta releases.
- #145381
-- Fixed a bug where CockroachDB could encounter an internal error when fetching from the `WITH HOLD` cursor with `FETCH FIRST` and `FETCH ABSOLUTE`. The bug was only present in v25.2 alpha and beta releases.
- #145409
+- `NULL` vectors can now be inserted into tables with vector indexes. #144858
+- Fixed a bug that caused vector indexes to return incorrect or no results from a standby reader in a physical cluster replication (PCR) setup. This bug existed in alpha versions of v25.2 and in v25.2.0-beta.1. #145157
+- Fixed a bug that allowed a set-returning PL/pgSQL function to be created before the version change was finalized. This bug existed in v25.2 alpha and beta releases. #145381
+- Fixed a bug where CockroachDB could encounter an internal error when fetching from the `WITH HOLD` cursor with `FETCH FIRST` and `FETCH ABSOLUTE`. The bug was only present in v25.2 alpha and beta releases. #145409
 
 <h3 id="v25-2-0-rc-1-performance-improvements">Performance improvements</h3>
 
-- Some internal queries executed by the jobs system are now less likely to perform full table scans of the `system.jobs` table, making them more efficient. This change can be reverted by disabling the `jobs.avoid_full_scans_in_find_running_jobs.enabled` cluster setting.
- #144825
+- Some internal queries executed by the jobs system are now less likely to perform full table scans of the `system.jobs` table, making them more efficient. This change can be reverted by disabling the `jobs.avoid_full_scans_in_find_running_jobs.enabled` cluster setting. #144825
 
 <h3 id="v25-2-0-rc-1-miscellaneous">Miscellaneous</h3>
 
-- SQL queries run on the source cluster by logical data replication (LDR) and physical cluster replication (PCR) will account to internal metrics like `sql.statements.active.internal` instead of the metrics like `sql.statements.active` that are used to monitor application workload.
- #145111
+- SQL queries run on the source cluster by logical data replication (LDR) and physical cluster replication (PCR) will account to internal metrics like `sql.statements.active.internal` instead of the metrics like `sql.statements.active` that are used to monitor application workload. #145111
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.1.md
+++ b/src/current/_includes/releases/v25.2/v25.2.1.md
@@ -6,70 +6,42 @@ Release Date: June 4, 2025
 
 <h3 id="v25-2-1-sql-language-changes">SQL language changes</h3>
 
-- Added the `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` cluster settings. These settings default to `false`. Set them to `true` to include the application and database name, respectively, in supported metrics.
- #144932
+- Added the `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` cluster settings. These settings default to `false`. Set them to `true` to include the application and database name, respectively, in supported metrics. #144932
 
 <h3 id="v25-2-1-operational-changes">Operational changes</h3>
 
-- Added the metric `changefeed.checkpoint.timestamp_count` that measures the number of unique timestamps in a changefeed span-level checkpoint. It may be useful to monitor this metric to determine if quantization settings should be changed.
- #145223
-- Logs for hot ranges (`hot_ranges_stats` events) have been moved to the `HEALTH` logging channel.
- #146762
+- Added the metric `changefeed.checkpoint.timestamp_count` that measures the number of unique timestamps in a changefeed span-level checkpoint. It may be useful to monitor this metric to determine if quantization settings should be changed. #145223
+- Logs for hot ranges (`hot_ranges_stats` events) have been moved to the `HEALTH` logging channel. #146762
 
 <h3 id="v25-2-1-db-console-changes">DB Console changes</h3>
 
-- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory.
- #145993
+- Schema insights that recommend replacing an index were previously a two-statement command consisting of a `CREATE INDEX` and a `DROP INDEX` statement. When these two DDL statements were run as a single batched command, it was possible for one statement to succeed and one to fail. This is because DDL statements do not have the same atomicity guarantees as other SQL statements in CockroachDB. Index-replacement insights are now a single `CREATE INDEX` statement followed by a comment with additional DDL statements to be run manually: an `ALTER INDEX ... NOT VISIBLE` statement, which makes the old index invisible to the optimizer, followed by a `DROP INDEX` statement that should only be run after making the old index invisible and verifying that workload performance is satisfactory. #145993
 
 <h3 id="v25-2-1-bug-fixes">Bug fixes</h3>
 
-- Improved the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects.
- #145004
-- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks.
- #145363
-- Fixed a bug where running `DROP INDEX` on a hash-sharded index did not properly detect dependencies from functions and procedures on the shard column. This caused the `DROP INDEX` statement to fail with an internal validation error. Now the statement returns a correct error message, and using `DROP INDEX ... CASCADE` works as expected by dropping the dependent functions and procedures.
- #145386
-- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues.
- #145545
-- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed.
- #145576
-- Fixed a bug that could cause a row-level TTL job to fail with the error "comparison of two different versions of enum" if an `ENUM` type referenced by the table experienced a schema change.
- #145917
-- Fixed a bug where the physical cluster replication (PCR) reader catalog job could hit validation errors when schema objects had dependencies between them (for example, when a sequence's default expression was being removed).
- #145999
-- Creating a vector index on a table that contains a `NULL` vector value will no longer cause an internal error.
- #146017
-- Row-level security (RLS) `SELECT` policies during `UPDATE` operations are now only applied when referenced columns appear in the `SET` or `WHERE` clauses, matching the behavior of PostgreSQL. This improves compatibility.
- #146128
-- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present.
- #146196
-- Fixed incorrect application of row-level security (RLS) `SELECT` policies to `RETURNING` clauses in `INSERT` and `UPDATE` when no table columns were referenced.
- #146292
-- Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index.
- #146326
-- Fixed a bug that could lead to a node stall.
- #146409
-- Fixed an integer overflow in the `split_part` function when using extremely negative field positions like Go's `math.MinInt64`.
- #146413
-- Fixed a bug where an invalid comment in the `system.comment` table for a schema object could make it inaccessible.
- #146418
-- Fixed a bug where a CockroachDB node could crash when executing `DO` statements that contain currently unsupported DDL statements like `CREATE TYPE` in a non-default configuration (additional logging needed to be enabled, e.g., via the `sql.log.all_statements.enabled` cluster setting). This bug was introduced in v25.1.
- #146501
-- Prevent use of future timestamps when using `AS OF SYSTEM TIME` with `CREATE TABLE ... AS` and materialized views. Previously, such timestamps could cause errors, delays, or hangs.
- #146605
-- Fixed a bug where CockroachDB would not use the vectorized fast path for `COPY` when it was supported. The bug was only present in previous v25.2 releases.
- #146697
-- Fixed an internal error that could be hit when `ADD COLUMN UNIQUE` and `ALTER PRIMARY KEY` were executed within the same transaction.
- #146743
-- Fixed a bug where `ALTER TABLE` operations with multiple commands could generate invalid zone configurations.
- #146750
-- Fixed a bug in v25.2.0 where a vector search operator could drop user-supplied filters if the same vector column was indexed twice and a vector index with no prefix columns was defined after a vector index with prefix columns.
- #146849
-- Fixed an issue where updating child metrics and reinitializing metrics at the same time could cause scrape errors.
- #147531
-- Fixed a runtime panic in the `substring_index` function that occurred when the count argument was the minimum 64-bit integer value.
- #147550
-- Fixed a memory leak in index backfill jobs where completed spans were duplicated in memory on each progress update after resuming from a checkpoint. This could cause out-of-memory (OOM) errors when backfilling indexes on large tables with many ranges. This bug affected release version v25.2.0 and pre-release versions v25.2.0-alpha.3 through v25.2.0-rc.1.
- #147564
+- Improved the performance of `SHOW CREATE TABLE` on multi-region databases with large numbers of objects. #145004
+- Fixed a bug that could cause queries that perform work in parallel to ignore the requested quality-of-service level. Affected operations include lookup joins, DistSQL execution, and foreign-key checks. #145363
+- Fixed a bug where running `DROP INDEX` on a hash-sharded index did not properly detect dependencies from functions and procedures on the shard column. This caused the `DROP INDEX` statement to fail with an internal validation error. Now the statement returns a correct error message, and using `DROP INDEX ... CASCADE` works as expected by dropping the dependent functions and procedures. #145386
+- Fixed a bug that could lead to schema changes hanging after a cluster recovered from availability issues. #145545
+- Previously, on a table with multiple column families, CockroachDB could encounter a `Non-nullable column "‹×›:‹×›" with no value` error in rare cases during table statistics collection. The bug was present since v19.2 and is now fixed. #145576
+- Fixed a bug that could cause a row-level TTL job to fail with the error "comparison of two different versions of enum" if an `ENUM` type referenced by the table experienced a schema change. #145917
+- Fixed a bug where the physical cluster replication (PCR) reader catalog job could hit validation errors when schema objects had dependencies between them (for example, when a sequence's default expression was being removed). #145999
+- Creating a vector index on a table that contains a `NULL` vector value will no longer cause an internal error. #146017
+- Row-level security (RLS) `SELECT` policies during `UPDATE` operations are now only applied when referenced columns appear in the `SET` or `WHERE` clauses, matching the behavior of PostgreSQL. This improves compatibility. #146128
+- Fixed an internal assertion failure that could occur during operations like `ALTER TYPE` or `ALTER DATABASE ... ADD REGION` when temporary tables were present. #146196
+- Fixed incorrect application of row-level security (RLS) `SELECT` policies to `RETURNING` clauses in `INSERT` and `UPDATE` when no table columns were referenced. #146292
+- Fixed a bug that prevented `TRUNCATE` from succeeding if any indexes on the table had back-reference dependencies, such as from a view or function referencing the index. #146326
+- Fixed a bug that could lead to a node stall. #146409
+- Fixed an integer overflow in the `split_part` function when using extremely negative field positions like Go's `math.MinInt64`. #146413
+- Fixed a bug where an invalid comment in the `system.comment` table for a schema object could make it inaccessible. #146418
+- Fixed a bug where a CockroachDB node could crash when executing `DO` statements that contain currently unsupported DDL statements like `CREATE TYPE` in a non-default configuration (additional logging needed to be enabled, e.g., via the `sql.log.all_statements.enabled` cluster setting). This bug was introduced in v25.1. #146501
+- Prevent use of future timestamps when using `AS OF SYSTEM TIME` with `CREATE TABLE ... AS` and materialized views. Previously, such timestamps could cause errors, delays, or hangs. #146605
+- Fixed a bug where CockroachDB would not use the vectorized fast path for `COPY` when it was supported. The bug was only present in previous v25.2 releases. #146697
+- Fixed an internal error that could be hit when `ADD COLUMN UNIQUE` and `ALTER PRIMARY KEY` were executed within the same transaction. #146743
+- Fixed a bug where `ALTER TABLE` operations with multiple commands could generate invalid zone configurations. #146750
+- Fixed a bug in v25.2.0 where a vector search operator could drop user-supplied filters if the same vector column was indexed twice and a vector index with no prefix columns was defined after a vector index with prefix columns. #146849
+- Fixed an issue where updating child metrics and reinitializing metrics at the same time could cause scrape errors. #147531
+- Fixed a runtime panic in the `substring_index` function that occurred when the count argument was the minimum 64-bit integer value. #147550
+- Fixed a memory leak in index backfill jobs where completed spans were duplicated in memory on each progress update after resuming from a checkpoint. This could cause out-of-memory (OOM) errors when backfilling indexes on large tables with many ranges. This bug affected release version v25.2.0 and pre-release versions v25.2.0-alpha.3 through v25.2.0-rc.1. #147564
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.2.md
+++ b/src/current/_includes/releases/v25.2/v25.2.2.md
@@ -6,51 +6,34 @@ Release Date: June 25, 2025
 
 <h3 id="v25-2-2-operational-changes">Operational changes</h3>
 
-- When `server.telemetry.hot_ranges_stats.enabled` cluster setting is enabled, nodes now log hot ranges every minute if they exceed 250ms of CPU time per second. In multi-tenant deployments, this check occurs every 5 minutes at the cluster level, improving visibility into transient performance issues.
- #146887
-- Added a new metric, `kv.loadsplitter.cleardirection`, which increments when the load-based splitter observes that more than 80% of replica access samples are moving in a single direction (either left/descending or right/ascending).
- #147169
+- When `server.telemetry.hot_ranges_stats.enabled` cluster setting is enabled, nodes now log hot ranges every minute if they exceed 250ms of CPU time per second. In multi-tenant deployments, this check occurs every 5 minutes at the cluster level, improving visibility into transient performance issues. #146887
+- Added a new metric, `kv.loadsplitter.cleardirection`, which increments when the load-based splitter observes that more than 80% of replica access samples are moving in a single direction (either left/descending or right/ascending). #147169
 
 <h3 id="v25-2-2-db-console-changes">DB Console changes</h3>
 
-- The Hot Ranges page node filter has been moved out of the main filter container and now filters nodes on the backend to reduce load time.
- #147778
+- The Hot Ranges page node filter has been moved out of the main filter container and now filters nodes on the backend to reduce load time. #147778
 
 <h3 id="v25-2-2-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console).
- #146886
-- Fixed a bug where the `kv.rangefeed.closed_timestamp.slow_ranges` would not be incremented when a rangefeed closed timestamp was slower than the target threshold.
- #146975
-- Fixed a bug that could cause an `AFTER` trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug had existed since `AFTER` triggers were introduced in v24.3.
- #146977
-- Fixed a bug that caused the SQL Activity > Statement Fingerprint page to fail to load details for statements run with application names containing a `#` character.
- #147223
-- Previously, CockroachDB could incorrectly evaluate the `to_regclass`, `to_regnamespace`, `to_regproc`, `to_regprocedure`, `to_regrole`, and `to_regtype` built-in functions when the query using them was evaluated in a distributed fashion. The bug was introduced with these built-in functions in v23.1 and is now fixed.
- #147376
-- Fixed a bug that caused the optimizer to ignore index hints when optimizing some forms of prepared statements. This could result in one of two unexpected behaviors: a query errors with the message `index cannot be used for this query` when the index can actually be used; or a query uses an index that does not adhere to the hint. The hints relevant to this bug are regular index hints, e.g., `SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX`, and `FORCE_ZIGZAG`.
- #147417
-- Fixed a bug where the `pg_catalog.pg_policy` table could contain duplicate OID values when multiple tables had policies with the same policy ID. All rows in `pg_policy` now have unique OIDs as required.
- #147438
-- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha.
- #147460
-- Fixed a runtime panic in the `substring_index` function that occurred when the count argument was the minimum 64-bit integer value.
- #147549
-- Fixed a memory leak in index backfill jobs where completed spans were duplicated in memory on each progress update after resuming from a checkpoint. This could cause out-of-memory (OOM) errors when backfilling indexes on large tables with many ranges. This bug affected release version v25.2.0 and pre-release versions v25.2.0-alpha.3 through v25.2.0-rc.1.
- #147563
-- Fixed a bug where prepared statements on schema changes could fail with runtime errors.
- #147671
-- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence.
- #147711
+- Fixed a bug that could cause the `cockroach` process to `segfault` when collecting runtime execution traces (typically collected via the **Advanced Debug** page in the Console). #146886
+- Fixed a bug where the `kv.rangefeed.closed_timestamp.slow_ranges` would not be incremented when a rangefeed closed timestamp was slower than the target threshold. #146975
+- Fixed a bug that could cause an `AFTER` trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug had existed since `AFTER` triggers were introduced in v24.3. #146977
+- Fixed a bug that caused the SQL Activity > Statement Fingerprint page to fail to load details for statements run with application names containing a `#` character. #147223
+- Previously, CockroachDB could incorrectly evaluate the `to_regclass`, `to_regnamespace`, `to_regproc`, `to_regprocedure`, `to_regrole`, and `to_regtype` built-in functions when the query using them was evaluated in a distributed fashion. The bug was introduced with these built-in functions in v23.1 and is now fixed. #147376
+- Fixed a bug that caused the optimizer to ignore index hints when optimizing some forms of prepared statements. This could result in one of two unexpected behaviors: a query errors with the message `index cannot be used for this query` when the index can actually be used; or a query uses an index that does not adhere to the hint. The hints relevant to this bug are regular index hints, e.g., `SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX`, and `FORCE_ZIGZAG`. #147417
+- Fixed a bug where the `pg_catalog.pg_policy` table could contain duplicate OID values when multiple tables had policies with the same policy ID. All rows in `pg_policy` now have unique OIDs as required. #147438
+- Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in v23.2.22, v24.1.14, v24.3.9, v25.1.2, and the v25.2 alpha. #147460
+- Fixed a runtime panic in the `substring_index` function that occurred when the count argument was the minimum 64-bit integer value. #147549
+- Fixed a memory leak in index backfill jobs where completed spans were duplicated in memory on each progress update after resuming from a checkpoint. This could cause out-of-memory (OOM) errors when backfilling indexes on large tables with many ranges. This bug affected release version v25.2.0 and pre-release versions v25.2.0-alpha.3 through v25.2.0-rc.1. #147563
+- Fixed a bug where prepared statements on schema changes could fail with runtime errors. #147671
+- Fixed a bug where `ALTER TABLE` was modifying identity attributes on columns not backed by a sequence. #147711
 
 <h3 id="v25-2-2-performance-improvements">Performance improvements</h3>
 
-- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes.
- #147083
+- TTL jobs now respond to cluster topology changes by restarting and rebalancing across available nodes. #147083
 
 <h3 id="v25-2-2-miscellaneous">Miscellaneous</h3>
 
-- Fixed an issue in Logical Data Replication (LDR) where unique indexes with lower index IDs than the primary key could cause incorrect DLQ entries during replication.
- #147350
+- Fixed an issue in Logical Data Replication (LDR) where unique indexes with lower index IDs than the primary key could cause incorrect DLQ entries during replication. #147350
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.3.md
@@ -47,7 +47,7 @@ Release Date: July 28, 2025
   - `transaction_read_only`
 
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled.
-    #149388
+    \#149388
 - In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
  #149625
 - Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.

--- a/src/current/_includes/releases/v25.2/v25.2.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.3.md
@@ -45,9 +45,9 @@ Release Date: July 28, 2025
   - `transaction_priority`
   - `transaction_status`
   - `transaction_read_only`
-  
+
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled.
- #149388
+    #149388
 - In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
  #149625
 - Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.

--- a/src/current/_includes/releases/v25.2/v25.2.3.md
+++ b/src/current/_includes/releases/v25.2/v25.2.3.md
@@ -6,37 +6,26 @@ Release Date: July 28, 2025
 
 <h3 id="v25-2-3-general-changes">General changes</h3>
 
-- Changefeeds emitting to Kafka sinks that were created in CockroachDB v24.2.1+, or v23.2.10+ and v24.1.4+ with the `changefeed.new_kafka_sink.enabled` cluster setting enabled now include the message key, size, and MVCC timestamp in message too large error logs.
- #147929
+- Changefeeds emitting to Kafka sinks that were created in CockroachDB v24.2.1+, or v23.2.10+ and v24.1.4+ with the `changefeed.new_kafka_sink.enabled` cluster setting enabled now include the message key, size, and MVCC timestamp in message too large error logs. #147929
 
 <h3 id="v25-2-3-sql-language-changes">SQL language changes</h3>
 
-- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors.
- #148207
-- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`).
- #148207
+- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors. #148207
+- Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`). #148207
 
 <h3 id="v25-2-3-db-console-changes">DB Console changes</h3>
 
-- Updated the "Learn more" link on the **Hot Ranges** page to direct users to a newer, more comprehensive reference guide about hotspots.
- #148522
+- Updated the "Learn more" link on the **Hot Ranges** page to direct users to a newer, more comprehensive reference guide about hotspots. #148522
 
 <h3 id="v25-2-3-bug-fixes">Bug fixes</h3>
 
-- Fixed a data race in the `cloudstorage` sink.
- #147163
-- Fixed a bug where searching a vector with a query vector that doesn't match the dimensions of the vector column in the table would cause a node to crash.
- #147875
-- Fixed a bug where functions lost their row-level security (RLS) policy backreferences, leading to schema change failures.
- #147905
-- Fixed an error in `crdb_internal.table_spans` that could occur when a table's schema had been dropped.
- #147977
-- Fixed a bug where adding multiple columns in a single statement with `AddGeometryColumn` would cause runtime errors.
- #148146
-- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg).
- #148468
-- Previously, CockroachDB could hit an internal error when performing a `DELETE`, `UPDATE`, or `UPSERT` where the initial scan of the mutation is locking and is on a table different from the one being mutated. A possible workaround was `SET enable_implicit_select_for_update = false`, but this could increase contention. The bug was introduced in v25.2 and is now fixed.
- #149301
+- Fixed a data race in the `cloudstorage` sink. #147163
+- Fixed a bug where searching a vector with a query vector that doesn't match the dimensions of the vector column in the table would cause a node to crash. #147875
+- Fixed a bug where functions lost their row-level security (RLS) policy backreferences, leading to schema change failures. #147905
+- Fixed an error in `crdb_internal.table_spans` that could occur when a table's schema had been dropped. #147977
+- Fixed a bug where adding multiple columns in a single statement with `AddGeometryColumn` would cause runtime errors. #148146
+- Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg). #148468
+- Previously, CockroachDB could hit an internal error when performing a `DELETE`, `UPDATE`, or `UPSERT` where the initial scan of the mutation is locking and is on a table different from the one being mutated. A possible workaround was `SET enable_implicit_select_for_update = false`, but this could increase contention. The bug was introduced in v25.2 and is now fixed. #149301
 - The `RESET ALL` statement no longer affects the following session variables:
   - `is_superuser`
   - `role`
@@ -47,21 +36,16 @@ Release Date: July 28, 2025
   - `transaction_read_only`
 
     This better matches PostgreSQL behavior for `RESET ALL`. In addition, the `DISCARD ALL` statement no longer errors when `default_transaction_use_follower_reads` is enabled.
+
     \#149388
-- In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
- #149625
-- Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.
- #149921
-- Fixed an issue where some SQL metrics were not reported when `server.child_metrics.enabled` was enabled, `server.child_metrics.include_aggregate.enabled` was disabled, and `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` were also disabled. Specifically, metrics with no children now report their aggregate metrics regardless of the `server.child_metrics.include_aggregate.enabled` cluster setting.
- #150185
-- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels.
- #150338
-- Fixed a bug where the entire schema would become inaccessible if a table was referenced as an implicit record type by a user-defined function (UDF) while the table was undergoing an `IMPORT`.
- #150441
+- In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created. #149625
+- Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node. #149921
+- Fixed an issue where some SQL metrics were not reported when `server.child_metrics.enabled` was enabled, `server.child_metrics.include_aggregate.enabled` was disabled, and `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` were also disabled. Specifically, metrics with no children now report their aggregate metrics regardless of the `server.child_metrics.include_aggregate.enabled` cluster setting. #150185
+- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels. #150338
+- Fixed a bug where the entire schema would become inaccessible if a table was referenced as an implicit record type by a user-defined function (UDF) while the table was undergoing an `IMPORT`. #150441
 
 <h3 id="v25-2-3-miscellaneous">Miscellaneous</h3>
 
-- Restore no longer gets stuck in the reverting state after failed cleanup of dropped temporary system tables.
- #148485
+- Restore no longer gets stuck in the reverting state after failed cleanup of dropped temporary system tables. #148485
 
 

--- a/src/current/_includes/releases/v25.2/v25.2.4.md
+++ b/src/current/_includes/releases/v25.2/v25.2.4.md
@@ -6,7 +6,6 @@ Release Date: August 1, 2025
 
 <h3 id="v25-2-4-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups.
- #151095
+- Fixed a bug that could cause some errors returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups. #151095
 
 

--- a/src/current/_includes/releases/v25.3/v25.3.0-alpha.2.md
+++ b/src/current/_includes/releases/v25.3/v25.3.0-alpha.2.md
@@ -6,10 +6,8 @@ Release Date: June 16, 2025
 
 <h3 id="v25-3-0-alpha-2-general-changes">General changes</h3>
 
-- Changefeed source metadata now includes the `crdb_internal_table_id` field, enabling downstream consumers to uniquely identify tables even if table names change.
- #147341
-- Changefeeds emitting to Kafka sinks that were created in CockroachDB v24.2.1+, or v23.2.10+ and v24.1.4+ with the `changefeed.new_kafka_sink.enabled` cluster setting enabled now include the message key, size, and MVCC timestamp in message too large error logs.
- #147543
+- Changefeed source metadata now includes the `crdb_internal_table_id` field, enabling downstream consumers to uniquely identify tables even if table names change. #147341
+- Changefeeds emitting to Kafka sinks that were created in CockroachDB v24.2.1+, or v23.2.10+ and v24.1.4+ with the `changefeed.new_kafka_sink.enabled` cluster setting enabled now include the message key, size, and MVCC timestamp in message too large error logs. #147543
 
 <h3 id="v25-3-0-alpha-2-sql-language-changes">SQL language changes</h3>
 
@@ -19,28 +17,21 @@ Release Date: June 16, 2025
     - In the `crdb_internal.cluster_execution_insights` and `crdb_internal.node_execution_insights` virtual tables in a new `query_tags` JSONB column.
     This feature is disabled by default and can be enabled using the `sql.sqlcommenter.enabled` cluster setting. Comments must follow the [SQLCommenter specification](https://google.github.io/sqlcommenter/spec/). #145435
 - Added a session variable `initial_retry_backoff_for_read_committed` that controls the initial backoff duration when retrying an individual statement in an explicit `READ COMMITTED` transaction. A duration of `0` disables exponential backoff. If a statement in an explicit `READ COMMITTED` transaction is failing with the `40001` error `ERROR: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=...`, then you should set `initial_retry_backoff_for_read_committed` to a duration proportional to the typical execution time of the statement (in addition to also increasing `max_retries_for_read_committed`). #146860
-- Added the `SHOW CREATE ALL ROUTINES` statement, which can be used to show `CREATE` statements for all user-defined functions (UDFs) and procedures in the current database.
- #147452
-- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors.
- #147682
+- Added the `SHOW CREATE ALL ROUTINES` statement, which can be used to show `CREATE` statements for all user-defined functions (UDFs) and procedures in the current database. #147452
+- Added the metrics `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count`, which count the number of automatic retries of SQL transactions and statements, respectively, within the database. These metrics differ from the related `txn.restarts.*` metrics, which count retryable errors emitted by the KV layer that must be retried. The new `sql.txn.auto_retry.count` and `sql.statements.auto_retry.count` metrics count auto-retry actions taken by the SQL layer in response to some of those retryable errors. #147682
 - Increased the default value for the `max_retries_for_read_committed` session variable from `10` to `100`. Testing has shown that some high-contention workloads running under `READ COMMITTED` isolation benefit from more statement retries. #147869
 - The session variable `initial_retry_backoff_for_read_committed` now defaults to `2` (milliseconds). Testing has shown that some high-contention workloads running under `READ COMMITTED` isolation benefit from exponential backoff. `2` might be too quick of an initial backoff for longer-running statements, but setting this value much higher than the normal duration of execution will cause excessive delay. #147869
 
 <h3 id="v25-3-0-alpha-2-operational-changes">Operational changes</h3>
 
-- Added an `alter_changefeed` structured log event to provide more visibility into when an `ALTER CHANGEFEED` event occurred and what changed.
- #147679
-- Added new timeseries metrics to the `storage.value_separation.*` namespace for observing the behavior of [storage engine value separation]({% link v25.3/architecture/storage-layer.md %}#value-separation).
- #147728
+- Added an `alter_changefeed` structured log event to provide more visibility into when an `ALTER CHANGEFEED` event occurred and what changed. #147679
+- Added new timeseries metrics to the `storage.value_separation.*` namespace for observing the behavior of [storage engine value separation]({% link v25.3/architecture/storage-layer.md %}#value-separation). #147728
 
 <h3 id="v25-3-0-alpha-2-db-console-changes">DB Console changes</h3>
 
-- The Hot Ranges page node filter has been moved out of the main filter container and now filters nodes on the backend to reduce load time.
- #147089
-- The Insights page in the DB Console now displays SQL commenter query tags for statement executions. These tags provide application context (such as application name, user ID, or feature flags) embedded in SQL comments using the `sqlcommenter` format. This information can help correlate slow query performance with specific application states. The Query Tags column is available in the Statement Executions view's Statement Insights table, but it is hidden by default. To display it, use the Columns selector.
- #147439
-- Retry counts for statements executing under `READ COMMITTED` isolation are now more accurate.
- #147682
+- The Hot Ranges page node filter has been moved out of the main filter container and now filters nodes on the backend to reduce load time. #147089
+- The Insights page in the DB Console now displays SQL commenter query tags for statement executions. These tags provide application context (such as application name, user ID, or feature flags) embedded in SQL comments using the `sqlcommenter` format. This information can help correlate slow query performance with specific application states. The Query Tags column is available in the Statement Executions view's Statement Insights table, but it is hidden by default. To display it, use the Columns selector. #147439
+- Retry counts for statements executing under `READ COMMITTED` isolation are now more accurate. #147682
 
 <h3 id="v25-3-0-alpha-2-bug-fixes">Bug fixes</h3>
 

--- a/src/current/_includes/releases/v25.3/v25.3.0-alpha.3.md
+++ b/src/current/_includes/releases/v25.3/v25.3.0-alpha.3.md
@@ -23,6 +23,5 @@ Release Date: June 23, 2025
 
 - Fixed a bug that allowed a column to be dropped from a table even if it was referenced in the `RETURNING` clause of an `UPDATE` or `DELETE` statement in a routine. In releases prior to v25.3, the fix must be enabled by setting the session variable `use_improved_routine_dependency_tracking` to `on`. #146250
 - Fixed a bug where `libpq` clients using the async API could hang with large result sets (Python: psycopg; Ruby: ActiveRecord, ruby-pg). #148222
-- Restore no longer gets stuck in the `reverting` state after failed cleanup of dropped temporary system tables.
- #148098
+- Restore no longer gets stuck in the `reverting` state after failed cleanup of dropped temporary system tables. #148098
 

--- a/src/current/_includes/releases/v25.3/v25.3.0-beta.1.md
+++ b/src/current/_includes/releases/v25.3/v25.3.0-beta.1.md
@@ -6,19 +6,14 @@ Release Date: July 2, 2025
 
 <h3 id="v25-3-0-beta-1-sql-language-changes">SQL language changes</h3>
 
-- Directionality may no longer be assigned to any vector index column. Prefix columns are not scannable in a vector index, so directionality is not relevant to them.
- #147307
-- Changed the basic sequence caching option to cache at the per-node level by default. The `PER SESSION CACHE` sequence option is added to provide the previous per-session cache behavior.
- #148290
-- Removed the 'started' column in `SHOW JOBS`, which was a duplicate of the 'created' column.
- #148464
+- Directionality may no longer be assigned to any vector index column. Prefix columns are not scannable in a vector index, so directionality is not relevant to them. #147307
+- Changed the basic sequence caching option to cache at the per-node level by default. The `PER SESSION CACHE` sequence option is added to provide the previous per-session cache behavior. #148290
+- Removed the 'started' column in `SHOW JOBS`, which was a duplicate of the 'created' column. #148464
 
 <h3 id="v25-3-0-beta-1-operational-changes">Operational changes</h3>
 
-- Introduced the following cluster settings for enabling and configuring [value separation in the storage engine]({% link v25.3/architecture/storage-layer.md %}#value-separation): `storage.value_separation.enabled`, `storage.value_separation.minimum_size`, and `storage.value_separation.max_reference_depth`.
- #148535
-- Non-admin users no longer have access to changefeed jobs they do not own and which are not owned by a role of which they are a member, regardless of whether they have the `CHANGEFEED` privilege on the table or tables those jobs may be watching. Admin users, or those with global `SHOWJOB` / `CONTROLJOB` privileges, can still interact with all jobs, regardless of ownership.
- #148537
+- Introduced the following cluster settings for enabling and configuring [value separation in the storage engine]({% link v25.3/architecture/storage-layer.md %}#value-separation): `storage.value_separation.enabled`, `storage.value_separation.minimum_size`, and `storage.value_separation.max_reference_depth`. #148535
+- Non-admin users no longer have access to changefeed jobs they do not own and which are not owned by a role of which they are a member, regardless of whether they have the `CHANGEFEED` privilege on the table or tables those jobs may be watching. Admin users, or those with global `SHOWJOB` / `CONTROLJOB` privileges, can still interact with all jobs, regardless of ownership. #148537
 - In order to selectively capture traces for transactions running in an active workload without having to capture them via statement diagnostic bundles, customers can now use the `sql.trace.txn.sample_rate` cluster setting to enable tracing for a fraction of their workload. The `sql.trace.txn.enable_threshold` will still need to be set to a positive value to provide a filter for how slow a transaction needs to be after being sampled to merit emitting a trace. Traces are emitted to the `SQL_EXEC` logging channel.
   #148542
 - Added the following cluster settings for configuring blob file rewrite compactions: `storage.value_separation.rewrite_minimum_age` and `storage.value_separation.compaction_garbage_threshold`.
@@ -32,14 +27,11 @@ Release Date: July 2, 2025
 
 <h3 id="v25-3-0-beta-1-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug where using column families on tables with vector indexes would cause the index to fail to return results.
- #147307
-- Large mutation statements (`INSERT`, `UPDATE`, `DELETE`, `UPSERT`) are now less likely to encounter contention with automatic table statistics collection in some cases. The bug was present since v19.1.
- #148488
+- Fixed a bug where using column families on tables with vector indexes would cause the index to fail to return results. #147307
+- Large mutation statements (`INSERT`, `UPDATE`, `DELETE`, `UPSERT`) are now less likely to encounter contention with automatic table statistics collection in some cases. The bug was present since v19.1. #148488
 
 <h3 id="v25-3-0-beta-1-performance-improvements">Performance improvements</h3>
 
-- The optimizer will no longer apply a fast-path to deletes cascading to `REGIONAL BY ROW` tables. This prevents the cascading delete from accessing more regions than necessary.
- #148105
+- The optimizer will no longer apply a fast-path to deletes cascading to `REGIONAL BY ROW` tables. This prevents the cascading delete from accessing more regions than necessary. #148105
 
 

--- a/src/current/_includes/releases/v25.3/v25.3.0-beta.2.md
+++ b/src/current/_includes/releases/v25.3/v25.3.0-beta.2.md
@@ -6,14 +6,11 @@ Release Date: July 9, 2025
 
 <h3 id="v25-3-0-beta-2-general-changes">General changes</h3>
 
-- For virtual clusters, hot range logging is now performed by a single job on one node, rather than by tasks on every node.
- #148926
+- For virtual clusters, hot range logging is now performed by a single job on one node, rather than by tasks on every node. #148926
 
 <h3 id="v25-3-0-beta-2-bug-fixes">Bug fixes</h3>
 
-- CockroachDB now prohibits `ORDER BY` and join equality operations on `REFCURSOR` types, matching PostgreSQL behavior.
- #149292
-- Fixed an issue where CockroachDB could hit an internal error when performing a `DELETE`, `UPDATE`, or `UPSERT` where the initial scan of the mutation is locking and is on a table different from the one being mutated. A possible workaround was `SET enable_implicit_select_for_update = false`, but this could increase contention. The bug was introduced in v25.2 and is now fixed.
- #149302
+- CockroachDB now prohibits `ORDER BY` and join equality operations on `REFCURSOR` types, matching PostgreSQL behavior. #149292
+- Fixed an issue where CockroachDB could hit an internal error when performing a `DELETE`, `UPDATE`, or `UPSERT` where the initial scan of the mutation is locking and is on a table different from the one being mutated. A possible workaround was `SET enable_implicit_select_for_update = false`, but this could increase contention. The bug was introduced in v25.2 and is now fixed. #149302
 
 

--- a/src/current/_includes/releases/v25.3/v25.3.0-beta.3.md
+++ b/src/current/_includes/releases/v25.3/v25.3.0-beta.3.md
@@ -6,16 +6,12 @@ Release Date: July 14, 2025
 
 <h3 id="v25-3-0-beta-3-sql-language-changes">SQL language changes</h3>
 
-- Added support for invoking a UDF from a view query. Renaming or setting the schema on the routine is currently not allowed if it is referenced by a view.
- #149514
-- The session setting `optimizer_prefer_bounded_cardinality` is now enabled by default. This setting instructs the optimizer to prefer query plans where every expression has a guaranteed upper-bound on the number of rows it will process.
- #149675
+- Added support for invoking a UDF from a view query. Renaming or setting the schema on the routine is currently not allowed if it is referenced by a view. #149514
+- The session setting `optimizer_prefer_bounded_cardinality` is now enabled by default. This setting instructs the optimizer to prefer query plans where every expression has a guaranteed upper-bound on the number of rows it will process. #149675
 
 <h3 id="v25-3-0-beta-3-bug-fixes">Bug fixes</h3>
 
-- Fixed a bug that would cause a `CALL` statement executed via a portal in the extended wire protocol to result in an error like `unknown portal ""` if the stored procedure contained `COMMIT` or `ROLLBACK` statements. The bug had existed since PL/pgSQL transaction control statements were introduced in v24.1. The fix is off by default in versions prior to v25.3.
- #149385
-- In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created.
- #149626
+- Fixed a bug that would cause a `CALL` statement executed via a portal in the extended wire protocol to result in an error like `unknown portal ""` if the stored procedure contained `COMMIT` or `ROLLBACK` statements. The bug had existed since PL/pgSQL transaction control statements were introduced in v24.1. The fix is off by default in versions prior to v25.3. #149385
+- In v25.1, automatic partial statistics collection was enabled by default (by setting the `sql.stats.automatic_partial_collection.enabled` cluster setting to `true`). Partial statistics collection may encounter certain expected scenarios that were previously reported as failed stats jobs with PostgreSQL error code `55000`. These errors are benign and are no longer reported. Instead, the stats job will be marked as "succeeded," though no new statistics will be created. #149626
 
 

--- a/src/current/_includes/releases/v25.3/v25.3.0-rc.1.md
+++ b/src/current/_includes/releases/v25.3/v25.3.0-rc.1.md
@@ -6,16 +6,11 @@ Release Date: July 23, 2025
 
 <h3 id="v25-3-0-rc-1-sql-language-changes">SQL language changes</h3>
 
-- The `CITEXT` data type is now supported, enabling case-insensitive comparisons for `CITEXT` columns. Internally, `CITEXT` is equivalent to using the undetermined level 2 collation `und-u-ks-level2`. For example, under `CITEXT`, the expression `'test' = 'TEST'` returns `TRUE`.
- #149819
-- Added support for automatically determining the region column for a `REGIONAL BY ROW` table using a foreign key constraint. The foreign key is specified by setting a new table storage parameter `infer_rbr_region_col_using_constraint`, and must contain the region column. This can be useful for applications that are unable to guarantee that a child row is inserted or updated from the same region as the matching parent row.
- #150366
-- The session setting `optimizer_min_row_count`, which sets a lower bound on row count estimates for relational expressions during query planning, is now set to `1` by default.
- #150376
-- The `options` column in the output of `SHOW ROLES` and `SHOW USERS` is now returned as an array of strings (e.g., `{NOLOGIN,CREATEDB}`) rather than as a single comma-separated string. This enables more efficient querying of role options using array functions like `unnest()`. For example: `SELECT * FROM [SHOW ROLES] AS r WHERE EXISTS (SELECT 1 FROM unnest(r.options) AS m(option) WHERE option LIKE 'SUBJECT=cn%');`
- #149537
-- The `SHOW ROLES` and `SHOW USERS` commands now include an `estimated_last_login_time` column that displays the estimated timestamp of when each user last authenticated to the database. This column shows `NULL` for users who have never logged in, and for existing users after upgrading to v25.3 until their next login. The tracking is performed on a best-effort basis and may not capture every login event.
- #149537
+- The `CITEXT` data type is now supported, enabling case-insensitive comparisons for `CITEXT` columns. Internally, `CITEXT` is equivalent to using the undetermined level 2 collation `und-u-ks-level2`. For example, under `CITEXT`, the expression `'test' = 'TEST'` returns `TRUE`. #149819
+- Added support for automatically determining the region column for a `REGIONAL BY ROW` table using a foreign key constraint. The foreign key is specified by setting a new table storage parameter `infer_rbr_region_col_using_constraint`, and must contain the region column. This can be useful for applications that are unable to guarantee that a child row is inserted or updated from the same region as the matching parent row. #150366
+- The session setting `optimizer_min_row_count`, which sets a lower bound on row count estimates for relational expressions during query planning, is now set to `1` by default. #150376
+- The `options` column in the output of `SHOW ROLES` and `SHOW USERS` is now returned as an array of strings (e.g., `{NOLOGIN,CREATEDB}`) rather than as a single comma-separated string. This enables more efficient querying of role options using array functions like `unnest()`. For example: `SELECT * FROM [SHOW ROLES] AS r WHERE EXISTS (SELECT 1 FROM unnest(r.options) AS m(option) WHERE option LIKE 'SUBJECT=cn%');` #149537
+- The `SHOW ROLES` and `SHOW USERS` commands now include an `estimated_last_login_time` column that displays the estimated timestamp of when each user last authenticated to the database. This column shows `NULL` for users who have never logged in, and for existing users after upgrading to v25.3 until their next login. The tracking is performed on a best-effort basis and may not capture every login event. #149537
 
 <h3 id="v25-3-0-rc-1-operational-changes">Operational changes</h3>
 
@@ -24,23 +19,17 @@ Release Date: July 23, 2025
   - `obs.execution_tracer.duration`: Specifies the duration for each captured trace.
   - `obs.execution_tracer.total_dump_size_limit`: Sets the maximum disk space allowed for storing execution traces. Older traces are automatically deleted when this limit is reached.
  #149705
-- The value of `sql.stats.error_on_concurrent_create_stats.enabled` now defaults to `false`, suppressing error counters for auto stats jobs that fail due to concurrent stats jobs in progress.
- #149857
+- The value of `sql.stats.error_on_concurrent_create_stats.enabled` now defaults to `false`, suppressing error counters for auto stats jobs that fail due to concurrent stats jobs in progress. #149857
 
 <h3 id="v25-3-0-rc-1-bug-fixes">Bug fixes</h3>
 
-- Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node.
- #149920
-- Fixed an issue where some SQL metrics were not reported when `server.child_metrics.enabled` was enabled, `server.child_metrics.include_aggregate.enabled` was disabled, and `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` were also disabled. Specifically, metrics with no children now report their aggregate metrics regardless of the `server.child_metrics.include_aggregate.enabled` cluster setting.
- #149929
-- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels.
- #150296
-- Fixed an issue where discarding zone configs on sequences did not actually remove the configuration.
- #150360
+- Fixed a slow memory leak that was introduced in v25.1.8, v25.2.1, v25.2.2, and v25.3 betas. The leak would accumulate whenever a node executed a part of the distributed plan (the gateway node of the plan was not affected), and could only be mitigated by restarting the node. #149920
+- Fixed an issue where some SQL metrics were not reported when `server.child_metrics.enabled` was enabled, `server.child_metrics.include_aggregate.enabled` was disabled, and `sql.metrics.application_name.enabled` and `sql.metrics.database_name.enabled` were also disabled. Specifically, metrics with no children now report their aggregate metrics regardless of the `server.child_metrics.include_aggregate.enabled` cluster setting. #149929
+- Fixed a bug that would allow a race condition in foreign key cascades under `READ COMMITTED` and `REPEATABLE READ` isolation levels. #150296
+- Fixed an issue where discarding zone configs on sequences did not actually remove the configuration. #150360
 
 <h3 id="v25-3-0-rc-1-performance-improvements">Performance improvements</h3>
 
-- Mutation statements (`UPDATE` and `DELETE`) that perform lookup joins into multi-region tables (perhaps as part of a `CASCADE`) are now more likely to parallelize the lookups across ranges, improving their performance.
- #150016
+- Mutation statements (`UPDATE` and `DELETE`) that perform lookup joins into multi-region tables (perhaps as part of a `CASCADE`) are now more likely to parallelize the lookups across ranges, improving their performance. #150016
 
 


### PR DESCRIPTION
Fixed instances of PR references being interpreted as H1 headings.

Since #23301, instances of continuation text (multi-paragraph bullets) followed by an PR reference on its own line, would have that reference and all others in the section (until the next intentional heading) interpreted as H1s.

This may have only affected sections of 3 releases' notes, but to be thorough/consistent, I made the following changes across the board:

- For single-line bullets, moved the reference to the end of the bullet's single line.
- For continuation bullets, matched the indentation of the continuation text, and prepended a `\` to the reference.

## Example changes:

**For single-line bullets:**

Before:
```markdown
- Fixed a slow memory leak that was introduced in v25.1.8.
 #149921
```

After:
```markdown
- Fixed a slow memory leak that was introduced in v25.1.8. #149921
```

**For continuation bullets:**

Before:
```markdown
- The `RESET ALL` statement no longer affects the following session variables:
  - `is_superuser`
  - `role`
  - `transaction_read_only`
  
    This better matches PostgreSQL behavior for `RESET ALL`.
 #149388
```

After:
```markdown
- The `RESET ALL` statement no longer affects the following session variables:
  - `is_superuser`
  - `role`
  - `transaction_read_only`
  
    This better matches PostgreSQL behavior for `RESET ALL`.

    \#149388
```

## Example of the bug

From https://www.cockroachlabs.com/docs/releases/v25.2#v25-2-3:

<img width="1081" height="940" alt="Screenshot 2026-06-01 at 4 00 25 PM" src="https://github.com/user-attachments/assets/03bd6a93-6e5c-4729-810b-a43b7c1bdd12" />