### PR TITLE
Publish point release binaries

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -11620,13 +11620,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v26.1.4
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
 
 - release_name: v25.4.11
   major_version: v25.4
@@ -11654,13 +11647,6 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.4.10
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).
 
 - release_name: v25.2.19
   major_version: v25.2
@@ -11688,10 +11674,3 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.2.18
-  cloud_only: true
-  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
-  cloud_only_message: >
-      This version is currently available only for select
-      CockroachDB Cloud clusters. To request to upgrade
-      a CockroachDB self-hosted cluster to this version,
-      [contact support](https://support.cockroachlabs.com/hc/requests/new).


### PR DESCRIPTION
Fixes:
- REL-4865
- REL-4875
- REL-4885

Summary of changes:
- Remove cloud_only metadata from v26.1.5.
- Remove cloud_only metadata from v25.4.11.
- Remove cloud_only metadata from v25.2.19.

Validation:
- git diff --check