### PR TITLE
Remove defunct release logic from pages

### DIFF
--- a/src/current/_data/releases.yml
+++ b/src/current/_data/releases.yml
@@ -10673,34 +10673,6 @@
   previous_release: v24.3.27
 
 
-- release_name: v25.2.14
-  major_version: v25.2
-  release_date: '2026-03-05'
-  release_type: Production
-  go_version: go1.25.5
-  sha: ad1c1bb5e905a1bb54ed1170c49bba8f65d8dffe
-  has_sql_only: true
-  has_sha256sum: true
-  mac:
-    mac_arm: true
-    mac_arm_experimental: true
-    mac_arm_limited_access: false
-  windows: true
-  linux:
-    linux_arm: true
-    linux_arm_experimental: false
-    linux_arm_limited_access: false
-    linux_intel_fips: true
-    linux_arm_fips: false
-  docker:
-    docker_image: cockroachdb/cockroach
-    docker_arm: true
-    docker_arm_experimental: false
-    docker_arm_limited_access: false
-  source: true
-  previous_release: v25.2.13
-
-
 - release_name: v24.3.28
   major_version: v24.3
   release_date: '2026-03-05'
@@ -11674,3 +11646,65 @@
     docker_arm_limited_access: false
   source: true
   previous_release: v25.2.18
+
+
+- release_name: v26.2.2
+  major_version: v26.2
+  release_date: '2026-06-05'
+  release_type: Production
+  go_version: go1.25.5
+  sha: 1a79ea7f3f8dfffbc9f0f32dc05ecc1c6627d5bd
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+    mac_arm_experimental: true
+    mac_arm_limited_access: false
+  windows: true
+  linux:
+    linux_arm: true
+    linux_arm_experimental: false
+    linux_arm_limited_access: false
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach
+    docker_arm: true
+    docker_arm_experimental: false
+    docker_arm_limited_access: false
+  source: true
+  previous_release: v26.2.1
+  cloud_only: true
+  cloud_only_message_short: 'Available only for select CockroachDB Cloud clusters'
+  cloud_only_message: >
+      This version is currently available only for select
+      CockroachDB Cloud clusters. To request to upgrade
+      a CockroachDB self-hosted cluster to this version,
+      [contact support](https://support.cockroachlabs.com/hc/requests/new).
+
+
+- release_name: v26.3.0-alpha.1
+  major_version: v26.3
+  release_date: '2026-06-10'
+  release_type: Testing
+  go_version: go1.26.2
+  sha: 3fc77ceb181d24d0225696d36cfefe5d17ae38ab
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+    mac_arm_experimental: true
+    mac_arm_limited_access: false
+  windows: true
+  linux:
+    linux_arm: true
+    linux_arm_experimental: false
+    linux_arm_limited_access: false
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach-unstable
+    docker_arm: true
+    docker_arm_experimental: false
+    docker_arm_limited_access: false
+  source: true

--- a/src/current/releases/v24.1.md
+++ b/src/current/releases/v24.1.md
@@ -9,25 +9,4 @@ pre_production_preview_version: v23.2.0-rc.2
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v24.2.md
+++ b/src/current/releases/v24.2.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v24.3.md
+++ b/src/current/releases/v24.3.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v25.1.md
+++ b/src/current/releases/v25.1.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v25.2.md
+++ b/src/current/releases/v25.2.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v25.3.md
+++ b/src/current/releases/v25.3.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v25.4.md
+++ b/src/current/releases/v25.4.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v26.1.md
+++ b/src/current/releases/v26.1.md
@@ -9,25 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v26.2.md
+++ b/src/current/releases/v26.2.md
@@ -9,27 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% if r.release_type == "Production" %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endif %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}

--- a/src/current/releases/v26.3.md
+++ b/src/current/releases/v26.3.md
@@ -9,27 +9,4 @@ pre_production_preview_version: false
 docs_area: releases
 ---
 
-{% comment %}Load releases from _data/releases.yml. Uncomment the commented line below to print the structure to debug.{% endcomment %}
-{% assign rel = site.data.releases | where_exp: "rel", "rel.major_version == page.major_version" | sort: "release_date" | reverse %}
-{% comment %}rel: {{ rel}}{% endcomment %}
-
-{% comment %}Load major-version support details from _data/versions.yml. Uncomment the commented line below to print the structure to debug. {% endcomment %}
-{% assign vers = site.data.versions | where_exp: "vers", "vers.major_version == page.major_version" | first %}
-
-{% if rel.size > 0 %}
-{% assign today = "today" | date: "%Y-%m-%d" %}
-{% comment %}vers: {{ vers }}{% endcomment %}
-
-{% include releases/testing-release-notice.md major_version=vers %}
-
-{% include releases/whats-new-intro.md major_version=vers %}
-
-{% for r in rel %}
-{% if r.release_type == "Production" %}
-{% include releases/{{ page.major_version }}/{{ r.release_name }}.md release=r.release_name %}
-{% endif %}
-{% endfor %}
-
-{% else %}
-No releases are available for this version. See the [Releases]({% link releases/index.md %}) page for all available releases.
-{% endif %}
+{% comment %}Remove defunct releases page logic{% endcomment %}


### PR DESCRIPTION
- Update releases.yml to be up-to-date.
- Remove logic from release pages that allows us to continue updating releases.yml without causing breakages from missing release notes files.