### PR TITLE
Fix ALTER TABLE/VIEW/SEQUENCE privilege and rename documentation

### DIFF
--- a/src/current/v23.1/alter-sequence.md
+++ b/src/current/v23.1/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v23.1/alter-sequence.md
+++ b/src/current/v23.1/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v23.1/alter-table.md
+++ b/src/current/v23.1/alter-table.md
@@ -448,7 +448,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v23.1/alter-view.md
+++ b/src/current/v23.1/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v23.1/alter-view.md
+++ b/src/current/v23.1/alter-view.md
@@ -81,7 +81,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v23.2/alter-sequence.md
+++ b/src/current/v23.2/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v23.2/alter-sequence.md
+++ b/src/current/v23.2/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v23.2/alter-table.md
+++ b/src/current/v23.2/alter-table.md
@@ -449,7 +449,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v23.2/alter-view.md
+++ b/src/current/v23.2/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v23.2/alter-view.md
+++ b/src/current/v23.2/alter-view.md
@@ -81,7 +81,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v24.1/alter-sequence.md
+++ b/src/current/v24.1/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v24.1/alter-sequence.md
+++ b/src/current/v24.1/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v24.1/alter-table.md
+++ b/src/current/v24.1/alter-table.md
@@ -439,7 +439,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v24.1/alter-view.md
+++ b/src/current/v24.1/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v24.1/alter-view.md
+++ b/src/current/v24.1/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v24.2/alter-sequence.md
+++ b/src/current/v24.2/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v24.2/alter-sequence.md
+++ b/src/current/v24.2/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v24.2/alter-table.md
+++ b/src/current/v24.2/alter-table.md
@@ -438,7 +438,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v24.2/alter-view.md
+++ b/src/current/v24.2/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v24.2/alter-view.md
+++ b/src/current/v24.2/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v24.3/alter-sequence.md
+++ b/src/current/v24.3/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v24.3/alter-sequence.md
+++ b/src/current/v24.3/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v24.3/alter-table.md
+++ b/src/current/v24.3/alter-table.md
@@ -439,7 +439,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v24.3/alter-view.md
+++ b/src/current/v24.3/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v24.3/alter-view.md
+++ b/src/current/v24.3/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v25.1/alter-sequence.md
+++ b/src/current/v25.1/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v25.1/alter-sequence.md
+++ b/src/current/v25.1/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v25.1/alter-table.md
+++ b/src/current/v25.1/alter-table.md
@@ -436,7 +436,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v25.1/alter-view.md
+++ b/src/current/v25.1/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v25.1/alter-view.md
+++ b/src/current/v25.1/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v25.2/alter-sequence.md
+++ b/src/current/v25.2/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v25.2/alter-sequence.md
+++ b/src/current/v25.2/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` |  The number of sequence values to cache in memory for reuse in the session. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default)
@@ -104,55 +104,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v25.2/alter-table.md
+++ b/src/current/v25.2/alter-table.md
@@ -440,7 +440,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v25.2/alter-view.md
+++ b/src/current/v25.2/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v25.2/alter-view.md
+++ b/src/current/v25.2/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v25.3/alter-sequence.md
+++ b/src/current/v25.3/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v25.3/alter-sequence.md
+++ b/src/current/v25.3/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` <a name="cache"></a> | The number of sequence values to cache in memory at the [node]({% link {{ page.version.version }}/architecture/overview.md %}#node) level. All sessions on the node share the same cache, which can be concurrently accessed, and which reduces the chance of creating large gaps between generated IDs. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default). While this parameter caches sequences per node, to cache sequence values per session, use [`PER SESSION CACHE`](#per-session-cache) explicitly.
@@ -106,55 +106,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v25.3/alter-table.md
+++ b/src/current/v25.3/alter-table.md
@@ -440,7 +440,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v25.3/alter-view.md
+++ b/src/current/v25.3/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v25.3/alter-view.md
+++ b/src/current/v25.3/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v25.4/alter-sequence.md
+++ b/src/current/v25.4/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v25.4/alter-sequence.md
+++ b/src/current/v25.4/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` <a name="cache"></a> | The number of sequence values to cache in memory at the [node]({% link {{ page.version.version }}/architecture/overview.md %}#node) level. All sessions on the node share the same cache, which can be concurrently accessed, and which reduces the chance of creating large gaps between generated IDs. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default). While this parameter caches sequences per node, to cache sequence values per session, use [`PER SESSION CACHE`](#per-session-cache) explicitly.
@@ -106,55 +106,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v25.4/alter-table.md
+++ b/src/current/v25.4/alter-table.md
@@ -444,7 +444,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v25.4/alter-view.md
+++ b/src/current/v25.4/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v25.4/alter-view.md
+++ b/src/current/v25.4/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v26.1/alter-sequence.md
+++ b/src/current/v26.1/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v26.1/alter-sequence.md
+++ b/src/current/v26.1/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` <a name="cache"></a> | The number of sequence values to cache in memory at the [node]({% link {{ page.version.version }}/architecture/overview.md %}#node) level. All sessions on the node share the same cache, which can be concurrently accessed, and which reduces the chance of creating large gaps between generated IDs. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default). While this parameter caches sequences per node, to cache sequence values per session, use [`PER SESSION CACHE`](#per-session-cache) explicitly.
@@ -106,55 +106,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v26.1/alter-table.md
+++ b/src/current/v26.1/alter-table.md
@@ -444,7 +444,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v26.1/alter-view.md
+++ b/src/current/v26.1/alter-view.md
@@ -78,7 +78,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v26.1/alter-view.md
+++ b/src/current/v26.1/alter-view.md
@@ -11,8 +11,8 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v26.2/alter-sequence.md
+++ b/src/current/v26.2/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v26.2/alter-sequence.md
+++ b/src/current/v26.2/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` <a name="cache"></a> | The number of sequence values to cache in memory at the [node]({% link {{ page.version.version }}/architecture/overview.md %}#node) level. All sessions on the node share the same cache, which can be concurrently accessed, and which reduces the chance of creating large gaps between generated IDs. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default). While this parameter caches sequences per node, to cache sequence values per session, use [`PER SESSION CACHE`](#per-session-cache) explicitly.
@@ -106,55 +106,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v26.2/alter-table.md
+++ b/src/current/v26.2/alter-table.md
@@ -446,7 +446,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v26.2/alter-view.md
+++ b/src/current/v26.2/alter-view.md
@@ -80,7 +80,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v26.2/alter-view.md
+++ b/src/current/v26.2/alter-view.md
@@ -11,9 +11,9 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
 - To set or reset `security_invoker`, the user must own the view.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's database.
 
 ## Syntax
 

--- a/src/current/v26.3/alter-sequence.md
+++ b/src/current/v26.3/alter-sequence.md
@@ -11,8 +11,9 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 ## Required privileges
 
-- To alter a sequence, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
-- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, or to change the database of a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence.
+- To alter a sequence, the user must be the owner of the sequence.
+- To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
+- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
 
 ## Syntax
 

--- a/src/current/v26.3/alter-sequence.md
+++ b/src/current/v26.3/alter-sequence.md
@@ -13,7 +13,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 
 - To alter a sequence, the user must be the owner of the sequence.
 - To change the schema of a sequence with `ALTER SEQUENCE ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the new schema.
-- To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's database.
+- {% include_cached new-in.html version="v26.3" %} To rename a sequence with `ALTER SEQUENCE ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the sequence and the `CREATE` privilege on the sequence's schema.
 
 ## Syntax
 

--- a/src/current/v26.3/alter-sequence.md
+++ b/src/current/v26.3/alter-sequence.md
@@ -27,7 +27,7 @@ The `ALTER SEQUENCE` [statement]({% link {{ page.version.version }}/sql-statemen
 -----------|------------
 `IF EXISTS` | Modify the sequence only if it exists; if it does not exist, do not return an error.
 `sequence_name` | The name of the sequence.
-`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>Note that `RENAME TO` can be used to move a sequence from one database to another, but it cannot be used to move a sequence from one schema to another. To change a sequence's schema, use `ALTER SEQUENCE ...SET SCHEMA` instead.
+`RENAME TO sequence_name` | Rename the sequence to `sequence_name`, which must be unique to its database and follow these [identifier rules]({% link {{ page.version.version }}/keywords-and-identifiers.md %}#identifiers). Name changes do not propagate to the  table(s) using the sequence.<br><br>`RENAME TO` only changes the name of the sequence; it cannot move the sequence to a different database or schema. To change a sequence's schema, use `ALTER SEQUENCE ... SET SCHEMA` instead.
 `CYCLE`/`NO CYCLE` | The sequence will wrap around when the sequence value reaches the maximum or minimum value. `CYCLE` is not implemented. If `NO CYCLE` is set, the sequence will not wrap.
 `OWNED BY column_name` | Associates the sequence to a particular column. If that column or its parent table is dropped, the sequence will also be dropped.<br><br>Specifying an owner column with `OWNED BY` replaces any existing owner column on the sequence. To remove existing column ownership on the sequence and make the column free-standing, specify `OWNED BY NONE`.<br><br>**Default:** `NONE`
 `CACHE` <a name="cache"></a> | The number of sequence values to cache in memory at the [node]({% link {{ page.version.version }}/architecture/overview.md %}#node) level. All sessions on the node share the same cache, which can be concurrently accessed, and which reduces the chance of creating large gaps between generated IDs. A cache size of `1` means that there is no cache, and cache sizes of less than `1` are not valid.<br><br>**Default:** `1` (sequences are not cached by default). While this parameter caches sequences per node, to cache sequence values per session, use [`PER SESSION CACHE`](#per-session-cache) explicitly.
@@ -106,55 +106,6 @@ In this example, we will change the name of sequence.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW SEQUENCES;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-### Change the database of a sequence
-
-In this example, we will move the sequence we renamed in the first example (`even_sequence`) from `defaultdb` (i.e., the default database) to a different database.
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-  public          | even_sequence
-(1 row)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE mydb;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> ALTER SEQUENCE even_sequence RENAME TO mydb.even_sequence;
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM defaultdb;
-~~~
-
-~~~
-  sequence_schema | sequence_name
-------------------+----------------
-(0 rows)
-~~~
-
-{% include_cached copy-clipboard.html %}
-~~~ sql
-> SHOW SEQUENCES FROM mydb;
 ~~~
 
 ~~~

--- a/src/current/v26.3/alter-table.md
+++ b/src/current/v26.3/alter-table.md
@@ -446,7 +446,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
+The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
 
 #### Parameters
 

--- a/src/current/v26.3/alter-table.md
+++ b/src/current/v26.3/alter-table.md
@@ -446,7 +446,7 @@ For examples, see [Rename tables](#rename-tables).
 
 #### Required privileges
 
-The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` on the parent database.
+{% include_cached new-in.html version="v26.3" %} The user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the table and the `CREATE` privilege on the table's schema.
 
 #### Parameters
 

--- a/src/current/v26.3/alter-view.md
+++ b/src/current/v26.3/alter-view.md
@@ -80,7 +80,7 @@ WITH x AS (SHOW TABLES) SELECT * FROM x WHERE type = 'view';
 (1 row)
 ~~~
 
-Note that `RENAME TO` can be used to move a view from one database to another, but it cannot be used to move a view from one schema to another. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view). In a future release, `RENAME TO` will be limited to changing the name of a view, and will not have the ability to change a view's database.
+Note that `RENAME TO` only changes the name of the view; it cannot move the view to a different database or schema. To change a view's schema, [use the `SET SCHEMA` clause](#change-the-schema-of-a-view).
 
 ### Change the schema of a view
 

--- a/src/current/v26.3/alter-view.md
+++ b/src/current/v26.3/alter-view.md
@@ -11,9 +11,9 @@ The `ALTER VIEW` [statement]({% link {{ page.version.version }}/sql-statements.m
 
 ## Required privileges
 
-- To alter a view, the user must have the `CREATE` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the parent database.
 - To set or reset `security_invoker`, the user must own the view.
-- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, or to change the name of a view with `ALTER VIEW ... RENAME TO`, the user must also have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view.
+- To change the schema of a view with `ALTER VIEW ... SET SCHEMA`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the new schema.
+- {% include_cached new-in.html version="v26.3" %} To rename a view with `ALTER VIEW ... RENAME TO`, the user must have the `DROP` [privilege]({% link {{ page.version.version }}/security-reference/authorization.md %}#managing-privileges) on the view and the `CREATE` privilege on the view's schema.
 
 ## Syntax
 


### PR DESCRIPTION
Corrects the required-privilege documentation for `ALTER SEQUENCE`, `ALTER VIEW`, and `ALTER TABLE`, and removes incorrect cross-database rename claims. All behavior verified against running v24.3 and v26.3-dev servers and the CockroachDB source.

### Commits

1. **Fix ALTER SEQUENCE required privileges** — A base `ALTER SEQUENCE` requires the user to be the **owner** (not `CREATE` on the parent database, which is not grantable on a sequence). `RENAME TO` requires `DROP` on the sequence + `CREATE` on the database; `SET SCHEMA` requires `DROP` on the sequence + `CREATE` on the new schema. Previously the `DROP` requirement was omitted and `SET SCHEMA` pointed at the parent database.

2. **Remove incorrect cross-database rename claims from ALTER TABLE/VIEW/SEQUENCE** — `RENAME TO` cannot move a relation to a different database (errors with `cannot change database of table using alter table rename to`); this has held since the `PublicSchemasWithDescriptors` migration (v22.1), so the claims were wrong in every documented release. Removes the "Change the database of a sequence" example, the view note, and the table sentence about needing `CREATE` on both source and target databases.

3. **v26.3: ALTER TABLE/VIEW/SEQUENCE ... RENAME TO checks CREATE on the schema** — In v26.3, `RENAME TO` checks `CREATE` on the relation's **schema** instead of its **database**, matching PostgreSQL (`DROP` still required). Tagged "New in v26.3". Refs cockroachdb/cockroach#171478.

4. **Fix ALTER VIEW required privileges for v23.1 through v26.2** — `SET SCHEMA` requires `DROP` on the view + `CREATE` on the **new schema** (not the parent database); `RENAME TO` requires `DROP` on the view + `CREATE` on the view's database. Removes the misleading standalone "`CREATE` on the parent database" bullet, aligning the view model with ALTER TABLE and the corrected ALTER SEQUENCE pages.
