### PR TITLE
Remove duplicated words across docs

### DIFF
--- a/src/current/v23.1/bulk-update-data.md
+++ b/src/current/v23.1/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v23.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v23.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v23.2/bulk-update-data.md
+++ b/src/current/v23.2/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v23.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v23.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v23.2/restore.md
+++ b/src/current/v23.2/restore.md
@@ -204,7 +204,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v24.1/bulk-update-data.md
+++ b/src/current/v24.1/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v24.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v24.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v24.1/restore.md
+++ b/src/current/v24.1/restore.md
@@ -204,7 +204,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v24.2/bulk-update-data.md
+++ b/src/current/v24.2/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v24.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v24.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v24.2/restore.md
+++ b/src/current/v24.2/restore.md
@@ -204,7 +204,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a target database matching the name of the database from which they were backed up. If the target database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the target database with the [`into_db` option](#into_db).
 
-The target database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore target's names are being used, you can:
+The target database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore target's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v24.3/bulk-update-data.md
+++ b/src/current/v24.3/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v24.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v24.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v24.3/restore.md
+++ b/src/current/v24.3/restore.md
@@ -204,7 +204,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v24.3/upgrade-cockroach-version.md
+++ b/src/current/v24.3/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 

--- a/src/current/v25.1/bulk-update-data.md
+++ b/src/current/v25.1/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v25.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v25.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v25.1/restore.md
+++ b/src/current/v25.1/restore.md
@@ -202,7 +202,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a target database matching the name of the database from which they were backed up. If the target database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the target database with the [`into_db` option](#into_db).
 
-The target database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore target's names are being used, you can:
+The target database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore target's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v25.2/bulk-update-data.md
+++ b/src/current/v25.2/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v25.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v25.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v25.2/restore.md
+++ b/src/current/v25.2/restore.md
@@ -202,7 +202,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v25.2/upgrade-cockroach-version.md
+++ b/src/current/v25.2/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 

--- a/src/current/v25.3/bulk-update-data.md
+++ b/src/current/v25.3/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v25.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v25.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v25.3/restore.md
+++ b/src/current/v25.3/restore.md
@@ -202,7 +202,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v25.3/upgrade-cockroach-version.md
+++ b/src/current/v25.3/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 

--- a/src/current/v25.4/bulk-update-data.md
+++ b/src/current/v25.4/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v25.4/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v25.4/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v25.4/restore.md
+++ b/src/current/v25.4/restore.md
@@ -202,7 +202,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v25.4/upgrade-cockroach-version.md
+++ b/src/current/v25.4/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 

--- a/src/current/v26.1/bulk-update-data.md
+++ b/src/current/v26.1/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v26.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v26.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v26.1/restore.md
+++ b/src/current/v26.1/restore.md
@@ -200,7 +200,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v26.1/upgrade-cockroach-version.md
+++ b/src/current/v26.1/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 

--- a/src/current/v26.2/bulk-update-data.md
+++ b/src/current/v26.2/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v26.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v26.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v26.2/restore.md
+++ b/src/current/v26.2/restore.md
@@ -201,7 +201,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v26.2/upgrade-cockroach-version.md
+++ b/src/current/v26.2/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 

--- a/src/current/v26.3/bulk-update-data.md
+++ b/src/current/v26.3/bulk-update-data.md
@@ -1,6 +1,6 @@
 ---
 title: Bulk-update Data
-summary: How to to update a large amount of data using batch-update loops.
+summary: How to update a large amount of data using batch-update loops.
 toc: true
 docs_area: develop
 ---

--- a/src/current/v26.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/src/current/v26.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -63,7 +63,7 @@ To enable the pods to communicate across regions, we peer the VPCs in all 3 regi
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
-Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
+Instead of using this approach, you can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access), which exposes the Kubernetes cluster's DNS servers via a load-balanced IP address that is visible to the public internet. With this approach, noone of the services in your Kubernetes cluster will be accessible publicly, but their names could leak out to a motivated attacker.
 {{site.data.alerts.end}}
 </section>
 

--- a/src/current/v26.3/restore.md
+++ b/src/current/v26.3/restore.md
@@ -201,7 +201,7 @@ You can also restore individual tables (which automatically includes their index
 
 By default, tables, views, and sequences are restored into a destination database matching the name of the database from which they were backed up. If the destination database does not exist, you must [create it]({% link {{ page.version.version }}/create-database.md %}). You can choose to change the destination database with the [`into_db` option](#into_db).
 
-The destination database must not have tables, views, or sequences with the same name as the the object you're restoring. If any of the restore destination's names are being used, you can:
+The destination database must not have tables, views, or sequences with the same name as the object you're restoring. If any of the restore destination's names are being used, you can:
 
 - [`DROP TABLE`]({% link {{ page.version.version }}/drop-table.md %}), [`DROP VIEW`]({% link {{ page.version.version }}/drop-view.md %}), or [`DROP SEQUENCE`]({% link {{ page.version.version }}/drop-sequence.md %}) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function]({% link {{ page.version.version }}/functions-and-operators.md %}#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table, view, or sequence into a different database](#into_db).

--- a/src/current/v26.3/upgrade-cockroach-version.md
+++ b/src/current/v26.3/upgrade-cockroach-version.md
@@ -9,7 +9,7 @@ This page describes how major-version and patch upgrades work and shows how to u
 
 To upgrade a cluster in CockroachDB {{ site.data.products.cloud }}, refer to [Upgrade a cluster in CockroachDB {{ site.data.products.cloud }}]({% link cockroachcloud/upgrade-cockroach-version.md %}) instead.
 
-To upgrade a cluster with with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
+To upgrade a cluster with [physical cluster replication (PCR)]({% link {{ page.version.version }}/physical-cluster-replication-overview.md %}), refer to [Upgrade a Cluster Running PCR]({% link {{ page.version.version }}/upgrade-with-pcr.md %}).
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Removes 4 unique duplicated words, each replicated across versioned docs (v23.1 through v26.3), totaling 42 file fixes.

## Fixes

| # | File | Versions | Change |
|---|------|----------|--------|
| 1 | `bulk-update-data.md` | v23.1 - v26.3 (12) | "How to to update" → "How to update" |
| 2 | `upgrade-cockroach-version.md` | v24.3 - v26.3 (7) | "a cluster with with [physical cluster replication" → "with [physical cluster replication" |
| 3 | `restore.md` | v23.2 - v26.3 (11) | "restoring the the object" → "restoring the object" |
| 4 | `orchestrate-cockroachdb-with-kubernetes-multi-cluster.md` | v23.1 - v26.3 (12) | "With this this approach" → "With this approach" |

All changes are doc-only, no functional impact. Each fix was manually verified as a genuine duplicate (not an intentional pattern).

> This PR was generated with AI assistance (regex scan + verification).