### PR TITLE
[CNSL-2288] Add automated fork main sync with upstream

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,23 @@
+name: Sync Fork
+
+# Pushes cockroachdb/docs's main to the fork's main on every
+# commit to main. The reusable workflow no-ops when invoked anywhere other
+# than the configured upstream_repo.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read  # Reusable workflow uses GITHUB_TOKEN to fetch this repo's main
+
+jobs:
+  sync:
+    uses: cockroachdb/actions/.github/workflows/sync-fork.yml@v0
+    with:
+      upstream_repo: cockroachdb/docs
+      fork_repo: crl-gh-actions-pr-bot/docs
+      allow_fork_force_sync: false
+    secrets:
+      fork_sync_token: ${{ secrets.FORK_SYNC_TOKEN }}


### PR DESCRIPTION
Adds sync-fork.yml: on every push to upstream main (and via manual workflow_dispatch), calls the cockroachdb/actions sync-fork reusable workflow to push upstream's main to crl-gh-actions-pr-bot's fork's main.

The reusable workflow no-ops unless github.repository matches the configured upstream_repo, so the file is safe to land on both upstream and any fork.