### PR TITLE
[ENGREQ-634] cockroachcloud: add missing aws byoc permission

### DIFF
--- a/src/current/cockroachcloud/byoc-aws-deployment.md
+++ b/src/current/cockroachcloud/byoc-aws-deployment.md
@@ -107,6 +107,7 @@ Follow these steps to create the intermediate IAM role:
     "ec2:CreateTags",
     "ec2:CreateVpc",
     "ec2:CreateVpcEndpoint",
+    "ec2:CreateVpcEndpointServiceConfiguration",
     "ec2:CreateVpcPeeringConnection",
     "ec2:DeleteFlowLogs",
     "ec2:DeleteInternetGateway",


### PR DESCRIPTION
This commit adds the missing `ec2:CreateVpcEndpointServiceConfiguration` IAM permission to the list of permissions to configure for BYOC accounts.